### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/gallery/text_reader.py
+++ b/gallery/text_reader.py
@@ -4,7 +4,7 @@
 """
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
-from ttkbootstrap.scrolled import ScrolledText
+from ttkbootstrap.widgets.scrolled import ScrolledText
 from tkinter.filedialog import askopenfilename
 
 


### PR DESCRIPTION
DeprecationWarning: ttkbootstrap.scrolled is deprecated; import from ttkbootstrap.widgets.scrolled
  from ttkbootstrap.scrolled import ScrolledText