### PR TITLE
Standardize Messagebox alert parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.5.4",
+    version="1.7.5.5",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -1155,7 +1155,7 @@ class Messagebox:
     and alert options."""
 
     @staticmethod
-    def show_info(message, title=" ", parent=None, **kwargs):
+    def show_info(message, title=" ", parent=None, alert=False, **kwargs):
         """Display a modal dialog box with an OK button and an INFO
         icon.
 
@@ -1175,12 +1175,16 @@ class Messagebox:
                 Makes the window the logical parent of the message box. The
                 message box is displayed on top of its parent window.
 
+            alert (bool):
+                Specified whether to ring the display bell.
+
             **kwargs (Dict):
                 Other optional keyword arguments.
         """
         dialog = MessageDialog(
             message=message,
             title=title,
+            alert=alert,
             parent=parent,
             buttons=["OK:primary"],
             icon=Icon.info,
@@ -1193,7 +1197,7 @@ class Messagebox:
         dialog.show(position)
 
     @staticmethod
-    def show_warning(message, title=" ", parent=None, **kwargs):
+    def show_warning(message, title=" ", parent=None, alert=True, **kwargs):
         """Display a modal dialog box with an OK button and a
         warning icon. Also will ring the display bell.
 
@@ -1213,6 +1217,9 @@ class Messagebox:
                 Makes the window the logical parent of the message box. The
                 message box is displayed on top of its parent window.
 
+            alert (bool):
+                Specified whether to ring the display bell.
+
             **kwargs (Dict):
                 Other optional keyword arguments.
         """
@@ -1222,7 +1229,7 @@ class Messagebox:
             parent=parent,
             buttons=["OK:primary"],
             icon=Icon.warning,
-            alert=True,
+            alert=alert,
             localize=True,
             **kwargs,
         )
@@ -1233,7 +1240,7 @@ class Messagebox:
         dialog.show(position)
 
     @staticmethod
-    def show_error(message, title=" ", parent=None, **kwargs):
+    def show_error(message, title=" ", parent=None, alert=True, **kwargs):
         """Display a modal dialog box with an OK button and an
         error icon. Also will ring the display bell.
 
@@ -1253,6 +1260,9 @@ class Messagebox:
                 Makes the window the logical parent of the message box. The
                 message box is displayed on top of its parent window.
 
+            alert (bool):
+                Specified whether to ring the display bell.
+
             **kwargs (Dict):
                 Other optional keyword arguments.
         """
@@ -1262,7 +1272,7 @@ class Messagebox:
             parent=parent,
             buttons=["OK:primary"],
             icon=Icon.error,
-            alert=True,
+            alert=alert,
             localize=True,
             **kwargs,
         )
@@ -1278,6 +1288,7 @@ class Messagebox:
         title=" ",
         parent=None,
         buttons=["No:secondary", "Yes:primary"],
+        alert=True,
         **kwargs,
     ):
         """Display a modal dialog box with yes, no buttons and a
@@ -1310,6 +1321,9 @@ class Messagebox:
                 the style is set to 'primary' by default.
                 `['Yes:success','No:danger']`.
 
+            alert (bool):
+                Specified whether to ring the display bell.
+
             **kwargs (Dict):
                 Other optional keyword arguments.
 
@@ -1325,7 +1339,7 @@ class Messagebox:
             parent=parent,
             buttons=buttons,
             icon=Icon.question,
-            alert=True,
+            alert=alert,
             localize=True,
             **kwargs,
         )


### PR DESCRIPTION
Some of the static method had an alert parameter with defaults set, but not all. I added the parameter to all static methods in order to standardize the api and expose this across the board.