### PR TITLE
Add regression tests for Tableview search and ScrolledFrame scrolling

### DIFF
--- a/tests/widgets/test_scrolledframe_scrolling.py
+++ b/tests/widgets/test_scrolledframe_scrolling.py
@@ -1,0 +1,64 @@
+"""Regression tests for ScrolledFrame enable/disable scrolling (PR #1064).
+
+A user calling ``disable_scrolling()`` must stay disabled even when the
+mouse later enters the frame. Previously ``_on_enter`` called the public
+``enable_scrolling()``, silently re-enabling scrolling on the next hover.
+
+Runnable headlessly with pytest, or directly as a script.
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.widgets.scrolled import ScrolledFrame
+
+# Mousewheel binding sequence differs by windowing system.
+_SEQUENCES = ("<MouseWheel>", "<Button-4>", "<Button-5>")
+
+
+def _make_frame():
+    app = ttk.Window()
+    app.withdraw()
+    frame = ScrolledFrame(app, autohide=False)
+    child = ttk.Label(frame, text="hi")
+    child.pack()
+    app.update_idletasks()
+    return app, frame, child
+
+
+def _is_bound(child):
+    bindings = child.bind()
+    return any(seq in bindings for seq in _SEQUENCES)
+
+
+def test_disable_survives_hover():
+    """The core bug: hovering must not re-enable a disabled frame."""
+    app, frame, child = _make_frame()
+    try:
+        frame.enable_scrolling()
+        assert _is_bound(child)
+
+        frame.disable_scrolling()
+        assert not _is_bound(child)
+
+        # Mouse enters the frame: must remain disabled.
+        frame._on_enter(None)
+        assert not _is_bound(child)
+    finally:
+        app.destroy()
+
+
+def test_enabled_hover_rebinds():
+    """When enabled, normal hover-in/out (autohide path) still works."""
+    app, frame, child = _make_frame()
+    try:
+        frame.enable_scrolling()
+        frame._on_leave(None)
+        assert not _is_bound(child)
+        frame._on_enter(None)
+        assert _is_bound(child)
+    finally:
+        app.destroy()
+
+
+if __name__ == "__main__":
+    test_disable_survives_hover()
+    test_enabled_hover_rebinds()
+    print("All ScrolledFrame scrolling regression tests passed.")

--- a/tests/widgets/test_tableview_search.py
+++ b/tests/widgets/test_tableview_search.py
@@ -1,0 +1,73 @@
+"""Regression tests for Tableview search (PR #1065).
+
+Search terms containing regex-special characters (``.``, ``(``, ``+``,
+``$``, etc.) must match literally. Previously the criteria was escaped
+with ``re.escape`` but then matched with ``in``, so any special
+character broke the search entirely.
+
+Runnable headlessly with pytest, or directly as a script.
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.widgets.tableview import Tableview
+
+COLDATA = ["Name", "Value"]
+ROWDATA = [
+    ("alpha", "a.b"),      # contains '.'
+    ("beta", "c(d)e"),     # contains '(' ')'
+    ("gamma", "x+y"),      # contains '+'
+    ("delta", "price $5"),  # contains '$'
+    ("eps", "plain"),      # no special chars
+]
+
+
+def _make_table():
+    app = ttk.Window()
+    app.withdraw()
+    table = Tableview(
+        master=app, coldata=COLDATA, rowdata=ROWDATA, paginated=False
+    )
+    return app, table
+
+
+def _search(table, criteria, *columns):
+    table.search_table_data(criteria, *columns)
+    names = sorted(r.values[0] for r in table.tablerows_filtered)
+    table.reset_row_filters()
+    return names
+
+
+def test_special_characters_match_literally():
+    app, table = _make_table()
+    try:
+        assert _search(table, "a.b") == ["alpha"]
+        assert _search(table, "(d)") == ["beta"]
+        assert _search(table, "x+y") == ["gamma"]
+        assert _search(table, "$5") == ["delta"]
+    finally:
+        app.destroy()
+
+
+def test_plain_text_still_matches():
+    app, table = _make_table()
+    try:
+        assert _search(table, "plain") == ["eps"]
+    finally:
+        app.destroy()
+
+
+def test_column_specific_search():
+    app, table = _make_table()
+    try:
+        # 'a.b' is literal special-char text in the Value column only
+        assert _search(table, "a.b", "Value") == ["alpha"]
+        # scoping the same query to the Name column finds nothing
+        assert _search(table, "a.b", "Name") == []
+    finally:
+        app.destroy()
+
+
+if __name__ == "__main__":
+    test_special_characters_match_literally()
+    test_plain_text_still_matches()
+    test_column_specific_search()
+    print("All Tableview search regression tests passed.")


### PR DESCRIPTION
Adds headless regression tests for the two fixes merged in #1064 and #1065, so they don't silently break again.

## Coverage
- **`test_tableview_search.py`** (#1065) — search terms with regex-special characters (`.`, `(`, `+`, `$`) must match literally; plain text still matches; column-scoped search respects the column.
- **`test_scrolledframe_scrolling.py`** (#1064) — `disable_scrolling()` stays disabled across a later mouse-enter; when enabled, normal hover-in/out rebinding still works.

## Notes
- Tests use a withdrawn root so they run headlessly.
- Each file is runnable via `pytest` or directly as a script (`python tests/widgets/<file>.py`).
- Verified both pass on current `master` (with the fixes), and fail on the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)