### PR TITLE
Fix Tableview bug in delete_rows method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.2",
+    version="1.7.2.1",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/tableview.py
+++ b/src/ttkbootstrap/tableview.py
@@ -892,9 +892,9 @@ class Tableview(ttk.Frame):
             self._tablerows.clear()
             self._tablerows_filtered.clear()
             self._viewdata.clear()
-            self._cidmap.clear()
+            #self._cidmap.clear()
             self._iidmap.clear()
-            records = self.view.get_children("")
+            records = self.view.get_children()
             self.view.delete(*records)
         # route to new page if no records visible
         if len(self._viewdata) == 0:


### PR DESCRIPTION
The cidmap was getting cleared when the delete rows method was called. I commented out this line to prevent this behavior. This fixes the issue reported in #208.