### PR TITLE
Add disabled and readonly state cursor for entry type widgets

### DIFF
--- a/development/tests/widget_styles/test_entry.py
+++ b/development/tests/widget_styles/test_entry.py
@@ -1,8 +1,7 @@
 import tkinter as tk
 import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
 from random import choice
-from ttkbootstrap import utility
-utility.enable_high_dpi_awareness()
 
 DARK = 'superhero'
 LIGHT = 'flatly'
@@ -27,28 +26,33 @@ def create_entry_test(bootstyle, style):
         entry.pack(padx=5, pady=5, fill=tk.BOTH)
         entry.insert(tk.END, color)
 
+    # readonly
+    entry = ttk.Entry(frame, bootstyle=bootstyle)
+    entry.insert(tk.END, 'readonly')
+    entry.configure(state=READONLY)
+    entry.pack(padx=5, pady=5, fill=tk.BOTH)        
+
     # disabled
     entry = ttk.Entry(frame, bootstyle=bootstyle)
-    entry.insert(tk.END, bootstyle)
-    entry.configure(state=tk.DISABLED)
+    entry.insert(tk.END, 'disabled')
+    entry.configure(state=DISABLED)
     entry.pack(padx=5, pady=5, fill=tk.BOTH)
 
     return frame
 
 
 def change_style():
-    theme = choice(style.theme_names())
-    style.theme_use(theme)    
+    theme = choice(root.style.theme_names())
+    root.style.theme_use(theme)    
 
 
 if __name__ == '__main__':
     # create visual widget style tests
-    root = tk.Tk()
-    style = ttk.Style()
+    root = ttk.Window(themename='sandstone')
 
     ttk.Button(text="Change Theme", command=change_style).pack(padx=10, pady=10)
 
-    test1 = create_entry_test('TEntry', style)
+    test1 = create_entry_test('TEntry', root.style)
     test1.pack(side=tk.LEFT, fill=tk.BOTH)
 
     root.mainloop()

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -38,3 +38,6 @@ SQUARE = 'square'
 TREE = 'tree'
 HEADINGS = 'headings'
 TREEHEADINGS = 'tree headings'
+
+# state constants
+READONLY = 'readonly'

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -188,13 +188,22 @@ class Window(tkinter.Tk):
     def _disabled_state_cursor(self, event):
         """Change the cursor of entry type widgets to 'arrow' if in a disabled
         or readonly state."""
-        widget = self.nametowidget(event.widget)
-        state = str(widget.cget('state'))
-        if state in (DISABLED, READONLY):
-            widget['cursor'] = 'arrow'
-        else:
-            widget['cursor'] = None
-
+        try:
+            widget = self.nametowidget(event.widget)
+            state = str(widget.cget('state'))
+            cursor = str(widget.cget('cursor'))
+            if state in (DISABLED, READONLY):
+                if cursor == 'arrow':
+                    return
+                else:
+                    widget['cursor'] = 'arrow'
+            else:
+                if cursor in ('ibeam', ''):
+                    return
+                else:
+                    widget['cursor'] = None
+        except:
+            pass
         
 
 class Toplevel(tkinter.Toplevel):

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -4,6 +4,7 @@
     consolidated api for initial application startup.
 """
 import tkinter
+from ttkbootstrap.constants import *
 from ttkbootstrap.style import Style
 from ttkbootstrap.icons import Icon
 from ttkbootstrap import utility
@@ -149,7 +150,9 @@ class Window(tkinter.Tk):
         if alpha:
             self.attributes("-alpha", alpha)
 
+        self._apply_entry_type_class_binding()
         self._style = Style(themename)
+
 
     @property
     def style(self):
@@ -162,6 +165,37 @@ class Window(tkinter.Tk):
         """
         self.eval("tk::PlaceWindow . center")
 
+    def _apply_entry_type_class_binding(self):
+        self.bind_class(
+            className="TEntry", 
+            sequence="<Configure>", 
+            func=self._disabled_state_cursor,
+            add="+"
+        )
+        self.bind_class(
+            className="TSpinbox", 
+            sequence="<Configure>", 
+            func=self._disabled_state_cursor,
+            add="+"
+        )
+        self.bind_class(
+            className="TCombobox", 
+            sequence="<Configure>", 
+            func=self._disabled_state_cursor,
+            add="+"
+        )
+
+    def _disabled_state_cursor(self, event):
+        """Change the cursor of entry type widgets to 'arrow' if in a disabled
+        or readonly state."""
+        widget = self.nametowidget(event.widget)
+        state = str(widget.cget('state'))
+        if state in (DISABLED, READONLY):
+            widget['cursor'] = 'arrow'
+        else:
+            widget['cursor'] = None
+
+        
 
 class Toplevel(tkinter.Toplevel):
     """A class that wraps the tkinter.Toplevel class in order to


### PR DESCRIPTION
When an entry type widget (Entry, Spinbox, Combobox) is put into a disabled or readonly state, a callback is invoked to change the cursor from the default to an 'arrow'. This binding automatically occurs when the `Window` class is used.