### PR TITLE
Fix/docstring markdown compatibility

### DIFF
--- a/src/ttkbootstrap/__main__.py
+++ b/src/ttkbootstrap/__main__.py
@@ -1,4 +1,4 @@
-"""CLI entry point — invoked as ``python -m ttkbootstrap`` to launch the ttkbootstrap CLI."""
+"""CLI entry point — invoked as `python -m ttkbootstrap` to launch the ttkbootstrap CLI."""
 from ttkbootstrap.cli import main
 
 if __name__ == "__main__":

--- a/src/ttkbootstrap/cli/add.py
+++ b/src/ttkbootstrap/cli/add.py
@@ -368,7 +368,7 @@ def _render_theme(name: str, mode: str) -> str:
     Light themes use the [600] step for semantic accents (so text on white
     has good contrast); dark themes use [400] (lighter accents on a dark
     background). Both schemas match the format consumed by
-    ``ttkbootstrap.style.theme_provider``.
+    `ttkbootstrap.style.theme_provider`.
     """
     if mode == "light":
         foreground, background, step = "#212529", "#ffffff", "600"

--- a/src/ttkbootstrap/cli/doctor.py
+++ b/src/ttkbootstrap/cli/doctor.py
@@ -176,9 +176,9 @@ def _check_build(config: TtkbConfig, project_root: Path) -> int:
 def _probe_tk() -> tuple[str | None, str | None]:
     """Return (version, None) on success, (None, error_message) on failure.
 
-    Uses ``_tkinter`` module constants directly so the probe does not have
+    Uses `_tkinter` module constants directly so the probe does not have
     to instantiate a Tk interpreter (ttkbootstrap monkey-patches
-    ``Tk.__init__`` to require an App, which would trip the probe).
+    `Tk.__init__` to require an App, which would trip the probe).
     """
     try:
         import _tkinter

--- a/src/ttkbootstrap/cli/templates/__init__.py
+++ b/src/ttkbootstrap/cli/templates/__init__.py
@@ -419,8 +419,8 @@ import ttkbootstrap as ttk
 class HomePage:
     """Home page content.
 
-    Pages in an AppShell are not widget subclasses. The ``parent`` frame
-    is created by ``shell.add_page()`` and this class populates it.
+    Pages in an AppShell are not widget subclasses. The `parent` frame
+    is created by `shell.add_page()` and this class populates it.
     """
 
     def __init__(self, parent):
@@ -466,8 +466,8 @@ import ttkbootstrap as ttk
 class SettingsPage:
     """Settings page content.
 
-    Pages in an AppShell are not widget subclasses. The ``parent`` frame
-    is created by ``shell.add_page()`` and this class populates it.
+    Pages in an AppShell are not widget subclasses. The `parent` frame
+    is created by `shell.add_page()` and this class populates it.
     """
 
     def __init__(self, parent):
@@ -511,8 +511,8 @@ import ttkbootstrap as ttk
 class {class_name}:
     """{page_title} page content.
 
-    Pages in an AppShell are not widget subclasses. The ``parent`` frame
-    is created by ``shell.add_page()`` and this class populates it.
+    Pages in an AppShell are not widget subclasses. The `parent` frame
+    is created by `shell.add_page()` and this class populates it.
     """
 
     def __init__(self, parent):
@@ -610,7 +610,7 @@ def create_page(
         class_name: Page class name (CamelCase).
         target_dir: Directory to create the page in.
         scrollable: If True, the page template notes that
-            ``scrollable=True`` should be passed to ``add_page()``.
+            `scrollable=True` should be passed to `add_page()`.
 
     Returns:
         Path to the created file.

--- a/src/ttkbootstrap/core/constants.py
+++ b/src/ttkbootstrap/core/constants.py
@@ -1,6 +1,6 @@
 """Backwards compatibility layer - constants moved to ttkbootstrap.constants.
 
-.. deprecated::
+!!! warning "Deprecated"
     Import from `ttkbootstrap.constants` instead of `ttkbootstrap.core.constants`.
 
 This module re-exports all constants from the root-level constants module

--- a/src/ttkbootstrap/core/images.py
+++ b/src/ttkbootstrap/core/images.py
@@ -9,21 +9,27 @@ loading images from various sources while automatically caching them to avoid
 repeated decoding and to prevent garbage collection issues with Tk images.
 
 Examples:
-    Basic usage with file paths::
+    Basic usage with file paths:
 
-        from ttkbootstrap import Image
+    ```python
+    from ttkbootstrap import Image
 
-        # Load an image from disk (cached automatically)
-        photo = Image.open("icons/save.png")
-        button = Button(app, image=photo)
+    # Load an image from disk (cached automatically)
+    photo = Image.open("icons/save.png")
+    button = Button(app, image=photo)
+    ```
 
-    Loading from bytes (e.g., embedded resources)::
+    Loading from bytes (e.g., embedded resources):
 
-        photo = Image.from_bytes(icon_data)
+    ```python
+    photo = Image.from_bytes(icon_data)
+    ```
 
-    Creating transparent spacer images::
+    Creating transparent spacer images:
 
-        spacer = Image.transparent(16, 16)
+    ```python
+    spacer = Image.transparent(16, 16)
+    ```
 """
 
 from __future__ import annotations

--- a/src/ttkbootstrap/core/localization/msgcat.py
+++ b/src/ttkbootstrap/core/localization/msgcat.py
@@ -71,15 +71,15 @@ class MessageCatalog:
         Args:
             root: Optional Tk root to ensure msgcat is available.
             locales_dir: Base directory containing gettext catalogs
-                (``<lang>/LC_MESSAGES/<domain>.mo``). If ``None``, the
+                (`<lang>/LC_MESSAGES/<domain>.mo`). If `None`, the
                 directory is auto-discovered.
             domain: Gettext domain name.
             default_locale: Locale to activate after initialization.
-            strip_ampersands: If true, remove mnemonic ``&`` markers.
+            strip_ampersands: If true, remove mnemonic `&` markers.
             emit_virtual_event: If true, generate a Tk virtual event after
                 locale changes so widgets can refresh themselves.
             virtual_event_name: The virtual event name to emit when the
-                locale changes (default ``"<<LocaleChanged>>"``).
+                locale changes (default `"<<LocaleChanged>>"`).
         """
         # Ensure a Tk exists so msgcat calls work even if root is omitted
         from ttkbootstrap.runtime.app import get_default_root
@@ -100,8 +100,8 @@ class MessageCatalog:
     def _install_gettext(lang: str) -> None:
         """Install gettext catalogs for the requested language.
 
-        Prefers an exact match (e.g. ``de_DE``) and falls back to base
-        language (``de``) if available.
+        Prefers an exact match (e.g. `de_DE`) and falls back to base
+        language (`de`) if available.
 
         Args:
             lang: Requested locale code.
@@ -127,12 +127,12 @@ class MessageCatalog:
         """Return a plausible locales directory for this installation.
 
         Priority order:
-        1) ``TTKBOOTSTRAP_LOCALES`` environment variable
-        2) Package asset ``src/ttkbootstrap/assets/locales``
-        3) Module-local ``ttkbootstrap/localization/locales``
-        4) Package-local ``src/ttkbootstrap/locales``
-        5) Repository root ``locales/``
-        6) Current working directory ``./locales``
+        1) `TTKBOOTSTRAP_LOCALES` environment variable
+        2) Package asset `src/ttkbootstrap/assets/locales`
+        3) Module-local `ttkbootstrap/localization/locales`
+        4) Package-local `src/ttkbootstrap/locales`
+        5) Repository root `locales/`
+        6) Current working directory `./locales`
         """
         import os
         env = os.environ.get("TTKBOOTSTRAP_LOCALES")
@@ -162,7 +162,7 @@ class MessageCatalog:
         """Set Tcl msgcat locale to match the Python-side locale.
 
         Args:
-            lang: Locale code (e.g. ``en``, ``de_DE``).
+            lang: Locale code (e.g. `en`, `de_DE`).
         """
         from ttkbootstrap.runtime.app import get_default_root
         root = get_default_root()
@@ -175,10 +175,10 @@ class MessageCatalog:
 
     @staticmethod
     def _normalize_lang(code: str) -> str:
-        """Normalize a locale code to gettext style (``ll`` or ``ll_RR``).
+        """Normalize a locale code to gettext style (`ll` or `ll_RR`).
 
         Args:
-            code: Input locale code (e.g. ``de-de``, ``pt_br``).
+            code: Input locale code (e.g. `de-de`, `pt_br`).
 
         Returns:
             Normalized locale code for gettext use.
@@ -190,10 +190,10 @@ class MessageCatalog:
 
     @staticmethod
     def _to_msgcat_locale(code: str) -> str:
-        """Normalize a locale code to msgcat style (``ll`` or ``ll_rr``).
+        """Normalize a locale code to msgcat style (`ll` or `ll_rr`).
 
         Args:
-            code: Input locale code (e.g. ``de-DE``, ``pt_BR``).
+            code: Input locale code (e.g. `de-DE`, `pt_BR`).
 
         Returns:
             Lowercased region code used by msgcat.

--- a/src/ttkbootstrap/core/signals/integration.py
+++ b/src/ttkbootstrap/core/signals/integration.py
@@ -1,8 +1,8 @@
 """Integration helpers for using Signal with tkinter/ttk widgets.
 
-Call ``enable_widget_integration()`` once early (after creating your Tk/Window)
-to allow passing ``Signal`` objects directly to widget constructors and
-``configure(...)`` for options like ``textvariable`` and ``variable``.
+Call `enable_widget_integration()` once early (after creating your Tk/Window)
+to allow passing `Signal` objects directly to widget constructors and
+`configure(...)` for options like `textvariable` and `variable`.
 
 Without this, some environments/widgets may not coerce custom objects to the
 required Tcl variable name automatically.
@@ -67,11 +67,11 @@ def _patch(classes: Iterable[type]) -> None:
 
 
 def enable_widget_integration() -> None:
-    """Enable passing ``Signal`` directly to widget options.
+    """Enable passing `Signal` directly to widget options.
 
-    Patches common tk/ttk widget classes so that when you pass a ``Signal``
-    instance to ``textvariable`` or ``variable`` in the constructor or in
-    ``configure(...)``, it is automatically converted to its Tcl name.
+    Patches common tk/ttk widget classes so that when you pass a `Signal`
+    instance to `textvariable` or `variable` in the constructor or in
+    `configure(...)`, it is automatically converted to its Tcl name.
     """
 
     ttk_classes: Tuple[type, ...] = (

--- a/src/ttkbootstrap/core/signals/signal.py
+++ b/src/ttkbootstrap/core/signals/signal.py
@@ -126,8 +126,8 @@ class Signal(Generic[T]):
     def get(self) -> T:
         """Return the current value of the signal.
 
-        Alias for calling the instance directly (``signal()``). Mirrors
-        tkinter's ``Variable.get`` naming for consistency.
+        Alias for calling the instance directly (`signal()`). Mirrors
+        tkinter's `Variable.get` naming for consistency.
         """
         return self()
 

--- a/src/ttkbootstrap/datasource/sqlite_source.py
+++ b/src/ttkbootstrap/datasource/sqlite_source.py
@@ -188,14 +188,14 @@ class SqliteDataSource(BaseDataSource):
         The fragment is interpolated into the query unmodified, so the caller
         is responsible for ensuring it is trusted/author-controlled. Do not
         pass strings built from end-user input — use parameterized queries
-        directly via ``self.conn`` instead.
+        directly via `self.conn` instead.
         """
         self._where = where_sql
 
     def set_sort(self, order_by_sql: str = ""):
         """Apply SQL ORDER BY clause for sorting.
 
-        Same trust contract as :meth:`set_filter`: the fragment is interpolated
+        Same trust contract as `set_filter`: the fragment is interpolated
         verbatim, so it must be author-controlled, not user input.
         """
         self._order_by = order_by_sql

--- a/src/ttkbootstrap/dialogs/colorchooser.py
+++ b/src/ttkbootstrap/dialogs/colorchooser.py
@@ -540,8 +540,8 @@ class ColorChooserDialog:
 
     !!! note "Events"
 
-        ``<<DialogResult>>``: Fired when the dialog is closed.
-          Provides ``event.data`` with keys: ``result`` (ColorChoice|None), ``confirmed`` (bool).
+        `<<DialogResult>>`: Fired when the dialog is closed.
+          Provides `event.data` with keys: `result` (ColorChoice|None), `confirmed` (bool).
     """
 
     def __init__(

--- a/src/ttkbootstrap/dialogs/colordropper.py
+++ b/src/ttkbootstrap/dialogs/colordropper.py
@@ -27,7 +27,7 @@ class ColorDropperDialog:
     """Screen color picker with zoom preview.
 
     Click anywhere on screen to select a color. The selected color is stored in
-    ``result`` as a ColorChoice named tuple with rgb, hsl, and hex values.
+    `result` as a ColorChoice named tuple with rgb, hsl, and hex values.
 
     Note:
         Supported on Windows and Linux. macOS is not supported due to ImageGrab

--- a/src/ttkbootstrap/dialogs/datedialog.py
+++ b/src/ttkbootstrap/dialogs/datedialog.py
@@ -209,10 +209,10 @@ class DateDialog:
         Args:
             master: Parent widget; positions dialog relative to it when set.
             title: Dialog window title text.
-            initial_date: Initial date shown; defaults to ``date.today()``.
+            initial_date: Initial date shown; defaults to `date.today()`.
             first_weekday: First weekday index (0=Monday, 6=Sunday).
-            accent: Calendar accent token (e.g., ``primary``, ``secondary``).
-            bootstyle: DEPRECATED - Use ``accent`` instead.
+            accent: Calendar accent token (e.g., `primary`, `secondary`).
+            bootstyle: DEPRECATED - Use `accent` instead.
             disabled_dates: Iterable of dates to disable selection.
             min_date: Lower bound for selectable dates.
             max_date: Upper bound for selectable dates.
@@ -363,13 +363,13 @@ class DateDialog:
     def on_result(self, callback: Callable[[date], None]) -> Optional[str]:
         """Bind a callback fired when a result is produced.
 
-        The callback receives ``event.data["result"]`` (a ``datetime.date``).
+        The callback receives `event.data["result"]` (a `datetime.date`).
 
         Args:
-            callback: Callable that receives the selected ``datetime.date``.
+            callback: Callable that receives the selected `datetime.date`.
 
         Returns:
-            The Tk binding identifier, which can be used with ``off_result``.
+            The Tk binding identifier, which can be used with `off_result`.
         """
         target = self._dialog.toplevel or self._master
         if target is None:
@@ -381,10 +381,10 @@ class DateDialog:
         return target.bind("<<DialogResult>>", handler, add="+")
 
     def off_result(self, funcid: str) -> None:
-        """Unbind a previously bound ``on_result`` callback.
+        """Unbind a previously bound `on_result` callback.
 
         Args:
-            funcid: Binding identifier returned by ``on_result``.
+            funcid: Binding identifier returned by `on_result`.
         """
         target = self._dialog.toplevel or self._master
         if target is None:

--- a/src/ttkbootstrap/dialogs/dialog.py
+++ b/src/ttkbootstrap/dialogs/dialog.py
@@ -1,6 +1,6 @@
 """Core dialog base class for ttkbootstrap dialogs.
 
