### PR TITLE
Enable font changes in Text widget

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.6.1",
+    version="1.7.6.2",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -744,6 +744,8 @@ class StyleBuilderTK:
                 The tk object to update.
         """
         widget.configure(background=self.colors.bg)
+        # add default initial font for text widget
+        widget.option_add('*Text*Font', 'TkDefaultFont')
 
     def update_toplevel_style(self, widget: tk.Toplevel):
         """Update the toplevel style.
@@ -1038,7 +1040,7 @@ class StyleBuilderTK:
             relief=tk.FLAT,
             padx=5,
             pady=5,
-            font="TkDefaultFont",
+            #font="TkDefaultFont",
         )
 
 

--- a/tests/widget_styles/test_text.py
+++ b/tests/widget_styles/test_text.py
@@ -1,4 +1,3 @@
-import tkinter as tk
 import ttkbootstrap as ttk
 from random import choice
 from ttkbootstrap import utility
@@ -7,18 +6,18 @@ utility.enable_high_dpi_awareness()
 DARK = 'superhero'
 LIGHT = 'flatly'
 
-def change_style():
-    theme = choice(style.theme_names())
-    style.theme_use(theme)    
+def change_style(window):
+    theme = choice(window.style.theme_names())
+    window.style.theme_use(theme)
 
 
 if __name__ == '__main__':
     # create visual widget style tests
-    root = tk.Tk()
-    style = ttk.Style()
+    window = ttk.Window(themename='darkly')
 
-    ttk.Button(text="Change Theme", command=change_style).pack(padx=10, pady=10)
+    ttk.Button(text="Change Theme", command=lambda x=window: change_style(x)).pack(padx=10, pady=10)
+    text = ttk.Text(window, font='helvetica 24 bold')
+    text.pack(padx=10, pady=10)
+    text.insert('end', 'Hello, this is my text.')
 
-    tk.Text(root).pack(padx=10, pady=10)
-
-    root.mainloop()
+    window.mainloop()


### PR DESCRIPTION
The current implementation sets specific default style parameters, and the font is one such element on the Text widget. However, the default Font on the text widget looks terrible. So, I'm going to set the initial font to 'TkDefaultFont' using the tkinter option database, and will remove the font as an option on the style updates. This will allow the user to update the font and still have the benefits of ttkbootstrap styling and theming.