### PR TITLE
Change default button binding to return instead of space

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.4",
+    version="1.7.5.1",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -313,7 +313,6 @@ class MessageDialog(Dialog):
                 text = MessageCatalog.translate(text)
 
             btn = ttk.Button(frame, bootstyle=bootstyle, text=text)
-            btn.bind("<Return>", lambda _: btn.invoke())
             btn.configure(command=lambda b=btn: self.on_button_press(b))
             btn.pack(padx=2, side=RIGHT)
             btn.lower()  # set focus traversal left-to-right

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -40,7 +40,8 @@ def apply_class_bindings(window: tkinter.Widget):
                 sequence=sequence,
                 func=on_select_all
         )
-
+    window.unbind_class("TButton", "<Key-space>")
+    window.bind_class("TButton", "<Key-Return>", lambda event: event.widget.invoke())
 
 def apply_all_bindings(window: tkinter.Widget):
     """Add bindings to all widgets in the application"""


### PR DESCRIPTION
Default \<Key-space\> binding was interfering with adding a <Key-Return> binding to the buttons. This removes the default tkinter behavior and sets the RETURN key as the default activation key for buttons. This closes issue #260.