### PR TITLE
Fix/meter interactive dead zone snaps to max instead of min

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tests/themes.json
 /.pypirc
 publish.bat
 /issues/
+site

--- a/src/ttkbootstrap/widgets/meter.py
+++ b/src/ttkbootstrap/widgets/meter.py
@@ -592,7 +592,7 @@ class Meter(Frame):
         rads = math.atan2(dy, dx)
         degs = math.degrees(rads)
 
-        if degs > self._arcoffset:
+        if degs > self._arcoffset - max(0, (360 - self._arcrange) / 2):
             factor = degs - self._arcoffset
         else:
             factor = 360 + degs - self._arcoffset

--- a/tests/widgets/meter_deadzone_fix.py
+++ b/tests/widgets/meter_deadzone_fix.py
@@ -1,0 +1,54 @@
+"""
+Demo: Meter dead-zone fix (issue #1047)
+
+Drag the mouse around and below the zero position on each meter.
+Before the fix, releasing in the gap snapped to MAX.
+After the fix, the gap is split: upper half snaps to MIN, lower half to MAX.
+
+Three meters cover the common arc configurations:
+  - 270° arc  (default interactive meter)
+  - 180° arc  (half-circle)
+  - 360° arc  (full circle, no dead zone — should be unaffected)
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+
+app = ttk.Window(title="Meter Dead-Zone Fix — Issue #1047", size=(900, 420))
+
+frame = ttk.Frame(app, padding=20)
+frame.pack(fill=BOTH, expand=YES)
+
+configs = [
+    {"label": "270° arc (default)", "arcrange": 270, "arcoffset": 135},
+    {"label": "180° arc", "arcrange": 180, "arcoffset": 180},
+    {"label": "360° arc (no dead zone)", "arcrange": 360, "arcoffset": -90},
+]
+
+for cfg in configs:
+    col = ttk.Frame(frame)
+    col.pack(side=LEFT, expand=YES, fill=BOTH, padx=10)
+
+    ttk.Label(col, text=cfg["label"], font="-size 11 -weight bold").pack(pady=(0, 6))
+
+    meter = ttk.Meter(
+        col,
+        metersize=220,
+        amountmin=0,
+        amounttotal=100,
+        amountused=0,
+        interactive=True,
+        arcrange=cfg["arcrange"],
+        arcoffset=cfg["arcoffset"],
+        subtext="drag me",
+        bootstyle=INFO,
+    )
+    meter.pack()
+
+    ttk.Label(
+        col,
+        text="Move mouse into the gap\nbelow zero — should snap\nto 0, not 100.",
+        justify=CENTER,
+        font="-size 9",
+    ).pack(pady=(8, 0))
+
+app.mainloop()


### PR DESCRIPTION
  ## Summary

  - When dragging the interactive `Meter` in the gap below zero, the value
    always snapped to **max** instead of **min** (fixes #1047)
  - Split the arc dead zone at its midpoint: upper half clamps to `amountmin`,
    lower half clamps to `amounttotal`
  - Full-circle meters (`arcrange=360`) are unaffected

  ## Changes

  - `src/ttkbootstrap/widgets/meter.py` — one-line condition fix in `_on_dial_interact`
  - `tests/widgets/meter_deadzone_fix.py` — interactive demo covering 270°, 180°, and 360° arc configurations