### PR TITLE
Update pillow Constant

### DIFF
--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -853,7 +853,7 @@ class Meter(ttk.Frame):
             self._draw_solid_meter(draw)
 
         self._meterimage = ImageTk.PhotoImage(
-            img.resize((self._metersize, self._metersize), Image.CUBIC)
+            img.resize((self._metersize, self._metersize), Image.Resampling.BICUBIC)
         )
         self.indicator.configure(image=self._meterimage)
 


### PR DESCRIPTION
With pillow version 9.1.0, Image.CUBIC was deprecated.  This causes and error when running python -m ttkbootstrap and python -m ttkcreator.  I've  updated the line 856 in widgets.py with Image.Resampling.BICUBIC and now both work again.