### PR TITLE
Fixed OS language issue in setlocale function

### DIFF
--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -17,6 +17,7 @@ from ttkbootstrap.icons import Icon
 from ttkbootstrap.constants import *
 from tkinter import BaseWidget
 from ttkbootstrap.localization import MessageCatalog
+import ctypes
 
 
 class Dialog(BaseWidget):
@@ -563,7 +564,11 @@ class DatePickerDialog:
 
     """
 
-    locale.setlocale(locale.LC_ALL, locale.setlocale(locale.LC_TIME, ""))
+    windll = ctypes.windll.kernel32
+
+    defaultOSLanguage = ".".join((locale.windows_locale[windll.GetUserDefaultUILanguage()], "utf-8"))
+
+    locale.setlocale(locale.LC_ALL, locale.setlocale(locale.LC_TIME, defaultOSLanguage))
 
     def __init__(
         self,


### PR DESCRIPTION
Hey,

I couldnt manage the use module and after some research I saw a bug that occurs in people with different os languages. I also found that there is an open issue about this (https://github.com/israel-dryer/ttkbootstrap/issues/505)
After a bit working I fixed the issue by getting os language with ctypes module and placing it.