### PR TITLE
Font dialog bug fixes

### DIFF
--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -897,15 +897,14 @@ class FontDialog(Dialog):
         _headingfont.configure(weight="bold")
 
         self._update_font_preview()
-
-        self._families = set()
+        self._families = set([self._family.get()])
         for f in font.families():
-            if f and not f.startswith("@") and "emoji" not in f.lower():
+            if all([f, not f.startswith("@"), "emoji" not in f.lower()]):
                 self._families.add(f)
 
     def create_body(self, master):
         width = utility.scale_size(master, 600)
-        height = utility.scale_size(master, 415)
+        height = utility.scale_size(master, 500)
         self._toplevel.geometry(f"{width}x{height}")
 
         family_size_frame = ttk.Frame(master, padding=10)
@@ -984,7 +983,7 @@ class FontDialog(Dialog):
         sizes_listbox = ttk.Treeview(container, height=7, columns=[0], show="")
         sizes_listbox.column(0, width=utility.scale_size(sizes_listbox, 24))
 
-        sizes = [*range(8, 12), *range(12, 30, 2), 36, 48, 72]
+        sizes = [*range(8, 13), *range(13, 30, 2), 36, 48, 72]
         for s in sizes:
             sizes_listbox.insert("", iid=s, index=END, values=[s])
 

--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -898,14 +898,14 @@ class FontDialog(Dialog):
 
         self._update_font_preview()
 
-        self._families = []
+        self._families = set()
         for f in font.families():
             if f and not f.startswith("@") and "emoji" not in f.lower():
-                self._families.append(f)
+                self._families.add(f)
 
     def create_body(self, master):
         width = utility.scale_size(master, 600)
-        height = utility.scale_size(master, 375)
+        height = utility.scale_size(master, 415)
         self._toplevel.geometry(f"{width}x{height}")
 
         family_size_frame = ttk.Frame(master, padding=10)


### PR DESCRIPTION
- Use set for fonts instead of list to remove duplicates in family list.
- Added the default font family in the set as this default is apparently not always returned by `font.families`.
- Updated height so it's visible on all 3 platforms. I don't really like this solution, but it's a quick fix for now that will at least make everything visible on Windows, Mac, Linux.
