### PR TITLE
remove incompatible type hint style to support python 3.9

### DIFF
--- a/src/ttkbootstrap/validation.py
+++ b/src/ttkbootstrap/validation.py
@@ -63,7 +63,7 @@ Example:
 """
 import re
 from tkinter import Misc
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 import ttkbootstrap as ttk
 
@@ -195,7 +195,9 @@ def _validate_options(event: ValidationEvent, options: list[Any]) -> bool:
 
 
 @validator
-def _validate_range(event: ValidationEvent, startrange: int | float, endrange: int | float) -> bool:
+def _validate_range(
+    event: ValidationEvent, startrange: Union[int, float], endrange: Union[int, float]
+) -> bool:
     """Contents is a number between the startrange and endrange
     inclusive
     """
@@ -283,7 +285,12 @@ def add_regex_validation(widget: Misc, pattern: str, when: str = "focusout") -> 
     add_validation(widget, _validate_regex, pattern=pattern, when=when)
 
 
-def add_range_validation(widget: Misc, startrange: int | float, endrange: int | float, when: str = "focusout") -> None:
+def add_range_validation(
+    widget: Misc,
+    startrange: Union[int, float],
+    endrange: Union[int, float],
+    when: str = "focusout",
+) -> None:
     """Check if widget contents is within a range of numbers, inclusive.
     Sets the state to 'Invalid' if the number is outside of the range.
 

--- a/src/ttkbootstrap/widgets/dateentry.py
+++ b/src/ttkbootstrap/widgets/dateentry.py
@@ -28,7 +28,7 @@ Example:
 """
 from datetime import date, datetime
 from tkinter import Misc
-from typing import Any
+from typing import Any, Optional, Union
 
 from ttkbootstrap import Button, Entry, Frame
 from ttkbootstrap.constants import END, LEFT, X, YES
@@ -67,10 +67,10 @@ class DateEntry(Frame):
 
     def __init__(
             self,
-            master: Misc | None = None,
+            master: Optional[Misc] = None,
             dateformat: str = r"%x",
             firstweekday: int = 6,
-            startdate: datetime | date | None = None,
+            startdate: Optional[Union[datetime, date]] = None,
             bootstyle: str = "",
             popup_title: str = 'Select new date',
             raise_exception: bool = False,
@@ -204,7 +204,7 @@ class DateEntry(Frame):
         else:
             return super(Frame, self).configure(cnf=cnf)
 
-    def configure(self, cnf: str | None = None, **kwargs: Any) -> Any:
+    def configure(self, cnf: Optional[str] = None, **kwargs: Any) -> Any:
         """Configure the options for this widget.
 
         Parameters:
@@ -293,7 +293,7 @@ class DateEntry(Frame):
             f'Given formatting string ("{dateformat}"), cannot be used to validate a given strings for dates or display a given datetime object as a date!')
 
     @staticmethod
-    def _clean_datetime(new_date: datetime | date) -> datetime:
+    def _clean_datetime(new_date: Union[datetime, date]) -> datetime:
         """Strip time components from a datetime object.
 
         Since this is a date picker, removes hours, minutes, seconds, and
@@ -310,7 +310,7 @@ class DateEntry(Frame):
         else:
             return datetime(new_date.year, new_date.month, new_date.day)
 
-    def set_date(self, new_date: datetime | date) -> None:
+    def set_date(self, new_date: Union[datetime, date]) -> None:
         """Set the currently selected date.
 
         Updates the entry field and internal state with the new date.

