### PR TITLE
Replace deprecated resampling method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.5.2",
+    version="1.7.5.3",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -1894,7 +1894,7 @@ class StyleBuilderTTK:
             draw.line([7, 5, 7, 8], fill=color)
             draw.line([8, 6, 8, 9], fill=color)
 
-            img = img.resize(size, Image.CUBIC)
+            img = img.resize(size, Image.BICUBIC)
 
             up_img = ImageTk.PhotoImage(img)
             up_name = util.get_image_name(up_img)
@@ -1946,7 +1946,7 @@ class StyleBuilderTTK:
             draw = ImageDraw.Draw(img)
             radius = min([x, y]) // 2
             draw.rounded_rectangle([0, 0, x - 1, y - 1], radius, fill)
-            image = ImageTk.PhotoImage(img.resize(size, Image.CUBIC))
+            image = ImageTk.PhotoImage(img.resize(size, Image.BICUBIC))
             name = util.get_image_name(image)
             self.theme_images[name] = image
             return name
@@ -2140,7 +2140,7 @@ class StyleBuilderTTK:
             x = size[0] * 10
             y = size[1] * 10
             img = Image.new("RGBA", (x, y), fill)
-            image = ImageTk.PhotoImage(img.resize(size), Image.CUBIC)
+            image = ImageTk.PhotoImage(img.resize(size), Image.BICUBIC)
             name = util.get_image_name(image)
             self.theme_images[name] = image
             return name


### PR DESCRIPTION
CUBIC sampling method is deprecated by the pillow library. Replacing with BICUBIC.