### PR TITLE
Configure styles not yet created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 experiment
 testing_notes.txt
 docsenv
+errors

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -4788,7 +4788,7 @@ class Bootstyle:
             str:
                 The ttkstyle or empty string if there is none.
         """
-        style = Style.get_instance()
+        style: Style = Style.get_instance() or Style()
 
         # get existing widget style if not provided
         if style_string is None:

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -4,7 +4,7 @@ import tkinter as tk
 from tkinter import font
 from math import ceil
 from tkinter import TclError, ttk
-from typing import Callable
+from typing import Any, Callable
 from PIL import ImageTk, ImageDraw, Image, ImageFont
 from ttkbootstrap.constants import *
 from ttkbootstrap.themes.standard import STANDARD_THEMES
@@ -469,6 +469,9 @@ class Style(ttk.Style):
         else:
             return []  # TODO refactor this
 
+    def configure(self, style, query_opt: Any=None, **kw):
+        return super().configure(style, query_opt=query_opt, **kw)
+
     def theme_names(self):
         """Return a list of all ttkbootstrap themes.
 
@@ -556,6 +559,11 @@ class Style(ttk.Style):
         return exists_in_theme and exists_in_registry
 
     @staticmethod
+    def get_instance():
+        """Returns and instance of the style class"""
+        return Style.instance
+
+    @staticmethod
     def _get_builder():
         """Get the object that builds the widget styles for the current
         theme.
@@ -566,7 +574,7 @@ class Style(ttk.Style):
                 The theme builder object that builds the ttk styles for
                 the current theme.
         """
-        style: Style = Style()
+        style: Style = Style.get_instance()
         theme_name = style.theme.name
         return style._theme_objects[theme_name]
 
@@ -645,7 +653,7 @@ class StyleBuilderTK:
     """
 
     def __init__(self):
-        self.style = Style()
+        self.style = Style.get_instance()
         self.master = self.style.master
 
     @property
@@ -981,7 +989,7 @@ class StyleBuilderTTK:
     """
 
     def __init__(self):
-        self.style = Style()
+        self.style = Style.get_instance()
         self.theme_images = {}
         self.builder_tk = StyleBuilderTK()
         self.create_theme()
@@ -4758,7 +4766,7 @@ class Bootstyle:
             str:
                 The ttkstyle or empty string if there is none.
         """
-        style = Style()
+        style = Style.get_instance()
 
         # get existing widget style if not provided
         if style_string is None:
@@ -4852,7 +4860,7 @@ class Bootstyle:
                 The tcl/tk name given by `tkinter.Widget.winfo_name()`
         """
         try:
-            style = Style()
+            style = Style.get_instance()
             method_name = Bootstyle.tkupdate_method_name(widget)
             builder = style._get_builder_tk()
             builder_method = getattr(StyleBuilderTK, method_name)

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -469,7 +469,9 @@ class Style(ttk.Style):
         else:
             return []  # TODO refactor this
 
-    def configure(self, style, query_opt: Any=None, **kw):
+    def configure(self, style, query_opt: Any = None, **kw):
+        if not self.style_exists_in_theme(style):
+            Bootstyle.update_ttk_widget_style(None, style)
         return super().configure(style, query_opt=query_opt, **kw)
 
     def theme_names(self):
@@ -591,6 +593,10 @@ class Style(ttk.Style):
         """
         builder = Style._get_builder()
         return builder.builder_tk
+
+    def _build_configure(self, style, **kw):
+        """Calls configure of superclass; used by style builder classes."""
+        super().configure(style, **kw)        
 
     def _load_themes(self):
         """Load all ttkbootstrap defined themes"""
@@ -989,7 +995,7 @@ class StyleBuilderTTK:
     """
 
     def __init__(self):
-        self.style = Style.get_instance()
+        self.style: Style = Style.get_instance()
         self.theme_images = {}
         self.builder_tk = StyleBuilderTK()
         self.create_theme()
