### PR TITLE
add fix for closing FontDialog window from 'X' button

### DIFF
--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -948,6 +948,9 @@ class FontDialog(Dialog):
         cancel_btn.pack(side=RIGHT, padx=5)
         cancel_btn.bind("<Return>", lambda _: cancel_btn.invoke())
 
+        self._toplevel.bind("<Escape>", func=lambda _:cancel_btn.invoke())
+        self._toplevel.protocol("WM_DELETE_WINDOW", func=cancel_btn.invoke)
+
     def _font_families_selector(self, master):
         container = ttk.Frame(master)
         container.pack(fill=BOTH, expand=YES, side=LEFT)


### PR DESCRIPTION
Hi,

Similar to the Cancel button sending a font object, closing the window will do that as well.
Not sure if my fix is the most correct way to do it but it worked for my use case so I thought I'd share it.

Credit to Akira Tomodachi for finding this fix