### PR TITLE
python -m ttkcreator break problem solution

### DIFF
--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -853,7 +853,7 @@ class Meter(ttk.Frame):
             self._draw_solid_meter(draw)
 
         self._meterimage = ImageTk.PhotoImage(
-            img.resize((self._metersize, self._metersize), Image.CUBIC)
+            img.resize((self._metersize, self._metersize), Image.BICUBIC)
         )
         self.indicator.configure(image=self._meterimage)
 


### PR DESCRIPTION
I wrote an issue #478 about the problem, and just like the screenshot, the bug seems to be a PIL problem. So just by changing the "CUBIC" to "BICUBIC", the bug seems to be solved(just like what python suggests in the error). 