### PR TITLE
Add selected option to tableview get rows method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 setuptools.setup(
     name="ttkbootstrap",
-    version="1.7.7.1",
+    version="1.7.7.2",
     author="Israel Dryer",
     author_email="israel.dryer@gmail.com",
     description="A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap.",

--- a/src/ttkbootstrap/tableview.py
+++ b/src/ttkbootstrap/tableview.py
@@ -1153,8 +1153,12 @@ class Tableview(ttk.Frame):
                 except ValueError:
                     return None
 
-    def get_rows(self, visible=False, filtered=False) -> List[TableRow]:
+    def get_rows(self, visible=False, filtered=False, selected=False) -> List[TableRow]:
         """Return a list of TableRow objects.
+
+        Return a subset of rows based on optional flags. Only ONE flag can be used
+        at a time. If more than one flag is set to `True`, then the first flag will
+        be used to return the data.
 
         Parameters:
 
@@ -1163,6 +1167,9 @@ class Tableview(ttk.Frame):
 
             filtered (bool):
                 If True, only rows in the filtered dataset will be returned.
+
+            selected (bool):
+                If True, only rows that are currently selected will be returned.
 
         Returns:
 
@@ -1173,6 +1180,8 @@ class Tableview(ttk.Frame):
             return self._viewdata
         elif filtered:
             return self._tablerows_filtered
+        elif selected:
+            return [row for row in self._viewdata if row.iid in self.view.selection()]
         else:
             return self._tablerows
 


### PR DESCRIPTION
Add the `selected` parameter to the `get_rows` method to return a list of currently selected rows. This exposes the `Tableview` version of the `selection` method that is available in the `Treeview`.