### PR TITLE
Fix visible 'hidden' scrollbar when content frame is shorter than container

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.0.1",
+    version="1.7.0.2",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/scrolled.py
+++ b/src/ttkbootstrap/scrolled.py
@@ -383,11 +383,11 @@ class ScrolledFrame(ttk.Frame):
 
     def hide_scrollbars(self):
         """Hide the scrollbars."""
-        self.vscroll.lower(self)
+        self.vscroll.pack_forget()
 
     def show_scrollbars(self):
         """Show the scrollbars."""
-        self.vscroll.lift(self)
+        self.vscroll.pack(side=RIGHT, fill=Y)
 
     def autohide_scrollbar(self):
         """Toggle the autohide funtionality. Show the scrollbars when


### PR DESCRIPTION
The scrollbar was still visible when 'hidden' if the content frame height was shorter than the container frame height. Using `pack` and `pack_forget` instead of `lift` and `lower` fixes this issue.