### PR TITLE
Add submenu for correct display on MacOS (#436)

### DIFF
--- a/src/ttkcreator/__main__.py
+++ b/src/ttkcreator/__main__.py
@@ -26,10 +26,12 @@ class ThemeCreator(ttk.Window):
     def setup_theme_creator(self):
         # application menu
         self.menu = ttk.Menu()
-        self.menu.add_command(label="Save", command=self.save_theme)
-        self.menu.add_command(label="Reset", command=self.change_base_theme)
-        self.menu.add_command(label="Import", command=self.import_user_themes)
-        self.menu.add_command(label="Export", command=self.export_user_themes)
+        self.file_submenu = ttk.Menu(self.menu)
+        self.file_submenu.add_command(label="Save", command=self.save_theme)
+        self.file_submenu.add_command(label="Reset", command=self.change_base_theme)
+        self.file_submenu.add_command(label="Import", command=self.import_user_themes)
+        self.file_submenu.add_command(label="Export", command=self.export_user_themes)
+        self.menu.add_cascade(menu=self.file_submenu, label="File")
         self.configure(menu=self.menu)
 
         # theme configuration settings

--- a/src/ttkcreator/__main__.py
+++ b/src/ttkcreator/__main__.py
@@ -1,3 +1,4 @@
+import sys
 import shutil
 import json
 from uuid import uuid4
@@ -26,12 +27,22 @@ class ThemeCreator(ttk.Window):
     def setup_theme_creator(self):
         # application menu
         self.menu = ttk.Menu()
-        self.file_submenu = ttk.Menu(self.menu)
-        self.file_submenu.add_command(label="Save", command=self.save_theme)
-        self.file_submenu.add_command(label="Reset", command=self.change_base_theme)
-        self.file_submenu.add_command(label="Import", command=self.import_user_themes)
-        self.file_submenu.add_command(label="Export", command=self.export_user_themes)
-        self.menu.add_cascade(menu=self.file_submenu, label="File")
+
+        if sys.platform == 'darwin':
+            # mac os menu
+            self.file_submenu = ttk.Menu(self.menu)
+            self.file_submenu.add_command(label="Save", command=self.save_theme)
+            self.file_submenu.add_command(label="Reset", command=self.change_base_theme)
+            self.file_submenu.add_command(label="Import", command=self.import_user_themes)
+            self.file_submenu.add_command(label="Export", command=self.export_user_themes)
+            self.menu.add_cascade(menu=self.file_submenu, label="File")
+        else:
+            # all other platforms
+            self.menu.add_command(label="Save", command=self.save_theme)
+            self.menu.add_command(label="Reset", command=self.change_base_theme)
+            self.menu.add_command(label="Import", command=self.import_user_themes)
+            self.menu.add_command(label="Export", command=self.export_user_themes)
+        
         self.configure(menu=self.menu)
 
         # theme configuration settings


### PR DESCRIPTION
As per Issue #436 there is no way to load/save from ttkcreator on MacOS. 

This is because MacOS seems to require commands to be on a labeled sub menu to be displayed correctly.

This PR moves the menu commands into a new "File" submenu as seen in this screenshot
<img width="751" alt="Screenshot 2023-03-08 at 15 08 46" src="https://user-images.githubusercontent.com/59835282/223750166-94d271b4-425a-4fc3-baa0-f1f8af3e5d81.png">
It changes the look slightly, but this should work on any platform (untested). An alternative fix would be to add buttons for save, reset etc. onto the configure frame

