### PR TITLE
Alternative state checkbox image

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.1.1",
+    version="1.7.1.2",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/__main__.py
+++ b/src/ttkbootstrap/__main__.py
@@ -89,8 +89,13 @@ Namespaces are one honking great idea -- let's do more of those!"""
     check1.pack(side=LEFT, expand=YES, padx=5)
     check1.invoke()
 
-    check2 = ttk.Checkbutton(rb_group, text="deselected")
+    check2 = ttk.Checkbutton(rb_group, text="alternate")
     check2.pack(side=LEFT, expand=YES, padx=5)
+
+    check4 = ttk.Checkbutton(rb_group, text="deselected")
+    check4.pack(side=LEFT, expand=YES, padx=5)    
+    check4.invoke()
+    check4.invoke()    
 
     check3 = ttk.Checkbutton(rb_group, text="disabled", state=DISABLED)
     check3.pack(side=LEFT, expand=YES, padx=5)

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -3994,6 +3994,7 @@ class StyleBuilderTTK:
             "image",
             images[1],
             ("disabled", images[2]),
+            ("alternate", images[3]),
             ("!selected", images[0]),
             width=width,
             border=borderpad,
@@ -4133,6 +4134,23 @@ class StyleBuilderTTK:
         on_name = util.get_image_name(on_img)
         self.theme_images[on_name] = on_img
 
+        # checkbutton alt
+        checkbutton_alt = Image.new("RGBA", (134, 134))
+        draw = ImageDraw.Draw(checkbutton_alt)
+        draw.rounded_rectangle(
+            [2, 2, 132, 132],
+            radius=16,
+            fill=on_fill,
+            outline=on_border,
+            width=3,
+        )        
+        draw.line([36, 67, 100, 67], fill=check_color, width=12)
+        alt_img = ImageTk.PhotoImage(
+            checkbutton_alt.resize(size, Image.LANCZOS)
+        )
+        alt_name = util.get_image_name(alt_img)
+        self.theme_images[alt_name] = alt_img
+
         # checkbutton disabled
         checkbutton_disabled = Image.new("RGBA", (134, 134))
         draw = ImageDraw.Draw(checkbutton_disabled)
@@ -4145,7 +4163,7 @@ class StyleBuilderTTK:
         disabled_name = util.get_image_name(disabled_img)
         self.theme_images[disabled_name] = disabled_img
 
-        return off_name, on_name, disabled_name
+        return off_name, on_name, disabled_name, alt_name
 
     def create_menubutton_style(self, colorname=DEFAULT):
         """Create a solid style for the ttk.Menubutton widget.


### PR DESCRIPTION
closes #145 by adding an alternative state style for the checkbutton widget. This state is the default state for the checkbutton, which is a solid background with a horizontal line in the middle.