### PR TITLE
Make tableview rowheight configurable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.1.2",
+    version="1.7.1.3",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -2513,7 +2513,7 @@ class StyleBuilderTTK:
             darkcolor=self.colors.inputbg,
             borderwidth=2,
             padding=0,
-            rowheight=rowheight,
+            #rowheight=rowheight,
             relief=tk.RAISED,
         )
         self.style.map(


### PR DESCRIPTION
This fixes the issue which prevents the rowheight from being configurable on the Tableview. The option was being configured on both the Treeview and subclassed Tableview causing the option to override the user customization.