### PR TITLE
Call original overridden methods after processing "bootstyle" and "style" options

### DIFF
--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -4960,10 +4960,8 @@ class Bootstyle:
 
         def configure(self, cnf=None, **kwargs):
             # get configuration
-            if cnf == "bootstyle":
+            if cnf in ("bootstyle", "style"):
                 return self.cget("style")
-            elif cnf is not None:
-                return self.cget(cnf)
 
             # set configuration
             if "bootstyle" in kwargs:
@@ -4983,7 +4981,7 @@ class Bootstyle:
                 kwargs.update(style=ttkstyle)
 
             # update widget configuration
-            func(self, **kwargs)
+            func(self, cnf, **kwargs)
 
         return configure
 
@@ -5073,11 +5071,18 @@ class Bootstyle:
                 widget.config = widget.configure
 
                 # override get and set methods
+                _orig_getitem = widget.__getitem
+                _orig_setitem = widget.__setitem
+
                 def __setitem(self, key, val):
-                    return _configure(self, **{key: val})
+                    if key in ("bootstyle", "style"):
+                        return _configure(self, **{key: val})
+                    return _orig_setitem(key, val)
 
                 def __getitem(self, key):
-                    return _configure(self, cnf=key)
+                    if key in ("bootstyle", "style"):
+                        return _configure(self, cnf=key)
+                    return _orig_getitem(key)
 
                 if (
                     widget.__name__ != "OptionMenu"


### PR DESCRIPTION
Hello. Fix for issue #252.
This allows to use ttkbootstrap with derived widgets that have custom options like the example bellow:

```python
import tkinter as tk
import ttkbootstrap as ttk


class EntryWithPlaceholder(ttk.Entry):
    def __init__(self, master=None, widget=None, **kw):
        self.placeholder = kw.pop('placeholder', '')
        super().__init__(master, widget, **kw)

        self.bind("<FocusIn>", self.foc_in)
        self.bind("<FocusOut>", self.foc_out)

        self.__put_placeholder()

    def __put_placeholder(self):
        if not self.get():
            self.insert(0, self.placeholder)

    def foc_in(self, *args):
        if self.get() == self.placeholder:
            self.delete('0', 'end')

    def foc_out(self, *args):
        self.__put_placeholder()

    def configure(self, cnf=None, **kw):
        args = tk._cnfmerge((cnf, kw))
        key = 'placeholder'

        if cnf == key:
            return (key, self.cget(key))
        if key in args:
            self.placeholder = args[key]
            self.__put_placeholder()
            args.pop(key, None)
        return super().configure(**args)

    config = configure

    def cget(self, key):
        if key == 'placeholder':
            return self.placeholder
        return super().cget(key)

    __getitem__ = cget


if __name__ == "__main__":
    root = tk.Tk()
    username = EntryWithPlaceholder(root)
    username.configure(bootstyle='primary')
    password = EntryWithPlaceholder(root)
    password.configure(style='MyPasswordEntry.TEntry')

    username.pack()
    password.pack()

    def on_click():
        password.configure(placeholder='--PASSWORD--')
        username['placeholder'] = '--USERNAME--'

    btn = ttk.Button(root, text='Test', takefocus=True, command=on_click)
    btn.pack()
    root.mainloop()

```

Regards
Alejandro A.