### PR TITLE
Add icon master to prevent crash with multiple tk instances

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.4.6",
+    version="1.7.4.7",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -209,17 +209,17 @@ class Window(tkinter.Tk):
         if iconphoto is not None:
             if iconphoto == '':
                 # the default ttkbootstrap icon
-                self._icon = tkinter.PhotoImage(data=Icon.icon)
+                self._icon = tkinter.PhotoImage(master=self, data=Icon.icon)
                 self.iconphoto(True, self._icon)
             else:
                 try:
                     # the user provided an image path
-                    self._icon = tkinter.PhotoImage(file=iconphoto)
+                    self._icon = tkinter.PhotoImage(file=iconphoto, master=self)
                     self.iconphoto(True, self._icon)
                 except tkinter.TclError:
                     # The fallback icon if the user icon fails.
                     print('iconphoto path is bad; using default image.')
-                    self._icon = tkinter.PhotoImage(data=Icon.icon)
+                    self._icon = tkinter.PhotoImage(data=Icon.icon, master=self)
                     self.iconphoto(True, self._icon)
 
         self.title(title)
@@ -402,7 +402,7 @@ class Toplevel(tkinter.Toplevel):
         if iconphoto != '':
             try:
                 # the user provided an image path
-                self._icon = tkinter.PhotoImage(file=iconphoto)
+                self._icon = tkinter.PhotoImage(file=iconphoto, master=self)
                 self.iconphoto(True, self._icon)
             except tkinter.TclError:
                 # The fallback icon if the user icon fails.


### PR DESCRIPTION
Destroying a window and re-creating would crash the window, or creating more than once instance of a tk window because the photo image default master was always tied to the original window. Setting the master directly when instantiating the image fixes this bug.