### PR TITLE
Update Pillow Library Dependency in ttkbootstrap Meters Widget for BICUBIC Interpolation

### DIFF
--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -853,7 +853,7 @@ class Meter(ttk.Frame):
             self._draw_solid_meter(draw)
 
         self._meterimage = ImageTk.PhotoImage(
-            img.resize((self._metersize, self._metersize), Image.CUBIC)
+            img.resize((self._metersize, self._metersize), Image.BICUBIC)
         )
         self.indicator.configure(image=self._meterimage)
 


### PR DESCRIPTION
I forked the ttkbootstrap repository to address a compatibility issue with the Pillow library's recent update. The original implementation in the Meters widget was using CUBIC interpolation, which has been deprecated in the latest version of Pillow in favor of BICUBIC. To ensure seamless integration and compatibility with the updated Pillow library, I have modified the relevant code in the Meters widget to use BICUBIC interpolation. This change resolves any potential issues that may arise when working with Meters in ttkbootstrap in conjunction with the latest version of Pillow.