### PR TITLE
2.0: add internal/ package, split public vs internal plumbing

### DIFF
--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -9,7 +9,7 @@ from tkinter import BaseWidget
 from typing import Any, Optional, Tuple
 
 import ttkbootstrap as ttk
-from ttkbootstrap.utility import center_on_parent
+from ttkbootstrap.internal.utility import center_on_parent
 
 
 class Dialog(BaseWidget):

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional, Tuple
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
-from ttkbootstrap.utility import center_on_parent
+from ttkbootstrap.internal.utility import center_on_parent
 
 
 class DatePickerDialog:

--- a/src/ttkbootstrap/internal/__init__.py
+++ b/src/ttkbootstrap/internal/__init__.py
@@ -1,0 +1,7 @@
+"""Internal plumbing for ttkbootstrap.
+
+Modules under `ttkbootstrap.internal` are implementation details with no
+backward-compatibility guarantee. They may change or be removed in any release.
+Public code should import from the top-level `ttkbootstrap` package and its
+documented modules instead.
+"""

--- a/src/ttkbootstrap/internal/publisher.py
+++ b/src/ttkbootstrap/internal/publisher.py
@@ -1,0 +1,147 @@
+"""Publisher-Subscriber pattern implementation for ttkbootstrap.
+
+This module implements a simple publisher-subscriber (pub-sub) pattern used
+for theme change notifications and widget updates throughout ttkbootstrap.
+
+The Publisher class manages subscribers on different channels and broadcasts
+messages to all subscribers when events occur (like theme changes).
+
+Classes:
+    Channel: Enum defining subscriber channels (STD for tk, TTK for ttk)
+    Subscriber: Data class storing subscriber information
+    Publisher: Manages subscriptions and publishes messages to subscribers
+
+Example:
+    ```python
+    from ttkbootstrap.internal.publisher import Publisher, Channel
+
+    # Subscribe a function to theme changes
+    def on_theme_change():
+        print("Theme changed!")
+
+    Publisher.subscribe(
+        func=on_theme_change,
+        channel=Channel.TTK
+    )
+
+    # Publish a message to all TTK subscribers
+    Publisher.publish(Channel.TTK)
+    ```
+"""
+from enum import Enum
+from typing import List
+
+
+class Channel(Enum):
+    """A grouping for Publisher subscribers. Indicates whether the
+    widget is a legacy `STD` tk widget or a styled `TTK` widget.
+
+    Attributes:
+
+        STD (1):
+            Legacy tkinter widgets.
+
+        TTK (2):
+            Themed tkinter widgets.
+    """
+
+    STD = 1
+    TTK = 2
+
+
+class Subscriber:
+    """A subscriber data class used to store information about a specific
+    subscriber to the `Publisher`."""
+
+    def __init__(self, name, func, channel):
+        """Create a subscriber.
+
+        Parameters:
+
+            name (str):
+                The name of the subscriber
+
+            func (Callable):
+                The function to call when messaging.
+
+            channel (Channel):
+                The subscription channel.
+        """
+        self.name = name
+        self.func = func
+        self.channel = channel
+
+
+class Publisher:
+    """Publish events to subscribed widgets for theme changes or configuration updates."""
+
+    __subscribers = {}
+
+    @staticmethod
+    def subscriber_count():
+        return len(Publisher.__subscribers)
+
+    @staticmethod
+    def subscribe(name, func, channel):
+        """Subscribe to an event.
+
+        Parameters:
+
+            name (str):
+                The widget's tkinter/tcl name.
+
+            func (Callable):
+                A function to call when passing a message.
+
+            channel (Channel):
+                Indicates the channel grouping the subscribers.
+        """
+        subs = Publisher.__subscribers
+        subs[name] = Subscriber(name, func, channel)
+
+    @staticmethod
+    def unsubscribe(name):
+        """Remove a subscriber.
+
+        Parameters:
+
+            name (str):
+                The widget's tkinter/tcl name.
+        """
+        subs = Publisher.__subscribers
+        try:
+            del subs[str(name)]
+        except:
+            pass
+
+    def get_subscribers(channel):
+        """Return a list of subscribers.
+
+        Returns:
+
+            List:
+                List of key-value tuples
+        """
+        subs = Publisher.__subscribers.values()
+        channel_subs = [s for s in subs if s.channel == channel]
+        return channel_subs
+
+    def publish_message(channel, *args):
+        """Publish a message to all subscribers.
+
+        Parameters:
+
+            channel (Channel):
+                The name of the channel to subscribe.
+
+            **args:
+                optional arguments to pass to the subscribers.
+        """
+        subs: list[Subscriber] = Publisher.get_subscribers(channel)
+        for sub in subs:
+            sub.func(*args)
+
+    @staticmethod
+    def clear_subscribers():
+        """Reset all subscriptions."""
+        Publisher.__subscribers.clear()

