### PR TITLE
Sort Font Families in Font Dialog

### DIFF
--- a/src/ttkbootstrap/dialogs/dialogs.py
+++ b/src/ttkbootstrap/dialogs/dialogs.py
@@ -1033,7 +1033,7 @@ class FontDialog(Dialog):
         listbox_vbar.pack(side=RIGHT, fill=Y)
         listbox.configure(yscrollcommand=listbox_vbar.set)
 
-        for f in self._families:
+        for f in sorted(self._families):
             listbox.insert("", iid=f, index=END, tags=[f], values=[f])
             listbox.tag_configure(f, font=(f, self._size.get()))
 

--- a/tests/localization/test_localization.py
+++ b/tests/localization/test_localization.py
@@ -85,7 +85,7 @@ def change_locale():
     selected_locale = locale_dialog.result
     if selected_locale:
         MessageCatalog.locale(selected_locale)
-        print(f"Selected locale: '{MessageCatalog.locale("")}'")
+        print(f"Selected locale: '{MessageCatalog.locale(None)}'")
 
 def create_window():
     """Create window."""


### PR DESCRIPTION
Sort the fonts by name in the FontDialog:

Compare unsorted (left) vs Sorted (right):
![image](https://github.com/user-attachments/assets/7ace66f3-c40f-4cfa-8ba9-4b29bba99fbc) ![image](https://github.com/user-attachments/assets/ad7b4c62-cdfc-4b3d-a313-c4d5ed210f0f)


