### PR TITLE
Expose separate track color in theme

### DIFF
--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -90,6 +90,7 @@ class Colors:
         inputfg,
         inputbg,
         active,
+        track,
     ):
         """
         Parameters:
@@ -141,6 +142,9 @@ class Colors:
 
             active (str):
                 An accent color.
+
+            track (str):
+                The color of the track for Scale and the background for Progressbar and Meter
         """
         self.primary = primary
         self.secondary = secondary
@@ -158,6 +162,7 @@ class Colors:
         self.inputfg = inputfg
         self.inputbg = inputbg
         self.active = active
+        self.track = track
 
     @staticmethod
     def make_transparent(alpha, foreground, background='#ffffff'):
@@ -295,6 +300,7 @@ class Colors:
                 "inputfg",
                 "inputbg",
                 "active",
+                "track",
             ]
         )
 

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -1408,10 +1408,10 @@ class StyleBuilderTTK:
                 troughcolor = self.colors.bg
                 bordercolor = self.colors.light
             else:
-                troughcolor = self.colors.light
+                troughcolor = self.colors.track
                 bordercolor = troughcolor
         else:
-            troughcolor = Colors.update_hsv(self.colors.selectbg, vd=-0.2)
+            troughcolor = self.colors.track
             bordercolor = troughcolor
 
         # ( horizontal, vertical )
@@ -1505,10 +1505,10 @@ class StyleBuilderTTK:
                 troughcolor = self.colors.bg
                 bordercolor = self.colors.light
             else:
-                troughcolor = self.colors.light
+                troughcolor = self.colors.track
                 bordercolor = troughcolor
         else:
-            troughcolor = Colors.update_hsv(self.colors.selectbg, vd=-0.2)
+            troughcolor = self.colors.track
             bordercolor = troughcolor
 
         if any([colorname == DEFAULT, colorname == ""]):
@@ -1619,10 +1619,10 @@ class StyleBuilderTTK:
             if colorname == LIGHT:
                 track_color = self.colors.bg
             else:
-                track_color = self.colors.light
+                track_color = self.colors.track
         else:
             disabled_color = self.colors.selectbg
-            track_color = Colors.update_hsv(self.colors.selectbg, vd=-0.2)
+            track_color = self.colors.track
 
         if any([colorname == DEFAULT, colorname == ""]):
             normal_color = self.colors.primary
@@ -3907,9 +3907,9 @@ class StyleBuilderTTK:
             if colorname == LIGHT:
                 troughcolor = self.colors.bg
             else:
-                troughcolor = self.colors.light
+                troughcolor = self.colors.track
         else:
-            troughcolor = Colors.update_hsv(self.colors.selectbg, vd=-0.2)
+            troughcolor = self.colors.track
 
         if any([colorname == DEFAULT, colorname == ""]):
             ttkstyle = STYLE

