### PR TITLE
Fix ScrollView autohide layout shift with stable gutter pattern

### DIFF
--- a/src/ttkbootstrap/widgets/composites/scrollview.py
+++ b/src/ttkbootstrap/widgets/composites/scrollview.py
@@ -163,6 +163,12 @@ class ScrollView(Frame):
                 self.horizontal_scrollbar.unbind('<Enter>')
                 self.horizontal_scrollbar.unbind('<Leave>')
 
+            # Sync gutter reservation with the new mode
+            if value in ('hover', 'scroll'):
+                self._set_scrollbar_gutter(reserve=True)
+            else:
+                self._set_scrollbar_gutter(reserve=False)
+
             # Bind new events and update scrollbar visibility
             self._bind_container_events()
             self._update_scrollbar_visibility()
@@ -208,7 +214,20 @@ class ScrollView(Frame):
             self.bind_class(self._scroll_tag, "<Shift-MouseWheel>", self._on_shift_mousewheel)
 
     def _layout_widgets(self):
-        """Layout the canvas and scrollbars."""
+        """Layout the canvas and scrollbars.
+
+        For 'hover' and 'scroll' visibility modes the grid column and row that
+        hold the scrollbars are given a fixed minimum size equal to the
+        scrollbar's natural dimensions before the scrollbars are hidden. This
+        reserves the gutter permanently so the canvas never resizes when a
+        scrollbar is toggled — the same principle as the CSS
+        ``scrollbar-gutter: stable`` property.
+
+        An overlay approach (lift/lower over the canvas) was considered but
+        rejected because the scrollbar then covers content, which was reported
+        as confusing by users. Reserving the gutter avoids both the
+        layout-shift problem *and* the content-coverage problem.
+        """
         self.canvas.grid(row=0, column=0, sticky='nsew')
 
         if self._direction in ('vertical', 'both'):
@@ -229,8 +248,40 @@ class ScrollView(Frame):
             self.vertical_scrollbar.grid_remove()
             self.horizontal_scrollbar.grid_remove()
         elif self._scrollbar_visibility in ('hover', 'scroll'):
+            # Hide scrollbars now; defer gutter measurement to after_idle so
+            # the style system has finished sizing the widgets before we read
+            # their dimensions.  Measuring too early (before the widget is
+            # placed in its parent) can return an inflated reqwidth and leave
+            # a visible gap beside the scrollbar when it appears.
             self.vertical_scrollbar.grid_remove()
             self.horizontal_scrollbar.grid_remove()
+            self.after_idle(lambda: self._set_scrollbar_gutter(reserve=True))
+
+    def _set_scrollbar_gutter(self, reserve: bool):
+        """Reserve or release the grid gutter used by each scrollbar.
+
+        When *reserve* is ``True`` the column (vertical scrollbar) and row
+        (horizontal scrollbar) are given a ``minsize`` equal to the scrollbar's
+        natural requested dimensions.  The minsize persists even after the
+        scrollbar widget is removed from the grid via ``grid_remove()``, so the
+        canvas occupies a constant area regardless of scrollbar visibility.
+
+        When *reserve* is ``False`` the minsize is cleared (set to 0), which
+        is appropriate for 'always' and 'never' modes where no gutter needs to
+        be held open.
+        """
+        if reserve:
+            if self._direction in ('vertical', 'both'):
+                width = self.vertical_scrollbar.winfo_reqwidth()
+                if width > 1:
+                    self.grid_columnconfigure(1, minsize=width)
+            if self._direction in ('horizontal', 'both'):
+                height = self.horizontal_scrollbar.winfo_reqheight()
+                if height > 1:
+                    self.grid_rowconfigure(1, minsize=height)
+        else:
+            self.grid_columnconfigure(1, minsize=0)
+            self.grid_rowconfigure(1, minsize=0)
 
     def _bind_container_events(self):
         """Bind events for the container (enter/leave for autohide)."""

