### PR TITLE
Fix/tkcalendar compatibility in ttk widget constructor and configure …

### DIFF
--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -5290,24 +5290,31 @@ class Bootstyle:
             # must be called AFTER instantiation in order to use winfo_class
             #    in the `get_ttkstyle_name` method
 
-            if style:
-                if Style.get_instance().style_exists_in_theme(style):
-                    self.configure(style=style)
-                else:
+            try:
+                if style:
+                    if Style.get_instance().style_exists_in_theme(style):
+                        self.configure(style=style)
+                    else:
+                        ttkstyle = Bootstyle.update_ttk_widget_style(
+                            self, style, **kwargs
+                        )
+                        self.configure(style=ttkstyle)
+                elif bootstyle:
                     ttkstyle = Bootstyle.update_ttk_widget_style(
-                        self, style, **kwargs
+                        self, bootstyle, **kwargs
                     )
                     self.configure(style=ttkstyle)
-            elif bootstyle:
-                ttkstyle = Bootstyle.update_ttk_widget_style(
-                    self, bootstyle, **kwargs
-                )
-                self.configure(style=ttkstyle)
-            else:
-                ttkstyle = Bootstyle.update_ttk_widget_style(
-                    self, "default", **kwargs
-                )
-                self.configure(style=ttkstyle)
+                else:
+                    ttkstyle = Bootstyle.update_ttk_widget_style(
+                        self, "default", **kwargs
+                    )
+                    self.configure(style=ttkstyle)
+            except AttributeError:
+                # Third-party widgets (e.g. tkcalendar.Calendar) override
+                # configure() and may access instance attributes that are not
+                # yet set when ttk.Frame.__init__ calls back into the
+                # subclass configure before the subclass __init__ completes.
+                pass
 
         return __init__
 
@@ -5393,7 +5400,12 @@ class Bootstyle:
             widget_color = Bootstyle.ttkstyle_widget_color(ttkstyle)
             method_name = Bootstyle.ttkstyle_method_name(widget, ttkstyle)
             builder: StyleBuilderTTK = style._get_builder()
-            builder_method = builder.name_to_method(method_name)
+            try:
+                builder_method = builder.name_to_method(method_name)
+            except AttributeError:
+                # Style name is from a third-party widget (e.g. tkcalendar) and
+                # doesn't map to any ttkbootstrap builder; pass it through as-is.
+                return style_string
             builder_method(builder, widget_color)
 
         # subscribe popdown style to theme changes

--- a/tests/widgets/test_tkcalendar_integration.py
+++ b/tests/widgets/test_tkcalendar_integration.py
@@ -1,0 +1,58 @@
+import ttkbootstrap as ttkb
+
+from tkcalendar import Calendar, DateEntry
+
+import tkinter as tk
+from tkinter import ttk
+
+def example1():
+    def print_sel():
+        print(cal.selection_get())
+        cal.see(datetime.date(year=2016, month=2, day=5))
+
+    top = tk.Toplevel(root)
+
+    import datetime
+    today = datetime.date.today()
+
+    mindate = datetime.date(year=2018, month=1, day=21)
+    maxdate = today + datetime.timedelta(days=5)
+    print(mindate, maxdate)
+
+    cal = Calendar(top, font="Arial 14", selectmode='day', locale='en_US',
+                   mindate=mindate, maxdate=maxdate, disabledforeground='red',
+                   cursor="hand1", year=2018, month=2, day=5)
+    cal.pack(fill="both", expand=True)
+    ttk.Button(top, text="ok", command=print_sel).pack()
+
+def example2():
+    top = tk.Toplevel(root)
+
+    cal = Calendar(top, selectmode='none')
+    date = cal.datetime.today() + cal.timedelta(days=2)
+    cal.calevent_create(date, 'Hello World', 'message')
+    cal.calevent_create(date, 'Reminder 2', 'reminder')
+    cal.calevent_create(date + cal.timedelta(days=-2), 'Reminder 1', 'reminder')
+    cal.calevent_create(date + cal.timedelta(days=3), 'Message', 'message')
+
+    cal.tag_config('reminder', background='red', foreground='yellow')
+
+    cal.pack(fill="both", expand=True)
+    ttk.Label(top, text="Hover over the events.").pack()
+
+
+def example3():
+    top = tk.Toplevel(root)
+
+    ttk.Label(top, text='Choose date').pack(padx=10, pady=10)
+
+    cal = DateEntry(top, width=12, background='darkblue',
+                    foreground='white', borderwidth=2, year=2010)
+    cal.pack(padx=10, pady=10)
+
+root = tk.Tk()
+ttk.Button(root, text='Calendar', command=example1).pack(padx=10, pady=10)
+ttk.Button(root, text='Calendar with events', command=example2).pack(padx=10, pady=10)
+ttk.Button(root, text='DateEntry', command=example3).pack(padx=10, pady=10)
+
+root.mainloop()


### PR DESCRIPTION
…(fixes #806)

Guard the post-init configure call in override_ttk_widget_constructor against AttributeError from third-party widgets (e.g. tkcalendar.Calendar) that override configure() and access uninitialized instance state during ttk.Frame.__init__.

Also fall back to the original style string in update_ttk_widget_style when no ttkbootstrap builder method handles the style name, so third-party style names are passed through unmodified instead of raising AttributeError.