### PR TITLE
replaces CUBIC deprecation

### DIFF
--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -853,7 +853,7 @@ class Meter(ttk.Frame):
             self._draw_solid_meter(draw)
 
         self._meterimage = ImageTk.PhotoImage(
-            img.resize((self._metersize, self._metersize), Image.CUBIC)
+            img.resize((self._metersize, self._metersize), Image.BICUBIC)
         )
         self.indicator.configure(image=self._meterimage)
 


### PR DESCRIPTION
"Image.CUBIC" has been deprecated and current code would fail. Changing to Image.BICUBIC solves the issue.

Solves  #467