### PR TITLE
Fix tooltip x11

### DIFF
--- a/src/ttkbootstrap/tooltip.py
+++ b/src/ttkbootstrap/tooltip.py
@@ -87,6 +87,7 @@ class ToolTip:
         # set keyword arguments
         kwargs["overrideredirect"] = True
         kwargs["master"] = self.widget
+        kwargs["windowtype"] = "tooltip"
         if "alpha" not in kwargs:
             kwargs["alpha"] = 0.95
         self.toplevel_kwargs = kwargs

--- a/src/ttkbootstrap/tooltip.py
+++ b/src/ttkbootstrap/tooltip.py
@@ -33,13 +33,14 @@ class ToolTip:
         ToolTip(b2, text="This is dangerous", bootstyle=(DANGER, INVERSE))
 
         app.mainloop()
-        ```    
+        ```
     """
 
     def __init__(
         self,
         widget,
         text="widget info",
+        padding=10,
         justify: Literal["left", "center", "right"] = "left",
         bootstyle=None,
         wraplength=None,
@@ -57,6 +58,9 @@ class ToolTip:
             text (str):
                 The text to display in the tooltip window.
 
+            padding (int):
+                The padding between the text and the border of the tooltip (default=10).
+
             bootstyle (str):
                 The style to apply to the tooltip label. You can use
                 any of the standard ttkbootstrap label styles.
@@ -71,6 +75,7 @@ class ToolTip:
         """
         self.widget = widget
         self.text = text
+        self.padding = padding
         self.justify = justify
         self.image = image
         self.bootstyle = bootstyle
@@ -136,7 +141,7 @@ class ToolTip:
             compound='bottom',
             justify=self.justify,
             wraplength=self.wraplength,
-            padding=10,
+            padding=self.padding,
         )
         lbl.pack(fill=BOTH, expand=YES)
         if self.bootstyle:

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -276,18 +276,15 @@ class Window(tkinter.Tk):
             width, height = resizable
             self.resizable(width, height)
 
-        if alpha is not None:
-            if self.winsys == 'x11':
-                self.alpha_bind = self.bind("<Visibility>", on_visibility, '+')
-                self.alpha = alpha
-            else:
-                self.attributes("-alpha", alpha)
-
         if transient is not None:
             self.transient(transient)
 
         if overrideredirect:
             self.overrideredirect(1)
+
+        if alpha is not None:
+            if self.winsys == 'x11':
+                self.wait_visibility(self)
 
         apply_class_bindings(self)
         apply_all_bindings(self)
@@ -466,13 +463,6 @@ class Toplevel(tkinter.Toplevel):
             width, height = resizable
             self.resizable(width, height)
 
-        if alpha is not None:
-            if self.winsys == 'x11':
-                self.alpha_bind = self.bind("<Visibility>", on_visibility, '+')
-                self.alpha = alpha
-            else:
-                self.attributes("-alpha", alpha)
-
         if iconify:
             self.iconify()
 
@@ -492,6 +482,10 @@ class Toplevel(tkinter.Toplevel):
         if toolwindow:
             if self.winsys == 'win32':
                 self.attributes("-toolwindow", 1)
+
+        if alpha is not None:
+            if self.winsys == 'x11':
+                self.wait_visibility(self)
 
     @property
     def style(self):

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -111,14 +111,6 @@ def on_select_all(event):
     return 'break'
 
 
-def on_visibility(event):
-    """Set alpha value once visible."""
-    widget = event.widget
-    if isinstance(widget, Window) or isinstance(widget, Toplevel):
-        widget.attributes("-alpha", widget.alpha)
-        widget.unbind("<Visibility>", widget.alpha_bind)
-
-
 class Window(tkinter.Tk):
     """A class that wraps the tkinter.Tk class in order to provide a
     more convenient api with additional bells and whistles. For more
@@ -285,6 +277,7 @@ class Window(tkinter.Tk):
         if alpha is not None:
             if self.winsys == 'x11':
                 self.wait_visibility(self)
+            self.attributes("-alpha", alpha)
 
         apply_class_bindings(self)
         apply_all_bindings(self)
@@ -486,6 +479,7 @@ class Toplevel(tkinter.Toplevel):
         if alpha is not None:
             if self.winsys == 'x11':
                 self.wait_visibility(self)
+            self.attributes("-alpha", alpha)
 
     @property
     def style(self):

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -1,5 +1,5 @@
 """
-    This module contains a class of the same name that wraps the 
+    This module contains a class of the same name that wraps the
     tkinter.Tk and ttkbootstrap.style.Style classes to provide a more
     consolidated api for initial application startup.
 """
@@ -29,14 +29,14 @@ def apply_class_bindings(window: tkinter.Widget):
     """Add class level event bindings in application"""
     for className in ["TEntry", "TSpinbox", "TCombobox", "Text"]:
         window.bind_class(
-            className=className, 
-            sequence="<Configure>", 
+            className=className,
+            sequence="<Configure>",
             func=on_disabled_readonly_state,
             add="+")
 
         for sequence in ["<Control-a>", "<Control-A>"]:
             window.bind_class(
-                className=className, 
+                className=className,
                 sequence=sequence,
                 func=on_select_all)
 
@@ -63,7 +63,7 @@ def apply_all_bindings(window: tkinter.Widget):
 
 
 def on_disabled_readonly_state(event):
-    """Change the cursor of entry type widgets to 'arrow' if in a 
+    """Change the cursor of entry type widgets to 'arrow' if in a
     disabled or readonly state."""
     try:
         widget = event.widget
