### PR TITLE
Fix missing font reference for button assets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.3",
+    version="1.7.3.1",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -4075,7 +4075,7 @@ class StyleBuilderTTK:
                     # because of how I'm scaling the image, but it 
                     # will prevent the program from crashing. I need 
                     # a better solution for a missing font
-                    ImageFont.load_default()
+                    fnt = ImageFont.load_default()
                     font_offset = 0        
                     indicator = "x"
         else:


### PR DESCRIPTION
The assignment to `fnt` was missing when there was not default font available on the OS.