### PR TITLE
Build base TButton style at theme load (fixes #1062)

### DIFF
--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -1376,6 +1376,15 @@ class StyleBuilderTTK:
             borderwidth=1,
             focuscolor="",
         )
+        # build the default button style up front so that native ttk
+        # widgets the application never instantiates directly -- e.g. the
+        # ttk::button widgets in Tk's file/message dialogs on Linux -- pick
+        # up the theme instead of falling back to the bare clam appearance.
+        # Without this, an app that only creates styled buttons (e.g.
+        # Outline.Toolbutton) would leave the base "TButton" unthemed and
+        # any linked dialog would lose its button coloring (see #1062).
+        self.create_button_style()
+
         # this is general style applied to the tableview
         self.create_link_button_style()
         self.style.configure("symbol.Link.TButton", font="-size 16")

--- a/tests/widget_styles/demo_default_button_style.py
+++ b/tests/widget_styles/demo_default_button_style.py
@@ -1,0 +1,55 @@
+"""Visual demo / validation for issue #1062.
+
+The bug: an app that creates only *styled* buttons (e.g. Outline.Toolbutton)
+left the base ``TButton`` style unthemed. Native ttk widgets that the app
+never builds directly -- like the ``ttk::button`` widgets inside Tk's file
+dialog on Linux -- then rendered with the bare clam look ("lost coloring").
+
+Tk's dialog buttons are created as raw ``ttk::button`` widgets, *not* via
+ttkbootstrap's overridden constructor, so they never trigger the lazy
+style builder. This demo reproduces that exact path with ``tk.call`` so
+the effect is visible on every platform, not just Linux.
+
+Run it:  python tests/widget_styles/demo_default_button_style.py
+
+With the fix, the "simulated dialog button" on the right is themed (it
+matches the app's primary color). Revert the fix in style.py and it
+renders as a plain grey clam button instead.
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+
+app = ttk.Window("Issue #1062 - base TButton theming", themename="sandstone")
+app.geometry("560x260")
+
+frame = ttk.Frame(app, padding=20)
+frame.pack(fill=BOTH, expand=YES)
+
+ttk.Label(
+    frame,
+    text="This app creates ONLY a styled button (Outline.Toolbutton).",
+    font="-size 10",
+).pack(anchor=W, pady=(0, 12))
+
+# 1. The only ttkbootstrap button the app builds -- a styled one.
+left = ttk.Labelframe(frame, text="App button (styled)", padding=15)
+left.pack(side=LEFT, fill=BOTH, expand=YES, padx=(0, 10))
+ttk.Button(left, text="Browse", style="Outline.Toolbutton").pack()
+
+# 2. A raw ttk::button created the way Tk's file dialog does -- this uses
+#    the base "TButton" style and never goes through ttkbootstrap.
+right = ttk.Labelframe(frame, text="Simulated dialog button (raw ttk::button)", padding=15)
+right.pack(side=LEFT, fill=BOTH, expand=YES)
+raw_path = str(right) + ".rawbtn"
+app.tk.call("ttk::button", raw_path, "-text", "OK")
+app.tk.call("pack", raw_path)
+
+bg = app.tk.call("ttk::style", "lookup", "TButton", "-background")
+ttk.Label(
+    frame,
+    text=f"base TButton background = {bg}   (theme primary = {ttk.Style().colors.primary})",
+    font="-size 9",
+    bootstyle="secondary",
+).pack(side=BOTTOM, anchor=W, pady=(12, 0))
+
+app.mainloop()

--- a/tests/widget_styles/test_default_button_style.py
+++ b/tests/widget_styles/test_default_button_style.py
@@ -1,0 +1,55 @@
+"""Regression test for issue #1062.
+
+ttkbootstrap builds widget styles lazily, so the base ``TButton`` style
+used to be configured only when the app created a *default* ``ttk.Button``.
+Native ttk widgets the app never instantiates directly -- such as the
+``ttk::button`` widgets inside Tk's file/message dialogs on Linux -- rely
+on that base style. An app that created only styled buttons (e.g.
+``Outline.Toolbutton``) therefore left ``TButton`` unthemed, and any
+linked dialog lost its button coloring.
+
+The base ``TButton`` style must now be themed at theme-load time, even
+when the application never creates a plain button, and it must follow
+runtime theme changes.
+
+Runnable headlessly with pytest, or directly as a script.
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.style import Style
+
+
+def _tbutton_background(app):
+    return str(app.tk.call("ttk::style", "lookup", "TButton", "-background")).lower()
+
+
+def test_base_tbutton_themed_without_default_button():
+    """The base ``TButton`` is themed at load, and follows theme changes,
+    even when the app only ever creates a styled button.
+
+    A single Tk root is used because ttkbootstrap's ``Style`` is a
+    singleton; creating multiple roots in one process is unsupported.
+    """
+    app = ttk.Window(themename="sandstone")
+    app.withdraw()
+    style = Style.get_instance()
+    try:
+        # Mirror the bug report: only a styled toolbutton is created.
+        ttk.Button(app, text="Browse", style="Outline.Toolbutton")
+
+        assert style.style_exists_in_theme("TButton"), \
+            "base TButton should be built at theme load"
+        assert _tbutton_background(app) == str(style.colors.primary).lower(), \
+            "base TButton should use the theme's primary color"
+
+        # The base style must keep tracking the active theme.
+        for theme in ("superhero", "flatly", "litera"):
+            style.theme_use(theme)
+            assert _tbutton_background(app) == str(style.colors.primary).lower(), \
+                f"base TButton did not follow change to {theme}"
+    finally:
+        app.destroy()
+
+
+if __name__ == "__main__":
+    test_base_tbutton_themed_without_default_button()
+    print("All default-button-style regression tests passed.")


### PR DESCRIPTION
Fixes #1062.

## Problem
ttkbootstrap builds widget styles lazily — the base `TButton` style is only configured once the app creates a default `ttk.Button`. Native ttk widgets that the app never instantiates directly — notably the `ttk::button` widgets inside Tk's file/message dialogs on Linux — rely on that base style. An app that creates only *styled* buttons (e.g. `Outline.Toolbutton`) therefore left `TButton` unthemed, and any linked dialog lost its button coloring.

This also explains the reporter's workaround: adding a plain `ttk.Button` (even unpacked) restored the dialog coloring, because constructing it triggered the lazy builder for `TButton`. The bug reproduces on Linux but not Windows because Windows uses the OS-native file dialog rather than Tk's ttk-based one.

## Fix
Configure the default `TButton` style in `create_default_style()` so the base style is themed at theme-load time regardless of which widgets the app creates. It is registered like any other style, so it also follows runtime theme changes. The call is asset-free and is exactly what ttkbootstrap already does the moment any default button is created — this just makes that the default state.

## Validation
- **Regression test** — `tests/widget_styles/test_default_button_style.py`: asserts the base `TButton` is themed at load with no default button created, and that it follows theme switches. Passes with the fix, fails without it.
- **Visual demo** — `tests/widget_styles/demo_default_button_style.py`: reproduces the dialog's exact widget path cross-platform via `tk.call("ttk::button", ...)`.

Before fix → the simulated dialog button renders as bare unthemed text; after fix → it is themed to the primary color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)