### PR TITLE
Enhanced date entry v2

### DIFF
--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -12,7 +12,7 @@ from ttkbootstrap.constants import *
 
 # date entry imports
 from ttkbootstrap.dialogs import Querybox
-from datetime import datetime
+from datetime import datetime, date
 
 # floodgauge imports
 import math
@@ -134,17 +134,24 @@ class DateEntry(ttk.Frame):
                 Other keyword arguments passed to the frame containing the
                 entry and date button.
         """
-        self._dateformat = dateformat
+        self.__dateformat = dateformat  # User/Programmer should NOT be able to change this, therefore double underscores
+        self.__enabled = True  # User/Programmer should NOT be able to change this, therefore double underscores
         self._firstweekday = firstweekday
+        self._popup_title = "Select new date"
 
         self._startdate = startdate or datetime.today()
         self._bootstyle = bootstyle
         super().__init__(master, **kwargs)
 
         # add visual components
-        entry_kwargs = {"bootstyle": self._bootstyle}
+        entry_kwargs = {
+            "bootstyle": self._bootstyle,
+        }
+
         if "width" in kwargs:
             entry_kwargs["width"] = kwargs.pop("width")
+        if "popup_title" in kwargs:
+            self._popup_title = kwargs.pop("popup_title")
 
         self.entry = ttk.Entry(self, **entry_kwargs)
         self.entry.pack(side=tk.LEFT, fill=tk.X, expand=tk.YES)
@@ -157,7 +164,7 @@ class DateEntry(ttk.Frame):
         self.button.pack(side=tk.LEFT)
 
         # starting value
-        self.entry.insert(tk.END, self._startdate.strftime(self._dateformat))
+        self.entry.insert(tk.END, self._startdate.strftime(self.__dateformat))
 
     def __getitem__(self, key: str):
         return self.configure(cnf=key)
@@ -179,7 +186,7 @@ class DateEntry(ttk.Frame):
             else:
                 kwargs[state] = state
         if "dateformat" in kwargs:
-            self._dateformat = kwargs.pop("dateformat")
+            self.__dateformat = kwargs.pop("dateformat")
         if "firstweekday" in kwargs:
             self._firstweekday = kwargs.pop("firstweekday")
         if "startdate" in kwargs:
@@ -201,7 +208,7 @@ class DateEntry(ttk.Frame):
             buttonstate = self.button.cget("state")
             return {"Entry": entrystate, "Button": buttonstate}
         if cnf == "dateformat":
-            return self._dateformat
+            return self.__dateformat
         if cnf == "firstweekday":
             return self._firstweekday
         if cnf == "startdate":
@@ -227,32 +234,100 @@ class DateEntry(ttk.Frame):
         else:
             return self._configure_set(**kwargs)
 
-    def _on_date_ask(self):
-        """Callback for pushing the date button"""
-        _val = self.entry.get() or datetime.today().strftime(self._dateformat)
-        try:
-            self._startdate = datetime.strptime(_val, self._dateformat)
-        except Exception as e:
-            print("Date entry text does not match", self._dateformat)
-            self._startdate = datetime.today()
-            self.entry.delete(first=0, last=tk.END)
-            self.entry.insert(
-                tk.END, self._startdate.strftime(self._dateformat)
-            )
+    @property
+    def enabled(self) -> bool:
+        """
+        If ``True`` this date picker is enabled and user can pick a new date, if ``False`` user can't use this picker
 