-This module provides the base ``Dialog`` class using a builder pattern
+This module provides the base `Dialog` class using a builder pattern
 for creating flexible, customizable dialogs with composition-based content
 and footer builders.
 """
@@ -33,11 +33,11 @@ class DialogButton:
     Attributes:
         text (str): Button label text displayed to the user.
         role (ButtonRole): Button role determining styling and behavior.
-            - ``"primary"``: Main action (blue, triggered by Enter)
-            - ``"secondary"``: Standard action (gray)
-            - ``"danger"``: Destructive action (red)
-            - ``"cancel"``: Cancel action (outline, triggered by Escape)
-            - ``"help"``: Help/info action (link style)
+            - `"primary"`: Main action (blue, triggered by Enter)
+            - `"secondary"`: Standard action (gray)
+            - `"danger"`: Destructive action (red)
+            - `"cancel"`: Cancel action (outline, triggered by Escape)
+            - `"help"`: Help/info action (link style)
         result (Any | None): Value assigned to dialog.result when clicked.
         closes (bool): Whether button closes the dialog when clicked.
         default (bool): Whether this is the default button (focused, triggered by Enter).
@@ -129,7 +129,7 @@ class Dialog:
             - "popover": Closes automatically when focus leaves dialog
             - "sheet": Like "modal" but on macOS applies the Cocoa sheet
               window class for a chromeless, sheet-styled dialog tied to
-              its parent (via ``transient``). Falls back to plain modal
+              its parent (via `transient`). Falls back to plain modal
               behavior on Windows/Linux where there's no equivalent.
             Defaults to "modal".
         frameless: If True, removes window decorations (title bar, borders) and adds

--- a/src/ttkbootstrap/dialogs/filterdialog.py
+++ b/src/ttkbootstrap/dialogs/filterdialog.py
@@ -179,8 +179,8 @@ class FilterDialog(ttk.Frame):
 
     !!! note "Events"
 
-        ``<<SelectionChange>>``: Triggered when OK is clicked and selections are confirmed.
-          Provides ``event.data`` with key: ``selected`` (list[Any]).
+        `<<SelectionChange>>`: Triggered when OK is clicked and selections are confirmed.
+          Provides `event.data` with key: `selected` (list[Any]).
 
     Attributes:
         result (list[Any] | None): List of selected values after dialog is closed,
@@ -245,7 +245,7 @@ class FilterDialog(ttk.Frame):
                 self.event_generate('<<SelectionChange>>', data={"selected": self.result.copy()})
 
     def on_selection_changed(self, callback: Callable) -> str:
-        """Bind to ``<<SelectionChange>>``. Callback receives ``event.data = {"selected": list[Any]}``.
+        """Bind to `<<SelectionChange>>`. Callback receives `event.data = {"selected": list[Any]}`.
 
         Returns:
             Binding identifier for use with off_selection_changed().

--- a/src/ttkbootstrap/dialogs/fontdialog.py
+++ b/src/ttkbootstrap/dialogs/fontdialog.py
@@ -43,7 +43,7 @@ class FontDialog:
 
     This dialog provides a comprehensive interface for selecting fonts,
     including family, size, weight, slant, and effects (underline, overstrike).
-    The selected font is returned as a ``tkinter.font.Font`` object when OK is
+    The selected font is returned as a `tkinter.font.Font` object when OK is
     pressed, or None if canceled.
 
     Attributes:

--- a/src/ttkbootstrap/dialogs/message.py
+++ b/src/ttkbootstrap/dialogs/message.py
@@ -25,13 +25,13 @@ class MessageDialog:
     message window is identified by a unique symbolic name. After the
     message window is popped up, the message box awaits for the user to
     select one of the buttons. Then it returns the symbolic name of the
-    selected button. Use a ``Toplevel`` widget for more advanced modal
+    selected button. Use a `Toplevel` widget for more advanced modal
     dialog designs.
 
     !!! note "Events"
 
-        ``<<DialogResult>>``: Fired when dialog closes.
-          Provides ``event.data`` with keys: ``result`` (str), ``confirmed`` (bool).
+        `<<DialogResult>>`: Fired when dialog closes.
+          Provides `event.data` with keys: `result` (str), `confirmed` (bool).
     """
 
     def __init__(
@@ -220,13 +220,13 @@ class MessageDialog:
     def on_dialog_result(self, callback: Callable[[Any], None]) -> Optional[str]:
         """Bind a callback fired when the dialog produces a result.
 
-        The callback receives ``event.data["result"]`` when available.
+        The callback receives `event.data["result"]` when available.
 
         Args:
             callback: Callable that receives the result payload.
 
         Returns:
-            Binding identifier for use with ``off_dialog_result``.
+            Binding identifier for use with `off_dialog_result`.
         """
         target = self._dialog.toplevel or self._master
         if target is None:

--- a/src/ttkbootstrap/dialogs/query.py
+++ b/src/ttkbootstrap/dialogs/query.py
@@ -30,8 +30,8 @@ class QueryDialog:
 
     !!! note "Events"
 
-        ``<<DialogResult>>``: Fired when dialog closes.
-          Provides ``event.data`` with keys: ``result`` (Any), ``confirmed`` (bool).
+        `<<DialogResult>>`: Fired when dialog closes.
+          Provides `event.data` with keys: `result` (Any), `confirmed` (bool).
     """
 
     def __init__(
@@ -274,13 +274,13 @@ class QueryDialog:
     def on_dialog_result(self, callback: Callable[[Any], None]) -> Optional[str]:
         """Bind a callback fired when the dialog produces a result.
 
-        The callback receives ``event.data["result"]`` when available.
+        The callback receives `event.data["result"]` when available.
 
         Args:
             callback: Callable that receives the result payload.
 
         Returns:
-            Binding identifier for use with ``off_dialog_result``.
+            Binding identifier for use with `off_dialog_result`.
         """
         target = self._dialog.toplevel or self._master
         if target is None:

--- a/src/ttkbootstrap/runtime/app.py
+++ b/src/ttkbootstrap/runtime/app.py
@@ -1,6 +1,6 @@
 """Application runtime — App window, lifecycle helpers, and settings.
 
-Provides the main ``App`` class (a ``Tk`` subclass), ``AppSettings``, and
+Provides the main `App` class (a `Tk` subclass), `AppSettings`, and
 process-wide helpers for accessing the active app instance, reading settings,
 and managing the current locale and theme from anywhere in the application.
 """
@@ -269,7 +269,7 @@ class AppSettings:
             When None, defaults to a per-app file under the OS config
             directory (Library/Application Support on macOS, %APPDATA% on
             Windows, $XDG_CONFIG_HOME on Linux). The leaf filename includes
-            ``app_name`` so multiple ttkbootstrap apps don't collide.
+            `app_name` so multiple ttkbootstrap apps don't collide.
 
     Examples:
         ```python
@@ -727,7 +727,7 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
         """Return True if the current windowing system reports an appearance.
 
         Currently only macOS exposes a Tk-level light/dark signal
-        (``<<TkSystemAppearanceChanged>>`` and ``MacWindowStyle isDark``).
+        (`<<TkSystemAppearanceChanged>>` and `MacWindowStyle isDark`).
         Win/Linux apps that want to track system theme need their own
         OS-specific hook, which is out of scope for this method.
         """
@@ -770,7 +770,7 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
         app, and clicking the Dock icon brings the main window back.
 
         This method installs the matching Tk handlers so apps that opt
-        into ``macos_quit_behavior='native'`` behave correctly without
+        into `macos_quit_behavior='native'` behave correctly without
         each app duplicating the boilerplate.
         """
         # Close button → withdraw. We replace the protocol unconditionally
@@ -806,9 +806,9 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
     def _trigger_close(self, _event=None) -> str:
         """Invoke the registered WM_DELETE_WINDOW handler for this window.
 
-        Lets ``Cmd+W`` and any other "close this window" gesture flow
+        Lets `Cmd+W` and any other "close this window" gesture flow
         through the same code path as clicking the close button, so a
-        custom ``app.on_close(handler)`` is honored.
+        custom `app.on_close(handler)` is honored.
         """
         try:
             handler_script = self.tk.call(
@@ -839,7 +839,7 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
     def on_about(self, handler: Callable[[], Any]) -> None:
         """Register a handler for the macOS "About <App>" menu item.
 
-        Tk on Aqua calls ``::tk::mac::standardAboutPanel`` when the user
+        Tk on Aqua calls `::tk::mac::standardAboutPanel` when the user
         picks About from the application menu. This method overrides
         that proc with the supplied Python callable. No-op on Win/Linux,
         where there's no equivalent system menu.
@@ -858,7 +858,7 @@ class App(BaseWindow, WidgetCapabilitiesMixin, tkinter.Tk):
     def on_preferences(self, handler: Callable[[], Any]) -> None:
         """Register a handler for the macOS "Preferences…" menu item.
 
-        Tk on Aqua calls ``::tk::mac::ShowPreferences`` when the user picks
+        Tk on Aqua calls `::tk::mac::ShowPreferences` when the user picks
         Preferences (Cmd+,) from the application menu. This method
         overrides that proc with the supplied Python callable. No-op on
         Win/Linux.

--- a/src/ttkbootstrap/runtime/menu.py
+++ b/src/ttkbootstrap/runtime/menu.py
@@ -81,13 +81,13 @@ class MenuManager:
 
     @classmethod
     def for_widget(cls, widget: Any) -> "MenuManager":
-        """Return the singleton MenuManager for ``widget``'s root window.
+        """Return the singleton MenuManager for `widget`'s root window.
 
         Creates one on first access and stores it on the root as
-        ``_menu_manager``. Use this to share icon-tracking and theme
+        `_menu_manager`. Use this to share icon-tracking and theme
         monitoring across all tk.Menu-based widgets in an application
         (menubars, context menus, etc.) without each one binding its own
-        ``<<ThemeChanged>>`` handler.
+        `<<ThemeChanged>>` handler.
         """
         root = widget.winfo_toplevel() if hasattr(widget, 'winfo_toplevel') else widget
         existing = getattr(root, '_menu_manager', None)
@@ -161,10 +161,10 @@ class MenuManager:
 
     @staticmethod
     def translate_label(text: Optional[str]) -> Optional[str]:
-        """Run a label through ``MessageCatalog.translate``.
+        """Run a label through `MessageCatalog.translate`.
 
-        Semantic keys (e.g. ``'table.sort_asc'``) become localized strings;
-        plain text passes through unchanged because ``translate`` returns
+        Semantic keys (e.g. `'table.sort_asc'`) become localized strings;
+        plain text passes through unchanged because `translate` returns
         the source when no translation is registered.
         """
         if not text:
@@ -175,12 +175,12 @@ class MenuManager:
             return text
 
     def resolve_icon(self, icon_spec: Union[str, dict, None]) -> tuple[Any, Optional[str], int]:
-        """Resolve an icon spec to a ``(PhotoImage, name, size)`` triple.
+        """Resolve an icon spec to a `(PhotoImage, name, size)` triple.
 
-        Returns ``(None, None, 0)`` for empty/unsupported specs. The returned
-        PhotoImage is the same kind ``MenuManager`` uses internally for its
+        Returns `(None, None, 0)` for empty/unsupported specs. The returned
+        PhotoImage is the same kind `MenuManager` uses internally for its
         own menus, so the caller can pass it straight to
-        ``menu.add_command(image=..., compound='left')``.
+        `menu.add_command(image=..., compound='left')`.
         """
         if not icon_spec or icon_spec == 'empty':
             return None, None, 0
@@ -196,17 +196,17 @@ class MenuManager:
     def register_icon(self, menu: tk.Menu, index: int, icon_name: str, icon_size: int) -> None:
         """Track a menu item for theme-aware icon re-rendering.
 
-        Call after ``menu.add_*(image=icon)`` so subsequent
-        ``<<ThemeChanged>>`` events refresh the entry's icon color.
+        Call after `menu.add_*(image=icon)` so subsequent
+        `<<ThemeChanged>>` events refresh the entry's icon color.
         """
         self._track_icon(menu, index, icon_name, icon_size)
 
     def unregister_menu(self, menu: tk.Menu) -> None:
-        """Drop all tracking entries for ``menu``.
+        """Drop all tracking entries for `menu`.
 
         Call when the menu is being destroyed or fully rebuilt so stale
-        ``(menu, index)`` references don't try to reconfigure deleted entries
-        on the next ``<<ThemeChanged>>``.
+        `(menu, index)` references don't try to reconfigure deleted entries
+        on the next `<<ThemeChanged>>`.
         """
         prefix = f"{id(menu)}_"
         for key in [k for k in self.menu_items if k.startswith(prefix)]:
@@ -227,11 +227,11 @@ class MenuManager:
         return None, default_size
 
     def _is_aqua_special_name(self, name: str) -> bool:
-        """Return True if ``name`` triggers macOS-native menu handling.
+        """Return True if `name` triggers macOS-native menu handling.
 
-        Tk on Aqua reserves three submenu names off the menubar: ``apple``
-        (the app menu — gets auto-filled with About/Hide/Quit), ``window``
-        (auto-populated with open Toplevels), and ``help`` (gets the
+        Tk on Aqua reserves three submenu names off the menubar: `apple`
+        (the app menu — gets auto-filled with About/Hide/Quit), `window`
+        (auto-populated with open Toplevels), and `help` (gets the
         system Help search field). Names are case-sensitive and only have
         meaning under windowingsystem='aqua'.
         """
@@ -263,7 +263,7 @@ class MenuManager:
             options = options.copy()
             sub_items = options.pop('items', [])
 
-            # Pull off the optional ``name`` early so it's never passed to
+            # Pull off the optional `name` early so it's never passed to
             # add_cascade. On Aqua, three magic names get system handling:
             # 'apple' → app menu (auto-fills with About/Hide/Quit),
             # 'window' → Tk auto-populates the open Toplevel list,
@@ -325,8 +325,8 @@ class MenuManager:
 
             # Resolve a shortcut spec (registered key or modifier pattern)
             # to a platform-correct accelerator display. Caller-supplied
-            # ``accelerator`` wins (legacy literal pass-through), so existing
-            # menus with ``accelerator='Ctrl+S'`` are not auto-translated.
+            # `accelerator` wins (legacy literal pass-through), so existing
+            # menus with `accelerator='Ctrl+S'` are not auto-translated.
             shortcut_spec = opts.pop('shortcut', None)
             if shortcut_spec and 'accelerator' not in opts:
                 display = format_shortcut(shortcut_spec)
@@ -383,23 +383,23 @@ def create_menu(parent: Any, items: list[dict]) -> tk.Menu:
         - **variable** (Variable): Tkinter variable for checkbutton/radiobutton
         - **value** (Any): Value for radiobutton items
         - **name** (str): Optional Tcl widget name for the cascade. On macOS
-          three names trigger system-native menu integration: ``'apple'``
+          three names trigger system-native menu integration: `'apple'`
           gives you the application menu (Tk auto-fills it with About,
           Hide, Hide Others, Show All, Quit; any items you add appear
-          before the system items), ``'window'`` gets auto-populated with
-          open Toplevels, and ``'help'`` enables system Help search.
+          before the system items), `'window'` gets auto-populated with
+          open Toplevels, and `'help'` enables system Help search.
           Ignored on Win/Linux.
         - **shortcut** (str): Platform-aware accelerator. Accepts a
-          registered shortcut key (e.g. ``'save'`` if you've called
-          ``Shortcuts.register('save', 'Mod+S', save_file)``) or a
-          modifier pattern like ``'Mod+S'``, ``'Ctrl+Shift+N'``, ``'F5'``.
-          Renders as ``⌘S`` on macOS and ``Ctrl+S`` on Win/Linux.
+          registered shortcut key (e.g. `'save'` if you've called
+          `Shortcuts.register('save', 'Mod+S', save_file)`) or a
+          modifier pattern like `'Mod+S'`, `'Ctrl+Shift+N'`, `'F5'`.
+          Renders as `⌘S` on macOS and `Ctrl+S` on Win/Linux.
           For the actual keypress binding, register the shortcut and call
-          ``Shortcuts.bind_to(app)`` — that's the canonical pathway.
+          `Shortcuts.bind_to(app)` — that's the canonical pathway.
         - **accelerator** (str): Legacy literal display string passed
-          straight through to ``tk.Menu`` (e.g. ``'Ctrl+S'``). No platform
-          translation. Prefer ``shortcut`` for new code. If both are
-          provided, ``accelerator`` wins.
+          straight through to `tk.Menu` (e.g. `'Ctrl+S'`). No platform
+          translation. Prefer `shortcut` for new code. If both are
+          provided, `accelerator` wins.
         - Any other valid Tkinter menu item options (underline, etc.)
 
     Args:

--- a/src/ttkbootstrap/runtime/shortcuts.py
+++ b/src/ttkbootstrap/runtime/shortcuts.py
@@ -141,9 +141,9 @@ class Shortcuts:
     Provides cross-platform keyboard shortcut registration and binding.
     The service automatically translates modifier keys for each platform:
 
-    - ``Mod`` becomes ``Ctrl`` on Windows/Linux, ``Command`` on Mac
-    - ``Alt`` becomes ``Alt`` on Windows/Linux, ``Option`` on Mac
-    - ``Shift`` works the same on all platforms
+    - `Mod` becomes `Ctrl` on Windows/Linux, `Command` on Mac
+    - `Alt` becomes `Alt` on Windows/Linux, `Option` on Mac
+    - `Shift` works the same on all platforms
 
     Examples:
         ```python
@@ -178,10 +178,10 @@ class Shortcuts:
         Args:
             key: Unique identifier (e.g., "save", "file.open")
             pattern: Shortcut pattern using symbolic modifiers:
-                - ``Mod+S`` - Primary modifier + S
-                - ``Mod+Shift+S`` - Primary modifier + Shift + S
-                - ``Alt+F4`` - Alt + F4
-                - ``F5`` - Function key alone
+                - `Mod+S` - Primary modifier + S
+                - `Mod+Shift+S` - Primary modifier + Shift + S
+                - `Alt+F4` - Alt + F4
+                - `F5` - Function key alone
             command: Function to call when triggered
 
         Returns:
@@ -371,11 +371,11 @@ def format_shortcut(spec: str | None) -> str:
 
     Accepts three forms in order of precedence:
 
-    1. **Registered key** — the key passed to ``Shortcuts.register``
-       (e.g. ``"save"``, ``"file.open"``). Returns the registered
+    1. **Registered key** — the key passed to `Shortcuts.register`
+       (e.g. `"save"`, `"file.open"`). Returns the registered
        shortcut's `display`.
-    2. **Pattern** — a modifier expression like ``"Mod+S"``,
-       ``"Ctrl+Shift+N"``, or ``"F5"``. Treated as a transient pattern;
+    2. **Pattern** — a modifier expression like `"Mod+S"`,
+       `"Ctrl+Shift+N"`, or `"F5"`. Treated as a transient pattern;
        returns the pattern's platform display without registering anything.
     3. **Plain text** — anything that doesn't parse as a pattern (no
        modifier separator, not a function key) is returned unchanged so
@@ -385,7 +385,7 @@ def format_shortcut(spec: str | None) -> str:
         spec: A registered key, modifier pattern, or literal display.
 
     Returns:
-        Platform-appropriate display string, or empty string when ``spec``
+        Platform-appropriate display string, or empty string when `spec`
         is empty/None.
 
     Examples:

--- a/src/ttkbootstrap/runtime/utility.py
+++ b/src/ttkbootstrap/runtime/utility.py
@@ -335,16 +335,16 @@ def center_on_parent(win, parent=None):
 def bind_right_click(widget, handler, add: str | bool = '+'):
     """Bind a right-click handler portably across Tk windowing systems.
 
-    On Win/Linux right-click maps to ``<Button-3>``. On macOS Tk maps the
-    right mouse button (and two-finger trackpad click) to ``<Button-2>``,
+    On Win/Linux right-click maps to `<Button-3>`. On macOS Tk maps the
+    right mouse button (and two-finger trackpad click) to `<Button-2>`,
     and Mac users also expect Ctrl+click as a context-menu trigger. This
     helper binds the appropriate event(s) for the current platform so
     callers don't have to repeat the platform check.
 
     Args:
-        widget: Any Tk widget with a ``.bind`` method and a ``.tk`` attribute.
+        widget: Any Tk widget with a `.bind` method and a `.tk` attribute.
         handler: Event handler callable (or Tcl command string).
-        add: Passed through to ``bind``. Defaults to ``'+'`` so the helper
+        add: Passed through to `bind`. Defaults to `'+'` so the helper
             never silently replaces an existing binding.
     """
     widget.bind('<Button-3>', handler, add=add)

--- a/src/ttkbootstrap/style/__init__.py
+++ b/src/ttkbootstrap/style/__init__.py
@@ -680,7 +680,7 @@
 #
 #         If themename is None, returns the theme in use, otherwise, set
 #         the current theme to themename, refreshes all widgets and emits
-#         a ``<<ThemeChanged>>`` event.
+#         a `<<ThemeChanged>>` event.
 #
 #         Only use this method if you are changing the theme *during*
 #         runtime. Otherwise, pass the theme name into the Style
@@ -5028,8 +5028,8 @@
 #     This class provides utilities to parse those tokens from strings and
 #     widget state, determine the target widget class and orientation, and
 #     resolve the requested color and variant. It also wires ttkbootstrap
-#     into tkinter/ttk via ``setup_ttkbootstrap_api`` so that widgets accept
-#     the ``bootstyle=...`` keyword at construction or during configure().
+#     into tkinter/ttk via `setup_ttkbootstrap_api` so that widgets accept
+#     the `bootstyle=...` keyword at construction or during configure().
 #
 #     Typical end users will not call these methods directly; they are used
 #     internally by the Style engine and by widget constructor overrides.

--- a/src/ttkbootstrap/style/style.py
+++ b/src/ttkbootstrap/style/style.py
@@ -452,7 +452,7 @@ def get_themes() -> list[dict[str, str]]:
     """Return the list of all registered themes.
 
     Returns:
-        List of dictionaries containing ``name`` and ``display_name`` for each theme.
+        List of dictionaries containing `name` and `display_name` for each theme.
 
     Examples:
         >>> themes = get_themes()

--- a/src/ttkbootstrap/style/theme_provider.py
+++ b/src/ttkbootstrap/style/theme_provider.py
@@ -49,7 +49,7 @@ def get_theme(name):
     """Return a registered theme by name.
 
     If the theme is not currently registered this will re-run
-    ``load_system_themes`` once to pick up any newly added themes before
+    `load_system_themes` once to pick up any newly added themes before
     failing.
     """
     if name in _registered_themes:
@@ -84,8 +84,8 @@ def get_theme(name):
 def load_system_themes():
     """Load system themes from the package.
 
-    Loads all v2 themes from ``ttkbootstrap.assets.themes`` and all legacy
-    themes from ``ttkbootstrap.assets.themes.legacy``. Themes matching
+    Loads all v2 themes from `ttkbootstrap.assets.themes` and all legacy
+    themes from `ttkbootstrap.assets.themes.legacy`. Themes matching
     app settings dark_theme or .light_theme are also registered with
     'dark' and 'light' aliases for convenience.
     """
@@ -141,9 +141,9 @@ def load_system_themes():
 def load_user_defined_theme(path):
     """Load a user-defined theme from a JSON file on disk.
 
-    The file must follow the v2 theme schema (top-level ``name``,
-    ``display_name``, ``mode``, ``foreground``, ``background``, plus
-    ``shades`` and ``semantic`` mappings).
+    The file must follow the v2 theme schema (top-level `name`,
+    `display_name`, `mode`, `foreground`, `background`, plus
+    `shades` and `semantic` mappings).
     """
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
@@ -225,11 +225,13 @@ class ThemeProvider:
     def list_themes(self) -> list[dict[str, str]]:
         """Return a list of available themes with names and display names.
 
-        The result is a list of dictionaries in the form::
+        The result is a list of dictionaries in the form:
 
-            {"name": "cosmo", "display_name": "Cosmo"}
+        ```python
+        {"name": "cosmo", "display_name": "Cosmo"}
+        ```
 
-        Aliases such as ``\"light\"`` and ``\"dark\"`` are not included; only the
+        Aliases such as `\"light\"` and `\"dark\"` are not included; only the
         canonical theme entries loaded into the provider are returned.
         """
         themes: list[dict[str, str]] = []

--- a/src/ttkbootstrap/style/utility.py
+++ b/src/ttkbootstrap/style/utility.py
@@ -162,18 +162,14 @@ def color_to_rgb(color, model: ColorModel = 'hex'):
     The value is expected to be a string for "name" and "hex" models and
     a Tuple or List for "rgb" and "hsl" models.
 
-    Parameters
-    ----------
-    color : Any
-        The color values for the model being converted.
+    **Parameters**
 
-    model : Literal['rbg', 'hsl', 'hex']
-        The color model being converted.
+    - `color` (Any): The color values for the model being converted.
+    - `model` (Literal['rbg', 'hsl', 'hex']): The color model being converted.
 
-    Returns
-    -------
-    Tuple[int, int, int]
-        The rgb color values.
+    **Returns**
+
+    `Tuple[int, int, int]` — The rgb color values.
     """
     conformed = conform_color_model(color, model)
     return ImageColor.getrgb(conformed)
@@ -186,18 +182,14 @@ def color_to_hex(color, model: ColorModel = 'rgb'):
     The value is expected to be a string for "name" and "hex" models and
     a Tuple or List for "rgb" and "hsl" models.
 
-    Parameters
-    ----------
-    color : Any
-        The color values for the model being converted.
+    **Parameters**
 
-    model : Literal['rgb', 'hsl', 'hex']
-        The color model being converted.
+    - `color` (Any): The color values for the model being converted.
+    - `model` (Literal['rgb', 'hsl', 'hex']): The color model being converted.
 
-    Returns
-    -------
-    str
-        The hexadecimal color value.
+    **Returns**
+
+    `str` — The hexadecimal color value.
     """
     r, g, b = color_to_rgb(color, model)
     return f'#{r:02x}{g:02x}{b:02x}'
@@ -210,18 +202,14 @@ def color_to_hsl(color, model: ColorModel = 'hex'):
     The value is expected to be a string for "name" and "hex" models and
     a Tuple or List for "rgb" and "hsl" models.
 
-    Parameters
-    ----------
-    color : Any
-        The color values for the model being converted.
+    **Parameters**
 
-    model : Literal['rgb', 'hsl', 'hex']
-        The color model being converted.
+    - `color` (Any): The color values for the model being converted.
+    - `model` (Literal['rgb', 'hsl', 'hex']): The color model being converted.
 
-    Returns
-    -------
-    Tuple[int, int, int]
-        The hsl color values.
+    **Returns**
+
+    `Tuple[int, int, int]` — The hsl color values.
     """
     r, g, b = color_to_rgb(color, model)
     hls = rgb_to_hls(r / 255, g / 255, b / 255)
@@ -238,30 +226,18 @@ def update_hsl_value(
     """Change hue, saturation, or luminosity of the color based on the hue,
     sat, lum parameters provided.
 
-    Parameters
-    ----------
-    color : Any
-        The color.
+    **Parameters**
 
-    hue : int, optional
-        A number between 0 and 360.
+    - `color` (Any): The color.
+    - `hue` (int, optional): A number between 0 and 360.
+    - `sat` (int, optional): A number between 0 and 100.
+    - `lum` (int, optional): A number between 0 and 100.
+    - `in_model` (Literal['rgb', 'hsl', 'hex']): The color model of the input color.
+    - `out_model` (Literal['rgb', 'hsl', 'hex']): The color model of the output color.
 
-    sat : int, optional
-        A number between 0 and 100.
+    **Returns**
 
-    lum : int, optional
-        A number between 0 and 100.
-
-    in_model : Literal['rgb', 'hsl', 'hex']
-        The color model of the input color.
-
-    out_model : Literal['rgb', 'hsl', 'hex']
-        The color model of the output color.
-
-    Returns
-    -------
-    Tuple[int, int, int]
-       The color value based on the selected color model.
+    `Tuple[int, int, int]` — The color value based on the selected color model.
     """
     h, s, l = color_to_hsl(color, in_model)
     if hue is not None:
@@ -284,24 +260,16 @@ def contrast_color(
     """The best matching contrasting light or dark color for the given color.
     https://stackoverflow.com/questions/1855884/determine-font-color-based-on-background-color
 
-    Parameters
-    ----------
-    color : str
-        The color value to evaluate.
+    **Parameters**
 
-    model : Literal['rgb', 'hsl', 'hex']
-        The model of the color value to be evaluated. 'rgb' by default.
+    - `color` (str): The color value to evaluate.
+    - `model` (Literal['rgb', 'hsl', 'hex']): The model of the color value to be evaluated. 'rgb' by default.
+    - `dark_color` (str): The color of the dark contrasting color.
+    - `light_color` (str): The color of the light contrasting color.
 
-    dark_color : str
-        The color of the dark contrasting color.
+    **Returns**
 
-    light_color : str
-        The color of the light contrasting color.
-
-    Returns
-    -------
-    str
-        The matching color value.
+    `str` — The matching color value.
     """
     if model != 'rgb':
         r, g, b = color_to_rgb(color, model)
@@ -319,19 +287,14 @@ def conform_color_model(color, model: ColorModel):
     """Conform the color values to a string that can be interpreted by the
     `PIL.ImageColor.getrgb method`.
 
-    Parameters
-    ----------
-    color : Any
-        The color value to conform.
+    **Parameters**
 
-    model : Literal['rgb', 'hsl', 'hex']
-        The model of the color to evaluate (rgb, hex, hsl).
+    - `color` (Any): The color value to conform.
+    - `model` (Literal['rgb', 'hsl', 'hex']): The model of the color to evaluate (rgb, hex, hsl).
 
-    Returns
-    -------
-    str
-        A color value string that can be used as a parameter in the
-        PIL.ImageColor.getrgb method.
+    **Returns**
+
+    `str` — A color value string that can be used as a parameter in the PIL.ImageColor.getrgb method.
     """
     if model == 'hsl':
         hue = clamp(color[0], 0, HUE)
@@ -350,22 +313,15 @@ def conform_color_model(color, model: ColorModel):
 def make_transparent(alpha, foreground, background='#fff'):
     """Simulate color transparency.
 
-    Parameters
-    ----------
-    alpha : float
-        The amount of transparency between 0.0 and 1.0.
+    **Parameters**
 
-    foreground : str
-        The foreground color.
+    - `alpha` (float): The amount of transparency between 0.0 and 1.0.
+    - `foreground` (str): The foreground color.
+    - `background` (str): The background color.
 
-    background : str
-        The background color.
+    **Returns**
 
-    Returns
-    -------
-    str
-        A hexadecimal color representing the "transparent" version of the
-        foreground color against the background color.
+    `str` — A hexadecimal color representing the "transparent" version of the foreground color against the background color.
     """
     fg = ImageColor.getrgb(foreground)
     bg = ImageColor.getrgb(background)

--- a/src/ttkbootstrap/widgets/composites/accordion.py
+++ b/src/ttkbootstrap/widgets/composites/accordion.py
@@ -17,8 +17,8 @@ class Accordion(Frame):
     """A container of Expander widgets with optional mutual exclusion.
 
     The Accordion manages a group of Expanders, optionally enforcing that only
-    one can be expanded at a time. When ``allow_multiple=False``, expanding one
-    section automatically collapses the others. When ``allow_collapse_all=False``,
+    one can be expanded at a time. When `allow_multiple=False`, expanding one
+    section automatically collapses the others. When `allow_collapse_all=False`,
     at least one section must remain open.
 
     Attributes:
@@ -26,8 +26,8 @@ class Accordion(Frame):
         expanded (list[Expander]): Currently expanded Expander(s).
 
     !!! note "Events"
-        - ``<<AccordionChange>>``: Fired when the expanded section(s) change.
-          ``event.data = {'expanded': list[Expander]}``
+        - `<<AccordionChange>>`: Fired when the expanded section(s) change.
+          `event.data = {'expanded': list[Expander]}`
     """
 
     def __init__(
@@ -365,21 +365,21 @@ class Accordion(Frame):
         return None
 
     def on_accordion_changed(self, callback: Callable) -> str:
-        """Bind callback to ``<<AccordionChange>>`` events.
+        """Bind callback to `<<AccordionChange>>` events.
 
         Args:
             callback: Function to call when expanded sections change.
-                Receives event with ``event.data = {'expanded': list[Expander]}``.
+                Receives event with `event.data = {'expanded': list[Expander]}`.
 
         Returns:
-            Bind ID that can be passed to ``off_accordion_changed`` to remove this callback.
+            Bind ID that can be passed to `off_accordion_changed` to remove this callback.
         """
         return self.bind('<<AccordionChange>>', callback, add='+')
 
     def off_accordion_changed(self, bind_id: str = None):
-        """Unbind ``<<AccordionChange>>`` callback(s).
+        """Unbind `<<AccordionChange>>` callback(s).
 
         Args:
-            bind_id (str | None): Bind ID returned by ``on_accordion_changed``. If None, unbinds all.
+            bind_id (str | None): Bind ID returned by `on_accordion_changed`. If None, unbinds all.
         """
         self.unbind('<<AccordionChange>>', bind_id)

--- a/src/ttkbootstrap/widgets/composites/appshell.py
+++ b/src/ttkbootstrap/widgets/composites/appshell.py
@@ -40,8 +40,8 @@ class AppShellKwargs(TypedDict, total=False):
 class AppShell(App):
     """A top-level application window with built-in navigation.
 
-    AppShell extends ``App`` and wires together a ``Toolbar``,
-    ``SideNav``, and ``PageStack`` into the common
+    AppShell extends `App` and wires together a `Toolbar`,
+    `SideNav`, and `PageStack` into the common
     toolbar + sidebar + content layout. Each component is optional
     and exposed as a property for customization.
 
@@ -92,8 +92,8 @@ class AppShell(App):
             resizable: Whether the window is resizable as (width, height).
             frameless: If True, remove OS window chrome (title bar, borders)
                 and rely on the toolbar for window controls and dragging.
-                Automatically enables ``show_window_controls`` and
-                ``draggable`` when True. Default False.
+                Automatically enables `show_window_controls` and
+                `draggable` when True. Default False.
             show_toolbar: Include the toolbar at the top. Default True.
             show_window_controls: Show minimize/maximize/close buttons
                 in the toolbar. Default False.
@@ -262,12 +262,12 @@ class AppShell(App):
 
         Returns:
             The page widget (passed or auto-created Frame). When
-            ``scrollable=True``, returns the ScrollView so that children
+            `scrollable=True`, returns the ScrollView so that children
             are packed into the scrollable area.
 
         Raises:
-            RuntimeError: If ``show_nav=False`` was set. Use
-                ``shell.pages.add()`` directly instead.
+            RuntimeError: If `show_nav=False` was set. Use
+                `shell.pages.add()` directly instead.
         """
         if self._nav is None:
             raise RuntimeError(
@@ -319,7 +319,7 @@ class AppShell(App):
     ):
         """Add a navigation group.
 
-        Passthrough to ``nav.add_group()``.
+        Passthrough to `nav.add_group()`.
 
         Args:
             key: Unique identifier for the group.
@@ -338,7 +338,7 @@ class AppShell(App):
     def add_header(self, text: str, **kwargs):
         """Add a section header to the navigation.
 
-        Passthrough to ``nav.add_header()``.
+        Passthrough to `nav.add_header()`.
 
         Args:
             text: Header text.
@@ -354,7 +354,7 @@ class AppShell(App):
     def add_separator(self, **kwargs):
         """Add a separator to the navigation.
 
-        Passthrough to ``nav.add_separator()``.
+        Passthrough to `nav.add_separator()`.
 
         Args:
             **kwargs: Additional arguments passed to SideNavSeparator.
@@ -392,7 +392,7 @@ class AppShell(App):
             self._navigating = False
 
     def select(self, key: str, data: dict = None):
-        """Alias for ``navigate()``.
+        """Alias for `navigate()`.
 
         Args:
             key: The page key to navigate to.
@@ -409,7 +409,7 @@ class AppShell(App):
             callback: Function to call when the page changes.
 
         Returns:
-            Binding identifier for use with ``off_page_changed()``.
+            Binding identifier for use with `off_page_changed()`.
         """
         return self._pages.on_page_changed(callback)
 
@@ -417,7 +417,7 @@ class AppShell(App):
         """Unbind from page change events.
 
         Args:
-            bind_id: The binding identifier returned by ``on_page_changed()``.
+            bind_id: The binding identifier returned by `on_page_changed()`.
         """
         self._pages.off_page_changed(bind_id)
 
@@ -425,12 +425,12 @@ class AppShell(App):
 
     @property
     def toolbar(self) -> Toolbar | None:
-        """The Toolbar widget, or None if ``show_toolbar=False``."""
+        """The Toolbar widget, or None if `show_toolbar=False`."""
         return self._toolbar
 
     @property
     def nav(self) -> SideNav | None:
-        """The SideNav widget, or None if ``show_nav=False``."""
+        """The SideNav widget, or None if `show_nav=False`."""
         return self._nav
 
     @property

--- a/src/ttkbootstrap/widgets/composites/calendar.py
+++ b/src/ttkbootstrap/widgets/composites/calendar.py
@@ -114,13 +114,13 @@ class Calendar(ttk.Frame):
         Args:
             master: Parent widget. If None, uses the default root window.
             value (date | datetime | str): Initial selected date for single selection mode.
-            start_date (date | datetime | str): Range start date. Use ``value`` instead
+            start_date (date | datetime | str): Range start date. Use `value` instead
                 for single selection mode.
             end_date (date | datetime | str): Range end date. Only used when
-                ``selection_mode='range'``.
+                `selection_mode='range'`.
             disabled_dates (Iterable): Collection of dates that cannot be selected.
-            selection_mode (str): Selection mode - ``'single'`` for single date or
-                ``'range'`` for date range selection.
+            selection_mode (str): Selection mode - `'single'` for single date or
+                `'range'` for date range selection.
             max_date (date | datetime | str): Maximum selectable date. Dates after
                 this are disabled.
             min_date (date | datetime | str): Minimum selectable date. Dates before
@@ -206,7 +206,7 @@ class Calendar(ttk.Frame):
     def set(self, value: date | datetime | str | None) -> None:
         """Set the selected date programmatically.
 
-        This method does NOT emit ``<<DateSelect>>``. Use for programmatic
+        This method does NOT emit `<<DateSelect>>`. Use for programmatic
         updates when you don't want to trigger event handlers.
 
         Args:
@@ -231,7 +231,7 @@ class Calendar(ttk.Frame):
     def value(self) -> date | None:
         """The currently selected date.
 
-        This property provides convenient access to ``get()`` and ``set()``.
+        This property provides convenient access to `get()` and `set()`.
         """
         return self.get()
 
@@ -257,7 +257,7 @@ class Calendar(ttk.Frame):
     ) -> None:
         """Set the selected date range programmatically.
 
-        This method does NOT emit ``<<DateSelect>>``. Use for programmatic
+        This method does NOT emit `<<DateSelect>>`. Use for programmatic
         updates when you don't want to trigger event handlers.
 
         If both start and end are provided and end < start, they are
@@ -281,8 +281,8 @@ class Calendar(ttk.Frame):
     def range(self) -> tuple[date | None, date | None]:
         """The selected date range as (start, end).
 
-        This property provides convenient access to ``get_range()`` and
-        ``set_range()``.
+        This property provides convenient access to `get_range()` and
+        `set_range()`.
         """
         return self.get_range()
 
@@ -308,11 +308,11 @@ class Calendar(ttk.Frame):
 
     # Event binding ---------------------------------------------------
     def on_date_selected(self, callback: Callable) -> str:
-        """Bind to ``<<DateSelect>>``. Callback receives ``event.data = {'date': date, 'range': tuple[date, date | None]}``."""
+        """Bind to `<<DateSelect>>`. Callback receives `event.data = {'date': date, 'range': tuple[date, date | None]}`."""
         return self.bind("<<DateSelect>>", callback, add=True)
 
     def off_date_selected(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<DateSelect>>``."""
+        """Unbind from `<<DateSelect>>`."""
         return self.unbind("<<DateSelect>>", bind_id)
 
     # --- UI construction --------------------------------------------

--- a/src/ttkbootstrap/widgets/composites/compositeframe.py
+++ b/src/ttkbootstrap/widgets/composites/compositeframe.py
@@ -193,11 +193,11 @@ class Composite:
         self._update_states()
 
     def on_invoked(self, callback) -> str:
-        """Bind to ``<<CompositeInvoke>>``. Callback receives ``event.data = None``. Fired when clicking on non-button registered widgets."""
+        """Bind to `<<CompositeInvoke>>`. Callback receives `event.data = None`. Fired when clicking on non-button registered widgets."""
         return self._event_target.bind('<<CompositeInvoke>>', callback, add='+')
 
     def off_invoked(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<CompositeInvoke>>``."""
+        """Unbind from `<<CompositeInvoke>>`."""
         return self._event_target.unbind('<<CompositeInvoke>>', bind_id)
 
 
@@ -274,9 +274,9 @@ class CompositeFrame(Frame):
         return self._composite.disabled
 
     def on_invoked(self, callback) -> str:
-        """Bind to ``<<CompositeInvoke>>``. Callback receives ``event.data = None``. Fired when clicking on non-button registered widgets."""
+        """Bind to `<<CompositeInvoke>>`. Callback receives `event.data = None`. Fired when clicking on non-button registered widgets."""
         return self._composite.on_invoked(callback)
 
     def off_invoked(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<CompositeInvoke>>``."""
+        """Unbind from `<<CompositeInvoke>>`."""
         return self._composite.off_invoked(bind_id)

--- a/src/ttkbootstrap/widgets/composites/contextmenu.py
+++ b/src/ttkbootstrap/widgets/composites/contextmenu.py
@@ -81,7 +81,7 @@ class ContextMenuItem:
 class _ToplevelContextMenu(CustomConfigMixin):
     """Themed Toplevel-backed context menu (Win/Linux backend).
 
-    Internal backend used by ``ContextMenu`` on Windows and Linux. Renders
+    Internal backend used by `ContextMenu` on Windows and Linux. Renders
     items as ttkbootstrap-styled widgets inside an overrideredirect Toplevel
     so theme tokens, density, and rich item types apply consistently.
     """
@@ -113,10 +113,10 @@ class _ToplevelContextMenu(CustomConfigMixin):
             anchor: Anchor point on the menu to align (e.g., 'nw', 'ne', 'sw', 'se', 'center').
             attach: Anchor point on the target to align to (same options as anchor).
             offset: Tuple (dx, dy) applied after alignment. Defaults to
-                ``(scale_from_source(10), 0)`` to account for the focus-ring
+                `(scale_from_source(10), 0)` to account for the focus-ring
                 affordance baked into trigger button images, so attached menus
                 align with the visible button border out of the box. Pass
-                ``(0, 0)`` explicitly to position the menu at the exact anchor
+                `(0, 0)` explicitly to position the menu at the exact anchor
                 point with no offset.
             hide_on_outside_click: If True, menu hides when clicking outside.
                 Default is True.
@@ -142,7 +142,7 @@ class _ToplevelContextMenu(CustomConfigMixin):
         self._click_bind_after_id = None
 
         # Create toplevel window. This backend is selected on Win/Linux only;
-        # Aqua dispatches to ``_NativeContextMenu`` to avoid the key-window
+        # Aqua dispatches to `_NativeContextMenu` to avoid the key-window
         # activation issues that affect a reused overrideredirect Toplevel
         # on macOS.
         self._toplevel = Toplevel(master)
@@ -234,7 +234,7 @@ class _ToplevelContextMenu(CustomConfigMixin):
         return key
 
     def on_item_click(self, callback: Callable) -> None:
-        """Set item click callback. Callback receives ``item_info = {'type': str, 'text': str, 'value': Any}``."""
+        """Set item click callback. Callback receives `item_info = {'type': str, 'text': str, 'value': Any}`."""
         self._on_item_click_callback = callback
 
     def off_item_click(self) -> None:
@@ -977,12 +977,12 @@ class _ToplevelContextMenu(CustomConfigMixin):
 
 
 class _NativeContextMenu(CustomConfigMixin):
-    """Native ``tk.Menu``-backed context menu (Aqua/Windows backend).
+    """Native `tk.Menu`-backed context menu (Aqua/Windows backend).
 
-    Internal backend used by ``ContextMenu`` on macOS so the popup is a real
+    Internal backend used by `ContextMenu` on macOS so the popup is a real
     NSMenu — sidesteps the key-window/activation issues that affect a
     reused overrideredirect Toplevel. Theming follows the system menu look;
-    icons resolve through ``BootstrapIcon`` and re-render on theme change.
+    icons resolve through `BootstrapIcon` and re-render on theme change.
     """
 
     def __init__(
@@ -1002,10 +1002,10 @@ class _NativeContextMenu(CustomConfigMixin):
     ):
         """Initialize the native tk.Menu backend.
 
-        Args mirror the themed backend so the public ``ContextMenu`` API is
-        identical across platforms. Several options (``minwidth``, ``width``,
-        ``height``, ``hide_on_outside_click``, ``density``) are stored for
-        ``cget`` parity but have no effect — the system menu controls
+        Args mirror the themed backend so the public `ContextMenu` API is
+        identical across platforms. Several options (`minwidth`, `width`,
+        `height`, `hide_on_outside_click`, `density`) are stored for
+        `cget` parity but have no effect — the system menu controls
         sizing, dismissal, and typography on the host platform.
         """
         import tkinter as tk
@@ -1080,7 +1080,7 @@ class _NativeContextMenu(CustomConfigMixin):
     def _resolve_icon(self, icon_spec: Any) -> tuple[Any, str | None, int]:
         """Resolve an icon spec via MenuManager.
 
-        Returns ``(None, None, 0)`` when no manager is available or the
+        Returns `(None, None, 0)` when no manager is available or the
         spec doesn't produce an icon, mirroring MenuManager's contract.
         """
         if self._mgr is None:
@@ -1103,9 +1103,9 @@ class _NativeContextMenu(CustomConfigMixin):
     def _resolve_shortcut(self, shortcut: str | None) -> str | None:
         """Platform-correct accelerator display via the Shortcuts service.
 
-        Accepts a registered key, a modifier pattern (``'Mod+S'``,
-        ``'F5'``), or a literal display string. See
-        ``ttkbootstrap.runtime.shortcuts.format_shortcut`` for details.
+        Accepts a registered key, a modifier pattern (`'Mod+S'`,
+        `'F5'`), or a literal display string. See
+        `ttkbootstrap.runtime.shortcuts.format_shortcut` for details.
         """
         if not shortcut:
             return None
@@ -1301,7 +1301,7 @@ class _NativeContextMenu(CustomConfigMixin):
         """Return the spec dict for an item.
 
         Note: native backend has no per-item widget. The returned dict is
-        the original spec passed to ``add_*`` — useful for inspection but
+        the original spec passed to `add_*` — useful for inspection but
         not a Tk widget. Mutating it does not affect the rendered menu.
         """
         key = self._resolve_key(key_or_index)
@@ -1398,7 +1398,7 @@ class _NativeContextMenu(CustomConfigMixin):
     def _rebuild_menu(self) -> None:
         """Tear down and re-add all entries from stored specs.
 
-        Used by ``insert_item`` and ``move_item`` since tk.Menu offers no
+        Used by `insert_item` and `move_item` since tk.Menu offers no
         atomic reorder. Icon tracking is unregistered then re-registered
         with MenuManager so theme-change updates target the right indices.
         """
@@ -1486,11 +1486,11 @@ class _NativeContextMenu(CustomConfigMixin):
                 )
 
     def _compute_position(self, position: tuple[int, int] | None) -> tuple[int, int]:
-        """Resolve the screen-coordinate target for ``tk_popup``.
+        """Resolve the screen-coordinate target for `tk_popup`.
 
         Mirrors the themed backend's anchor/attach/offset semantics, but
         without the menu-size step (the native menu auto-positions). When
-        ``position`` is given, anchor/attach are ignored and only ``offset``
+        `position` is given, anchor/attach are ignored and only `offset`
         applies, matching the themed backend behavior.
         """
         if position is not None:
@@ -1616,14 +1616,14 @@ class _NativeContextMenu(CustomConfigMixin):
 class ContextMenu:
     """Public ContextMenu — dispatches to a platform-appropriate backend.
 
-    On macOS this materializes as a native ``tk.Menu`` (NSMenu) so popups
+    On macOS this materializes as a native `tk.Menu` (NSMenu) so popups
     integrate with the system, dodging the key-window/activation issues
     that affect a reused overrideredirect Toplevel on Aqua. On Windows
     and Linux it uses the themed Toplevel-backed implementation so
     bootstyle, density, and rich item types apply consistently.
 
     The public API is identical across backends. Consumers should not
-    rely on ``item()`` returning a Tk widget — on the native backend it
+    rely on `item()` returning a Tk widget — on the native backend it
     returns the original spec dict, since no per-item widget exists.
     """
 
@@ -1645,31 +1645,31 @@ class ContextMenu:
     ):
         """Create a ContextMenu.
 
-        Args mirror the underlying backend; ``trigger`` is a dispatcher-level
-        convenience that auto-binds the menu to ``target``'s click event so
-        callers don't have to wire a ``bind('<Button-3>', show_at)`` handler
-        themselves. Set ``trigger=None`` (or ``'manual'``) to opt out and
+        Args mirror the underlying backend; `trigger` is a dispatcher-level
+        convenience that auto-binds the menu to `target`'s click event so
+        callers don't have to wire a `bind('<Button-3>', show_at)` handler
+        themselves. Set `trigger=None` (or `'manual'`) to opt out and
         manage activation in caller code (e.g. when the menu is built lazily).
 
-        ``target`` defaults to ``master`` when omitted, since the menu is
-        usually attached to the same widget that owns it. Pass ``target=None``
+        `target` defaults to `master` when omitted, since the menu is
+        usually attached to the same widget that owns it. Pass `target=None`
         explicitly to opt out of positioning/auto-binding (e.g. when calling
-        ``show(position=(x, y))`` with cursor-driven coordinates instead).
+        `show(position=(x, y))` with cursor-driven coordinates instead).
 
         Trigger values:
-            - ``'right-click'`` (default): portable right-click via
-              ``ttkbootstrap.runtime.utility.bind_right_click`` —
-              ``<Button-3>`` on Win/Linux plus ``<Button-2>`` and
-              ``<Control-Button-1>`` on Aqua.
-            - ``'click'`` / ``'left-click'``: ``<Button-1>``.
-            - ``'double-click'``: ``<Double-Button-1>``.
-            - ``'shift-click'``: ``<Shift-Button-1>``.
-            - ``'ctrl-click'`` / ``'control-click'``: ``<Control-Button-1>``
+            - `'right-click'` (default): portable right-click via
+              `ttkbootstrap.runtime.utility.bind_right_click` —
+              `<Button-3>` on Win/Linux plus `<Button-2>` and
+              `<Control-Button-1>` on Aqua.
+            - `'click'` / `'left-click'`: `<Button-1>`.
+            - `'double-click'`: `<Double-Button-1>`.
+            - `'shift-click'`: `<Shift-Button-1>`.
+            - `'ctrl-click'` / `'control-click'`: `<Control-Button-1>`
               (note that on Aqua this is the same as Ctrl+click for context
               menus, since macOS uses Ctrl+click as a context-menu gesture).
-            - ``None`` or ``'manual'``: no auto-binding.
+            - `None` or `'manual'`: no auto-binding.
         """
-        # Default target to master when omitted; explicit ``None`` opts out.
+        # Default target to master when omitted; explicit `None` opts out.
         if target is _TARGET_DEFAULT:
             target = master
 
@@ -1713,7 +1713,7 @@ class ContextMenu:
             self._bind_trigger(target, trigger)
 
     def _bind_trigger(self, target: Misc, trigger: str) -> None:
-        """Bind ``target``'s activation event to show this menu at the click."""
+        """Bind `target`'s activation event to show this menu at the click."""
         from ttkbootstrap.runtime.utility import bind_right_click
 
         def show_at(event):
@@ -1737,7 +1737,7 @@ class ContextMenu:
             )
 
     # Forward every other attribute (methods, configure delegates, etc.)
-    # to the active backend. ``_impl`` itself is a real instance attribute
+    # to the active backend. `_impl` itself is a real instance attribute
     # so it's resolved by normal attribute lookup before __getattr__ runs.
     def __getattr__(self, name: str):
         # __getattr__ is only consulted when normal lookup fails, so we

--- a/src/ttkbootstrap/widgets/composites/dateentry.py
+++ b/src/ttkbootstrap/widgets/composites/dateentry.py
@@ -26,22 +26,22 @@ class DateEntry(Field):
     supports various date format presets and custom ICU date format patterns,
     and can accept input as strings, date objects, or datetime objects.
 
-    The available date format presets are: ``longDate`` (January 15, 2025),
-    ``shortDate`` (1/15/25), ``monthAndDate`` (January 15), ``monthAndYear``
-    (January 2025), ``quarterAndYear`` (Q1 2025), ``day`` (15), ``dayOfWeek``
-    (Wednesday), ``month`` (January), ``quarter`` (Q1), ``year`` (2025),
-    ``longTime`` (3:30:45 PM PST), ``shortTime`` (3:30 PM), ``longDateLongTime``,
-    ``shortDateShortTime``, or any custom ICU date format pattern (e.g., "yyyy-MM-dd").
+    The available date format presets are: `longDate` (January 15, 2025),
+    `shortDate` (1/15/25), `monthAndDate` (January 15), `monthAndYear`
+    (January 2025), `quarterAndYear` (Q1 2025), `day` (15), `dayOfWeek`
+    (Wednesday), `month` (January), `quarter` (Q1), `year` (2025),
+    `longTime` (3:30:45 PM PST), `shortTime` (3:30 PM), `longDateLongTime`,
+    `shortDateShortTime`, or any custom ICU date format pattern (e.g., "yyyy-MM-dd").
 
     !!! note "Events"
 
-        - ``<<Change>>``: Fired when date value changes after commit.
-        - ``<<Input>>``: Fired on each keystroke.
-        - ``<<Valid>>``: Fired when validation passes.
-        - ``<<Invalid>>``: Fired when validation fails.
+        - `<<Change>>`: Fired when date value changes after commit.
+        - `<<Input>>`: Fired on each keystroke.
+        - `<<Valid>>`: Fired when validation passes.
+        - `<<Invalid>>`: Fired when validation fails.
 
         The calendar picker button uses a DateDialog. The button can be hidden
-        using ``show_picker_button=False``.
+        using `show_picker_button=False`.
 
     Attributes:
         entry_widget (TextEntryPart): Access to the underlying TextEntryPart widget.

--- a/src/ttkbootstrap/widgets/composites/dropdownbutton.py
+++ b/src/ttkbootstrap/widgets/composites/dropdownbutton.py
@@ -120,7 +120,7 @@ class DropdownButton(MenuButton):
         self.items = self._context_menu.items
 
     def on_item_click(self, callback: Callable) -> None:
-        """Set item click callback. Callback receives ``item_info = {'type': str, 'text': str, 'value': Any}``."""
+        """Set item click callback. Callback receives `item_info = {'type': str, 'text': str, 'value': Any}`."""
         self._item_click_callback = callback
         self._context_menu.on_item_click(callback)
 

--- a/src/ttkbootstrap/widgets/composites/expander.py
+++ b/src/ttkbootstrap/widgets/composites/expander.py
@@ -22,8 +22,8 @@ class Expander(Frame):
     button. Clicking anywhere on the header toggles the visibility of the
     content area.
 
-    Expander also supports selection state via ``signal``/``variable`` and
-    ``value``, similar to RadioButton. When clicked, it sets the variable to
+    Expander also supports selection state via `signal`/`variable` and
+    `value`, similar to RadioButton. When clicked, it sets the variable to
     its value, enabling radio-group-like behavior for navigation.
 
     Attributes:
@@ -31,10 +31,10 @@ class Expander(Frame):
         is_selected (bool): Whether this expander's value matches the variable (read-only).
 
     !!! note "Events"
-        - ``<<Toggle>>``: Fired when expanded/collapsed.
-          ``event.data = {'expanded': bool}``
-        - ``<<Selected>>``: Fired when this expander is selected.
-          ``event.data = {'value': Any}``
+        - `<<Toggle>>`: Fired when expanded/collapsed.
+          `event.data = {'expanded': bool}`
+        - `<<Selected>>`: Fired when this expander is selected.
+          `event.data = {'value': Any}`
     """
 
     def __init__(
@@ -326,42 +326,42 @@ class Expander(Frame):
         return False
 
     def on_toggled(self, callback: Callable) -> str:
-        """Bind callback to ``<<Toggle>>`` events.
+        """Bind callback to `<<Toggle>>` events.
 
         Args:
             callback: Function to call when toggled. Receives event with
-                ``event.data = {'expanded': bool}``.
+                `event.data = {'expanded': bool}`.
 
         Returns:
-            Bind ID that can be passed to ``off_toggled`` to remove this callback.
+            Bind ID that can be passed to `off_toggled` to remove this callback.
         """
         return self.bind('<<Toggle>>', callback, add='+')
 
     def off_toggled(self, bind_id: str | None = None) -> None:
-        """Unbind ``<<Toggle>>`` callback(s).
+        """Unbind `<<Toggle>>` callback(s).
 
         Args:
-            bind_id: Bind ID returned by ``on_toggled``. If None, unbinds all.
+            bind_id: Bind ID returned by `on_toggled`. If None, unbinds all.
         """
         self.unbind('<<Toggle>>', bind_id)
 
     def on_selected(self, callback: Callable) -> str:
-        """Bind callback to ``<<Selected>>`` events.
+        """Bind callback to `<<Selected>>` events.
 
         Args:
             callback: Function to call when selected. Receives event with
-                ``event.data = {'value': Any}``.
+                `event.data = {'value': Any}`.
 
         Returns:
-            Bind ID that can be passed to ``off_selected`` to remove this callback.
+            Bind ID that can be passed to `off_selected` to remove this callback.
         """
         return self.bind('<<Selected>>', callback, add='+')
 
     def off_selected(self, bind_id: str = None):
-        """Unbind ``<<Selected>>`` callback(s).
+        """Unbind `<<Selected>>` callback(s).
 
         Args:
-            bind_id (str | None): Bind ID returned by ``on_selected``. If None, unbinds all.
+            bind_id (str | None): Bind ID returned by `on_selected`. If None, unbinds all.
         """
         self.unbind('<<Selected>>', bind_id)
 

--- a/src/ttkbootstrap/widgets/composites/field.py
+++ b/src/ttkbootstrap/widgets/composites/field.py
@@ -92,24 +92,24 @@ class Field(EntryMixin, Frame):
 
     The widget automatically handles layout, focus states, validation feedback, and
     provides a consistent API for all entry-based components. It supports both text
-    and numeric input types through the ``kind`` parameter.
+    and numeric input types through the `kind` parameter.
 
     !!! note "Events"
 
-        - ``<<Input>>``: Triggered on each keystroke.
-          Provides ``event.data`` with keys: ``text``.
+        - `<<Input>>`: Triggered on each keystroke.
+          Provides `event.data` with keys: `text`.
 
-        - ``<<Change>>``: Triggered when value changes after commit.
-          Provides ``event.data`` with keys: ``value``, ``prev_value``, ``text``.
+        - `<<Change>>`: Triggered when value changes after commit.
+          Provides `event.data` with keys: `value`, `prev_value`, `text`.
 
-        - ``<<Valid>>``: Triggered when validation passes.
-          Provides ``event.data`` with keys: ``value``, ``is_valid`` (True), ``message``.
+        - `<<Valid>>`: Triggered when validation passes.
+          Provides `event.data` with keys: `value`, `is_valid` (True), `message`.
 
-        - ``<<Invalid>>``: Triggered when validation fails.
-          Provides ``event.data`` with keys: ``value``, ``is_valid`` (False), ``message``.
+        - `<<Invalid>>`: Triggered when validation fails.
+          Provides `event.data` with keys: `value`, `is_valid` (False), `message`.
 
-        - ``<<Validate>>``: Triggered after any validation.
-          Provides ``event.data`` with keys: ``value``, ``is_valid`` (bool), ``message``.
+        - `<<Validate>>`: Triggered after any validation.
+          Provides `event.data` with keys: `value`, `is_valid` (bool), `message`.
 
     Attributes:
         variable (Variable): Tkinter Variable linked to entry text.

--- a/src/ttkbootstrap/widgets/composites/floodgauge.py
+++ b/src/ttkbootstrap/widgets/composites/floodgauge.py
@@ -39,22 +39,22 @@ class FloodGauge(ConfigureDelegationMixin, Canvas):
             master: Parent widget. If None, uses the default root window.
             value (int): Initial progress value (0-maximum).
             maximum (int): Maximum value for determinate range.
-            mode (str): Progress mode - ``'determinate'`` for known progress or
-                ``'indeterminate'`` for unknown duration.
-            mask (str): Format string for text overlay with ``'{}'`` placeholder for
-                the value. Examples: ``'{}% Complete'`` or ``'Progress: {}/100'``.
+            mode (str): Progress mode - `'determinate'` for known progress or
+                `'indeterminate'` for unknown duration.
+            mask (str): Format string for text overlay with `'{}'` placeholder for
+                the value. Examples: `'{}% Complete'` or `'Progress: {}/100'`.
                 If None, no automatic text formatting is applied.
             text (str): Static text label shown when no mask is specified.
-            font (tuple | str): Font specification as tuple ``(family, size)`` or
-                string like ``'Arial 12 bold'``.
-            accent (str): Accent token from ttkbootstrap (e.g., ``'primary'``,
-                ``'success'``, ``'info'``, ``'warning'``, ``'danger'``).
-            orient (str): Widget orientation - ``'horizontal'`` or ``'vertical'``.
+            font (tuple | str): Font specification as tuple `(family, size)` or
+                string like `'Arial 12 bold'`.
+            accent (str): Accent token from ttkbootstrap (e.g., `'primary'`,
+                `'success'`, `'info'`, `'warning'`, `'danger'`).
+            orient (str): Widget orientation - `'horizontal'` or `'vertical'`.
             length (int): Size in pixels along the main axis (width if horizontal,
                 height if vertical).
             thickness (int): Size in pixels along the minor axis (height if horizontal,
                 width if vertical).
-            increment (int): Step size for value changes when using ``step()`` method
+            increment (int): Step size for value changes when using `step()` method
                 or during animations.
 
         Other Parameters:
@@ -63,7 +63,7 @@ class FloodGauge(ConfigureDelegationMixin, Canvas):
 
         Note:
             The widget automatically updates colors when the theme changes via the
-            ``<<ThemeChanged>>`` event. When using variable or textvariable bindings,
+            `<<ThemeChanged>>` event. When using variable or textvariable bindings,
             the widget redraws automatically when the variables change.
         """
 

--- a/src/ttkbootstrap/widgets/composites/form.py
+++ b/src/ttkbootstrap/widgets/composites/form.py
@@ -115,20 +115,20 @@ class Form(Frame):
     and manipulating form fields and their values.
 
     Field Access:
-        - ``field(key)`` — returns the Field widget for a key
-        - ``fields()`` — returns all Field widgets in order
-        - ``keys()`` — returns all field keys in order
+        - `field(key)` — returns the Field widget for a key
+        - `fields()` — returns all Field widgets in order
+        - `keys()` — returns all field keys in order
 
     Value Operations:
-        - ``get_field_value(key)`` — get a single field's value
-        - ``set_field_value(key, value)`` — set a single field's value
-        - ``get()`` / ``set(values)`` — get/set all values as a dict
-        - ``value`` property — get/set all values as a dict
+        - `get_field_value(key)` — get a single field's value
+        - `set_field_value(key, value)` — set a single field's value
+        - `get()` / `set(values)` — get/set all values as a dict
+        - `value` property — get/set all values as a dict
 
     Variable & Signal Access:
-        - ``field_variable(key)`` — get Tk Variable for a field
-        - ``field_signal(key)`` — get Signal for a field's value
-        - ``field_textsignal(key)`` — get Signal for a field's text
+        - `field_variable(key)` — get Tk Variable for a field
+        - `field_signal(key)` — get Signal for a field's value
+        - `field_textsignal(key)` — get Signal for a field's text
 
     Attributes:
         data (dict): Current form data (read-only property).
@@ -393,7 +393,7 @@ class Form(Frame):
         """Return the Tk variable associated with a field key, if any.
 
         Deprecated:
-            Use ``field_variable(key)`` instead.
+            Use `field_variable(key)` instead.
         """
         return self.field_variable(key)
 
@@ -401,7 +401,7 @@ class Form(Frame):
         """Return the Signal associated with a field key, if any.
 
         Deprecated:
-            Use ``field_signal(key)`` instead.
+            Use `field_signal(key)` instead.
         """
         return self.field_signal(key)
 
@@ -409,7 +409,7 @@ class Form(Frame):
         """Return the TextSignal associated with a field key, if any.
 
         Deprecated:
-            Use ``field_textsignal(key)`` instead.
+            Use `field_textsignal(key)` instead.
         """
         return self.field_textsignal(key)
 

--- a/src/ttkbootstrap/widgets/composites/list/listitem.py
+++ b/src/ttkbootstrap/widgets/composites/list/listitem.py
@@ -21,13 +21,13 @@ class ListItem(CompositeFrame):
     registered child widgets using the Composite state coordinator.
 
     !!! note "Events"
-        - ``<<ItemClick>>``: Fired when the item is clicked.
-        - ``<<ItemSelecting>>``: Fired when the item is being selected/deselected.
-        - ``<<ItemRemoving>>``: Fired when the remove button is clicked.
-        - ``<<ItemFocus>>``: Fired when the item receives keyboard focus.
-        - ``<<ItemDragStart>>``: Fired when a drag operation begins.
-        - ``<<ItemDrag>>``: Fired during a drag operation.
-        - ``<<ItemDragEnd>>``: Fired when a drag operation ends.
+        - `<<ItemClick>>`: Fired when the item is clicked.
+        - `<<ItemSelecting>>`: Fired when the item is being selected/deselected.
+        - `<<ItemRemoving>>`: Fired when the remove button is clicked.
+        - `<<ItemFocus>>`: Fired when the item receives keyboard focus.
+        - `<<ItemDragStart>>`: Fired when a drag operation begins.
+        - `<<ItemDrag>>`: Fired during a drag operation.
+        - `<<ItemDragEnd>>`: Fired when a drag operation ends.
 
     Data fields:
         When update_data() is called, the following fields are recognized:

--- a/src/ttkbootstrap/widgets/composites/list/listview.py
+++ b/src/ttkbootstrap/widgets/composites/list/listview.py
@@ -333,15 +333,15 @@ class ListView(Frame):
     implementation for more complex scenarios (database, API, etc.).
 
     !!! note "Events"
-        - ``<<SelectionChange>>``: Fired when selection state changes. ``event.data = None`` (use ``get_selected()`` to get current selection)
-        - ``<<ItemDelete>>``: Fired when an item is deleted. ``event.data = {'record': dict}``
-        - ``<<ItemDeleteFail>>``: Fired when item deletion fails. ``event.data = {'record': dict, 'error': str}``
-        - ``<<ItemInsert>>``: Fired when a new item is inserted. ``event.data = {'record': dict}``
-        - ``<<ItemUpdate>>``: Fired when an item is updated. ``event.data = {'record': dict}``
-        - ``<<ItemClick>>``: Fired when an item is clicked. ``event.data = {'record': dict}``
-        - ``<<ItemDragStart>>``: Fired when a drag begins. ``event.data = {'record': dict, 'index': int}``
-        - ``<<ItemDrag>>``: Fired when an item is being dragged. ``event.data = {'source_index': int, 'target_index': int, 'x': int, 'y': int}``
-        - ``<<ItemDragEnd>>``: Fired when a drag ends. ``event.data = {'moved': bool, 'source_index': int, 'target_index': int}``
+        - `<<SelectionChange>>`: Fired when selection state changes. `event.data = None` (use `get_selected()` to get current selection)
+        - `<<ItemDelete>>`: Fired when an item is deleted. `event.data = {'record': dict}`
+        - `<<ItemDeleteFail>>`: Fired when item deletion fails. `event.data = {'record': dict, 'error': str}`
+        - `<<ItemInsert>>`: Fired when a new item is inserted. `event.data = {'record': dict}`
+        - `<<ItemUpdate>>`: Fired when an item is updated. `event.data = {'record': dict}`
+        - `<<ItemClick>>`: Fired when an item is clicked. `event.data = {'record': dict}`
+        - `<<ItemDragStart>>`: Fired when a drag begins. `event.data = {'record': dict, 'index': int}`
+        - `<<ItemDrag>>`: Fired when an item is being dragged. `event.data = {'source_index': int, 'target_index': int, 'x': int, 'y': int}`
+        - `<<ItemDragEnd>>`: Fired when a drag ends. `event.data = {'moved': bool, 'source_index': int, 'target_index': int}`
     """
 
     def __init__(
@@ -809,11 +809,11 @@ class ListView(Frame):
             pass
 
     def _bind_scroll_events(self, widget) -> None:
-        """Bind the platform-correct scroll-wheel events to ``widget``.
+        """Bind the platform-correct scroll-wheel events to `widget`.
 
-        On Aqua/Win the event is ``<MouseWheel>`` with ``event.delta``
+        On Aqua/Win the event is `<MouseWheel>` with `event.delta`
         carrying direction and magnitude. On X11 there's no MouseWheel —
-        scroll up is ``<Button-4>`` and scroll down is ``<Button-5>``.
+        scroll up is `<Button-4>` and scroll down is `<Button-5>`.
         """
         if self.winsys.lower() == 'x11':
             widget.bind('<Button-4>', self._on_mousewheel, add='+')
@@ -1435,73 +1435,73 @@ class ListView(Frame):
     # Event handler API
 
     def on_selection_changed(self, callback: Callable) -> str:
-        """Bind to ``<<SelectionChange>>``. Callback receives ``event.data = None`` (use ``get_selected()`` to get current selection)."""
+        """Bind to `<<SelectionChange>>`. Callback receives `event.data = None` (use `get_selected()` to get current selection)."""
         return self.bind('<<SelectionChange>>', callback, add='+')
 
     def off_selection_changed(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<SelectionChange>>``."""
+        """Unbind from `<<SelectionChange>>`."""
         self.unbind('<<SelectionChange>>', bind_id)
 
     def on_item_delete(self, callback: Callable) -> str:
-        """Bind to ``<<ItemDelete>>``. Callback receives ``event.data = {'record': dict}``."""
+        """Bind to `<<ItemDelete>>`. Callback receives `event.data = {'record': dict}`."""
         return self.bind('<<ItemDelete>>', callback, add='+')
 
     def off_item_delete(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<ItemDelete>>``."""
+        """Unbind from `<<ItemDelete>>`."""
         self.unbind('<<ItemDelete>>', bind_id)
 
     def on_item_delete_fail(self, callback: Callable) -> str:
-        """Bind to ``<<ItemDeleteFail>>``. Callback receives ``event.data = {'record': dict, 'error': str}``."""
+        """Bind to `<<ItemDeleteFail>>`. Callback receives `event.data = {'record': dict, 'error': str}`."""
         return self.bind('<<ItemDeleteFail>>', callback, add='+')
 
     def off_item_delete_fail(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<ItemDeleteFail>>``."""
+        """Unbind from `<<ItemDeleteFail>>`."""
         self.unbind('<<ItemDeleteFail>>', bind_id)
 
     def on_item_insert(self, callback: Callable) -> str:
-        """Bind to ``<<ItemInsert>>``. Callback receives ``event.data = {'record': dict}``."""
+        """Bind to `<<ItemInsert>>`. Callback receives `event.data = {'record': dict}`."""
         return self.bind('<<ItemInsert>>', callback, add='+')
 
     def off_item_insert(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<ItemInsert>>``."""
+        """Unbind from `<<ItemInsert>>`."""
         self.unbind('<<ItemInsert>>', bind_id)
 
     def on_item_update(self, callback: Callable) -> str:
-        """Bind to ``<<ItemUpdate>>``. Callback receives ``event.data = {'record': dict}``."""
+        """Bind to `<<ItemUpdate>>`. Callback receives `event.data = {'record': dict}`."""
         return self.bind('<<ItemUpdate>>', callback, add='+')
 
     def off_item_update(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<ItemUpdate>>``."""
+        """Unbind from `<<ItemUpdate>>`."""
         self.unbind('<<ItemUpdate>>', bind_id)
 
     def on_item_click(self, callback: Callable) -> str:
-        """Bind to ``<<ItemClick>>``. Callback receives ``event.data = {'record': dict}``."""
+        """Bind to `<<ItemClick>>`. Callback receives `event.data = {'record': dict}`."""
         return self.bind('<<ItemClick>>', callback, add='+')
 
     def off_item_click(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<ItemClick>>``."""
+        """Unbind from `<<ItemClick>>`."""
         self.unbind('<<ItemClick>>', bind_id)
 
     def on_item_drag_start(self, callback: Callable) -> str:
-        """Bind to ``<<ItemDragStart>>``. Callback receives ``event.data = {'record': dict, 'index': int}``."""
+        """Bind to `<<ItemDragStart>>`. Callback receives `event.data = {'record': dict, 'index': int}`."""
         return self.bind('<<ItemDragStart>>', callback, add='+')
 
     def off_item_drag_start(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<ItemDragStart>>``."""
+        """Unbind from `<<ItemDragStart>>`."""
         self.unbind('<<ItemDragStart>>', bind_id)
 
     def on_item_drag(self, callback: Callable) -> str:
-        """Bind to ``<<ItemDrag>>``. Callback receives ``event.data = {'source_index': int, 'target_index': int, 'x': int, 'y': int}``."""
+        """Bind to `<<ItemDrag>>`. Callback receives `event.data = {'source_index': int, 'target_index': int, 'x': int, 'y': int}`."""
         return self.bind('<<ItemDrag>>', callback, add='+')
 
     def off_item_drag(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<ItemDrag>>``."""
+        """Unbind from `<<ItemDrag>>`."""
         self.unbind('<<ItemDrag>>', bind_id)
 
     def on_item_drag_end(self, callback: Callable) -> str:
-        """Bind to ``<<ItemDragEnd>>``. Callback receives ``event.data = {'moved': bool, 'source_index': int, 'target_index': int}``."""
+        """Bind to `<<ItemDragEnd>>`. Callback receives `event.data = {'moved': bool, 'source_index': int, 'target_index': int}`."""
         return self.bind('<<ItemDragEnd>>', callback, add='+')
 
     def off_item_drag_end(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<ItemDragEnd>>``."""
+        """Unbind from `<<ItemDragEnd>>`."""
         self.unbind('<<ItemDragEnd>>', bind_id)

--- a/src/ttkbootstrap/widgets/composites/meter.py
+++ b/src/ttkbootstrap/widgets/composites/meter.py
@@ -23,14 +23,14 @@ class Meter(Frame):
 
     The meter value can be accessed and modified using:
 
-    - ``get()`` / ``set(value)`` - Standard value-widget API methods
-    - ``.value`` property - Direct property access
-    - ``configure(value=x)`` - Via the configure interface
+    - `get()` / `set(value)` - Standard value-widget API methods
+    - `.value` property - Direct property access
+    - `configure(value=x)` - Via the configure interface
 
     !!! note "Events"
 
-        ``<<Change>>``: Fired whenever the meter value changes.
-          Provides ``event.data`` with keys: ``value``, ``prev_value``.
+        `<<Change>>`: Fired whenever the meter value changes.
+          Provides `event.data` with keys: `value`, `prev_value`.
     """
 
     def __init__(
@@ -74,7 +74,7 @@ class Meter(Frame):
         Args:
             master: The parent widget.
             accent: Accent token for the meter indicator (e.g., 'primary', 'success').
-            bootstyle: DEPRECATED - Use ``accent`` instead.
+            bootstyle: DEPRECATED - Use `accent` instead.
 
             value: Current meter value.
             minvalue: Minimum value for the meter range.
@@ -104,7 +104,7 @@ class Meter(Frame):
             **kwargs: Additional keyword arguments passed to the Frame parent class.
 
         !!! note "Events"
-            - ``<<Change>>``: Emitted when the value changes (see on_changed()).
+            - `<<Change>>`: Emitted when the value changes (see on_changed()).
         """
         legacy = Meter._coerce_legacy_params(kwargs)
         super().__init__(master, **kwargs)
@@ -244,7 +244,7 @@ class Meter(Frame):
         """Return the current meter value.
 
         This is part of the standard value-widget API. It is equivalent
-        to accessing the ``.value`` property.
+        to accessing the `.value` property.
 
         Returns:
             The current meter value (int or float depending on dtype).
@@ -255,7 +255,7 @@ class Meter(Frame):
         """Set the meter value.
 
         This is part of the standard value-widget API. It is equivalent
-        to setting the ``.value`` property.
+        to setting the `.value` property.
 
         Args:
             value: The new meter value.
@@ -874,10 +874,10 @@ class Meter(Frame):
             self._value_var.set(value_updated)
 
     def on_changed(self, callback: Callable[[Any], Any]) -> str:
-        """Bind a callback to the ``<<Change>>`` virtual event."""
+        """Bind a callback to the `<<Change>>` virtual event."""
         return self.bind('<<Change>>', callback, add="+")
 
     def off_changed(self, bind_id: str):
-        """Remove a previously registered ``<<Change>>`` callback."""
+        """Remove a previously registered `<<Change>>` callback."""
         self.unbind('<<Change>>', bind_id)
 

--- a/src/ttkbootstrap/widgets/composites/numericentry.py
+++ b/src/ttkbootstrap/widgets/composites/numericentry.py
@@ -22,12 +22,12 @@ class NumericEntry(Field):
 
     !!! note "Events"
 
-        - ``<<Increment>>``: Fired when increment is requested (before step occurs).
-        - ``<<Decrement>>``: Fired when decrement is requested (before step occurs).
-        - ``<<Change>>``: Fired when value changes after commit.
-        - ``<<Input>>``: Fired on each keystroke.
-        - ``<<Valid>>``: Fired when validation passes.
-        - ``<<Invalid>>``: Fired when validation fails.
+        - `<<Increment>>`: Fired when increment is requested (before step occurs).
+        - `<<Decrement>>`: Fired when decrement is requested (before step occurs).
+        - `<<Change>>`: Fired when value changes after commit.
+        - `<<Input>>`: Fired on each keystroke.
+        - `<<Valid>>`: Fired when validation passes.
+        - `<<Invalid>>`: Fired when validation fails.
 
     Attributes:
         entry_widget (NumberEntryPart): The underlying entry widget.
@@ -61,7 +61,7 @@ class NumericEntry(Field):
             master: Parent widget. If None, uses the default root window.
             value (int | float): Initial numeric value to display.
             label (str): Optional label text to display above the entry field.
-                If ``required=True``, an asterisk (*) is automatically appended.
+                If `required=True`, an asterisk (*) is automatically appended.
             message (str): Optional message text to display below the entry field.
                 Used for hints or help text. Replaced by validation errors when
                 validation fails.
@@ -76,8 +76,8 @@ class NumericEntry(Field):
         Other Parameters:
             wrap (bool): If True, values wrap around at min/max boundaries.
             value_format (str): Number format specification for IntlFormatter.
-                Examples: ``'decimal'``, ``'percent'``, ``'currency'``, ``'#,##0.00'``.
-            locale (str): Locale identifier for number formatting (e.g., ``'en_US'``).
+                Examples: `'decimal'`, `'percent'`, `'currency'`, `'#,##0.00'`.
+            locale (str): Locale identifier for number formatting (e.g., `'en_US'`).
             required (bool): If True, field cannot be empty.
             accent (str): Accent token for the focus ring and active border.
             bootstyle (str): DEPRECATED - Use `accent` instead.
@@ -87,7 +87,7 @@ class NumericEntry(Field):
             font (str): Font for text display.
             foreground (str): Text color.
             initial_focus (bool): If True, widget receives focus on creation.
-            justify (str): Text alignment (``'left'``, ``'center'``, ``'right'``).
+            justify (str): Text alignment (`'left'`, `'center'`, `'right'`).
             show_message (bool): If True, displays message area.
             padding (int | tuple): Padding around entry widget.
             takefocus (bool): If True, widget accepts Tab focus.

--- a/src/ttkbootstrap/widgets/composites/pagestack.py
+++ b/src/ttkbootstrap/widgets/composites/pagestack.py
@@ -38,14 +38,14 @@ class PageStack(Frame):
 
     !!! note "Events"
 
-        - ``<<PageUnmount>>``: Triggered when the current page is hidden.
-        - ``<<PageWillMount>>``: Triggered before a new page is displayed.
-        - ``<<PageMount>>``: Triggered after a new page is displayed.
-        - ``<<PageChange>>``: Triggered after page navigation completes.
+        - `<<PageUnmount>>`: Triggered when the current page is hidden.
+        - `<<PageWillMount>>`: Triggered before a new page is displayed.
+        - `<<PageMount>>`: Triggered after a new page is displayed.
+        - `<<PageChange>>`: Triggered after page navigation completes.
 
-        All events provide ``event.data`` with keys: ``page``, ``prev_page``, ``prev_data``,
-        ``nav`` ('push', 'back', 'forward'), ``index``, ``length``, ``can_back``,
-        ``can_forward``.
+        All events provide `event.data` with keys: `page`, `prev_page`, `prev_data`,
+        `nav` ('push', 'back', 'forward'), `index`, `length`, `can_back`,
+        `can_forward`.
     """
 
     def __init__(self, master: Master = None, **kwargs: Unpack[PageStackKwargs]):
@@ -130,8 +130,8 @@ class PageStack(Frame):
         """Navigate to the page with the given key.
 
         This method handles page transitions, manages navigation history,
-        and triggers lifecycle events (``<<PageUnmount>>``, ``<<PageWillMount>>``,
-        ``<<PageMount>>``, ``<<PageChange>>``).
+        and triggers lifecycle events (`<<PageUnmount>>`, `<<PageWillMount>>`,
+        `<<PageMount>>`, `<<PageChange>>`).
 
         Args:
             key: The identifier of the page to navigate to
@@ -318,7 +318,7 @@ class PageStack(Frame):
             return self._pages[key].configure(**kwargs)
 
     def on_page_changed(self, callback: Callable) -> str:
-        """Bind to ``<<PageChange>>``. Callback receives ``event.data`` with navigation info.
+        """Bind to `<<PageChange>>`. Callback receives `event.data` with navigation info.
 
         Returns:
             Binding identifier for use with off_page_changed().
@@ -326,5 +326,5 @@ class PageStack(Frame):
         return self.bind('<<PageChange>>', callback, add="+")
 
     def off_page_changed(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<PageChange>>``."""
+        """Unbind from `<<PageChange>>`."""
         self.unbind("<<PageChange>>", bind_id)

--- a/src/ttkbootstrap/widgets/composites/passwordentry.py
+++ b/src/ttkbootstrap/widgets/composites/passwordentry.py
@@ -21,11 +21,11 @@ class PasswordEntry(Field):
 
     !!! note "Events"
 
-        - ``<<Input>>``: Triggered on each keystroke.
-        - ``<<Change>>``: Triggered when value changes after commit.
-        - ``<<Valid>>``: Triggered when validation passes.
-        - ``<<Invalid>>``: Triggered when validation fails.
-        - ``<<Validate>>``: Triggered after any validation.
+        - `<<Input>>`: Triggered on each keystroke.
+        - `<<Change>>`: Triggered when value changes after commit.
+        - `<<Valid>>`: Triggered when validation passes.
+        - `<<Invalid>>`: Triggered when validation fails.
+        - `<<Validate>>`: Triggered after any validation.
 
     Attributes:
         entry_widget (TextEntryPart): The underlying text entry widget.
@@ -61,7 +61,7 @@ class PasswordEntry(Field):
                 validation fails.
             show_visibility_toggle: If True, displays the visibility toggle button
                 (eye icon) that reveals the password while pressed. Default is True.
-                Can be changed at runtime via ``configure(show_visibility_toggle=...)``.
+                Can be changed at runtime via `configure(show_visibility_toggle=...)`.
 
         Other Parameters:
             show (str): Character to mask password input. Default is '•'.

--- a/src/ttkbootstrap/widgets/composites/pathentry.py
+++ b/src/ttkbootstrap/widgets/composites/pathentry.py
@@ -42,14 +42,14 @@ class PathEntry(Field):
 
     !!! note "Events"
 
-        ``<<Change>>``: Fired when a path is selected from the dialog.
-          Provides ``event.data`` with keys: ``value``, ``prev_value``, ``text``, ``dialog_result``.
+        `<<Change>>`: Fired when a path is selected from the dialog.
+          Provides `event.data` with keys: `value`, `prev_value`, `text`, `dialog_result`.
 
-        ``<<Input>>``: Fired when user manually types in the entry.
+        `<<Input>>`: Fired when user manually types in the entry.
 
-        ``<<Valid>>``: Fired when validation passes.
+        `<<Valid>>`: Fired when validation passes.
 
-        ``<<Invalid>>``: Fired when validation fails.
+        `<<Invalid>>`: Fired when validation fails.
 
     Attributes:
         entry_widget (TextEntryPart): The underlying text entry widget.
@@ -100,7 +100,7 @@ class PathEntry(Field):
                 Common options: title, initialdir, initialfile, filetypes,
                 defaultextension, multiple.
             button_text: Text to display on the browse button. Default is "Browse".
-                Can be changed at runtime via ``configure(button_text=...)``.
+                Can be changed at runtime via `configure(button_text=...)`.
             label (str): Label text to display above the entry field (from FieldOptions).
             message (str): Message text to display below the field.
 
@@ -123,7 +123,7 @@ class PathEntry(Field):
         Note:
             When multiple files are selected (using 'openfilenames' or 'openfiles'),
             the paths are joined with ", " (comma-space) and displayed in the entry.
-            The raw dialog result (tuple/list) is available via the ``dialog_result``
+            The raw dialog result (tuple/list) is available via the `dialog_result`
             property.
         """
         self._dialog = dialog

--- a/src/ttkbootstrap/widgets/composites/radiogroup.py
+++ b/src/ttkbootstrap/widgets/composites/radiogroup.py
@@ -350,7 +350,7 @@ class RadioGroup(Frame):
         button.configure(**kwargs)
 
     def on_changed(self, callback: Callable) -> Any:
-        """Subscribe to value changes. Callback receives ``new_value: str`` directly."""
+        """Subscribe to value changes. Callback receives `new_value: str` directly."""
         return self._signal.subscribe(callback)
 
     def off_changed(self, bind_id: Any) -> None:

--- a/src/ttkbootstrap/widgets/composites/scrollview.py
+++ b/src/ttkbootstrap/widgets/composites/scrollview.py
@@ -221,7 +221,7 @@ class ScrollView(Frame):
         scrollbar's natural dimensions before the scrollbars are hidden. This
         reserves the gutter permanently so the canvas never resizes when a
         scrollbar is toggled — the same principle as the CSS
-        ``scrollbar-gutter: stable`` property.
+        `scrollbar-gutter: stable` property.
 
         An overlay approach (lift/lower over the canvas) was considered but
         rejected because the scrollbar then covers content, which was reported
@@ -260,13 +260,13 @@ class ScrollView(Frame):
     def _set_scrollbar_gutter(self, reserve: bool):
         """Reserve or release the grid gutter used by each scrollbar.
 
-        When *reserve* is ``True`` the column (vertical scrollbar) and row
-        (horizontal scrollbar) are given a ``minsize`` equal to the scrollbar's
+        When *reserve* is `True` the column (vertical scrollbar) and row
+        (horizontal scrollbar) are given a `minsize` equal to the scrollbar's
         natural requested dimensions.  The minsize persists even after the
-        scrollbar widget is removed from the grid via ``grid_remove()``, so the
+        scrollbar widget is removed from the grid via `grid_remove()`, so the
         canvas occupies a constant area regardless of scrollbar visibility.
 
-        When *reserve* is ``False`` the minsize is cleared (set to 0), which
+        When *reserve* is `False` the minsize is cleared (set to 0), which
         is appropriate for 'always' and 'never' modes where no gutter needs to
         be held open.
         """

--- a/src/ttkbootstrap/widgets/composites/selectbox.py
+++ b/src/ttkbootstrap/widgets/composites/selectbox.py
@@ -14,12 +14,12 @@ class SelectBox(Field):
     """Dropdown-like field widget built on top of Field.
 
     Renders a field with a suffix button that opens a popup list of available
-    items. Selecting an item updates the field value and emits ``<<Change>>``.
+    items. Selecting an item updates the field value and emits `<<Change>>`.
 
     !!! note "Events"
 
-          ``<<Change>>``: Fired when the selection changes (user or code).
-          Provides ``event.data`` with keys: ``value``, ``prev_value``, ``text``.
+          `<<Change>>`: Fired when the selection changes (user or code).
+          Provides `event.data` with keys: `value`, `prev_value`, `text`.
 
     Attributes:
         entry_widget (TextEntryPart): The underlying entry widget.
@@ -47,7 +47,7 @@ class SelectBox(Field):
 
         Args:
             master: Parent widget. If None, uses the default root window.
-            value (str): Initial selected value; should typically be present in ``items``.
+            value (str): Initial selected value; should typically be present in `items`.
             items (list): Sequence of string options to present in the popup list.
             label (str): Optional label text shown above the field.
             message (str): Optional helper/error message shown below the field.
@@ -525,7 +525,7 @@ class SelectBox(Field):
 
     @value.setter
     def value(self, value):
-        """Set the selected value and emit ``<<Change>>`` when it differs."""
+        """Set the selected value and emit `<<Change>>` when it differs."""
         prev_value = Field.value.fget(self)
         Field.value.fset(self, value)
         new_value = Field.value.fget(self)

--- a/src/ttkbootstrap/widgets/composites/sidenav/group.py
+++ b/src/ttkbootstrap/widgets/composites/sidenav/group.py
@@ -49,10 +49,10 @@ class SideNavGroup(Frame):
     The group shows as selected if any of its child items are currently selected.
 
     !!! note "Events"
-        - ``<<GroupExpanding>>``: Fired before the group expands.
-          ``event.data = {'key': str}``
-        - ``<<GroupCollapsed>>``: Fired after the group collapses.
-          ``event.data = {'key': str}``
+        - `<<GroupExpanding>>`: Fired before the group expands.
+          `event.data = {'key': str}`
+        - `<<GroupCollapsed>>`: Fired after the group collapses.
+          `event.data = {'key': str}`
 
     Example:
         ```python

--- a/src/ttkbootstrap/widgets/composites/sidenav/item.py
+++ b/src/ttkbootstrap/widgets/composites/sidenav/item.py
@@ -52,8 +52,8 @@ class SideNavItem(Frame):
     and NavigationButton.TLabel for the icon and text labels.
 
     !!! note "Events"
-        - ``<<ItemInvoked>>``: Fired when the item is clicked.
-          ``event.data = {'key': str}``
+        - `<<ItemInvoked>>`: Fired when the item is clicked.
+          `event.data = {'key': str}`
 
     Example:
         ```python
@@ -394,7 +394,7 @@ class SideNavItem(Frame):
     # --- Event Binding Helpers ---
 
     def on_invoked(self, callback) -> str:
-        """Bind to ``<<ItemInvoked>>``.
+        """Bind to `<<ItemInvoked>>`.
 
         Args:
             callback: Function to call when item is invoked.
@@ -405,7 +405,7 @@ class SideNavItem(Frame):
         return self.bind('<<ItemInvoked>>', callback, add='+')
 
     def off_invoked(self, bind_id: str = None) -> None:
-        """Unbind from ``<<ItemInvoked>>``.
+        """Unbind from `<<ItemInvoked>>`.
 
         Args:
             bind_id (str | None): Binding identifier from on_invoked().

--- a/src/ttkbootstrap/widgets/composites/sidenav/view.py
+++ b/src/ttkbootstrap/widgets/composites/sidenav/view.py
@@ -59,13 +59,13 @@ class SideNav(Frame):
     for radio-group behavior.
 
     !!! note "Events"
-        - ``<<PaneToggled>>``: Fired when pane is opened/closed.
-          ``event.data = {'is_open': bool}``
-        - ``<<DisplayModeChanged>>``: Fired when display mode changes.
-          ``event.data = {'mode': str}``
-        - ``<<SelectionChanged>>``: Fired when selected item changes.
-          ``event.data = {'key': str}``
-        - ``<<BackRequested>>``: Fired when back button is clicked.
+        - `<<PaneToggled>>`: Fired when pane is opened/closed.
+          `event.data = {'is_open': bool}`
+        - `<<DisplayModeChanged>>`: Fired when display mode changes.
+          `event.data = {'mode': str}`
+        - `<<SelectionChanged>>`: Fired when selected item changes.
+          `event.data = {'key': str}`
+        - `<<BackRequested>>`: Fired when back button is clicked.
 
     Example:
         ```python
@@ -874,7 +874,7 @@ class SideNav(Frame):
     # --- Event Binding Helpers ---
 
     def on_selection_changed(self, callback) -> str:
-        """Bind to ``<<SelectionChanged>>``.
+        """Bind to `<<SelectionChanged>>`.
 
         Args:
             callback: Function to call when selection changes.
@@ -885,11 +885,11 @@ class SideNav(Frame):
         return self.bind('<<SelectionChanged>>', callback, add='+')
 
     def off_selection_changed(self, bind_id: str = None) -> None:
-        """Unbind from ``<<SelectionChanged>>``."""
+        """Unbind from `<<SelectionChanged>>`."""
         self.unbind('<<SelectionChanged>>', bind_id)
 
     def on_back_requested(self, callback) -> str:
-        """Bind to ``<<BackRequested>>``.
+        """Bind to `<<BackRequested>>`.
 
         Args:
             callback: Function to call when back button is clicked.
@@ -900,11 +900,11 @@ class SideNav(Frame):
         return self.bind('<<BackRequested>>', callback, add='+')
 
     def off_back_requested(self, bind_id: str = None) -> None:
-        """Unbind from ``<<BackRequested>>``."""
+        """Unbind from `<<BackRequested>>`."""
         self.unbind('<<BackRequested>>', bind_id)
 
     def on_pane_toggled(self, callback) -> str:
-        """Bind to ``<<PaneToggled>>``.
+        """Bind to `<<PaneToggled>>`.
 
         Args:
             callback: Function to call when pane is toggled.
@@ -915,5 +915,5 @@ class SideNav(Frame):
         return self.bind('<<PaneToggled>>', callback, add='+')
 
     def off_pane_toggled(self, bind_id: str = None) -> None:
-        """Unbind from ``<<PaneToggled>>``."""
+        """Unbind from `<<PaneToggled>>`."""
         self.unbind('<<PaneToggled>>', bind_id)

--- a/src/ttkbootstrap/widgets/composites/spinnerentry.py
+++ b/src/ttkbootstrap/widgets/composites/spinnerentry.py
@@ -22,10 +22,10 @@ class SpinnerEntry(Field):
 
     !!! note "Events"
 
-        - ``<<Change>>``  : Fired when value changes after commit.
-        - ``<<Input>>``   : Fired on each keystroke.
-        - ``<<Valid>>``   : Fired when validation passes.
-        - ``<<Invalid>>`` : Fired when validation fails.
+        - `<<Change>>`  : Fired when value changes after commit.
+        - `<<Input>>`   : Fired on each keystroke.
+        - `<<Valid>>`   : Fired when validation passes.
+        - `<<Invalid>>` : Fired when validation fails.
 
     Attributes:
         entry_widget (SpinnerEntryPart): The underlying spinbox entry widget.

--- a/src/ttkbootstrap/widgets/composites/tableview/tableview.py
+++ b/src/ttkbootstrap/widgets/composites/tableview/tableview.py
@@ -61,14 +61,14 @@ class TableView(Frame):
     optional grouping, column striping, and configurable exporting/editing.
 
     !!! note "Events"
-        - ``<<SelectionChange>>``: Fired when row selection changes. ``event.data = {'records': list[dict], 'iids': list[str]}``
-        - ``<<RowClick>>``: Fired on single row click. ``event.data = {'record': dict, 'iid': str}``
-        - ``<<RowDoubleClick>>``: Fired on row double-click. ``event.data = {'record': dict, 'iid': str}``
-        - ``<<RowRightClick>>``: Fired on row right-click. ``event.data = {'record': dict, 'iid': str}``
-        - ``<<RowInsert>>``: Fired when rows are inserted. ``event.data = {'records': list[dict]}``
-        - ``<<RowUpdate>>``: Fired when rows are updated. ``event.data = {'records': list[dict]}``
-        - ``<<RowDelete>>``: Fired when rows are deleted. ``event.data = {'records': list[dict]}``
-        - ``<<RowMove>>``: Fired when rows are moved/reordered. ``event.data = {'records': list[dict]}``
+        - `<<SelectionChange>>`: Fired when row selection changes. `event.data = {'records': list[dict], 'iids': list[str]}`
+        - `<<RowClick>>`: Fired on single row click. `event.data = {'record': dict, 'iid': str}`
+        - `<<RowDoubleClick>>`: Fired on row double-click. `event.data = {'record': dict, 'iid': str}`
+        - `<<RowRightClick>>`: Fired on row right-click. `event.data = {'record': dict, 'iid': str}`
+        - `<<RowInsert>>`: Fired when rows are inserted. `event.data = {'records': list[dict]}`
+        - `<<RowUpdate>>`: Fired when rows are updated. `event.data = {'records': list[dict]}`
+        - `<<RowDelete>>`: Fired when rows are deleted. `event.data = {'records': list[dict]}`
+        - `<<RowMove>>`: Fired when rows are moved/reordered. `event.data = {'records': list[dict]}`
     """
 
     def __init__(
@@ -287,67 +287,67 @@ class TableView(Frame):
 
     # ------------------------------------------------------------------ Public event API
     def on_selection_changed(self, callback) -> str:
-        """Bind to ``<<SelectionChange>>``. Callback receives ``event.data = {'records': list[dict], 'iids': list[str]}``."""
+        """Bind to `<<SelectionChange>>`. Callback receives `event.data = {'records': list[dict], 'iids': list[str]}`."""
         return self.bind("<<SelectionChange>>", callback, add=True)
 
     def off_selection_changed(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<SelectionChange>>``."""
+        """Unbind from `<<SelectionChange>>`."""
         self.unbind("<<SelectionChange>>", bind_id)
 
     def on_row_click(self, callback) -> str:
-        """Bind to ``<<RowClick>>``. Callback receives ``event.data = {'record': dict, 'iid': str}``."""
+        """Bind to `<<RowClick>>`. Callback receives `event.data = {'record': dict, 'iid': str}`."""
         return self.bind("<<RowClick>>", callback, add=True)
 
     def off_row_click(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<RowClick>>``."""
+        """Unbind from `<<RowClick>>`."""
         self.unbind("<<RowClick>>", bind_id)
 
     def on_row_double_click(self, callback) -> str:
-        """Bind to ``<<RowDoubleClick>>``. Callback receives ``event.data = {'record': dict, 'iid': str}``."""
+        """Bind to `<<RowDoubleClick>>`. Callback receives `event.data = {'record': dict, 'iid': str}`."""
         return self.bind("<<RowDoubleClick>>", callback, add=True)
 
     def off_row_double_click(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<RowDoubleClick>>``."""
+        """Unbind from `<<RowDoubleClick>>`."""
         self.unbind("<<RowDoubleClick>>", bind_id)
 
     def on_row_right_click(self, callback) -> str:
-        """Bind to ``<<RowRightClick>>``. Callback receives ``event.data = {'record': dict, 'iid': str}``."""
+        """Bind to `<<RowRightClick>>`. Callback receives `event.data = {'record': dict, 'iid': str}`."""
         return self.bind("<<RowRightClick>>", callback, add=True)
 
     def off_row_right_click(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<RowRightClick>>``."""
+        """Unbind from `<<RowRightClick>>`."""
         self.unbind("<<RowRightClick>>", bind_id)
 
     def on_row_deleted(self, callback) -> str:
-        """Bind to ``<<RowDelete>>``. Callback receives ``event.data = {'records': list[dict]}``."""
+        """Bind to `<<RowDelete>>`. Callback receives `event.data = {'records': list[dict]}`."""
         return self.bind("<<RowDelete>>", callback, add=True)
 
     def off_row_deleted(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<RowDelete>>``."""
+        """Unbind from `<<RowDelete>>`."""
         self.unbind("<<RowDelete>>", bind_id)
 
     def on_row_inserted(self, callback) -> str:
-        """Bind to ``<<RowInsert>>``. Callback receives ``event.data = {'records': list[dict]}``."""
+        """Bind to `<<RowInsert>>`. Callback receives `event.data = {'records': list[dict]}`."""
         return self.bind("<<RowInsert>>", callback, add=True)
 
     def off_row_inserted(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<RowInsert>>``."""
+        """Unbind from `<<RowInsert>>`."""
         self.unbind("<<RowInsert>>", bind_id)
 
     def on_row_updated(self, callback) -> str:
-        """Bind to ``<<RowUpdate>>``. Callback receives ``event.data = {'records': list[dict]}``."""
+        """Bind to `<<RowUpdate>>`. Callback receives `event.data = {'records': list[dict]}`."""
         return self.bind("<<RowUpdate>>", callback, add=True)
 
     def off_row_updated(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<RowUpdate>>``."""
+        """Unbind from `<<RowUpdate>>`."""
         self.unbind("<<RowUpdate>>", bind_id)
 
     def on_row_moved(self, callback) -> str:
-        """Bind to ``<<RowMove>>``. Callback receives ``event.data = {'records': list[dict]}``."""
+        """Bind to `<<RowMove>>`. Callback receives `event.data = {'records': list[dict]}`."""
         return self.bind("<<RowMove>>", callback, add=True)
 
     def off_row_moved(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<RowMove>>``."""
+        """Unbind from `<<RowMove>>`."""
         self.unbind("<<RowMove>>", bind_id)
 
     # ------------------------------------------------------------------ Public data/selection API

--- a/src/ttkbootstrap/widgets/composites/tabs/tabitem.py
+++ b/src/ttkbootstrap/widgets/composites/tabs/tabitem.py
@@ -25,8 +25,8 @@ class TabItem(CompositeFrame):
     via signal/variable and optional close functionality.
 
     !!! note "Events"
-        - ``<<TabSelect>>``: Fired when the tab is clicked (for selection).
-        - ``<<TabClose>>``: Fired when the close button is clicked.
+        - `<<TabSelect>>`: Fired when the tab is clicked (for selection).
+        - `<<TabClose>>`: Fired when the close button is clicked.
 
     Attributes:
         selected (bool): Current selection state (read-only).

--- a/src/ttkbootstrap/widgets/composites/tabs/tabs.py
+++ b/src/ttkbootstrap/widgets/composites/tabs/tabs.py
@@ -26,9 +26,9 @@ class Tabs(Frame):
     orientation, and styling of child TabItems.
 
     !!! note "Events"
-        - ``<<TabSelect>>``: Fired when a tab is selected (bubbled from TabItem).
-        - ``<<TabClose>>``: Fired when a tab's close button is clicked (bubbled from TabItem).
-        - ``<<TabAdd>>``: Fired when the add button is clicked (if enable_adding=True).
+        - `<<TabSelect>>`: Fired when a tab is selected (bubbled from TabItem).
+        - `<<TabClose>>`: Fired when a tab's close button is clicked (bubbled from TabItem).
+        - `<<TabAdd>>`: Fired when the add button is clicked (if enable_adding=True).
 
     Attributes:
         orient (str): The orientation of the tab bar ('horizontal' or 'vertical').
@@ -220,7 +220,7 @@ class Tabs(Frame):
         self.event_generate('<<TabAdd>>')
 
     def on_tab_added(self, callback: Callable) -> str:
-        """Bind to ``<<TabAdd>>`` event.
+        """Bind to `<<TabAdd>>` event.
 
         Args:
             callback: Function to call when add button is clicked.

--- a/src/ttkbootstrap/widgets/composites/tabs/tabview.py
+++ b/src/ttkbootstrap/widgets/composites/tabs/tabview.py
@@ -21,10 +21,10 @@ class TabView(Frame):
     page.
 
     !!! note "Events"
-        - ``<<TabSelect>>``: Fired when a tab is selected.
-        - ``<<TabClose>>``: Fired when a tab's close button is clicked.
-        - ``<<TabAdd>>``: Fired when the add button is clicked (if enable_adding=True).
-        - ``<<PageChange>>``: Fired when the page changes (from PageStack).
+        - `<<TabSelect>>`: Fired when a tab is selected.
+        - `<<TabClose>>`: Fired when a tab's close button is clicked.
+        - `<<TabAdd>>`: Fired when the add button is clicked (if enable_adding=True).
+        - `<<PageChange>>`: Fired when the page changes (from PageStack).
     """
 
     def __init__(
@@ -322,7 +322,7 @@ class TabView(Frame):
         tab.configure(**kwargs)
 
     def on_page_changed(self, callback: Callable) -> str:
-        """Bind to ``<<PageChange>>`` event.
+        """Bind to `<<PageChange>>` event.
 
         Args:
             callback: Function to call when page changes.
@@ -333,11 +333,11 @@ class TabView(Frame):
         return self._page_stack.on_page_changed(callback)
 
     def off_page_changed(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<PageChange>>`` event."""
+        """Unbind from `<<PageChange>>` event."""
         self._page_stack.off_page_changed(bind_id)
 
     def on_tab_added(self, callback: Callable) -> str:
-        """Bind to ``<<TabAdd>>`` event (when add button is clicked).
+        """Bind to `<<TabAdd>>` event (when add button is clicked).
 
         Args:
             callback: Function to call when add button is clicked.
@@ -348,5 +348,5 @@ class TabView(Frame):
         return self._tabs.on_tab_added(callback)
 
     def off_tab_added(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<TabAdd>>`` event."""
+        """Unbind from `<<TabAdd>>` event."""
         self._tabs.off_tab_added(bind_id)

--- a/src/ttkbootstrap/widgets/composites/textentry.py
+++ b/src/ttkbootstrap/widgets/composites/textentry.py
@@ -14,24 +14,24 @@ class TextEntry(Field):
     text input with deferred parsing, validation support, and visual feedback.
 
     The widget separates user input (display text) from the committed/parsed value,
-    only parsing and formatting when the user commits via ``<FocusOut>`` or ``<Return>``.
+    only parsing and formatting when the user commits via `<FocusOut>` or `<Return>`.
 
     !!! note "Events"
 
-        - ``<<Input>>``: Triggered on each keystroke.
-          Provides ``event.data`` with keys: ``text``.
+        - `<<Input>>`: Triggered on each keystroke.
+          Provides `event.data` with keys: `text`.
 
-        - ``<<Change>>``: Triggered when value changes after commit.
-          Provides ``event.data`` with keys: ``value``, ``prev_value``, ``text``.
+        - `<<Change>>`: Triggered when value changes after commit.
+          Provides `event.data` with keys: `value`, `prev_value`, `text`.
 
-        - ``<<Valid>>``: Triggered when validation passes.
-          Provides ``event.data`` with keys: ``value``, ``is_valid`` (True), ``message``.
+        - `<<Valid>>`: Triggered when validation passes.
+          Provides `event.data` with keys: `value`, `is_valid` (True), `message`.
 
-        - ``<<Invalid>>``: Triggered when validation fails.
-          Provides ``event.data`` with keys: ``value``, ``is_valid`` (False), ``message``.
+        - `<<Invalid>>`: Triggered when validation fails.
+          Provides `event.data` with keys: `value`, `is_valid` (False), `message`.
 
-        - ``<<Validate>>``: Triggered after any validation.
-          Provides ``event.data`` with keys: ``value``, ``is_valid`` (bool), ``message``.
+        - `<<Validate>>`: Triggered after any validation.
+          Provides `event.data` with keys: `value`, `is_valid` (bool), `message`.
 
     Attributes:
         entry_widget (TextEntryPart): The underlying text entry widget.

--- a/src/ttkbootstrap/widgets/composites/timeentry.py
+++ b/src/ttkbootstrap/widgets/composites/timeentry.py
@@ -25,10 +25,10 @@ class TimeEntry(SelectBox):
 
     !!! note "Events"
 
-        - ``<<Change>>``: Fired when time value changes after commit.
-        - ``<<Input>>``: Fired on each keystroke.
-        - ``<<Valid>>``: Fired when validation passes.
-        - ``<<Invalid>>``: Fired when validation fails.
+        - `<<Change>>`: Fired when time value changes after commit.
+        - `<<Input>>`: Fired on each keystroke.
+        - `<<Valid>>`: Fired when validation passes.
+        - `<<Invalid>>`: Fired when validation fails.
 
     Attributes:
         entry_widget (TextEntryPart): The underlying text entry widget.

--- a/src/ttkbootstrap/widgets/composites/togglegroup.py
+++ b/src/ttkbootstrap/widgets/composites/togglegroup.py
@@ -336,7 +336,7 @@ class ToggleGroup(Frame):
         return tuple(self._buttons.keys())
 
     def on_changed(self, callback: Callable) -> Any:
-        """Subscribe to value changes. Callback receives ``new_value: str | set[str]`` directly (str in 'single' mode, set in 'multi' mode)."""
+        """Subscribe to value changes. Callback receives `new_value: str | set[str]` directly (str in 'single' mode, set in 'multi' mode)."""
         return self._signal.subscribe(callback)
 
     def off_changed(self, bind_id: Any) -> None:

--- a/src/ttkbootstrap/widgets/composites/toolbar.py
+++ b/src/ttkbootstrap/widgets/composites/toolbar.py
@@ -35,7 +35,7 @@ class Toolbar(Frame):
     arranged horizontally. It optionally supports window control buttons
     (minimize, maximize, close) and window dragging for custom titlebars.
 
-    Items are added from left to right. Use ``add_spacer()`` to push
+    Items are added from left to right. Use `add_spacer()` to push
     subsequent items to the right side.
 
     Example:
@@ -321,7 +321,7 @@ class Toolbar(Frame):
         """Add a custom widget to the toolbar.
 
         The widget must already be created with the toolbar's content frame
-        as its parent. Use ``toolbar.content`` to get the parent frame.
+        as its parent. Use `toolbar.content` to get the parent frame.
 
         Args:
             widget (Widget): The widget to add.

--- a/src/ttkbootstrap/widgets/internal/wrapper_base.py
+++ b/src/ttkbootstrap/widgets/internal/wrapper_base.py
@@ -321,10 +321,10 @@ class TTKWrapperBase(FontMixin, ConfigureDelegationMixin):
         """Get or set the widget style options if handled by the widget's style builder.
 
         Special cascading keys:
-            surface: Updates ``_surface`` on this widget and (via Frame subclass) triggers
-                ``_refresh_descendant_surfaces`` to propagate the change to children.
-            input_background: Updates ``_input_background`` on this widget and (via Frame
-                subclass) triggers ``_refresh_descendant_input_backgrounds`` to propagate
+            surface: Updates `_surface` on this widget and (via Frame subclass) triggers
+                `_refresh_descendant_surfaces` to propagate the change to children.
+            input_background: Updates `_input_background` on this widget and (via Frame
+                subclass) triggers `_refresh_descendant_input_backgrounds` to propagate
                 the change to all descendant input widgets.
         """
         options = getattr(self, "_style_options", {})

--- a/src/ttkbootstrap/widgets/mixins/font_mixin.py
+++ b/src/ttkbootstrap/widgets/mixins/font_mixin.py
@@ -4,8 +4,8 @@ This module provides a mixin that enables concise font modification syntax for a
 ttkbootstrap widgets. The syntax uses bracket notation similar to bootstyle modifiers,
 allowing inline font customization without creating custom Font objects.
 
-Syntax
-------
+## Syntax
+
 The full modifier syntax follows the pattern: `family[size][weight][style]`
 
 All components are optional and can be mixed in any combination. When components are
@@ -24,57 +24,67 @@ Font Tokens:
     body, label, heading-md, heading-lg, heading-xl, display-lg, display-xl,
     code, hyperlink, caption, body-sm, body-lg, body-xl
 
-Behavior
---------
+## Behavior
+
 - **At widget creation**: Modifiers are applied to the widget's default style font
 - **At runtime**: Modifiers are applied to the widget's current font
 - **Missing family**: Uses widget's current font family (or 'body' token if none)
 - **Missing size**: Uses widget's current font size (or 'body' token size if none)
 
-Examples
---------
-Basic modifications::
+## Examples
 
-    # Use body token, make it bold
-    Label(root, text="Title", font="body[bold]")
+Basic modifications:
 
-    # Change current font to 16pt (preserves family)
-    label.configure(font="[16]")
+```python
+# Use body token, make it bold
+Label(root, text="Title", font="body[bold]")
 
-    # Make current font bold and italic (preserves family and size)
-    label.configure(font="[bold,italic]")
+# Change current font to 16pt (preserves family)
+label.configure(font="[16]")
 
-Custom font families::
+# Make current font bold and italic (preserves family and size)
+label.configure(font="[bold,italic]")
+```
 
-    # Helvetica, 16pt, bold
-    Button(root, text="Click", font="helvetica[16][bold]")
+Custom font families:
 
-    # Arial, 14 pixels (negative in Tk), bold and italic
-    Label(root, text="Text", font="arial[14px][bold,italic]")
+```python
+# Helvetica, 16pt, bold
+Button(root, text="Click", font="helvetica[16][bold]")
 
-Size tokens::
+# Arial, 14 pixels (negative in Tk), bold and italic
+Label(root, text="Text", font="arial[14px][bold,italic]")
+```
 
-    # Small size (10pt) with bold
-    Entry(root, font="[sm][bold]")
+Size tokens:
 
-    # Large size (14pt)
-    Label(root, font="[lg]")
+```python
+# Small size (10pt) with bold
+Entry(root, font="[sm][bold]")
 
-Font tokens with modifiers::
+# Large size (14pt)
+Label(root, font="[lg]")
+```
 
-    # Heading-lg token with italic style
-    Label(root, text="Heading", font="heading-lg[italic]")
+Font tokens with modifiers:
 
-    # Label token at custom size
-    Button(root, text="Button", font="label[16]")
+```python
+# Heading-lg token with italic style
+Label(root, text="Heading", font="heading-lg[italic]")
 
-Multiple style modifiers::
+# Label token at custom size
+Button(root, text="Button", font="label[16]")
+```
 
-    # Bold, italic, and underlined
-    Label(root, text="Emphasis", font="[16][bold,italic,underline]")
+Multiple style modifiers:
 
-Integration
------------
+```python
+# Bold, italic, and underlined
+Label(root, text="Emphasis", font="[16][bold,italic,underline]")
+```
+
+## Integration
+
 FontMixin is automatically integrated into all ttkbootstrap widgets via TTKWrapperBase.
 No additional setup is required - all widgets supporting the 'font' argument automatically
 gain modifier syntax support.

--- a/src/ttkbootstrap/widgets/mixins/validation_mixin.py
+++ b/src/ttkbootstrap/widgets/mixins/validation_mixin.py
@@ -18,18 +18,18 @@ class ValidationMixin(Widget):
     """Pure-Tkinter validation mixin for bound widgets.
 
     Provides debounced auto-validation on key/blur with virtual event emission.
-    Event data is accessible via ``event.data`` in handlers.
+    Event data is accessible via `event.data` in handlers.
 
     !!! note "Events"
 
-        - ``<<Valid>>``: Fired when validation passes.
-          Provides ``event.data`` with keys: ``value``, ``is_valid`` (True), ``message``.
+        - `<<Valid>>`: Fired when validation passes.
+          Provides `event.data` with keys: `value`, `is_valid` (True), `message`.
 
-        - ``<<Invalid>>``: Fired when validation fails.
-          Provides ``event.data`` with keys: ``value``, ``is_valid`` (False), ``message``.
+        - `<<Invalid>>`: Fired when validation fails.
+          Provides `event.data` with keys: `value`, `is_valid` (False), `message`.
 
-        - ``<<Validate>>``: Fired after any validation.
-          Provides ``event.data`` with keys: ``value``, ``is_valid`` (bool), ``message``.
+        - `<<Validate>>`: Fired after any validation.
+          Provides `event.data` with keys: `value`, `is_valid` (bool), `message`.
     """
 
     EVENT_VALID = '<<Valid>>'
@@ -89,7 +89,7 @@ class ValidationMixin(Widget):
     def validate(self, value: Any, trigger: RuleTriggerType = "manual") -> bool:
         """Run validation rules against a value.
 
-        Emits ``<<Valid>>``, ``<<Invalid>>``, and ``<<Validate>>`` events
+        Emits `<<Valid>>`, `<<Invalid>>`, and `<<Validate>>` events
         with data payload containing validation results.
 
         Args:

--- a/src/ttkbootstrap/widgets/parts/numberentry_part.py
+++ b/src/ttkbootstrap/widgets/parts/numberentry_part.py
@@ -19,9 +19,9 @@ class NumberEntryPart(TextEntryPart):
     via keyboard and mouse wheel, and optional wrapping.
 
     !!! note "Events"
-        - ``<<Increment>>``: Fired when an increment is requested (before step occurs). ``event.data = {'value': current_value}``
-        - ``<<Decrement>>``: Fired when a decrement is requested (before step occurs). ``event.data = {'value': current_value}``
-        - Plus all events from TextEntryPart: ``<<Input>>``, ``<<Change>>``, ``<Return>``
+        - `<<Increment>>`: Fired when an increment is requested (before step occurs). `event.data = {'value': current_value}`
+        - `<<Decrement>>`: Fired when a decrement is requested (before step occurs). `event.data = {'value': current_value}`
+        - Plus all events from TextEntryPart: `<<Input>>`, `<<Change>>`, `<Return>`
     """
 
     def __init__(
@@ -291,19 +291,19 @@ class NumberEntryPart(TextEntryPart):
             self._normalize_display_from_value()
 
     def on_increment(self, callback) -> str:
-        """Bind to ``<<Increment>>``. Callback receives ``event.data = {'value': current_value}``."""
+        """Bind to `<<Increment>>`. Callback receives `event.data = {'value': current_value}`."""
         return self.bind('<<Increment>>', callback, add=True)
 
     def off_increment(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<Increment>>``."""
+        """Unbind from `<<Increment>>`."""
         self.unbind('<<Increment>>', bind_id)
 
     def on_decrement(self, callback) -> str:
-        """Bind to ``<<Decrement>>``. Callback receives ``event.data = {'value': current_value}``."""
+        """Bind to `<<Decrement>>`. Callback receives `event.data = {'value': current_value}`."""
         return self.bind('<<Decrement>>', callback, add=True)
 
     def off_decrement(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<Decrement>>``."""
+        """Unbind from `<<Decrement>>`."""
         self.unbind('<<Decrement>>', bind_id)
 
     @configure_delegate('minvalue')

--- a/src/ttkbootstrap/widgets/parts/spinnerentry_part.py
+++ b/src/ttkbootstrap/widgets/parts/spinnerentry_part.py
@@ -23,14 +23,14 @@ class SpinnerEntryPart(ValidationMixin, Spinbox):
 
     !!! note "Events"
 
-        - ``<<Input>>``: Triggered on each keystroke.
-          Provides ``event.data`` with keys: ``text``.
+        - `<<Input>>`: Triggered on each keystroke.
+          Provides `event.data` with keys: `text`.
 
-        - ``<<Change>>``: Triggered when value changes after commit.
-          Provides ``event.data`` with keys: ``value``, ``prev_value``, ``text``.
+        - `<<Change>>`: Triggered when value changes after commit.
+          Provides `event.data` with keys: `value`, `prev_value`, `text`.
 
         - **<Return>**: Triggered on Enter key press.
-          Provides ``event.data`` with keys: ``value``, ``text``.
+          Provides `event.data` with keys: `value`, `text`.
     """
 
     def __init__(

--- a/src/ttkbootstrap/widgets/parts/textentry_part.py
+++ b/src/ttkbootstrap/widgets/parts/textentry_part.py
@@ -12,12 +12,12 @@ class TextEntryPart(ValidationMixin, Entry):
 
     This widget separates user input (display text) from the committed/parsed value,
     providing a clean pattern for handling formatted data entry. Parsing and formatting
-    only occur when the user commits the value via ``<FocusOut>`` or ``<Return>``.
+    only occur when the user commits the value via `<FocusOut>` or `<Return>`.
 
     !!! note "Events"
-        - ``<<Input>>``: Triggered on each keystroke. ``event.data = {'text': str}``
-        - ``<<Change>>``: Triggered when value changes after commit. ``event.data = {'value': Any, 'prev_value': Any, 'text': str}``
-        - ``<Return>``: Triggered on Enter key press. ``event.data = {'value': Any, 'text': str}``
+        - `<<Input>>`: Triggered on each keystroke. `event.data = {'text': str}`
+        - `<<Change>>`: Triggered when value changes after commit. `event.data = {'value': Any, 'prev_value': Any, 'text': str}`
+        - `<Return>`: Triggered on Enter key press. `event.data = {'value': Any, 'text': str}`
     """
 
     def __init__(
@@ -41,8 +41,8 @@ class TextEntryPart(ValidationMixin, Entry):
             value: Initial value to display and parse. Can be a string or any value
                 that can be formatted using value_format. Default is empty string.
             value_format (str): ICU format pattern for parsing and formatting the value.
-                Common patterns: ``'#,##0.00'`` (decimal), ``'¤#,##0.00'`` (currency),
-                ``'yyyy-MM-dd'`` (date), ``'#,##0.00%'`` (percent).
+                Common patterns: `'#,##0.00'` (decimal), `'¤#,##0.00'` (currency),
+                `'yyyy-MM-dd'` (date), `'#,##0.00%'` (percent).
                 If None, value is treated as plain text (no parsing/formatting).
             initial_focus (bool): If True, widget receives focus when created.
             allow_blank (bool): If True, empty input is parsed as None. If False, empty
@@ -51,7 +51,7 @@ class TextEntryPart(ValidationMixin, Entry):
 
         Note:
             The widget automatically subscribes to text changes and sets up
-            event handlers for ``<FocusIn>``, ``<FocusOut>``, and ``<Return>``.
+            event handlers for `<FocusIn>`, `<FocusOut>`, and `<Return>`.
         """
         kwargs.setdefault('ttk_class', 'TField')
         kwargs.setdefault('variant', 'input')
@@ -176,15 +176,15 @@ class TextEntryPart(ValidationMixin, Entry):
             return str(value)
 
     def on_input(self, callback: Callable) -> str:
-        """Bind to ``<<Input>>``. Callback receives ``event.data = {'text': str}``."""
+        """Bind to `<<Input>>`. Callback receives `event.data = {'text': str}`."""
         return self.bind('<<Input>>', callback, add=True)
 
     def off_input(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<Input>>``."""
+        """Unbind from `<<Input>>`."""
         self.unbind('<<Input>>', bind_id)
 
     def on_enter(self, callback: Callable) -> str:
-        """Bind to ``<Return>``. Callback receives ``event.data = {'value': Any, 'text': str}``."""
+        """Bind to `<Return>`. Callback receives `event.data = {'value': Any, 'text': str}`."""
 
         def enrich_callback(event: Event) -> None:
             data = {"value": self._value, "text": self.textsignal.get()}
@@ -194,15 +194,15 @@ class TextEntryPart(ValidationMixin, Entry):
         return self.bind('<Return>', enrich_callback, add=True)
 
     def off_enter(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<Return>``."""
+        """Unbind from `<Return>`."""
         self.unbind('<Return>', bind_id)
 
     def on_changed(self, callback: Callable) -> str:
-        """Bind to ``<<Change>>``. Callback receives ``event.data = {'value': Any, 'prev_value': Any, 'text': str}``."""
+        """Bind to `<<Change>>`. Callback receives `event.data = {'value': Any, 'prev_value': Any, 'text': str}`."""
         return self.bind("<<Change>>", callback, add=True)
 
     def off_changed(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<Change>>``."""
+        """Unbind from `<<Change>>`."""
         self.unbind('<<Change>>', bind_id)
 
     def value(self, value=None):

--- a/src/ttkbootstrap/widgets/primitives/frame.py
+++ b/src/ttkbootstrap/widgets/primitives/frame.py
@@ -61,11 +61,11 @@ class Frame(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Frame):
             surface (str): Optional surface token; otherwise inherited.
             input_background (str): Surface token used as the fill color for all input
                 widgets (Entry, Combobox, Spinbox, Field) inside this container. Cascades
-                to descendants the same way ``surface`` does. Input foreground, border,
+                to descendants the same way `surface` does. Input foreground, border,
                 and focus-ring colors are all derived from this fill so contrast is always
-                correct. Defaults to ``'content'`` (the app background), which keeps
+                correct. Defaults to `'content'` (the app background), which keeps
                 inputs visually distinct regardless of the container surface. Override
-                with any surface token (e.g. ``'card'``) to match the container.
+                with any surface token (e.g. `'card'`) to match the container.
             show_border (bool): Draw a border around the frame.
             style_options (dict): Optional dict forwarded to the style builder.
         """

--- a/src/ttkbootstrap/widgets/primitives/notebook.py
+++ b/src/ttkbootstrap/widgets/primitives/notebook.py
@@ -65,13 +65,13 @@ class Notebook(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Noteb
 
     !!! note "Events"
 
-        - ``<<NotebookTabChange>>``: Triggered when the selected tab changes.
-        - ``<<NotebookTabActivate>>``: Triggered when a tab becomes active.
-        - ``<<NotebookTabDeactivate>>``: Triggered when a tab becomes inactive.
+        - `<<NotebookTabChange>>`: Triggered when the selected tab changes.
+        - `<<NotebookTabActivate>>`: Triggered when a tab becomes active.
+        - `<<NotebookTabDeactivate>>`: Triggered when a tab becomes inactive.
 
-        All events provide ``event.data`` with keys: ``current`` (TabRef), ``previous``
-        (TabRef), ``reason`` ('user', 'api', 'hide', 'forget', 'reorder'),
-        ``via`` ('click', 'key', 'programmatic').
+        All events provide `event.data` with keys: `current` (TabRef), `previous`
+        (TabRef), `reason` ('user', 'api', 'hide', 'forget', 'reorder'),
+        `via` ('click', 'key', 'programmatic').
     """
 
     _ttk_base = ttk.Notebook
@@ -307,7 +307,7 @@ class Notebook(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Noteb
         fmtargs: tuple[Any, ...] | list[Any] = (),
         **kwargs
     ) -> tkinter.Widget:
-        """Insert a widget as a tab at position ``index``, optionally creating a Frame.
+        """Insert a widget as a tab at position `index`, optionally creating a Frame.
 
         Args:
             index (str | int): Position to insert the widget. Defaults to 'end'.
@@ -448,63 +448,63 @@ class Notebook(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Noteb
         return self.tab(key, option, **kwargs)
 
     def on_tab_activated(self, callback: Callable[[Any], Any]) -> str:
-        """Bind a callback to the ``<<NotebookTabActivate>>`` event.
+        """Bind a callback to the `<<NotebookTabActivate>>` event.
 
-        The ``event.data`` payload includes ``current`` (TabRef), ``previous``
-        (TabRef), ``reason`` (ChangeReason), and ``via`` (ChangeMethod).
+        The `event.data` payload includes `current` (TabRef), `previous`
+        (TabRef), `reason` (ChangeReason), and `via` (ChangeMethod).
 
         Args:
             callback (Callable): Function to call when a tab is activated.
 
         Returns:
-            str: The funcid that can be used with ``off_tab_activated()``.
+            str: The funcid that can be used with `off_tab_activated()`.
         """
         return self.bind("<<NotebookTabActivate>>", callback, add=True)
 
     def off_tab_activated(self, bind_id: str | None = None) -> None:
-        """Remove a ``<<NotebookTabActivate>>`` binding.
+        """Remove a `<<NotebookTabActivate>>` binding.
 
         Args:
-            bind_id (str): The bind_id returned by ``on_tab_activated()``.
+            bind_id (str): The bind_id returned by `on_tab_activated()`.
         """
         self.unbind("<<NotebookTabActivate>>", bind_id)
 
     def on_tab_deactivated(self, callback: Callable[[Any], Any]) -> str:
-        """Bind a callback to the ``<<NotebookTabDeactivate>>`` event.
+        """Bind a callback to the `<<NotebookTabDeactivate>>` event.
 
-        The ``event.data`` payload includes ``current`` (TabRef), ``previous``
-        (TabRef), ``reason`` (ChangeReason), and ``via`` (ChangeMethod).
+        The `event.data` payload includes `current` (TabRef), `previous`
+        (TabRef), `reason` (ChangeReason), and `via` (ChangeMethod).
 
         Args:
             callback (Callable): Function to call when a tab is deactivated.
 
         Returns:
-            str: The funcid that can be used with ``off_tab_deactivated()``.
+            str: The funcid that can be used with `off_tab_deactivated()`.
         """
         return self.bind("<<NotebookTabDeactivate>>", callback, add=True)
 
     def off_tab_deactivated(self, bind_id: str | None = None) -> None:
-        """Remove a ``<<NotebookTabDeactivate>>`` binding.
+        """Remove a `<<NotebookTabDeactivate>>` binding.
 
         Args:
-            bind_id (str): The bind_id returned by ``on_tab_deactivated()``.
+            bind_id (str): The bind_id returned by `on_tab_deactivated()`.
         """
         self.unbind("<<NotebookTabDeactivate>>", bind_id)
 
     def on_tab_changed(self, callback: Callable[[Any], Any]) -> str:
-        """Bind a callback to the ``<<NotebookTabChange>>`` event.
+        """Bind a callback to the `<<NotebookTabChange>>` event.
 
-        This also emits ``<<NotebookTabActivate>>`` and ``<<NotebookTabDeactivate>>``
+        This also emits `<<NotebookTabActivate>>` and `<<NotebookTabDeactivate>>`
         events for the affected tabs.
 
-        The ``event.data`` payload includes ``current`` (TabRef), ``previous``
-        (TabRef), ``reason`` (ChangeReason), and ``via`` (ChangeMethod).
+        The `event.data` payload includes `current` (TabRef), `previous`
+        (TabRef), `reason` (ChangeReason), and `via` (ChangeMethod).
 
         Args:
             callback (Callable): Function to call when the tab selection changes.
 
         Returns:
-            str: The funcid that can be used with ``off_tab_changed()``.
+            str: The funcid that can be used with `off_tab_changed()`.
         """
 
         def build_payload(event: Any) -> Any:
@@ -543,9 +543,9 @@ class Notebook(TTKWrapperBase, WidgetCapabilitiesMixin, TtkStateMixin, ttk.Noteb
         return self.bind("<<NotebookTabChange>>", wrapper, add=True)
 
     def off_tab_changed(self, bind_id: str | None = None) -> None:
-        """Remove a ``<<NotebookTabChange>>`` binding.
+        """Remove a `<<NotebookTabChange>>` binding.
 
         Args:
-            bind_id (str): The bind_id returned by ``on_tab_changed()``.
+            bind_id (str): The bind_id returned by `on_tab_changed()`.
         """
         self.unbind("<<NotebookTabChange>>", bind_id)

--- a/src/ttkbootstrap/widgets/primitives/optionmenu.py
+++ b/src/ttkbootstrap/widgets/primitives/optionmenu.py
@@ -63,7 +63,7 @@ class OptionMenu(MenuButton):
         """Create an OptionMenu backed by a ContextMenu.
 
         !!! note "Events"
-            - ``<<Change>>``: Fired when the selected value changes. ``event.data = {'value': Any}``
+            - `<<Change>>`: Fired when the selected value changes. `event.data = {'value': Any}`
 
         Args:
             master: Parent widget. If None, uses the default root window.
@@ -154,7 +154,7 @@ class OptionMenu(MenuButton):
             anchor="nw", attach="sw",
             offset=(offset_x, 0),
             density=density,
-            # OptionMenu drives activation via ``show_menu`` (left-click,
+            # OptionMenu drives activation via `show_menu` (left-click,
             # Return/KP_Enter), not ContextMenu's auto-trigger.
             trigger=None,
         )
@@ -190,11 +190,11 @@ class OptionMenu(MenuButton):
         self.set(value)
 
     def on_changed(self, callback: Callable) -> str:
-        """Bind to ``<<Change>>``. Callback receives ``event.data = {'value': Any}``."""
+        """Bind to `<<Change>>`. Callback receives `event.data = {'value': Any}`."""
         return self.bind('<<Change>>', callback, add="+")
 
     def off_changed(self, bind_id: str | None = None) -> None:
-        """Unbind from ``<<Change>>``."""
+        """Unbind from `<<Change>>`."""
         self.unbind('<<Change>>', bind_id)
 
     @configure_delegate('options')


### PR DESCRIPTION
Convert all docstrings from reStructuredText to MkDocs-compatible Markdown:
- Replace RST double backticks with single Markdown backticks (523 instances, 68 files)
- Convert NumPy-style Parameters/Returns sections to Markdown bold headers with bullet lists
- Replace RST `::` code block markers with triple-backtick fences
- Replace RST section underlines (`------`) with `##` Markdown headers
- Replace `:meth:` role with plain backtick reference
- Replace `.. deprecated::` directive with MkDocs `!!! warning` admonition