### PR TITLE
Make default root function part of window module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.5.1.1",
+    version="1.5.1.2",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/localization/__init__.py
+++ b/src/ttkbootstrap/localization/__init__.py
@@ -11,7 +11,7 @@
     https://www.tcl.tk/man/tcl/TclCmd/msgcat.html    
 """
 from pathlib import Path
-from tkinter import _get_default_root as default_root
+from ttkbootstrap.window import get_default_root
 
 MSGS_PATH = (Path(__file__).parent / 'msgs').as_posix()
 
@@ -51,7 +51,7 @@ class MessageCatalog:
             str:
                 The translated string.
         """
-        root = default_root()
+        root = get_default_root()
         command = '::msgcat::mc'
         return root.tk.eval(f'{command} "{src}"')
 
@@ -76,7 +76,7 @@ class MessageCatalog:
                 The current locale name if newlocale is None or an empty 
                 string.
         """
-        root = default_root()
+        root = get_default_root()
         command = '::msgcat::mclocale'
         return root.tk.eval(f'{command} {newlocale or ""}')
 
@@ -92,7 +92,7 @@ class MessageCatalog:
             List[str]:
                 Locales preferred by the user.
         """
-        root = default_root("preferences")
+        root = get_default_root()
         command = '::msgcat::mcpreferences'
         items = root.tk.eval(command).split(' ')
         if len(items) > 0:
@@ -112,7 +112,7 @@ class MessageCatalog:
             dirname (str):
                 The directory path of the msg files.
         """
-        root = default_root()
+        root = get_default_root()
         command = '::msgcat::mcload'
         root.tk.eval(f'{command} {dirname}')
 
@@ -132,7 +132,7 @@ class MessageCatalog:
             translated (str):
                 The translated string.
         """
-        root = default_root()
+        root = get_default_root()
         command = '::msgcat::mcset'
         root.tk.eval(f'{command} {locale} {src} {translated or ""}')
 
@@ -154,7 +154,7 @@ class MessageCatalog:
             int:
                 The number of translation sets.
         """
-        root = default_root()
+        root = get_default_root()
         command = '::msgcat::mcmset'
         return int(root.tk.eval(f'{command} {locale} {" ".join(args)}'))
 
@@ -174,7 +174,7 @@ class MessageCatalog:
             int:
                 The length of the longest str.
         """
-        root = default_root()
+        root = get_default_root()
         command = '::msgcat::mcmax'
         return int(root.tk.eval(f'{command} {" ".join(src)}'))
 

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -10,6 +10,17 @@ from ttkbootstrap.icons import Icon
 from ttkbootstrap import utility
 
 
+def get_default_root(what=None):
+    if not tkinter._support_default_root:
+        raise RuntimeError("No master specified and tkinter is "
+                           "configured to not support default root")
+    if not tkinter._default_root:
+        if what:
+            raise RuntimeError(f"Too early to {what}: no default root window")
+        root = tkinter.Tk()
+        assert tkinter._default_root is root
+    return tkinter._default_root
+
 class Window(tkinter.Tk):
     """A class that wraps the tkinter.Tk class in order to provide a
     more convenient api with additional bells and whistles. For more


### PR DESCRIPTION
Fixes the missing `_get_default_root` method in some versions of python