-        old_date = datetime.strptime(_val, self._dateformat)
+        :return: ``True`` if usable, ``False`` otherwise
+        """
+        return self.__enabled
+
+    @property
+    def dateformat(self) -> str:
+        """
+        Returns date format string, that is used to convert from strings to datetime objects respectively vice versa
+
+        :return: Date format as string
+        """
+        return self.__dateformat
+
+    def get_date(self) -> datetime:
+        """
+        Returns currently selected date as datetime object
+
+        :return: Currently selected date
+        """
+        return self.configure(cnf='startdate')
+
+    @staticmethod
+    def __clean_datetime(new_date: datetime | date) -> datetime:
+        """This is a date picker, therefore erase all unnecessary elements: hours, minutes, seconds, ..."""
+        if isinstance(new_date, datetime):
+            return datetime(new_date.year, new_date.month, new_date.day, tzinfo=new_date.tzinfo)
+        else:
+            return datetime(new_date.year, new_date.month, new_date.day)
+
+    def set_date(self, new_date: datetime | date) -> None:
+        """
+        Sets given date/datetime object as currently selected date.
+
+        (NOTE: Hours, minutes, seconds, milliseconds, microseconds will be ignored)
+
+        :param new_date: New date that will become the currently selected one
+        """
+        _date = self.__clean_datetime(new_date)
+        if self.__enabled:
+            self.configure(startdate=_date)
+            self.entry.delete(first=0, last=END)
+            self.entry.insert(END, new_date.strftime(self.__dateformat))
+        else:
+            self.enable()
+            self.configure(startdate=_date)
+            self.entry.delete(first=0, last=END)
+            self.entry.insert(END, new_date.strftime(self.__dateformat))
+            self.disable()
+
+    def disable(self) -> None:
+        """ Disables this date picker """
+        self.__enabled = False
+        self.entry.state(['disabled'])
+        self.button.state(['disabled'])
+
+    def enable(self) -> None:
+        """ Enables this date picker """
+        self.__enabled = True
+        self.entry.state(['!disabled'])
+        self.button.state(['!disabled'])
+
+    def _on_date_ask(self):
+        """
+        Callback for pushing the date button
+
+        :raise ValueError: If entered string does NOT match with currently used date format
+        """
+        current_date = self.entry.get() or datetime.today().strftime(self.__dateformat)
+        try:
+            self._startdate = datetime.strptime(current_date, self.__dateformat)
+        except ValueError:
+            # Rollback to current date & reraise exception
+            self.entry.delete(first=0, last=END)
+            self.entry.insert(END, self._startdate.strftime(self.__dateformat))
+            raise
+
+        old_date = datetime.strptime(current_date, self.__dateformat)
 
         # get the new date and insert into the entry
         new_date = Querybox.get_date(
             parent=self.entry,
+            title=self._popup_title,
             startdate=old_date,
             firstweekday=self._firstweekday,
             bootstyle=self._bootstyle,
         )
-        self.entry.delete(first=0, last=tk.END)
-        self.entry.insert(tk.END, new_date.strftime(self._dateformat))
+        self.entry.delete(first=0, last=END)
+        self.entry.insert(END, new_date.strftime(self.__dateformat))
         self.entry.focus_force()
-        self.event_generate("<<DateEntrySelected>>")
 
 
 class Floodgauge(tk.Canvas):

--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -159,13 +159,14 @@ class DateEntry(ttk.Frame):
         entry_kwargs = {
             "bootstyle": self._bootstyle,
         }
-
         if "width" in kwargs:
             entry_kwargs["width"] = kwargs.pop("width")
 
+        # Build date Widget button (this shows the date in the wanted format)
         self.entry = ttk.Entry(self, **entry_kwargs)
         self.entry.pack(side=tk.LEFT, fill=tk.X, expand=tk.YES)
 
+        # Build datepicker button & place it right to the date widget
         self.button = ttk.Button(
             master=self,
             command=self._on_date_ask,
@@ -173,8 +174,8 @@ class DateEntry(ttk.Frame):
         )
         self.button.pack(side=tk.LEFT)
 
-        # starting value
-        self.entry.insert(tk.END, self._startdate.strftime(self.__dateformat))
+        # Initialize this widget
+        self.set_date(self._startdate)
 
     def __getitem__(self, key: str):
         return self.configure(cnf=key)
@@ -302,7 +303,7 @@ class DateEntry(ttk.Frame):
         if has_week_number and has_week_day and has_year:
             return dateformat
 
-        raise ValueError(f'Given formatting string ("{dateformat}"), cannot be used to validate a given strings for dates!')
+        raise ValueError(f'Given formatting string ("{dateformat}"), cannot be used to validate a given strings for dates or display a given datetime object as a date!')
 
     @staticmethod
     def _clean_datetime(new_date: datetime | date) -> datetime:
@@ -329,7 +330,7 @@ class DateEntry(ttk.Frame):
             self.enable()
             self.configure(startdate=_date)
             self.entry.delete(first=0, last=END)
-            self.entry.insert(END, new_date.strftime(self.__dateformat))
+            self.entry.insert(tk.END, new_date.strftime(self.__dateformat))
             self.disable()
 
     def disable(self) -> None:
@@ -368,9 +369,7 @@ class DateEntry(ttk.Frame):
             firstweekday=self._firstweekday,
             bootstyle=self._bootstyle,
         )
-        self.entry.delete(first=0, last=END)
-        self.entry.insert(END, new_date.strftime(self.__dateformat))
-        self.entry.focus_force()
+        self.set_date(new_date)
         self.event_generate("<<DateEntrySelected>>")
 
 

--- a/src/ttkbootstrap/widgets.py
+++ b/src/ttkbootstrap/widgets.py
@@ -134,9 +134,12 @@ class DateEntry(ttk.Frame):
                 options include -> primary, secondary, success, info,
                 warning, danger, dark, light.
 
+            popup_title (str, optional):
+                Title for PopUp window (Default: `Select new date`)
+
             raise_exception (bool, optional):
                 If a `ValueError` should be raised, if the user enters an invalid date string. If this is set to `False`,
-                faulty date strings will be ignored. Only a warning on the terminal/console will be printed.
+                faulty date strings will be ignored. Only a warning on the terminal/console will be printed. (Default: `False`)
 
             **kwargs (dict[str, Any], optional):
                 Other keyword arguments passed to the frame containing the


### PR DESCRIPTION
Hi,

this is continuation of my privious PR #392. There were so many changes in the meantime that I found it easier to re-implement everything instead of doing a merge/rebase, so here we are...

- As requested, I removed the callback
- I kept the capability to enable/disable this Widget
- I kept the capability to change the date programmatically
- I kept the capability to provide/change a window title for the PopUp window of the calendar and renamed it to `popup_title`.
- I added a validation for the formatting string
- I added an additional boolean: `raise_exception`. If set to `True` an `ValueError` is raised if the user enters a invalid string for a date. If set to `False` an invalid date will just be ignored. Only a warning will be printed on the terminal/console.

### Problems:
I am confused, where you want me to put popup title? I don't know what you mean with:
> Add this to the popup if it's not already there and I think it will work.

The relevant method is: `_on_date_ask()`. This function gets called if the button is clicked.
Within this method the Popup is created:
```python
new_date = Querybox.get_date(
    parent=self.entry,
    title=self._popup_title,
    startdate=old_date,
    firstweekday=self._firstweekday,
    bootstyle=self._bootstyle,
)
```
