### PR TITLE
Fixed several window module api issues

### DIFF
--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -115,7 +115,7 @@ class Window(tkinter.Tk):
 
         super().__init__()
 
-        if scaling:
+        if scaling is not None:
             utility.enable_high_dpi_awareness(self, scaling)
 
         try:
@@ -127,26 +127,35 @@ class Window(tkinter.Tk):
 
         self.title(title)
 
-        if size:
+        if size is not None:
             width, height = size
             self.geometry(f"{width}x{height}")
-        if position:
+        
+        if position is not None:
             xpos, ypos = position
             self.geometry(f"+{xpos}+{ypos}")
-        if minsize:
+        
+        if minsize is not None:
             width, height = minsize
             self.minsize(width, height)
-        if maxsize:
+        
+        if maxsize is not None:
             width, height
             self.maxsize(width, height)
-        if resizable:
+        
+        if resizable is not None:
             width, height = resizable
             self.resizable(width, height)
-        if transient:
+        
+        if transient is not None:
             self.transient(transient)
+        
         if overrideredirect:
             self.overrideredirect(1)
-        if alpha:
+        
+        if alpha is not None:
+            if self.tk.call('tk', 'windowingsystem') == 'x11':
+                self.wait_visibility()
             self.attributes("-alpha", alpha)
 
         self._style = Style(themename)
