### PR TITLE
Refactor floodgauge variable param

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.6",
+    version="1.7.6.1",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -381,7 +381,7 @@ class Floodgauge(Progressbar):
             self._variable = kwargs.pop('variable')
         else:
             self._variable = tk.IntVar(value=value)
-        if 'textvariable':
+        if 'textvariable' in kwargs:
             self._textvariable = kwargs.pop('textvariable')
         else:
             self._textvariable = tk.StringVar(value=text)

--- a/tests/widget_styles/test_floodgauge.py
+++ b/tests/widget_styles/test_floodgauge.py
@@ -41,4 +41,9 @@ assert p1['font'] == 'arial 18'
 p1['mask'] = '{}% Complete'
 assert p1.configure('mask') == '{}% Complete'
 
+var = ttk.IntVar(value=30)
+p1['variable'] = var
+assert p1['value'] == 30
+assert(str(var) == p1.cget('variable'))
+
 root.mainloop()


### PR DESCRIPTION
This update allows the user to pass in a variable or textvariable object while instantiating the widget instead of using the built-in objects. I also added getters and setters for this properties and moved the existing fields to private. 