### PR TITLE
Enable round scrollbar on scrolled widgets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.2.1",
+    version="1.7.2.2",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/scrolled.py
+++ b/src/ttkbootstrap/scrolled.py
@@ -259,7 +259,7 @@ class ScrolledFrame(ttk.Frame):
         super().__init__(
             master=self.container,
             padding=padding,
-            bootstyle=bootstyle,
+            bootstyle=bootstyle.replace('round', ''),
             **kwargs,
         )
         self.place(rely=0.0, relwidth=1.0, height=scrollheight)


### PR DESCRIPTION
Fixed issue with passing in 'rounded' bootstyle keyword on ScrolledFrame widget. This keyword is removed for the frame, but included for the scrollbar.

```python
from ttkbootstrap.constants import *
from ttkbootstrap.scrolled import ScrolledFrame

scrollbar = ScrolledFrame(bootstyle=ROUND)
```