### PR TITLE
Bug Fix : Issue #556

### DIFF
--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -853,7 +853,7 @@ class Meter(ttk.Frame):
             self._draw_solid_meter(draw)
 
         self._meterimage = ImageTk.PhotoImage(
-            img.resize((self._metersize, self._metersize), Image.BICUBIC)
+            img.resize((self._metersize, self._metersize), Image.Resampling.BICUBIC)
         )
         self.indicator.configure(image=self._meterimage)
 


### PR DESCRIPTION
Image.CUBIC doesn't exist anymore, should be replaced with Image.Resampling.BICUBIC