--- a/src/ttkbootstrap/widgets/floodgauge.py
+++ b/src/ttkbootstrap/widgets/floodgauge.py
@@ -32,7 +32,7 @@ Example:
     ```
 """
 from tkinter import Event, Misc, TclError
-from typing import Any
+from typing import Any, Optional, Union
 
 from ttkbootstrap import Canvas, IntVar, Progressbar, StringVar
 from ttkbootstrap.colorutils import contrast_color
@@ -96,13 +96,13 @@ class Floodgauge(Canvas):
 
     def __init__(
             self,
-            master: Misc | None = None,
+            master: Optional[Misc] = None,
             value: int = 0,
             maximum: int = 100,
             mode: str = "determinate",
-            mask: str | None = None,
+            mask: Optional[str] = None,
             text: str = "",
-            font: tuple[str, int] | str = ("Helvetica", 12),
+            font: Union[tuple[str, int], str] = ("Helvetica", 12),
             bootstyle: str = "primary",
             orient: str = "horizontal",
             length: int = 200,
@@ -224,7 +224,7 @@ class Floodgauge(Canvas):
         self.variable.set(self.value)
         self._draw()
 
-    def start(self, step_size: int | None = None, interval: int | None = None) -> None:
+    def start(self, step_size: Optional[int] = None, interval: Optional[int] = None) -> None:
         """Start the progress animation.
 
         For indeterminate mode, starts the bouncing animation. For determinate
@@ -300,7 +300,7 @@ class Floodgauge(Canvas):
         self._draw()
         self._after_id = self.after(interval, lambda: self._animate_indeterminate(interval))
 
-    def configure(self, cnf: str | None = None, **kwargs: Any) -> Any:
+    def configure(self, cnf: Optional[str] = None, **kwargs: Any) -> Any:
         """Configure the options for this widget.
 
         Parameters:
@@ -437,18 +437,18 @@ class FloodgaugeLegacy(Progressbar):
 
     def __init__(
             self,
-            master: Misc | None = None,
-            cursor: str | None = None,
-            font: tuple[str, int] | str | None = None,
-            length: int | None = None,
-            maximum: int | float = 100,
+            master: Optional[Misc] = None,
+            cursor: Optional[str] = None,
+            font: Optional[Union[tuple[str, int], str]] = None,
+            length: Optional[int] = None,
+            maximum: Union[int, float] = 100,
             mode: str = DETERMINATE,
             orient: str = HORIZONTAL,
             bootstyle: str = PRIMARY,
             takefocus: bool = False,
-            text: str | None = None,
-            value: int | float = 0,
-            mask: str | None = None,
+            text: Optional[str] = None,
+            value: Union[int, float] = 0,
+            mask: Optional[str] = None,
             **kwargs: Any,
     ) -> None:
         """
@@ -614,7 +614,7 @@ class FloodgaugeLegacy(Progressbar):
     def __setitem__(self, key: str, value: Any) -> None:
         self._configure_set(**{key: value})
 
-    def configure(self, cnf: str | None = None, **kwargs: Any) -> Any:
+    def configure(self, cnf: Optional[str] = None, **kwargs: Any) -> Any:
         """Configure the options for this widget.
 
         Parameters:

--- a/src/ttkbootstrap/widgets/labeledscale.py
+++ b/src/ttkbootstrap/widgets/labeledscale.py
@@ -20,7 +20,7 @@ Example:
     ```
 """
 from tkinter import Misc
-from typing import Any
+from typing import Any, Optional, Union
 
 from ttkbootstrap import (
     Frame, IntVar, Label, Scale
@@ -41,10 +41,10 @@ class LabeledScale(Frame):
 
     def __init__(
             self,
-            master: Misc | None = None,
-            variable: IntVar | None = None,
-            from_: int | float = 0,
-            to: int | float = 10,
+            master: Optional[Misc] = None,
+            variable: Optional[IntVar] = None,
+            from_: Union[int, float] = 0,
+            to: Union[int, float] = 10,
             bootstyle: str = DEFAULT,
             **kwargs: Any
     ) -> None:
@@ -117,7 +117,7 @@ class LabeledScale(Frame):
         self.label = None
         self.scale = None
 
-    def _to_number(self, x: str | int | float) -> int | float:
+    def _to_number(self, x: Union[str, int, float]) -> Union[int, float]:
         """Convert a string to int or float.
 
         Parameters:
@@ -175,7 +175,7 @@ class LabeledScale(Frame):
         self.after_idle(adjust_label)
 
     @property
-    def value(self) -> int | float:
+    def value(self) -> Union[int, float]:
         """Get the current scale value.
 
         Returns:
@@ -184,7 +184,7 @@ class LabeledScale(Frame):
         return self._variable.get()
 
     @value.setter
-    def value(self, val: int | float) -> None:
+    def value(self, val: Union[int, float]) -> None:
         """Set the scale to a new value.
 
         Parameters:

