### PR TITLE
Allow path object and format msgs path for message catalog.load

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.5",
+    version="1.7.5.1",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/localization/msgcat.py
+++ b/src/ttkbootstrap/localization/msgcat.py
@@ -79,7 +79,7 @@ class MessageCatalog:
 
         Parameters:
 
-            dirname (str):
+            dirname (str or Pathlike object):
                 The directory path of the msg files.
 
         Returns:
@@ -88,9 +88,12 @@ class MessageCatalog:
                 Then number of message files which matched the
                 specification and were loaded.
         """
+        from pathlib import Path
+        msgs = Path(dirname).as_posix() # format path for tcl/tk
+        
         root = get_default_root()
         command = "::msgcat::mcload"
-        return int(root.tk.eval(f"{command} [list {dirname}]"))
+        return int(root.tk.eval(f"{command} [list {msgs}]"))
 
     @staticmethod
     def set(locale, src, translated=None):


### PR DESCRIPTION
Some users experiences issues when passing a Window's style path "``" to the MessageCatalog.load method. I convert the `dirname` argument internally to a Path object (or ingest the path object that is the argument) and then pass a reformatted path to the msgcat command using the `as_posix()` method to return the path with forward slashes.