### PR TITLE
 add ttkbootstrap-icons as required dependency #765

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = ["pillow>=10,<12"]
+dependencies = [
+    "pillow>=10,<12",
+    "ttkbootstrap-icons"
+]
 
 [project.urls]
 Homepage = "https://github.com/israel-dryer/ttkbootstrap"


### PR DESCRIPTION
 ## Summary
  - Adds `ttkbootstrap-icons` as a required dependency in `pyproject.toml`
  - Enables users to use icons out-of-the-box without separate installation
  - Aligns with v2 roadmap for built-in icon support