### PR TITLE
fixes #434

### DIFF
--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -256,7 +256,7 @@ class MessageDialog(Dialog):
         self._command = command
         self._width = width
         self._alert = alert
-        self._default = (default,)
+        self._default = default
         self._padding = padding
         self._icon = icon
         self._localize = kwargs.get("localize")


### PR DESCRIPTION
 The "default" must not be wrapped in a tuple for it to work properly in create_buttonbox() in class MessageDialog. Manual test using the reproducing code published for issue #434 shows that this fixes the issue.

![image](https://user-images.githubusercontent.com/4211175/221599868-f32b1183-b30e-4b75-b993-df12ee99dfbc.png)
