### PR TITLE
Fix tooltip flickering

### DIFF
--- a/src/ttkbootstrap/widgets/tooltip.py
+++ b/src/ttkbootstrap/widgets/tooltip.py
@@ -179,8 +179,9 @@ class ToolTip:
         if self.toplevel:
             return
 
-        # Create the tooltip window at a temporary position
-        self.toplevel = ttk.window.Toplevel(position=(0, 0), **self.toplevel_kwargs)
+        # Create the tooltip window at a temporary position offscreen
+        offscreen_pos = -99999
+        self.toplevel = ttk.window.Toplevel(position=(offscreen_pos, offscreen_pos), **self.toplevel_kwargs)
 
         lbl = ttk.Label(
             master=self.toplevel,


### PR DESCRIPTION
I found that tooltips momentarily appear at the temporary position due to needing to wait for packing to compute for 1 frame, which appears like an annoying flicker. By setting the temporary position to something far off-screen, the flickering is hidden.