### PR TITLE
Update font.preview_text translation to 'Preview Text'

### DIFF
--- a/src/ttkbootstrap/assets/locales/en/LC_MESSAGES/ttkbootstrap.po
+++ b/src/ttkbootstrap/assets/locales/en/LC_MESSAGES/ttkbootstrap.po
@@ -95,7 +95,7 @@ msgid "font.selector"
 msgstr "Font Selector"
 
 msgid "font.preview_text"
-msgstr "The quick brown fox jumps over the lazy dog."
+msgstr "Preview Text"
 
 msgid "font.weight.normal"
 msgstr "Normal"


### PR DESCRIPTION
The message string associated with the ID "font.preview_text" was 
"The quick brown fox jumps over the lazy dog."
changed to 
"Preview Text"