@@ -1038,8 +1044,8 @@ class StyleBuilderTTK:
             size (Union[int, List, Tuple]):
                 A single integer or an iterable of integers
         """
-        winsys = self.style.master.tk.call('tk', 'windowingsystem')
-        if winsys == 'aqua':
+        winsys = self.style.master.tk.call("tk", "windowingsystem")
+        if winsys == "aqua":
             BASELINE = 1.000492368291482
         else:
             BASELINE = 1.33398982438864281
@@ -1072,7 +1078,7 @@ class StyleBuilderTTK:
         method should be called *first* before any other style is applied
         during theme creation.
         """
-        self.style.configure(
+        self.style._build_configure(
             style=".",
             background=self.colors.bg,
             darkcolor=self.colors.border,
@@ -1122,7 +1128,7 @@ class StyleBuilderTTK:
         if all([colorname, colorname != DEFAULT]):
             bordercolor = focuscolor
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             bordercolor=bordercolor,
             darkcolor=self.colors.inputbg,
@@ -1363,7 +1369,7 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(
+        self.style._build_configure(
             h_ttkstyle,
             troughcolor=troughcolor,
             thickness=thickness,
@@ -1397,7 +1403,7 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(
+        self.style._build_configure(
             v_ttkstyle,
             troughcolor=troughcolor,
             bordercolor=bordercolor,
@@ -1440,7 +1446,7 @@ class StyleBuilderTTK:
             h_ttkstyle = f"{colorname}.{H_STYLE}"
             v_ttkstyle = f"{colorname}.{V_STYLE}"
 
-        self.style.configure(
+        self.style._build_configure(
             h_ttkstyle,
             thickness=thickness,
             borderwidth=1,
@@ -1451,7 +1457,7 @@ class StyleBuilderTTK:
         )
         existing_elements = self.style.element_names()
 
-        self.style.configure(
+        self.style._build_configure(
             v_ttkstyle,
             thickness=thickness,
             borderwidth=1,
@@ -1484,7 +1490,7 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(h_ttkstyle, background=background)
+        self.style._build_configure(h_ttkstyle, background=background)
 
         # vertical progressbar
         v_element = v_ttkstyle.replace(".TP", ".P")
@@ -1493,7 +1499,7 @@ class StyleBuilderTTK:
         if trough_element not in existing_elements:
             self.style.element_create(trough_element, "from", TTK_CLAM)
             self.style.element_create(pbar_element, "from", TTK_DEFAULT)
-            self.style.configure(v_ttkstyle, background=background)
+            self.style._build_configure(v_ttkstyle, background=background)
         self.style.layout(
             v_ttkstyle,
             [
@@ -1748,7 +1754,7 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(
+        self.style._build_configure(
             h_ttkstyle,
             thickness=50,
             borderwidth=1,
@@ -1781,7 +1787,7 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(
+        self.style._build_configure(
             v_ttkstyle,
             thickness=50,
             borderwidth=1,
@@ -1947,7 +1953,7 @@ class StyleBuilderTTK:
         )
 
         # horizontal scrollbar
-        self.style.configure(
+        self.style._build_configure(
             h_ttkstyle,
             troughcolor=troughcolor,
             darkcolor=troughcolor,
@@ -1994,13 +2000,13 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(h_ttkstyle, arrowcolor=background)
+        self.style._build_configure(h_ttkstyle, arrowcolor=background)
         self.style.map(
             h_ttkstyle, arrowcolor=[("pressed", pressed), ("active", active)]
         )
 
         # vertical scrollbar
-        self.style.configure(
+        self.style._build_configure(
             v_ttkstyle,
             troughcolor=troughcolor,
             darkcolor=troughcolor,
@@ -2046,7 +2052,7 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(v_ttkstyle, arrowcolor=background)
+        self.style._build_configure(v_ttkstyle, arrowcolor=background)
         self.style.map(
             v_ttkstyle, arrowcolor=[("pressed", pressed), ("active", active)]
         )
@@ -2141,7 +2147,7 @@ class StyleBuilderTTK:
         )
 
         # horizontal scrollbar
-        self.style.configure(
+        self.style._build_configure(
             h_ttkstyle,
             troughcolor=troughcolor,
             darkcolor=troughcolor,
@@ -2187,13 +2193,13 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(h_ttkstyle, arrowcolor=background)
+        self.style._build_configure(h_ttkstyle, arrowcolor=background)
         self.style.map(
             h_ttkstyle, arrowcolor=[("pressed", pressed), ("active", active)]
         )
 
         # vertical scrollbar
-        self.style.configure(
+        self.style._build_configure(
             v_ttkstyle,
             troughcolor=troughcolor,
             darkcolor=troughcolor,
@@ -2239,7 +2245,7 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(v_ttkstyle, arrowcolor=background)
+        self.style._build_configure(v_ttkstyle, arrowcolor=background)
         self.style.map(
             v_ttkstyle, arrowcolor=[("pressed", pressed), ("active", active)]
         )
@@ -2331,7 +2337,7 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             bordercolor=bordercolor,
             darkcolor=self.colors.inputbg,
@@ -2417,7 +2423,7 @@ class StyleBuilderTTK:
             bordercolor = focuscolor
 
         # treeview header
-        self.style.configure(
+        self.style._build_configure(
             header_style,
             background=background,
             foreground=foreground,
@@ -2430,7 +2436,7 @@ class StyleBuilderTTK:
             bordercolor=[("focus !disabled", background)],
         )
         # treeview body
-        self.style.configure(
+        self.style._build_configure(
             body_style,
             background=self.colors.inputbg,
             fieldbackground=self.colors.inputbg,
@@ -2511,7 +2517,7 @@ class StyleBuilderTTK:
             ttkstyle = f"{colorname}.{STYLE}"
             background = self.colors.get(colorname)
 
-        self.style.configure(ttkstyle, background=background)
+        self.style._build_configure(ttkstyle, background=background)
 
         # register style
         self.style._register_ttkstyle(ttkstyle)
@@ -2546,7 +2552,7 @@ class StyleBuilderTTK:
         pressed = Colors.update_hsv(background, vd=-0.1)
         hover = Colors.update_hsv(background, vd=0.10)
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=foreground,
             background=background,
@@ -2610,7 +2616,7 @@ class StyleBuilderTTK:
         pressed = foreground
         hover = foreground
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=foreground,
             background=self.colors.bg,
@@ -2683,7 +2689,7 @@ class StyleBuilderTTK:
         else:
             disabled_fg = Colors.update_hsv(self.colors.selectbg, vd=-0.3)
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=foreground,
             background=self.colors.bg,
@@ -2952,7 +2958,7 @@ class StyleBuilderTTK:
             Round Toggle style"""
             pass
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             relief=tk.FLAT,
             borderwidth=0,
@@ -3063,7 +3069,7 @@ class StyleBuilderTTK:
                 )
             ],
         )
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle, relief=tk.FLAT, borderwidth=0, foreground=self.colors.fg
         )
         self.style.map(
@@ -3109,7 +3115,7 @@ class StyleBuilderTTK:
             disabled_fg = self.colors.selectbg
             disabled_bg = Colors.update_hsv(disabled_fg, vd=-0.2)
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=self.colors.selectfg,
             background=toggle_off,
@@ -3186,7 +3192,7 @@ class StyleBuilderTTK:
         pressed = foreground
         hover = foreground
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=foreground,
             background=self.colors.bg,
@@ -3267,7 +3273,7 @@ class StyleBuilderTTK:
             focuscolor = self.colors.get(colorname)
             bordercolor = focuscolor
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             bordercolor=bordercolor,
             darkcolor=self.colors.inputbg,
@@ -3400,7 +3406,7 @@ class StyleBuilderTTK:
             sticky=tk.W,
         )
         self.style.map(ttkstyle, foreground=[("disabled", disabled_fg)])
-        self.style.configure(ttkstyle)
+        self.style._build_configure(ttkstyle)
         self.style.layout(
             ttkstyle,
             [
@@ -3516,7 +3522,7 @@ class StyleBuilderTTK:
         pressed = Colors.update_hsv(background, vd=-0.1)
         hover = Colors.update_hsv(background, vd=0.10)
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=foreground,
             background=background,
@@ -3581,7 +3587,7 @@ class StyleBuilderTTK:
             disabled_fg = Colors.update_hsv(self.colors.inputbg, vd=-0.3)
             pressed = Colors.update_hsv(prime_color, vd=0.1)
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=self.colors.fg,
             background=self.colors.bg,
@@ -3650,7 +3656,9 @@ class StyleBuilderTTK:
                 ("hover !disabled", pressed),
             ],
         )
-        self.style.configure(chevron_style, font="-size 14", focuscolor="")
+        self.style._build_configure(
+            chevron_style, font="-size 14", focuscolor=""
+        )
 
         # register ttkstyle
         self.style._register_ttkstyle(ttkstyle)
@@ -3679,7 +3687,7 @@ class StyleBuilderTTK:
 
         background = self.colors.bg
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle, foreground=foreground, background=background
         )
         # register ttkstyle
@@ -3719,7 +3727,7 @@ class StyleBuilderTTK:
             textcolor = self.colors.get(colorname)
             background = self.colors.bg
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=textcolor,
             background=background,
@@ -3748,7 +3756,7 @@ class StyleBuilderTTK:
             background = self.colors.bg
 
         # standard label
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle, foreground=foreground, background=background
         )
         # register ttkstyle
@@ -3776,7 +3784,7 @@ class StyleBuilderTTK:
             background = self.colors.get(colorname)
             foreground = self.colors.get_foreground(colorname)
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle, foreground=foreground, background=background
         )
         # register ttkstyle
@@ -3809,12 +3817,12 @@ class StyleBuilderTTK:
             ttkstyle = f"{colorname}.{STYLE}"
 
         # create widget style
-        self.style.configure(
+        self.style._build_configure(
             f"{ttkstyle}.Label",
             foreground=foreground,
             background=background,
         )
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             relief=tk.RAISED,
             borderwidth=1,
@@ -3863,7 +3871,7 @@ class StyleBuilderTTK:
             border=borderpad,
             sticky=tk.W,
         )
-        self.style.configure(ttkstyle, foreground=self.colors.fg)
+        self.style._build_configure(ttkstyle, foreground=self.colors.fg)
         self.style.map(ttkstyle, foreground=[("disabled", disabled_fg)])
         self.style.layout(
             ttkstyle,
@@ -4021,7 +4029,7 @@ class StyleBuilderTTK:
         pressed = Colors.update_hsv(background, vd=-0.1)
         hover = Colors.update_hsv(background, vd=0.1)
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=foreground,
             background=background,
@@ -4092,7 +4100,7 @@ class StyleBuilderTTK:
         pressed = foreground
         hover = foreground
 
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             foreground=foreground,
             background=self.colors.bg,
@@ -4169,7 +4177,7 @@ class StyleBuilderTTK:
         ttkstyle_tab = f"{ttkstyle}.Tab"
 
         # create widget style
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle,
             background=self.colors.bg,
             bordercolor=bordercolor,
@@ -4177,7 +4185,7 @@ class StyleBuilderTTK:
             darkcolor=self.colors.bg,
             tabmargins=(0, 1, 1, 0),
         )
-        self.style.configure(
+        self.style._build_configure(
             ttkstyle_tab, focuscolor="", foreground=foreground, padding=(6, 5)
         )
         self.style.map(
@@ -4225,11 +4233,11 @@ class StyleBuilderTTK:
             h_ttkstyle = f"{colorname}.{H_STYLE}"
             v_ttkstyle = f"{colorname}.{V_STYLE}"
 
-        self.style.configure(
+        self.style._build_configure(
             "Sash", gripcount=0, sashthickness=self.scale_size(2)
         )
-        self.style.configure(h_ttkstyle, background=sashcolor)
-        self.style.configure(v_ttkstyle, background=sashcolor)
+        self.style._build_configure(h_ttkstyle, background=sashcolor)
+        self.style._build_configure(v_ttkstyle, background=sashcolor)
 
         # register ttkstyle
         self.style._register_ttkstyle(h_ttkstyle)
@@ -4745,7 +4753,7 @@ class Bootstyle:
 
     @staticmethod
     def update_ttk_widget_style(
-        widget: ttk.Widget, style_string: str = None, **kwargs
+        widget: ttk.Widget = None, style_string: str = None, **kwargs
     ):
         """Update the ttk style or create if not existing.
 
@@ -4786,16 +4794,21 @@ class Bootstyle:
             builder_method(builder, widget_color)
 
         # subscribe popdown style to theme changes
-        if widget.winfo_class() == "TCombobox":
-            builder: StyleBuilderTTK = style._get_builder()
-            winfo_id = hex(widget.winfo_id())
-            winfo_pathname = widget.winfo_pathname(winfo_id)
-            Publisher.subscribe(
-                name=winfo_pathname,
-                func=lambda w=widget: builder.update_combobox_popdown_style(w),
-                channel=Channel.STD,
-            )
-            builder.update_combobox_popdown_style(widget)
+        try:
+            if widget.winfo_class() == "TCombobox":
+                builder: StyleBuilderTTK = style._get_builder()
+                winfo_id = hex(widget.winfo_id())
+                winfo_pathname = widget.winfo_pathname(winfo_id)
+                Publisher.subscribe(
+                    name=winfo_pathname,
+                    func=lambda w=widget: builder.update_combobox_popdown_style(
+                        w
+                    ),
+                    channel=Channel.STD,
+                )
+                builder.update_combobox_popdown_style(widget)
+        except:
+            pass
 
         return ttkstyle
 
@@ -4908,5 +4921,5 @@ class Bootstyle:
             Publisher.clear_subscribers()
             super(tk.Tk, self).quit()
         elif isinstance(self, tk.Toplevel):
-            Publisher.unsubscribe(str(self))            
+            Publisher.unsubscribe(str(self))
             super(tk.Toplevel, self).destroy()

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -470,9 +470,22 @@ class Style(ttk.Style):
             return []  # TODO refactor this
 
     def configure(self, style, query_opt: Any = None, **kw):
+        if query_opt:
+            return super().configure(style, query_opt=query_opt, **kw)
+        
         if not self.style_exists_in_theme(style):
-            Bootstyle.update_ttk_widget_style(None, style)
-        return super().configure(style, query_opt=query_opt, **kw)
+            ttkstyle = Bootstyle.update_ttk_widget_style(None, style)
+        else:
+            ttkstyle = style
+
+        if ttkstyle == style:
+            # configure an existing ttkbootrap theme
+            return super().configure(style, query_opt=query_opt, **kw)
+        else:
+            # subclass a ttkbootstrap theme
+            result = super().configure(style, query_opt=query_opt, **kw)
+            self._register_ttkstyle(style)
+            return result
 
     def theme_names(self):
         """Return a list of all ttkbootstrap themes.
@@ -4695,10 +4708,11 @@ class Bootstyle:
             #    in the `get_ttkstyle_name` method
 
             if style:
-                ttkstyle = Bootstyle.update_ttk_widget_style(
-                    self, style, **kwargs
-                )
-                self.configure(style=ttkstyle)
+                if Style.get_instance().style_exists_in_theme(style):
+                    self.configure(style=style)
+                else:
+                    ttkstyle = Bootstyle.update_ttk_widget_style(self, style, **kwargs)
+                    self.configure(style=ttkstyle)
             elif bootstyle:
                 ttkstyle = Bootstyle.update_ttk_widget_style(
                     self, bootstyle, **kwargs


### PR DESCRIPTION
split the Style.configure method into two...`Style.configure` and `Style._build_configure`, the last is a private method used by the style builder classes and is essentially the `configure` method of the `Style` superclass. The `Style.configure` method runs a check to see if the style exists, and if not, creates a style, and then configures it using the `configure` method of the superclass. This will imitate the expected behavior of configuring or subclassing a style in ttk.

