### PR TITLE
Update widgets.py

### DIFF
--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -853,7 +853,7 @@ class Meter(ttk.Frame):
             self._draw_solid_meter(draw)
 
         self._meterimage = ImageTk.PhotoImage(
-            img.resize((self._metersize, self._metersize), Image.CUBIC)
+            img.resize((self._metersize, self._metersize), Image.BICUBIC)
         )
         self.indicator.configure(image=self._meterimage)
 


### PR DESCRIPTION
.venv\Lib\site-packages\ttkbootstrap\widgets.py", line 856, in _draw_meter
    img.resize((self._metersize, self._metersize), Image.CUBIC)
                                                   ^^^^^^^^^^^
AttributeError: module 'PIL.Image' has no attribute 'CUBIC'. Did you mean: 'BICUBIC'?