@@ -108,7 +108,15 @@ def on_select_all(event):
     else:
         widget.select_range(0, END)
         widget.icursor(END)
-    return 'break'    
+    return 'break'
+
+
+def on_visibility(event):
+    """Set alpha value once visible."""
+    widget = event.widget
+    if isinstance(widget, Window) or isinstance(widget, Toplevel):
+        widget.attributes("-alpha", widget.alpha)
+        widget.unbind("<Visibility>", widget.alpha_bind)
 
 
 class Window(tkinter.Tk):
@@ -251,38 +259,39 @@ class Window(tkinter.Tk):
         if size is not None:
             width, height = size
             self.geometry(f"{width}x{height}")
-        
+
         if position is not None:
             xpos, ypos = position
             self.geometry(f"+{xpos}+{ypos}")
-        
+
         if minsize is not None:
             width, height = minsize
             self.minsize(width, height)
-        
+
         if maxsize is not None:
             width, height = maxsize
             self.maxsize(width, height)
-        
+
         if resizable is not None:
             width, height = resizable
             self.resizable(width, height)
-        
+
         if alpha is not None:
             if self.winsys == 'x11':
-                self.wait_visibility(self)
-            self.attributes("-alpha", alpha)
-        
+                self.alpha_bind = self.bind("<Visibility>", on_visibility, '+')
+                self.alpha = alpha
+            else:
+                self.attributes("-alpha", alpha)
+
         if transient is not None:
             self.transient(transient)
-        
+
         if overrideredirect:
             self.overrideredirect(1)
 
         apply_class_bindings(self)
         apply_all_bindings(self)
         self._style = Style(themename)
-
 
     @property
     def style(self):
@@ -444,11 +453,11 @@ class Toplevel(tkinter.Toplevel):
         if position is not None:
             xpos, ypos = position
             self.geometry(f"+{xpos}+{ypos}")
-        
+
         if minsize is not None:
             width, height = minsize
             self.minsize(width, height)
-        
+
         if maxsize is not None:
             width, height = maxsize
             self.maxsize(width, height)
@@ -456,28 +465,30 @@ class Toplevel(tkinter.Toplevel):
         if resizable is not None:
             width, height = resizable
             self.resizable(width, height)
-        
+
         if alpha is not None:
             if self.winsys == 'x11':
-                self.wait_visibility(self)
-            self.attributes("-alpha", alpha)
-        
+                self.alpha_bind = self.bind("<Visibility>", on_visibility, '+')
+                self.alpha = alpha
+            else:
+                self.attributes("-alpha", alpha)
+
         if iconify:
             self.iconify()
-        
+
         if transient is not None:
             self.transient(transient)
-        
+
         if overrideredirect:
             self.overrideredirect(1)
-        
+
         if windowtype is not None:
             if self.winsys == 'x11':
                 self.attributes("-type", windowtype)
-        
+
         if topmost:
             self.attributes("-topmost", 1)
-        
+
         if toolwindow:
             if self.winsys == 'win32':
                 self.attributes("-toolwindow", 1)

--- a/tests/widgets/tooltip.py
+++ b/tests/widgets/tooltip.py
@@ -15,7 +15,8 @@ b2 = ttk.Button(app, text="styled tooltip")
 b2.pack(side=LEFT, padx=10, pady=10, fill=X, expand=YES)
 ToolTip(
     b2,
-    text="This is a styled tooltip. You can change this style by using the `bootstyle` parameter with label style keywords.",
+    text="This is a styled tooltip with less padding. You can change this style by using the `bootstyle` parameter with label style keywords.",
+    padding=1,
     bootstyle="danger-inverse",
 )
 


### PR DESCRIPTION
On x11 the alpha value has to be set when the windows is visible (otherwise it is ignored).
to ensure this on x11  ```self.wait_visibility(self)```is  called in TopLevel and Window classes..

However, calling this shows the window early causing Tooltips to show with titlebar and incorrect dimensions (ignoring the ```overrideredirect=1```).

Tooltips on X11/Linux Mint **without this fix**:
![tooltip_x11_nok](https://github.com/user-attachments/assets/271b135b-1176-4198-b379-ac451921535c)

Tooltips on X11/Linux Mint **with this fix**:
![tooltip_x11_ok](https://github.com/user-attachments/assets/5f1f8438-905b-42bb-8f32-67bfd594a287)

Also added possibility to configure the padding / whitespace between the tooltip text and the tooltip edge (padding)