### PR TITLE
Update broken link for "DatePickerDialog" API documentation and update Chinese Copyright page.

### DIFF
--- a/docs/license.zh.md
+++ b/docs/license.zh.md
@@ -2,7 +2,7 @@
 
 **MIT 许可**
 
-Copyright © 2021-2022 Israel Dryer
+Copyright © 2021-2025 Israel Dryer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/styleguide/datepickerpopup.md
+++ b/docs/styleguide/datepickerpopup.md
@@ -1,19 +1,19 @@
-# DatePickerPopup
+# DatePickerDialog
 
 This widget style encomposses a collection of button and label widgets. The 
 _header_ and _active date_ are **primary** colored (default) or the 
 [selected color](index.md#colors). The _weekdays header_ and _current date_ use the 
 `secondary` color.
 
-Check out the [api documentation](../../api/dialogs/datepickerpopup) for
+Check out the [api documentation](../../api/dialogs/DatePickerDialog/) for
 more information on how to use this widget.
 
 ![date picker](../assets/widget-styles/date-picker-popup.gif)
 
 ```python
 # default popup
-DatePickerPopup()
+DatePickerDialog()
 
 # warning colored popup
-DatePickerPopup(bootstyle="warning")
+DatePickerDialog(bootstyle="warning")
 ```

--- a/docs/styleguide/datepickerpopup.md
+++ b/docs/styleguide/datepickerpopup.md
@@ -5,7 +5,7 @@ _header_ and _active date_ are **primary** colored (default) or the
 [selected color](index.md#colors). The _weekdays header_ and _current date_ use the 
 `secondary` color.
 
-Check out the [api documentation](../../api/dialogs/DatePickerDialog/) for
+Check out the [api documentation](../../api/dialogs/datepickerdialog/) for
 more information on how to use this widget.
 
 ![date picker](../assets/widget-styles/date-picker-popup.gif)

--- a/docs/styleguide/datepickerpopup.zh.md
+++ b/docs/styleguide/datepickerpopup.zh.md
@@ -1,19 +1,19 @@
-# DatePickerPopup
+# DatePickerDialog
 
 This widget style encomposses a collection of button and label widgets. The 
 _header_ and _active date_ are **primary** colored (default) or the 
 [selected color](index.md#colors). The _weekdays header_ and _current date_ use the 
 `secondary` color.
 
-Check out the [api documentation](../../api/dialogs/datepickerpopup) for
+Check out the [api documentation](../../api/dialogs/datepickerdialog/) for
 more information on how to use this widget.
 
 ![date picker](../assets/widget-styles/date-picker-popup.gif)
 
 ```python
 # default popup
-DatePickerPopup()
+DatePickerDialog()
 
 # warning colored popup
-DatePickerPopup(bootstyle="warning")
+DatePickerDialog(bootstyle="warning")
 ```


### PR DESCRIPTION
1. Fix broken link to "datepickerdialog" API documentation.
2. Update Chinese "DatePickerDialog" page associated with the English update.
3. Update Chinese Copyright page.