### PR TITLE
Fix issue with window close on destroy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.5.1",
+    version="1.7.6",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -5092,15 +5092,12 @@ class Bootstyle:
                 # this may fail in python 3.6 for ttk widgets that do not exist
                 #   in that version.
                 continue
+
         # TK WIDGETS
         for widget in TK_WIDGETS:
-
             # override widget constructor
             _init = Bootstyle.override_tk_widget_constructor(widget.__init__)
             widget.__init__ = _init
-
-            # override widget destroy method (quit for tk.Tk)
-            widget.destroy = Bootstyle.override_widget_destroy_method
 
     @staticmethod
     def update_tk_widget_style(widget):
@@ -5157,16 +5154,3 @@ class Bootstyle:
                 Bootstyle.update_tk_widget_style(self)
 
         return __init__wrapper
-
-    @staticmethod
-    def override_widget_destroy_method(self):
-        """Unsubscribe widget from publication and destroy."""
-        if isinstance(self, tk.Widget):
-            Publisher.unsubscribe(str(self))
-            super(tk.Widget, self).destroy()
-        elif isinstance(self, tk.Tk):
-            Publisher.clear_subscribers()
-            super(tk.Tk, self).quit()
-        elif isinstance(self, tk.Toplevel):
-            Publisher.unsubscribe(str(self))
-            super(tk.Toplevel, self).destroy()

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -5,6 +5,7 @@
 """
 import tkinter
 from ttkbootstrap.constants import *
+from ttkbootstrap.publisher import Publisher
 from ttkbootstrap.style import Style
 from ttkbootstrap.icons import Icon
 from ttkbootstrap import utility
@@ -43,9 +44,11 @@ def apply_class_bindings(window: tkinter.Widget):
     window.unbind_class("TButton", "<Key-space>")
     window.bind_class("TButton", "<Key-Return>", lambda event: event.widget.invoke())
 
+
 def apply_all_bindings(window: tkinter.Widget):
     """Add bindings to all widgets in the application"""
     window.bind_all('<Map>', on_map_child, '+')
+    window.bind_all('<Destroy>', lambda e: Publisher.unsubscribe(e.widget))
 
 
 def on_disabled_readonly_state(event):


### PR DESCRIPTION
The window was not closing on destroy because of the way I implemented the destroy method override. The goal of the override was to unsubscribe a widget from the Publisher when it was destroyed, however, this caused too many other issues.

The resolution was to remove the override on the destroy method and to utilize the <Destroy> event which is generated when a widget is destroyed. I catch this event and then call the Publisher.unsubscribe method on the widget generating the event. There is now no need to override the destroy method.