### PR TITLE
Set alpha on dropper screenshot to 1.0

### DIFF
--- a/src/ttkbootstrap/dialogs/colordropper.py
+++ b/src/ttkbootstrap/dialogs/colordropper.py
@@ -135,7 +135,7 @@ class ColorDropperDialog:
 
     def show(self):
         """Show the toplevel window"""
-        self.toplevel = ttk.Toplevel(alpha=0.01)
+        self.toplevel = ttk.Toplevel(alpha=1)
         self.toplevel.wm_attributes('-fullscreen', True)
         self.build_screenshot_canvas()
 


### PR DESCRIPTION
The taskbar disappeared on Linux when using the dropper. Setting the alpha to 1.0 fixes this issue as the user is essentially looking at a fixed screenshot of the background when they initiated the dropper.