### PR TITLE
Enable tableview value updates with property setter

### DIFF
--- a/development/tests/tableview.py
+++ b/development/tests/tableview.py
@@ -2,10 +2,10 @@ import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
 from pathlib import Path
 import csv
-from ttkbootstrap.tableview import Tableview
+from ttkbootstrap.tableview import TableRow, Tableview
 from ttkbootstrap.utility import scale_size
 
-app = ttk.Window(themename='darkly')
+app = ttk.Window(themename='flatly')
 colors = app.style.colors
 
 p = Path(".") / "development/new_widgets/Sample1000.csv"
@@ -39,5 +39,14 @@ dt.pack(fill=BOTH, expand=YES, padx=5, pady=5)
 
 dt.build_table_data(coldata, rowdata)
 #dt.delete_columns(indices=[2, 3])
+
+# modify the contents of a single cell
+row = dt.get_row(0)
+row.values[2] = "Israel"
+row.refresh()
+
+# modify an entire row
+row = dt.get_row(1)
+row.values = ['123456', 'My Company', 'Israel', 'Something here', 45]
 
 app.mainloop()

--- a/src/ttkbootstrap/tableview.py
+++ b/src/ttkbootstrap/tableview.py
@@ -1367,10 +1367,10 @@ class Tableview(ttk.Frame):
         self._filtered = False
         self.searchcriteria = ""
         try:
-            sortedrows = sorted(self.tablerows, key=lambda x: x.original_index)
+            sortedrows = sorted(self.tablerows, key=lambda x: x._sort)
         except IndexError:
             self.fill_empty_columns()
-            sortedrows = sorted(self.tablerows, key=lambda x: x.original_index)
+            sortedrows = sorted(self.tablerows, key=lambda x: x._sort)
         self._tablerows = sortedrows
         self.unload_table_data()
 

--- a/src/ttkbootstrap/tableview.py
+++ b/src/ttkbootstrap/tableview.py
@@ -263,6 +263,11 @@ class TableRow:
         """The table row values"""
         return self._values
 
+    @values.setter
+    def values(self, values):
+        self._values = values
+        self.refresh()
+
     @property
     def iid(self):
         """A unique record identifier"""
@@ -288,6 +293,9 @@ class TableRow:
 
         if opt is not None:
             return self.view.item(self.iid, opt)
+        elif 'values' in kwargs:
+            values = kwargs.pop('values')
+            self.values = values
         else:
             self.view.item(self.iid, **kwargs)
 
@@ -1085,7 +1093,7 @@ class Tableview(ttk.Frame):
 
     def get_column(
         self, index=None, visible=False, cid=None
-    ) -> Union[TableColumn, None]:
+    ) -> TableColumn:
         """Returns the `TableColumn` object from an index or a cid.
 
         If index is specified, the column index refers to the index
@@ -1161,7 +1169,7 @@ class Tableview(ttk.Frame):
         else:
             return self._tablerows
 
-    def get_row(self, index=None, visible=False, filtered=False, iid=None):
+    def get_row(self, index=None, visible=False, filtered=False, iid=None) -> TableRow:
         """Returns the `TableRow` object from an index or the iid.
 
         If an index is specified, the row index refers to the index


### PR DESCRIPTION
Added setter to `TableRow.values` so that you can update the row values simply. The `refresh` method is called automatically within the setter so that the underlying Treeview is updated as well.

I updated the configure method so that it catches the update to values and passes is through to the property. This will ensure everything stays in sync.

Fixed a bug related to sort in previous removal of the original_index property

