### PR TITLE
Added kwargs passthrough to tkinter.Tk on init of Window

### DIFF
--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -143,6 +143,7 @@ class Window(tkinter.Tk):
         transient=None,
         overrideredirect=False,
         alpha=1.0,
+        **kwargs,
     ):
         """
         Parameters:
@@ -215,11 +216,15 @@ class Window(tkinter.Tk):
                 On Windows, specifies the alpha transparency level of the
                 toplevel. Where not supported, alpha remains at 1.0. Internally,
                 this is processed as `Toplevel.attributes('-alpha', alpha)`.
+
+            **kwargs:
+                Any other keyword arguments that are passed through to tkinter.Tk() constructor
+                List of available keywords available at: https://docs.python.org/3/library/tkinter.html#tkinter.Tk
         """
         if hdpi:
             utility.enable_high_dpi_awareness()
 
-        super().__init__()
+        super().__init__(**kwargs)
         self.winsys = self.tk.call('tk', 'windowingsystem')
 
         if scaling is not None:


### PR DESCRIPTION
Hello,

First of all, thanks for providing such a nice wrapper around basic tkinter application. This modules allows to achieve a really nice looking tkinter application as opposed to using bare tkinter app.

I have noticed that `Window` class usage is preffered as opposed to `tkinter.Tk()` when creating main/root window of an application. However, I have realised that `Window` class is missing some argument passthrough functionality -  when `Window`'s class `super`(in this case - `tkinter.Tk()`) class init method is called, there is no possibility to pass some arguments which are available according to an official [tkinter documentation](https://docs.python.org/3/library/tkinter.html#tkinter.Tk).

Hence, I have added missing functionality in.

Motivation behind it is following - I am using Ubuntu with GNOME environment. When creating a tkinter window using `Window` class, it creates an app which name defaults to `Tk` when I am hovering over the icon of the running app. In order to adjust it, I must change the value of `className`. However, there is no way of controlling it from `Window` class & I am not willing to revert back to "old" way of creating a window via calling tkinter.Tk() myself. Hence, I decided to make my contribution at this stage to lift the limitation of `ttkbootstrap`'s `Window` class as this is where the limitation resides.

Current behaviour on Ubuntu using GNOME:
![image](https://github.com/israel-dryer/ttkbootstrap/assets/19535998/20549fd5-af7c-47d9-b8eb-bfc272dea233)

Proposed change allows to change the pop-up text using `className` under Ubuntu GNOME:
![image](https://github.com/israel-dryer/ttkbootstrap/assets/19535998/f8117d2b-bb9b-45ec-94ac-8178a47f16a2)

Below is the minimal code that I used to achieve the result displayed above:

```python
import ttkbootstrap as ttk

class RootWindow(ttk.Window):

    def __init__(self):
        super().__init__(className="My awesome app")

app = RootWindow()
app.mainloop()
```

