### PR TITLE
fix disabled fg color for entry, combobox, spinbox

### DIFF
--- a/development/tests/widget_styles/test_spinbox.py
+++ b/development/tests/widget_styles/test_spinbox.py
@@ -33,6 +33,12 @@ def create_spinbox_test(bootstyle, style):
     spinbox.configure(state=tk.DISABLED)
     spinbox.pack(padx=5, pady=5, fill=tk.BOTH)
 
+    # readonly
+    spinbox = ttk.Spinbox(frame)
+    spinbox.insert(tk.END, 'readonly')
+    spinbox.configure(state='readonly')
+    spinbox.pack(padx=5, pady=5, fill=tk.BOTH)    
+
     return frame
 
 

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -1124,7 +1124,7 @@ class StyleBuilderTTK:
         STYLE = "TCombobox"
 
         if self.is_light_theme:
-            disabled_fg = Colors.update_hsv(self.colors.inputbg, vd=-0.2)
+            disabled_fg = self.colors.border
             bordercolor = self.colors.border
             readonly = self.colors.light
         else:
@@ -2281,7 +2281,7 @@ class StyleBuilderTTK:
         STYLE = "TSpinbox"
 
         if self.is_light_theme:
-            disabled_fg = Colors.update_hsv(self.colors.inputbg, vd=-0.2)
+            disabled_fg = self.colors.border
             bordercolor = self.colors.border
             readonly = self.colors.light
         else:
@@ -3369,7 +3369,7 @@ class StyleBuilderTTK:
 
         # general default colors
         if self.is_light_theme:
-            disabled_fg = Colors.update_hsv(self.colors.inputbg, vd=-0.2)
+            disabled_fg = self.colors.border
             bordercolor = self.colors.border
             readonly = self.colors.light
         else:


### PR DESCRIPTION
The previous color was not muted enough. The new color is a lot more muted and it is clear that the widget is in a disabled state.