### PR TITLE
Update dialogs.py

### DIFF
--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -1126,6 +1126,7 @@ class FontDialog(Dialog):
         return self.result
 
     def _on_cancel(self):
+        self._result = None
         self._toplevel.destroy()
 
     def _update_font_preview(self, *_):


### PR DESCRIPTION
line 1129, in _on_cancel
In a FontDialog, pressing the Cancel button returns a font object.
Fixed so that None is returned when the cancel button is pressed.