### PR TITLE
add autostyle flag to legacy tkinter widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 experiment
 testing_notes.txt
 docsenv
+errors

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -4878,15 +4878,22 @@ class Bootstyle:
 
         def __init__wrapper(self, *args, **kwargs):
 
+            # check for autostyle flag
+            if 'autostyle' in kwargs:
+                autostyle = kwargs.pop('autostyle')
+            else:
+                autostyle = True
+            
             # instantiate the widget
             func(self, *args, **kwargs)
 
-            Publisher.subscribe(
-                name=str(self),
-                func=lambda w=self: Bootstyle.update_tk_widget_style(w),
-                channel=Channel.STD,
-            )
-            Bootstyle.update_tk_widget_style(self)
+            if autostyle:
+                Publisher.subscribe(
+                    name=str(self),
+                    func=lambda w=self: Bootstyle.update_tk_widget_style(w),
+                    channel=Channel.STD,
+                )
+                Bootstyle.update_tk_widget_style(self)
 
         return __init__wrapper
 


### PR DESCRIPTION
I've added an autostyle flag to legacy tkinter widgets that is implicitly "True". The normal behavior is for a default style to be applied to legacy widgets so that they do not look out-of-place when used together with themed ttk widgets. The `autostyle` parameter will enable the user to turn off this style and prevent it from being registered with the `Publisher` which updates the legacy widget styles whenever the theme is changed. However, this does mean that all styling must be done by the user if they choose to turn off the default styling.