### PR TITLE
Fix TCL name reference for publisher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.7",
+    version="1.7.7.1",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/publisher.py
+++ b/src/ttkbootstrap/publisher.py
@@ -81,7 +81,7 @@ class Publisher:
         """
         subs = Publisher.__subscribers
         try:
-            del subs[name]
+            del subs[str(name)]
         except:
             pass
 


### PR DESCRIPTION
This fixes an issue that prevents widgets that contain internal tcl widgets (ie. combobox) from being unsubscribed to the event publisher because it is not passing the string representation of the name.