--- a/src/ttkbootstrap/widgets/meter.py
+++ b/src/ttkbootstrap/widgets/meter.py
@@ -39,7 +39,7 @@ Example:
 """
 import math
 from tkinter import Event, Misc
-from typing import Any
+from typing import Any, Optional, Union
 
 from PIL import Image, ImageDraw, ImageTk
 from PIL.Image import Resampling
@@ -121,13 +121,13 @@ class Meter(Frame):
 
     def __init__(
             self,
-            master: Misc | None = None,
+            master: Optional[Misc] = None,
             bootstyle: str = DEFAULT,
-            arcrange: int | None = None,
-            arcoffset: int | None = None,
-            amountmin: int | float = 0,
-            amounttotal: int | float = 100,
-            amountused: int | float = 0,
+            arcrange: Optional[int] = None,
+            arcoffset: Optional[int] = None,
+            amountmin: Union[int, float] = 0,
+            amounttotal: Union[int, float] = 100,
+            amountused: Union[int, float] = 0,
             amountformat: str = "{:.0f}",
             wedgesize: int = 0,
             metersize: int = 200,
@@ -136,13 +136,13 @@ class Meter(Frame):
             showtext: bool = True,
             interactive: bool = False,
             stripethickness: int = 0,
-            textleft: str | None = None,
-            textright: str | None = None,
+            textleft: Optional[str] = None,
+            textright: Optional[str] = None,
             textfont: str = "-size 20 -weight bold",
-            subtext: str | None = None,
+            subtext: Optional[str] = None,
             subtextstyle: str = DEFAULT,
             subtextfont: str = "-size 10",
-            stepsize: int | float = 1,
+            stepsize: Union[int, float] = 1,
             **kwargs: Any,
     ) -> None:
         """
@@ -414,7 +414,9 @@ class Meter(Frame):
             self.indicator.unbind(seq2, self._bindids.get(seq2))
             self._bindids.clear()
 
-    def _set_arc_offset_range(self, metertype: str, arcoffset: int | None, arcrange: int | None) -> None:
+    def _set_arc_offset_range(
+        self, metertype: str, arcoffset: Optional[int], arcrange: Optional[int]
+    ) -> None:
         """Configure the arc parameters based on meter type.
 
         Sets default arc offset and range values for full or semi-circle meters
@@ -782,7 +784,7 @@ class Meter(Frame):
     def __setitem__(self, key: str, value: Any) -> None:
         self._configure_set(**{key: value})
 
-    def configure(self, cnf: str | None = None, **kwargs: Any) -> Any:
+    def configure(self, cnf: Optional[str] = None, **kwargs: Any) -> Any:
         """Configure the options for this widget.
 
         Parameters:
@@ -802,7 +804,7 @@ class Meter(Frame):
         else:
             return self._configure_set(**kwargs)
 
-    def step(self, delta: int | float = 1) -> None:
+    def step(self, delta: Union[int, float] = 1) -> None:
         """Increment or decrement the meter value.
 
         The indicator will bounce back when reaching the minimum or maximum

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -44,7 +44,7 @@ Example:
     ```
 """
 from tkinter import font
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, Optional, Union
 
 from ttkbootstrap.constants import *
 
@@ -84,12 +84,12 @@ class ToastNotification:
             self,
             title: str,
             message: str,
-            duration: int | None = None,
+            duration: Optional[int] = None,
             bootstyle: str = LIGHT,
             alert: bool = False,
-            icon: str | None = None,
-            iconfont: font.Font | str | None = None,
-            position: tuple[int, int, str] | None = None,
+            icon: Optional[str] = None,
+            iconfont: Optional[Union[font.Font, str]] = None,
+            position: Optional[tuple[int, int, str]] = None,
             **kwargs: Any,
     ) -> None:
         """

--- a/src/ttkbootstrap/widgets/tooltip.py
+++ b/src/ttkbootstrap/widgets/tooltip.py
@@ -44,7 +44,7 @@ Example:
     ```
 """
 from tkinter import Event, Misc
-from typing import Any, Literal
+from typing import Any, Literal, Optional, Union
 
 import ttkbootstrap as ttk
 from ttkbootstrap import utility
@@ -88,11 +88,11 @@ class ToolTip:
             text: str = "widget info",
             padding: int = 10,
             justify: Literal["left", "center", "right"] = "left",
-            bootstyle: str | tuple[str, ...] | None = None,
-            wraplength: int | None = None,
+            bootstyle: Optional[Union[str, tuple[str, ...]]] = None,
+            wraplength: Optional[int] = None,
             delay: int = 250,  # milliseconds
             image: Any = None,
-            position: str | None = None,
+            position: Optional[str] = None,
             **kwargs: Any,
     ) -> None:
         """
@@ -157,10 +157,10 @@ class ToolTip:
         self.widget.bind("<Motion>", self.move_tip)
         self.widget.bind("<ButtonPress>", self.leave)
 
-    def enter(self, event: Event | None = None) -> None:
+    def enter(self, event: Optional[Event] = None) -> None:
         self.schedule()
 
-    def leave(self, event: Event | None = None) -> None:
+    def leave(self, event: Optional[Event] = None) -> None:
         self.unschedule()
         self.hide_tip()
 


### PR DESCRIPTION
Fixes #780 by removing incompatible type hint style.