### PR TITLE
Fix sizing of scrolled frame

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.3.1",
+    version="1.7.3.2",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/scrolled.py
+++ b/src/ttkbootstrap/scrolled.py
@@ -275,6 +275,8 @@ class ScrolledFrame(ttk.Frame):
             master=self.container,
             padding=padding,
             bootstyle=bootstyle.replace('round', ''),
+            width=width,
+            height=height,
             **kwargs,
         )
         self.place(rely=0.0, relwidth=1.0, height=scrollheight)


### PR DESCRIPTION
Scrolled frame width and height are not passed to the content frame so the size is not propagated when the place method is used to add the frame to the window. 