@@ -273,35 +282,47 @@ class Toplevel(tkinter.Toplevel):
                 Other optional keyword arguments.
         """
         super().__init__(**kwargs)
+
         if iconphoto:
             self._icon = iconphoto or tkinter.PhotoImage(data=Icon.icon)
             self.iconphoto(False, self._icon)
 
         self.title(title)
 
-        if position:
+        if position is not None:
             xpos, ypos = position
             self.geometry(f"+{xpos}+{ypos}")
-        if minsize:
+        
+        if minsize is not None:
             width, height = minsize
             self.minsize(width, height)
-        if maxsize:
+        
+        if maxsize is not None:
             width, height
             self.maxsize(width, height)
-        if resizable:
+
+        if resizable is not None:
             width, height = resizable
             self.resizable(width, height)
-        if transient:
+        
+        if transient is not None:
             self.transient(transient)
+        
         if overrideredirect:
             self.overrideredirect(1)
-        if windowtype:
+        
+        if windowtype is not None:
             self.attributes("-type", windowtype)
+        
         if topmost:
             self.attributes("-topmost", 1)
+        
         if toolwindow:
             self.attributes("-toolwindow", 1)
-        if alpha:
+        
+        if alpha is not None:
+            if self.tk.call('tk', 'windowingsystem') == 'x11':
+                self.wait_visibility()
             self.attributes("-alpha", alpha)
 
     @property
@@ -313,15 +334,13 @@ class Toplevel(tkinter.Toplevel):
         """Position the toplevel in the center of the screen. Does not
         account for the titlebar when placing the window.
         """
-        winfoid = hex(self.winfo_id())
-        pathname = self.winfo_pathname(winfoid)
-        self.tk.eval(f"tk::PlaceWindow {pathname} center")
+        self.tk.eval(f"tk::PlaceWindow {self._w} center")
 
 
 if __name__ == "__main__":
 
     root = Window(themename="superhero")
-    root.update_idletasks()
+    #root.update_idletasks()
     root.position_center()
 
     top = Toplevel(title="My Toplevel", toolwindow=True, alpha=0.4)

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -202,8 +202,7 @@ class Toplevel(tkinter.Toplevel):
         self,
         title="ttkbootstrap",
         iconphoto=None,
-        height=None,
-        width=None,
+        size=None,
         position=None,
         minsize=None,
         maxsize=None,
@@ -226,11 +225,10 @@ class Toplevel(tkinter.Toplevel):
                 The titlebar icon. This image is applied to all future
                 toplevels as well.
 
-            height (int):
-                Specifies the desired height for the window.
-
-            width (int):
-                Specifies the desired width for the window.
+            size (Tuple[int, int]):
+                The width and height of the application window.
+                Internally, this argument is passed to the
+                `Toplevel.geometry` method.
 
             position (Tuple[int, int]):
                 The horizontal and vertical position of the window on
@@ -299,6 +297,10 @@ class Toplevel(tkinter.Toplevel):
 
         self.title(title)
 
+        if size is not None:
+            width, height = size
+            self.geometry(f'{width}x{height}')
+
         if position is not None:
             xpos, ypos = position
             self.geometry(f"+{xpos}+{ypos}")
@@ -359,10 +361,12 @@ class Toplevel(tkinter.Toplevel):
 
 if __name__ == "__main__":
 
-    root = Window(themename="superhero", alpha=0.5)
+    root = Window(themename="superhero", alpha=0.5, size=(1000, 500))
+    root.withdraw()
     root.place_window_center()
+    root.deiconify()
 
-    top = Toplevel(title="My Toplevel", alpha=0.4)
+    top = Toplevel(title="My Toplevel", alpha=0.4, size=(1000, 500))
     top.place_window_center()
 
     root.mainloop()

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -169,13 +169,18 @@ class Window(tkinter.Tk):
     def place_window_center(self):
         """Position the toplevel in the center of the screen."""
         self.update_idletasks()
-        tbar_height = self.winfo_rooty() - self.winfo_y()
+        # get height of titlebar
+        _y1 = int(self.geometry().split('+')[-1])
+        _y2 = self.winfo_rooty()
+        t_height = _y2 - _y1
+        
+        # get window and widget height
         w_height = self.winfo_height()
         w_width = self.winfo_width()
         s_height = self.winfo_screenheight()
         s_width = self.winfo_screenwidth()
         xpos = (s_width - w_width) // 2
-        ypos = (s_height - w_height - tbar_height) // 2
+        ypos = (s_height - w_height - t_height) // 2
         self.geometry(f'+{xpos}+{ypos}')
 
     position_center = place_window_center # alias
@@ -335,7 +340,6 @@ class Toplevel(tkinter.Toplevel):
                 self.attributes("-toolwindow", 1)
         
         if alpha is not None:
-            print(winsys)
             if winsys == 'x11':
                 self.wait_visibility(self)
             self.attributes("-alpha", alpha)
@@ -348,25 +352,30 @@ class Toplevel(tkinter.Toplevel):
     def place_window_center(self):
         """Position the toplevel in the center of the screen."""
         self.update_idletasks()
-        tbar_height = self.winfo_rooty() - self.winfo_y()
+        # get height of titlebar
+        _y1 = int(self.geometry().split('+')[-1])
+        _y2 = self.winfo_rooty()
+        t_height = _y2 - _y1
+        
+        # get window and widget height
         w_height = self.winfo_height()
         w_width = self.winfo_width()
         s_height = self.winfo_screenheight()
         s_width = self.winfo_screenwidth()
         xpos = (s_width - w_width) // 2
-        ypos = (s_height - w_height - tbar_height) // 2
+        ypos = (s_height - w_height - t_height) // 2
         self.geometry(f'+{xpos}+{ypos}')
 
     position_center = place_window_center # alias
 
 if __name__ == "__main__":
 
-    root = Window(themename="superhero", alpha=0.5, size=(1000, 500))
+    root = Window(themename="superhero", alpha=0.5, size=(1000, 1000))
     root.withdraw()
     root.place_window_center()
     root.deiconify()
 
-    top = Toplevel(title="My Toplevel", alpha=0.4, size=(1000, 500))
+    top = Toplevel(title="My Toplevel", alpha=0.4, size=(1000, 1000))
     top.place_window_center()
 
     root.mainloop()

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -167,20 +167,15 @@ class Window(tkinter.Tk):
         return self._style
 
     def place_window_center(self):
-        """Position the toplevel in the center of the screen."""
+        """Position the toplevel in the center of the screen. Does not
+        account for titlebar height."""
         self.update_idletasks()
-        # get height of titlebar
-        _y1 = int(self.geometry().split('+')[-1])
-        _y2 = self.winfo_rooty()
-        t_height = _y2 - _y1
-        
-        # get window and widget height
         w_height = self.winfo_height()
         w_width = self.winfo_width()
         s_height = self.winfo_screenheight()
         s_width = self.winfo_screenwidth()
         xpos = (s_width - w_width) // 2
-        ypos = (s_height - w_height - t_height) // 2
+        ypos = (s_height - w_height) // 2
         self.geometry(f'+{xpos}+{ypos}')
 
     position_center = place_window_center # alias
@@ -350,20 +345,15 @@ class Toplevel(tkinter.Toplevel):
         return Style()
 
     def place_window_center(self):
-        """Position the toplevel in the center of the screen."""
+        """Position the toplevel in the center of the screen. Does not
+        account for titlebar height."""
         self.update_idletasks()
-        # get height of titlebar
-        _y1 = int(self.geometry().split('+')[-1])
-        _y2 = self.winfo_rooty()
-        t_height = _y2 - _y1
-        
-        # get window and widget height
         w_height = self.winfo_height()
         w_width = self.winfo_width()
         s_height = self.winfo_screenheight()
         s_width = self.winfo_screenwidth()
         xpos = (s_width - w_width) // 2
-        ypos = (s_height - w_height - t_height) // 2
+        ypos = (s_height - w_height) // 2
         self.geometry(f'+{xpos}+{ypos}')
 
     position_center = place_window_center # alias
@@ -371,9 +361,9 @@ class Toplevel(tkinter.Toplevel):
 if __name__ == "__main__":
 
     root = Window(themename="superhero", alpha=0.5, size=(1000, 1000))
-    root.withdraw()
+    #root.withdraw()
     root.place_window_center()
-    root.deiconify()
+    #root.deiconify()
 
     top = Toplevel(title="My Toplevel", alpha=0.4, size=(1000, 1000))
     top.place_window_center()


### PR DESCRIPTION
- fixed issues caused by 'falsey' checks on `Window` and `Toplevel` parameters
- fixed alpha on Linux
- set platform checks on several platform specific parameters
- updated logic for centering screen, prev method caused issues on Linux when setting alpha; this still does not account for titlebar height however
- replaced **height** and **width** parameters with **size** parameter on `Toplevel` to be consistent with `Window` class. The old parameters are still accepted via kwargs. The original arguments were not getting passed to the superclass anyway, so this fixes a bug as well