### PR TITLE
Set alpha value on visibility to prevent "flashing" (X11)

### DIFF
--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -62,6 +62,14 @@ def apply_all_bindings(window: tkinter.Widget):
     window.bind_all('<Destroy>', lambda e: Publisher.unsubscribe(e.widget))
 
 
+def on_visibility(event):
+    """Set Window or Toplevel alpha value on Visibility (X11)"""
+    widget = event.widget
+    if isinstance(widget, (Window, Toplevel)) and widget.alpha_bind:
+        widget.unbind(widget.alpha_bind)
+        widget.attributes("-alpha", widget.alpha)
+
+
 def on_disabled_readonly_state(event):
     """Change the cursor of entry type widgets to 'arrow' if in a
     disabled or readonly state."""
@@ -276,8 +284,10 @@ class Window(tkinter.Tk):
 
         if alpha is not None:
             if self.winsys == 'x11':
-                self.wait_visibility(self)
-            self.attributes("-alpha", alpha)
+                self.alpha = alpha
+                self.alpha_bind = self.bind("<Visibility>", on_visibility, '+')
+            else:
+                self.attributes("-alpha", alpha)
 
         apply_class_bindings(self)
         apply_all_bindings(self)
@@ -478,8 +488,10 @@ class Toplevel(tkinter.Toplevel):
 
         if alpha is not None:
             if self.winsys == 'x11':
-                self.wait_visibility(self)
-            self.attributes("-alpha", alpha)
+                self.alpha = alpha
+                self.alpha_bind = self.bind("<Visibility>", on_visibility, '+')
+            else:
+                self.attributes("-alpha", alpha)
 
     @property
     def style(self):


### PR DESCRIPTION
Minor improvement on https://github.com/israel-dryer/ttkbootstrap/pull/649

Though setting the alpha value last in the TopLevel and Window __  init __ fixes the Tooltip issue, an incorrectly styled window can  be seen (very shortly) when opening other dialogs, such as ColorChooser, FontDialog, MsgBoxes, etc.

This is caused by the calling of  ```self.wait_visibility(self)``` on X11 systems.
This fix moves the applying of the alpha value until _after_ the window becomes visible.

The gif below shows the behavior without the fix; in the top/middle of the gif this incorrectly styled window can be seen _briefly_ each time a button was clicked to open a dialog.


![nok](https://github.com/user-attachments/assets/89c11dc5-f015-4ec8-be89-b4d6f6591ce9)