--- a/src/ttkbootstrap/themes/standard.py
+++ b/src/ttkbootstrap/themes/standard.py
@@ -18,6 +18,7 @@ STANDARD_THEMES = {
             "inputfg": "#373a3c",
             "inputbg": "#fdfdfe",
             "active": "#efefef",
+            "track": "#F8F9FA",
         },
     },
     "flatly": {
@@ -39,6 +40,7 @@ STANDARD_THEMES = {
             "inputfg": "#212529",
             "inputbg": "#ffffff",
             "active": "#e2e2e2",
+            "track": "#ECF0F1",
         },
     },
     "litera": {
@@ -60,6 +62,7 @@ STANDARD_THEMES = {
             "inputfg": "#343a40",
             "inputbg": "#fff",
             "active": "#e5e5e5",
+            "track": "#F8F9FA",
         },
     },
     "minty": {
@@ -81,6 +84,7 @@ STANDARD_THEMES = {
             "inputfg": "#696969",
             "inputbg": "#fff",
             "active": "#e5e5e5",
+            "track": "#F8F9FA",
         },
     },
     "lumen": {
@@ -102,6 +106,7 @@ STANDARD_THEMES = {
             "inputfg": "#555555",
             "inputbg": "#fff",
             "active": "#e5e5e5",
+            "track": "#F6F6F6",
         },
     },
     "sandstone": {
@@ -123,6 +128,7 @@ STANDARD_THEMES = {
             "inputfg": "#6E6D69",
             "inputbg": "#fff",
             "active": "#e5e5e5",
+            "track": "#F8F5F0",
         },
     },
     "yeti": {
@@ -144,6 +150,7 @@ STANDARD_THEMES = {
             "inputfg": "#222222",
             "inputbg": "#fff",
             "active": "#e5e5e5",
+            "track": "#EEEEEE",
         },
     },
     "pulse": {
@@ -165,6 +172,7 @@ STANDARD_THEMES = {
             "inputfg": "#444444",
             "inputbg": "#fdfdfe",
             "active": "#e5e5e5",
+            "track": "#F9F8FC",
         },
     },
     "united": {
@@ -186,6 +194,7 @@ STANDARD_THEMES = {
             "inputfg": "#333333",
             "inputbg": "#fff",
             "active": "#e5e5e5",
+            "track": "#E9ECEF",
         },
     },
     "morph": {
@@ -207,6 +216,7 @@ STANDARD_THEMES = {
             "inputfg": "#7F8EBA",
             "inputbg": "#F0F5FA",
             "active": "#C3CCD8",
+            "track": "#F0F5FA",
         },
     },
     "journal": {
@@ -228,6 +238,7 @@ STANDARD_THEMES = {
             "inputfg": "#565656",
             "inputbg": "#fff",
             "active": "#e5e5e5",
+            "track": "#F8F9FA",
         },
     },
     "darkly": {
@@ -249,6 +260,7 @@ STANDARD_THEMES = {
             "inputfg": "#ffffff",
             "inputbg": "#2f2f2f",
             "active": "#1F1F1F",
+            "track": "#444444",
         },
     },
     "superhero": {
@@ -270,6 +282,7 @@ STANDARD_THEMES = {
             "inputfg": "#ebebeb",
             "inputbg": "#32465a",
             "active": "#2B4155",
+            "track": "#414d59",
         },
     },
     "solar": {
@@ -291,6 +304,7 @@ STANDARD_THEMES = {
             "inputfg": "#A9BDBD",
             "inputbg": "#073642",
             "active": "#002730",
+            "track": "#08404e",
         },
     },
     "cyborg": {
@@ -312,6 +326,7 @@ STANDARD_THEMES = {
             "inputfg": "#ffffff",
             "inputbg": "#191919",
             "active": "#282828",
+            "track": "#373737",
         },
     },
     "vapor": {
@@ -333,6 +348,7 @@ STANDARD_THEMES = {
             "inputfg": "#bfb6cd",
             "inputbg": "#30115e",
             "active": "#17082E",
+            "track": "#38146e",
         },
     },
     "simplex": {
@@ -354,6 +370,7 @@ STANDARD_THEMES = {
             "inputfg": "#3b3d3f",
             "inputbg": "#fcfcfc",
             "active": "#e2e2e2",
+            "track": "#f2f2f2",
         },
     },
     "cerculean": {
@@ -375,6 +392,7 @@ STANDARD_THEMES = {
             "inputfg": "#495057",
             "inputbg": "#ffffff",
             "active": "#e5e5e5",
+            "track": "#eceef1",
         },
     },
 }


### PR DESCRIPTION
Make the choice of color for the Slider tracker, and the unused portion of the Progress Bar and Meter more explicit.
It now becomes a design choice in the theme, rather than being hard coded.

Motivation: 

1. The original Bootswatch.com Litera theme has darker Slider trackers, which means that it can be a reasonable design choice
2. The light themes have a Slider tracker that is hard to see, same with the progress bars. In some designs this is perfectly fine, but in others it makes the design hard to parse visually.
3. Let the designer of the theme decide... don't link this parameter in a hard coded way

I have updated all the standard themes to expose the originally hard coded color, to this is expected to be a drop-in replacement.

Before this modification:

- For light themes:
  - the tracker color is always colors.light  (except when the widget is specifically styled "light", then it's colors.bg)
- For dark themes:
  - the tracker color is always -20% Value (HSV) adjusted from colors.selectbg
    
After this modification:
- Exposed to themes with the color name "track", and initialized to the color scheme that used to be hard-coded, to allow a drop-in replacement.

Tested by running TTKCreator and trying all themes:
python -m ttkcreator

