### PR TITLE
Bug fixes on ScrolledFrame

### DIFF
--- a/src/ttkbootstrap/scrolled.py
+++ b/src/ttkbootstrap/scrolled.py
@@ -243,7 +243,9 @@ class ScrolledFrame(ttk.Frame):
                 Other keyword arguments.
         """
         self.container = ttk.Frame(
-            master=master, padding=padding, relief=FLAT, borderwidth=0
+            master=master, 
+            relief=FLAT, 
+            borderwidth=0
         )
         self._canvas = ttk.Canvas(
             self.container,
@@ -263,7 +265,12 @@ class ScrolledFrame(ttk.Frame):
         self._vbar.place(relx=1.0, relheight=1.0, anchor=NE)
         self._canvas.configure(yscrollcommand=self._vbar.set)
 
-        super().__init__(self._canvas, **kwargs)
+        super().__init__(
+            master=self._canvas, 
+            padding=padding, 
+            bootstyle=bootstyle, 
+            **kwargs
+        )
         self._winsys = self.tk.call('tk', 'windowingsystem')
         self._wid = self._canvas.create_window((0, 0), anchor=NW, window=self)
 

--- a/src/ttkbootstrap/scrolled.py
+++ b/src/ttkbootstrap/scrolled.py
@@ -273,7 +273,7 @@ class ScrolledFrame(ttk.Frame):
             if any(["pack" in method, "grid" in method, "place" in method]):
                 setattr(self, method, getattr(self.container, method))
 
-        self.container.bind("<Configure>", self._resize_canvas)
+        self.bind("<Configure>", self._resize_canvas)
         self._canvas.bind("<Enter>", self._enable_scrolling, "+")
         self._canvas.bind("<Leave>", self._disable_scrolling, "+")
 


### PR DESCRIPTION
Internal frame was not resizes automatically when widgets were added. This was the result of the resize binding being associated with the outer container instead of the inner frame.

The padding, and bootstyle args were not being passed to the internal frame.