### PR TITLE
Fix Tableview search broken by regex-special characters in query

### DIFF
--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -1603,7 +1603,7 @@ class Tableview(ttk.Frame):
                 for col_index in column_indices:
                     try:
                         col_value = str(row.values[col_index]).lower()
-                        if search_text_escaped in col_value:
+                        if re.search(search_text_escaped, col_value):
                             self.tablerows_filtered.append(row)
                             break
                     except IndexError:
@@ -1612,7 +1612,7 @@ class Tableview(ttk.Frame):
             else:
                 # Search all columns
                 for col in row.values:
-                    if search_text_escaped in str(col).lower():
+                    if re.search(search_text_escaped, str(col).lower()):
                         self.tablerows_filtered.append(row)
                         break
 


### PR DESCRIPTION
Currently, adding any regex special characters to the search field in a Tableview widget breaks the search. This is because the search criteria is being escaped for use as a regex, but then not used as a regex (using `in` instead). Could just stop escaping it, but this PR instead switches to matching with `re.search`.