### PR TITLE
Support multiple validators per Entry Widget

### DIFF
--- a/src/ttkbootstrap/validation.py
+++ b/src/ttkbootstrap/validation.py
@@ -173,7 +173,7 @@ def add_validation(widget, func, when="focusout", **kwargs):
                 if reason == 'all' or event.validationreason in triggers.get(reason, ()):  # check trigger
                     event.validationtype = reason  # preserve original "when"
                     results.append(fn(event, **kw))
-            return all(results)
+            return False if len(results) == 0 and len(widget._validators) != 0 else all(results)
 
         tid = widget.register(_dispatch)
         widget.configure(
@@ -399,11 +399,13 @@ if __name__ == "__main__":
 
         return min <= len(value) <= max
 
-    entry = ttk.Entry()
+
+    entry = ttk.Entry(bootstyle="success")
     entry.pack(padx=10, pady=10)
 
     add_numeric_validation(entry, when="key")  # Restricts input to digits during typing
     add_validation(entry, validate_length, min=5, max=10, when="focusout")  # Ensures length on focus loss
+    entry.validate()
 
     ttk.Button(text="Submit").pack(padx=10, pady=10)
     app.mainloop()

--- a/src/ttkbootstrap/validation.py
+++ b/src/ttkbootstrap/validation.py
@@ -173,7 +173,7 @@ def add_validation(widget, func, when="focusout", **kwargs):
                 if reason == 'all' or event.validationreason in triggers.get(reason, ()):  # check trigger
                     event.validationtype = reason  # preserve original "when"
                     results.append(fn(event, **kw))
-            return False if len(results) == 0 and len(widget._validators) != 0 else all(results)
+            return all(results)
 
         tid = widget.register(_dispatch)
         widget.configure(


### PR DESCRIPTION
This request enhances the validation system by allowing multiple validators to be attached to a single widget, each responding to specific events.

Additionally, it introduces two utility functions related to this change:
- `remove_validation(widget, func=None, when=None):` Removes a specific validator or all validators matching the criteria from a widget.
- `clear_validations(widget):` Clears all validators from a widget.

---
Example usage
```python
@validator
def validate_length(event, min=0, max=float("inf")):
    value = event.postchangetext or ""
    return min <= len(value) <= max

entry = ttk.Entry()
entry.pack(padx=10, pady=10)

add_numeric_validation(entry, when="key")  # Restricts input to digits during typing
add_validation(entry, validate_length, min=5, max=10, when="focusout")  # Ensures length on focus loss

ttk.Button(text="Submit").pack(padx=10, pady=10)
app.mainloop()
```
In the above example;
- `add_numeric_validation` ensures that only numbers are inputted during typing
- `validate_length` checks that the input length is between 5 and 10 chars when the widget loses focus.

This allows for more modular and flexibile input validation code. (Instead of having to create one validation function per widget handling several cases - make several generic ones that can be added to multiple widgets)