### PR TITLE
Message catalog.set many does not work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.6.1",
+    version="1.6.1.1",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/localization/msgcat.py
+++ b/src/ttkbootstrap/localization/msgcat.py
@@ -134,7 +134,7 @@ class MessageCatalog:
         """
         root = get_default_root()
         command = "::msgcat::mcmset"
-        return int(root.tk.eval(f'{command} {locale} {" ".join(args)}'))
+        return int(root.tk.eval(f'{command} {locale} {{{" ".join(args)}}}'))
 
     @staticmethod
     def max(*src):

--- a/src/ttkbootstrap/localization/msgcat.py
+++ b/src/ttkbootstrap/localization/msgcat.py
@@ -159,8 +159,8 @@ class MessageCatalog:
 
 
 if __name__ == "__main__":
-
-    initialize_localities()
+    from ttkbootstrap import localization
+    localization.initialize_localities()
     MessageCatalog.locale("zh_cn")
     result = MessageCatalog.translate("Skip Messages")
     print(result)


### PR DESCRIPTION
The tcl code was missing \{ \} to indicate a list of src-translation pairs.