--- a/src/ttkbootstrap/internal/utility.py
+++ b/src/ttkbootstrap/internal/utility.py
@@ -1,0 +1,46 @@
+"""Internal utility helpers for ttkbootstrap.
+
+These are implementation details with no backward-compatibility guarantee.
+Public utility functions (`enable_high_dpi_awareness`, `scale_size`) live in
+the top-level `ttkbootstrap.utility` module.
+"""
+
+
+def get_image_name(image):
+    """Extract and return the tcl/tk image name from a PhotoImage
+    object.
+
+    Parameters:
+
+        image (ImageTk.PhotoImage):
+            A photoimage object.
+
+    Returns:
+
+        str:
+            The tcl/tk name of the photoimage object.
+    """
+    return image._PhotoImage__photo.name
+
+
+def center_on_parent(win, parent=None):
+    """Center `win` on parent or over its master if not given"""
+    win.update_idletasks()  # ensure geometry
+    if parent is None:
+        parent = getattr(win, 'master', None) or win  # root if no parent
+
+    # parent geometry
+    parent.update_idletasks()
+    px, py = parent.winfo_rootx(), parent.winfo_rooty()
+    pw, ph = parent.winfo_width(), parent.winfo_height()
+    if pw <= 1 or ph <= 1:
+        # not yet realized, fallback to requested size
+        pw, ph = parent.winfo_reqwidth(), parent.winfo_reqheight()
+
+    # window geometry
+    ww = win.winfo_width() or win.winfo_reqwidth()
+    wh = win.winfo_height() or win.winfo_reqheight()
+
+    x = px + (pw - ww) // 2
+    y = py + (ph - wh) // 2
+    win.geometry(f"{ww}x{wh}+{x}+{y}")

--- a/src/ttkbootstrap/publisher.py
+++ b/src/ttkbootstrap/publisher.py
@@ -1,147 +1,16 @@
-"""Publisher-Subscriber pattern implementation for ttkbootstrap.
+"""Deprecated location for ttkbootstrap's internal publisher.
 
