### PR TITLE
remove support for python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ttkbootstrap"
 version = "1.18.2"
 description = "A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT AND (Apache-2.0 OR BSD-2-Clause)"
 authors = [
     { name = "Israel Dryer", email = "israel.dryer@gmail.com" }
@@ -34,7 +34,6 @@ classifiers = [
     "Environment :: X11 Applications :: GTK",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -43,7 +42,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
-dependencies = ["pillow>=10,<12"]
+dependencies = ["pillow>=10, <=12"]
 
 [project.urls]
 Homepage = "https://github.com/israel-dryer/ttkbootstrap"


### PR DESCRIPTION
3.9 reached end-of-life in October 2025.