--- a/src/ttkbootstrap/widgets/composites/sidenav/view.py
+++ b/src/ttkbootstrap/widgets/composites/sidenav/view.py
@@ -192,7 +192,9 @@ class SideNav(Frame):
         """Build the internal widget structure."""
         # Pane container - uses 'chrome' surface for UI chrome
         pane_width = self._pane_width or self.PANE_WIDTH_EXPANDED
-        self._pane_frame = Frame(self, width=pane_width, padding=4, surface='chrome')
+        # padding=(left, top, right, bottom): right=0 so the scrollbar lane in
+        # the ScrollView runs flush to the pane edge with no trailing gap.
+        self._pane_frame = Frame(self, width=pane_width, padding=(4, 4, 0, 4), surface='chrome')
         self._pane_frame.pack(side='left', fill='y')
         self._pane_frame.pack_propagate(False)  # Fixed width
 
@@ -294,13 +296,13 @@ class SideNav(Frame):
         # Update pane width and visibility
         if self._display_mode == 'expanded':
             width = self._pane_width or self.PANE_WIDTH_EXPANDED
-            self._pane_frame.configure(width=width, padding=4)
+            self._pane_frame.configure(width=width, padding=(4, 4, 0, 4))
             if self._is_pane_open:
                 self._pane_frame.pack(side='left', fill='y')
             else:
                 self._pane_frame.pack_forget()
         elif self._display_mode == 'compact':
-            self._pane_frame.configure(width=self.PANE_WIDTH_COMPACT, padding=2)
+            self._pane_frame.configure(width=self.PANE_WIDTH_COMPACT, padding=(2, 2, 0, 2))
             self._pane_frame.pack(side='left', fill='y')
         elif self._display_mode == 'minimal':
             if self._is_pane_open:
@@ -330,6 +332,17 @@ class SideNav(Frame):
                 self._title_label.pack_forget()
             else:
                 self._title_label.pack(side='left', fill='x', expand=True)
+
+        # In compact mode the pane is icon-only (52 px) and content never
+        # overflows vertically, so reserving a scrollbar gutter wastes ~25 % of
+        # the pane width.  Switch the ScrollView to 'never' visibility to
+        # release the gutter; restore 'hover' (with stable gutter) when the
+        # pane is expanded again.
+        if self._content_scroll:
+            if is_compact:
+                self._content_scroll.configure(scrollbar_visibility='never')
+            else:
+                self._content_scroll.configure(scrollbar_visibility='hover')
 
         # Set compact mode on all items and groups
         for item in self._items.values():


### PR DESCRIPTION
  ## Summary                                                                                                 
                                                                                                             
  - **Stable gutter pattern**: For `hover` and `scroll` visibility modes, the scrollbar column/row is given a
   permanent `minsize` so the canvas never resizes when a scrollbar is toggled — same principle as CSS
  `scrollbar-gutter: stable`. Overlay scrollbars were considered but rejected because they cover content.    
  - **Deferred measurement**: Gutter sizing is deferred via `after_idle` so the style system has finished    
  sizing widgets before `winfo_reqwidth()` is read, preventing an inflated value that would leave a visible  
  gap beside the scrollbar.                                                                                  
  - **SideNav right padding**: `_pane_frame` right padding set to 0 (left/top/bottom keep their values) so   
  the scrollbar lane is flush to the pane edge.                                                              
  - **SideNav compact mode**: Sets `scrollbar_visibility='never'` in compact mode to release the gutter — a  
  ~14 px gutter in a 52 px icon-only pane consumed ~25% of its width.                                        
                                                                                                             
  ## Test plan                                                                                               
                                                                                                             
  - [x] Hover over a `ScrollView` with `scrollbar_visibility='hover'` — scrollbar appears with no content    
  shift                                                                                                      
  - [x] Scroll in a `ScrollView` with `scrollbar_visibility='scroll'` — scrollbar appears/hides with no      
  content shift                                                                                              
  - [x] AppShell SideNav expanded mode: scrollbar flush to right edge, no trailing gap                       
  - [x] AppShell SideNav compact mode: no gutter reserved, full 52 px available for icons                    
  - [x] Toggle between expanded and compact — gutter appears/disappears cleanly
