### PR TITLE
Make arrow size consistent

### DIFF
--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -611,7 +611,7 @@ class StylerTTK:
                     'relief': 'flat',
                     'borderwidth ': 0,  # only applies to dark theme border
                     'padding': 5,
-                    'arrowsize ': 16},
+                    'arrowsize ': 14},
                 'map': {
                     'bordercolor': [
                         ('focus', self.theme.colors.primary),
@@ -855,7 +855,7 @@ class StylerTTK:
                     'background': self.theme.colors.light,
                     'relief': 'flat',
                     'arrowcolor': self.theme.colors.inputfg,
-                    'arrowsize': 16,
+                    'arrowsize': 14,
                     'padding': (10, 5)
                 },
                 'map': {
@@ -1327,6 +1327,7 @@ class StylerTTK:
                     'bordercolor': self.theme.colors.primary,
                     'darkcolor': self.theme.colors.primary,
                     'lightcolor': self.theme.colors.primary,
+                    'arrowsize': 4,
                     'arrowcolor': self.theme.colors.bg if self.theme.type == 'light' else 'white',
                     'arrowpadding': (0, 0, 15, 0),
                     'relief': 'raised',
@@ -1356,6 +1357,7 @@ class StylerTTK:
                         'bordercolor': self.theme.colors.get(color),
                         'darkcolor': self.theme.colors.get(color),
                         'lightcolor': self.theme.colors.get(color),
+                        'arrowsize': 4,
                         'arrowcolor': self.theme.colors.bg if self.theme.type == 'light' else 'white',
                         'arrowpadding': (0, 0, 15, 0),
                         'relief': 'raised',


### PR DESCRIPTION
The spinbox and optionmenu arrows were larger than the scrollbar arrows, making them stand out. This makes all arrows visually the same size.