### PR TITLE
Fix issues with hex_to_rgb

### DIFF
--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -311,14 +311,14 @@ class Colors:
         """
         if len(color) == 4:
             # 3 digit hexadecimal colors
-            r = round(int(color[1], 16) / 255, 2)
-            g = round(int(color[2], 16) / 255, 2)
-            b = round(int(color[3], 16) / 255, 2)
+            r = int(color[1], 16) / 15
+            g = int(color[2], 16) / 15
+            b = int(color[3], 16) / 15
         else:
             # 6 digit hexadecimal colors
-            r = round(int(color[1:3], 16) / 255, 2)
-            g = round(int(color[3:5], 16) / 255, 2)
-            b = round(int(color[5:], 16) / 255, 2)
+            r = int(color[1:3], 16) / 255
+            g = int(color[3:5], 16) / 255
+            b = int(color[5:], 16) / 255
         return r, g, b
 
     @staticmethod


### PR DESCRIPTION
The new 3-digit colours in the theme definitions revealed an error in the hex_to_rgb function, which I fixed here. I've also removed the rounding, as that decreased the colour space during conversion (form 255 to 100 values per colour).

This was very noticeable with widgets in the disabled state, which look better now. The new inputbg colours in dark themes do make disabled widgets very hard to see, I'll submit a PR fixing that in a few minutes.