-This module implements a simple publisher-subscriber (pub-sub) pattern used
-for theme change notifications and widget updates throughout ttkbootstrap.
-
-The Publisher class manages subscribers on different channels and broadcasts
-messages to all subscribers when events occur (like theme changes).
-
-Classes:
-    Channel: Enum defining subscriber channels (STD for tk, TTK for ttk)
-    Subscriber: Data class storing subscriber information
-    Publisher: Manages subscriptions and publishes messages to subscribers
-
-Example:
-    ```python
-    from ttkbootstrap.publisher import Publisher, Channel
-
-    # Subscribe a function to theme changes
-    def on_theme_change():
-        print("Theme changed!")
-
-    Publisher.subscribe(
-        func=on_theme_change,
-        channel=Channel.TTK
-    )
-
-    # Publish a message to all TTK subscribers
-    Publisher.publish(Channel.TTK)
-    ```
+The publisher is internal plumbing and has moved to
+`ttkbootstrap.internal.publisher`. This shim re-exports it for backward
+compatibility and will be removed in 3.0.
 """
-from enum import Enum
-from typing import List
+import warnings
 
+warnings.warn(
+    "ttkbootstrap.publisher is internal and has moved to "
+    "ttkbootstrap.internal.publisher; this shim will be removed in 3.0.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-class Channel(Enum):
-    """A grouping for Publisher subscribers. Indicates whether the
-    widget is a legacy `STD` tk widget or a styled `TTK` widget.
-
-    Attributes:
-
-        STD (1):
-            Legacy tkinter widgets.
-
-        TTK (2):
-            Themed tkinter widgets.
-    """
-
-    STD = 1
-    TTK = 2
-
-
-class Subscriber:
-    """A subscriber data class used to store information about a specific
-    subscriber to the `Publisher`."""
-
-    def __init__(self, name, func, channel):
-        """Create a subscriber.
-
-        Parameters:
-
-            name (str):
-                The name of the subscriber
-
-            func (Callable):
-                The function to call when messaging.
-
-            channel (Channel):
-                The subscription channel.
-        """
-        self.name = name
-        self.func = func
-        self.channel = channel
-
-
-class Publisher:
-    """Publish events to subscribed widgets for theme changes or configuration updates."""
-
-    __subscribers = {}
-
-    @staticmethod
-    def subscriber_count():
-        return len(Publisher.__subscribers)
-
-    @staticmethod
-    def subscribe(name, func, channel):
-        """Subscribe to an event.
-
-        Parameters:
-
-            name (str):
-                The widget's tkinter/tcl name.
-
-            func (Callable):
-                A function to call when passing a message.
-
-            channel (Channel):
-                Indicates the channel grouping the subscribers.
-        """
-        subs = Publisher.__subscribers
-        subs[name] = Subscriber(name, func, channel)
-
-    @staticmethod
-    def unsubscribe(name):
-        """Remove a subscriber.
-
-        Parameters:
-
-            name (str):
-                The widget's tkinter/tcl name.
-        """
-        subs = Publisher.__subscribers
-        try:
-            del subs[str(name)]
-        except:
-            pass
-
-    def get_subscribers(channel):
-        """Return a list of subscribers.
-
-        Returns:
-
-            List:
-                List of key-value tuples
-        """
-        subs = Publisher.__subscribers.values()
-        channel_subs = [s for s in subs if s.channel == channel]
-        return channel_subs
-
-    def publish_message(channel, *args):
-        """Publish a message to all subscribers.
-
-        Parameters:
-
-            channel (Channel):
-                The name of the channel to subscribe.
-
-            **args:
-                optional arguments to pass to the subscribers.
-        """
-        subs: list[Subscriber] = Publisher.get_subscribers(channel)
-        for sub in subs:
-            sub.func(*args)
-
-    @staticmethod
-    def clear_subscribers():
-        """Reset all subscriptions."""
-        Publisher.__subscribers.clear()
+from ttkbootstrap.internal.publisher import Channel, Subscriber, Publisher  # noqa: F401,E402

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -63,9 +63,10 @@ from typing import Any, Callable
 from PIL import Image, ImageColor, ImageDraw, ImageFont, ImageTk
 from PIL.Image import Resampling, Transpose
 
-from ttkbootstrap import colorutils, utility as util
+from ttkbootstrap import colorutils
+from ttkbootstrap.internal import utility as util
 from ttkbootstrap.constants import *
-from ttkbootstrap.publisher import Channel, Publisher
+from ttkbootstrap.internal.publisher import Channel, Publisher
 from ttkbootstrap.themes.standard import STANDARD_THEMES
 
 try:

--- a/src/ttkbootstrap/utility.py
+++ b/src/ttkbootstrap/utility.py
@@ -1,14 +1,11 @@
-"""Utility functions for ttkbootstrap.
+"""Public utility functions for ttkbootstrap.
 
-This module provides various utility functions for common tasks in
-ttkbootstrap applications, including high-DPI support, screen geometry
-calculations, and color manipulations.
+This module provides high-DPI support and size scaling helpers for
+ttkbootstrap applications.
 
 Functions:
     enable_high_dpi_awareness: Enable high-DPI scaling on Windows/Linux
     scale_size: Scale a size value for high-DPI displays
-    get_desktop_geometry: Get the screen dimensions
-    get_asset_path: Get the path to an asset file
 
 Example:
     ```python
@@ -22,6 +19,26 @@ Example:
     root.mainloop()
     ```
 """
