### PR TITLE
Import Dialog from base instead of dialogs

### DIFF
--- a/src/ttkbootstrap/dialogs/colorchooser.py
+++ b/src/ttkbootstrap/dialogs/colorchooser.py
@@ -568,7 +568,7 @@ class ColorChooser(ttk.Frame):
         self.sync_color_values(HSL)
 
 
-from .dialogs import Dialog
+from .base import Dialog
 
 
 class ColorChooserDialog(Dialog):


### PR DESCRIPTION
Fix related to #791 and also to maintain consistency of "import" statement.
For example, following scripts also import from ".base" instead of ".dialogs".
ttkbootstrap\dialogs\message.py
ttkbootstrap\dialogs\query.py