+import warnings
+
+# Helpers that used to live here but are implementation details. They now live
+# in ttkbootstrap.internal.utility; accessing them through this module is
+# deprecated and the forwarding will be removed in 3.0.
+_MOVED_TO_INTERNAL = ("get_image_name", "center_on_parent")
+
+
+def __getattr__(name):
+    if name in _MOVED_TO_INTERNAL:
+        warnings.warn(
+            f"ttkbootstrap.utility.{name} is internal and has moved to "
+            f"ttkbootstrap.internal.utility.{name}; this forwarding will be "
+            "removed in 3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from ttkbootstrap.internal import utility as internal_utility
+        return getattr(internal_utility, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def enable_high_dpi_awareness(root=None, scaling=None):
@@ -82,21 +99,6 @@ def enable_high_dpi_awareness(root=None, scaling=None):
     except:
         pass
 
-def get_image_name(image):
-    """Extract and return the tcl/tk image name from a PhotoImage 
-    object.
-    
-    Parameters:
-
-        image (ImageTk.PhotoImage):
-            A photoimage object.
-
-    Returns:
-
-        str:
-            The tcl/tk name of the photoimage object.
-    """
-    return image._PhotoImage__photo.name
 
 def scale_size(widget, size):
     """Scale the size based on the scaling factor of tkinter. 
@@ -124,26 +126,3 @@ def scale_size(widget, size):
         return int(size * factor)
     elif isinstance(size, tuple) or isinstance(size, list):
         return [int(x * factor) for x in size]
-
-
-def center_on_parent(win, parent=None):
-    """Center `win` on parent or over its master if not given"""
-    win.update_idletasks() # ensure geometry
-    if parent is None:
-        parent = getattr(win, 'master', None) or win # root if no parent
-
-    # parent geometry
-    parent.update_idletasks()
-    px, py = parent.winfo_rootx(), parent.winfo_rooty()
-    pw, ph = parent.winfo_width(), parent.winfo_height()
-    if pw <= 1 or ph <= 1:
-        # not yet realized, fallback to requested size
-        pw, ph = parent.winfo_reqwidth(), parent.winfo_reqheight()
-
-    # window geometry
-    ww = win.winfo_width() or win.winfo_reqwidth()
-    wh = win.winfo_height() or win.winfo_reqheight()
-
-    x = px + (pw - ww) // 2
-    y = py + (ph - wh) // 2
-    win.geometry(f"{ww}x{wh}+{x}+{y}")

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -49,7 +49,7 @@ from typing import Any, Optional, Tuple, Union
 from ttkbootstrap import utility
 from ttkbootstrap.constants import *
 from ttkbootstrap.icons import Icon
-from ttkbootstrap.publisher import Publisher
+from ttkbootstrap.internal.publisher import Publisher
 from ttkbootstrap.style import Style
 
 


### PR DESCRIPTION
Second 2.0 cleanup slice (Workstream G — public/internal split). Establishes `ttkbootstrap/internal/` as the home for implementation-detail modules, separate from the documented public surface.

## What moved
| Module | Verdict | Action |
|---|---|---|
| `publisher.py` (Channel/Subscriber/Publisher) | **internal** — not documented, not in the typing stub; only the legacy-tk repaint plumbing uses it | → `internal/publisher.py`; top-level `ttkbootstrap.publisher` is now a warn-and-reexport shim (removed in 3.0) |
| `utility.py` | **public** — has an API docs page; `enable_high_dpi_awareness` is user-facing | stays public, but trimmed |
| `utility.get_image_name` | internal (used only by the style engine, 38 sites) | → `internal/utility.py` |
| `utility.center_on_parent` | internal (dialog helper) | → `internal/utility.py` |

The public `utility.py` keeps `enable_high_dpi_awareness` + `scale_size` and forwards the two moved names via module `__getattr__` with a `DeprecationWarning` (removed in 3.0), so any external `from ttkbootstrap.utility import center_on_parent` still works but warns.

Internal importers (`style.py`, `window.py`, `dialogs/base.py`, `dialogs/datepicker.py`) rewired to the new paths. All `scale_size` callers were already importing the public `utility` module and are unchanged.

## Deferred
Eliminating `Publisher` outright — replacing it with bootstack's version-stamped theme walk — is **Workstream A engine work in `style.py`** and is reserved for that design session. This PR only relocates it.

## Verification
- `12 passed`, suite green.
- Smoke test: tk-widget recolor + combobox popdown repaint on `theme_use`, and `<Destroy>` unsubscribe (3→2 subscribers).
- `import ttkbootstrap` emits zero deprecation warnings; the shims warn only when the old paths are used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)