### PR TITLE
Fix widget lifecycle leaks: traces, after-loops, popdown subscription (2.0)

### DIFF
--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -8,7 +8,7 @@ _Last updated: 2026-06-25._
 ## Where we are
 
 Integration branch: **`2.0`** (cut all 2.0 PRs against it, not `master`).
-Suite: `python -m pytest -q` → **12 passed**, headless, order-independent.
+Suite: `python -m pytest -q` → **18 passed**, headless, order-independent.
 
 ### Merged into `2.0`
 - **#1068** — Tier-0 cleanup:
@@ -28,6 +28,21 @@ Suite: `python -m pytest -q` → **12 passed**, headless, order-independent.
   - `utility` stays public (`enable_high_dpi_awareness`, `scale_size`); its two
     internal helpers (`get_image_name`, `center_on_parent`) moved to
     `internal/utility.py`, forwarded from `utility.py` via `__getattr__` + warning.
+- **Workstream B (widget-level lifecycle leaks)** — `destroy()`/unsubscribe paths:
+  - Canvas `Floodgauge`: trace ids tracked; removed on `destroy()` and when a
+    `variable`/`textvariable` is swapped via `configure` (was unbounded trace
+    accumulation + external vars pinning a dead widget). `destroy()` also cancels
+    the running `after()` animation loop.
+  - `Meter`: `_set_interactive_bind()` unbinds before rebinding (no orphaned
+    indicator binds when toggling `interactive`); `destroy()` detaches the
+    `amountusedvar` write trace.
+  - `Combobox` popdown: self-unsubscribes from `Publisher` via a once-bound
+    `<Destroy>` handler (`style.py` ~`5434`), so cleanup no longer depends solely
+    on the `Window` global `<Destroy>` binding (absent under a vanilla `tk.Tk()`).
+  - New `tests/widgets/test_lifecycle.py` (6 headless regression tests).
+  - **Not done (left for the engine session):** the `Publisher` mechanism itself
+    (keystone, below). `FloodgaugeLegacy` has the same trace-leak pattern but is
+    slated for deprecation — left alone.
 
 ## The hard rule
 
@@ -43,12 +58,10 @@ low-risk cleanup can proceed without it.
    lean: **add a `DeprecationWarning` in 2.0, remove in 3.0** rather than delete
    cold. Exported from `__init__.py`, `widgets/__init__.py`, `__init__.pyi`,
    defined in `widgets/floodgauge.py`.
-2. **Lifecycle leaks (Workstream B)** — `destroy()`/unsubscribe paths for
-   Floodgauge `after()` loops + variable traces, Meter binding IDs, Combobox
-   `Publisher.subscribe` with no unsubscribe. Self-contained; pairs well with a
-   destroy/recreate stress harness.
-3. **Wart:** ~30 demos in `examples/` still carry `test_` prefixes (no longer
+2. **Wart:** ~30 demos in `examples/` still carry `test_` prefixes (no longer
    collected, just misleading names). Trivial rename.
+
+(Workstream B widget-level lifecycle leaks — **done**, see Merged section above.)
 
 ## The keystone (needs the design session)
 

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -5431,6 +5431,17 @@ class Bootstyle:
                     ),
                     channel=Channel.STD,
                 )
+                # Drop the subscription when the combobox is destroyed, even
+                # when not using a ttkbootstrap Window (whose global <Destroy>
+                # binding would otherwise be the only thing that unsubscribes).
+                # Bind once; this resolver runs on every style update.
+                if not getattr(widget, "_tb_popdown_unsub_bound", False):
+                    widget.bind(
+                        "<Destroy>",
+                        lambda e, n=winfo_pathname: Publisher.unsubscribe(n),
+                        add="+",
+                    )
+                    widget._tb_popdown_unsub_bound = True
                 builder.update_combobox_popdown_style(widget)
         except:
             pass

--- a/src/ttkbootstrap/widgets/floodgauge.py
+++ b/src/ttkbootstrap/widgets/floodgauge.py
@@ -124,8 +124,10 @@ class Floodgauge(Canvas):
 
         super().__init__(master, **canvas_kwargs)
 
-        self.variable.trace_add("write", lambda n, i, m: self._on_var_change())
-        self.textvariable.trace_add("write", lambda n, i, m: self._on_text_change())
+        self._var_traceid = None
+        self._textvar_traceid = None
+        self._bind_variable(self.variable)
+        self._bind_textvariable(self.textvariable)
 
         self.value = self.variable.get()
         self.text = self.textvariable.get()
@@ -212,6 +214,57 @@ class Floodgauge(Canvas):
     def _on_text_change(self) -> None:
         self.text = self.textvariable.get()
         self._draw()
+
+    def _bind_variable(self, variable: IntVar) -> None:
+        """Trace `variable` for value changes, dropping any prior trace.
+
+        The trace id is retained so it can be removed when the variable is
+        swapped via `configure` or when the widget is destroyed, preventing
+        traces from accumulating (and from keeping an external variable's
+        write callback pointed at a dead widget).
+        """
+        if self._var_traceid is not None:
+            try:
+                self.variable.trace_remove("write", self._var_traceid)
+            except TclError:
+                pass
+        self.variable = variable
+        self._var_traceid = variable.trace_add(
+            "write", lambda n, i, m: self._on_var_change()
+        )
+
+    def _bind_textvariable(self, textvariable: StringVar) -> None:
+        """Trace `textvariable` for changes, dropping any prior trace."""
+        if self._textvar_traceid is not None:
+            try:
+                self.textvariable.trace_remove("write", self._textvar_traceid)
+            except TclError:
+                pass
+        self.textvariable = textvariable
+        self._textvar_traceid = textvariable.trace_add(
+            "write", lambda n, i, m: self._on_text_change()
+        )
+
+    def destroy(self) -> None:
+        """Cancel the animation loop and detach variable traces.
+
+        Without this, a running `after()` loop keeps firing on the destroyed
+        canvas (raising `TclError`) and an external `variable`/`textvariable`
+        keeps the widget alive through its write trace.
+        """
+        self.stop()
+        for variable, traceid in (
+            (self.variable, self._var_traceid),
+            (self.textvariable, self._textvar_traceid),
+        ):
+            if traceid is not None:
+                try:
+                    variable.trace_remove("write", traceid)
+                except TclError:
+                    pass
+        self._var_traceid = None
+        self._textvar_traceid = None
+        super().destroy()
 
     def step(self, amount: int = 1) -> None:
         """Increment the progress value.
@@ -356,11 +409,9 @@ class Floodgauge(Canvas):
             else:
                 self.configure(width=self.thickness)
         if "variable" in kwargs:
-            self.variable = kwargs.pop("variable")
-            self.variable.trace_add("write", lambda n, i, m: self._on_var_change())
+            self._bind_variable(kwargs.pop("variable"))
         if "textvariable" in kwargs:
-            self.textvariable = kwargs.pop("textvariable")
-            self.textvariable.trace_add("write", lambda n, i, m: self._on_text_change())
+            self._bind_textvariable(kwargs.pop("textvariable"))
 
         result = super().configure(**kwargs)
         self._draw()

--- a/src/ttkbootstrap/widgets/meter.py
+++ b/src/ttkbootstrap/widgets/meter.py
@@ -38,7 +38,7 @@ Example:
     ```
 """
 import math
-from tkinter import Event, Misc
+from tkinter import Event, Misc, TclError
 from typing import Any, Optional, Union
 
 from PIL import Image, ImageDraw, ImageTk
@@ -239,7 +239,9 @@ class Meter(Frame):
         # widget variables
         self.amountminvar = IntVar(value=amountmin)
         self.amountusedvar = IntVar(value=amountused)
-        self.amountusedvar.trace_add("write", self._update_meter)
+        self._amountused_traceid = self.amountusedvar.trace_add(
+            "write", self._update_meter
+        )
         self.amountuseddisplayvar = StringVar(value=amountformat.format(amountused))
         self.amounttotalvar = IntVar(value=amounttotal)
         self.labelvar = StringVar(value=subtext)
@@ -275,6 +277,20 @@ class Meter(Frame):
         self._draw_meter()
         amount_used = self.amountusedvar.get()
         self.amountuseddisplayvar.set(self._amountformat.format(amount_used))
+
+    def destroy(self) -> None:
+        """Detach the value-variable trace before teardown.
+
+        The trace's write callback holds a reference back to the meter, so
+        leaving it attached keeps the widget alive after destroy.
+        """
+        if self._amountused_traceid is not None:
+            try:
+                self.amountusedvar.trace_remove("write", self._amountused_traceid)
+            except TclError:
+                pass
+            self._amountused_traceid = None
+        super().destroy()
 
     def _setup_widget(self) -> None:
         """Initialize and configure all meter components.
@@ -400,6 +416,12 @@ class Meter(Frame):
         seq1 = "<B1-Motion>"
         seq2 = "<Button-1>"
 
+        # Drop any existing binds first so repeated calls (e.g. toggling
+        # `interactive` via configure) don't leak orphaned bind callbacks.
+        for seq in (seq1, seq2):
+            if seq in self._bindids:
+                self.indicator.unbind(seq, self._bindids.pop(seq))
+
         if self._interactive:
             self._bindids[seq1] = self.indicator.bind(
                 seq1, self._on_dial_interact
@@ -407,12 +429,6 @@ class Meter(Frame):
             self._bindids[seq2] = self.indicator.bind(
                 seq2, self._on_dial_interact
             )
-            return
-
-        if seq1 in self._bindids:
-            self.indicator.unbind(seq1, self._bindids.get(seq1))
-            self.indicator.unbind(seq2, self._bindids.get(seq2))
-            self._bindids.clear()
 
     def _set_arc_offset_range(
         self, metertype: str, arcoffset: Optional[int], arcrange: Optional[int]

--- a/tests/widgets/test_lifecycle.py
+++ b/tests/widgets/test_lifecycle.py
@@ -1,0 +1,97 @@
+"""Lifecycle/leak regression tests (2.0 Workstream B).
+
+Widgets that schedule `after()` loops, add variable traces, or subscribe to
+the `Publisher` must release those resources when they are reconfigured or
+destroyed. Otherwise a destroyed widget keeps firing callbacks (raising
+`TclError`) or is kept alive by an external variable's trace.
+
+Runnable headlessly with pytest.
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.internal.publisher import Publisher
+from ttkbootstrap.widgets.floodgauge import Floodgauge
+from ttkbootstrap.widgets.meter import Meter
+
+
+# --------------------------------------------------------------------------- #
+# Floodgauge (canvas)
+# --------------------------------------------------------------------------- #
+def test_floodgauge_external_var_trace_released_on_destroy(root):
+    """Destroying a Floodgauge detaches traces from an external variable."""
+    var = ttk.IntVar(master=root, value=0)
+    fg = Floodgauge(root, variable=var)
+    root.update_idletasks()
+    assert len(var.trace_info()) == 1
+
+    fg.destroy()
+    assert len(var.trace_info()) == 0
+
+
+def test_floodgauge_configure_variable_no_trace_accumulation(root):
+    """Swapping the variable via configure removes the old trace."""
+    fg = Floodgauge(root)
+    v1 = ttk.IntVar(master=root)
+    fg.configure(variable=v1)
+    assert len(v1.trace_info()) == 1
+
+    v2 = ttk.IntVar(master=root)
+    fg.configure(variable=v2)
+    assert len(v1.trace_info()) == 0  # old trace gone
+    assert len(v2.trace_info()) == 1  # new var traced exactly once
+
+
+def test_floodgauge_destroy_cancels_animation(root):
+    """A running animation loop is cancelled on destroy."""
+    fg = Floodgauge(root, mode="indeterminate")
+    fg.pack()
+    root.update_idletasks()
+    fg.start()
+    assert fg._after_id is not None
+
+    fg.destroy()
+    assert fg._after_id is None
+    root.update()  # a stale after-callback would raise here
+
+
+# --------------------------------------------------------------------------- #
+# Meter
+# --------------------------------------------------------------------------- #
+def test_meter_interactive_toggle_no_bind_accumulation(root):
+    """Toggling interactive mode does not accumulate indicator bindings."""
+    m = Meter(root, interactive=True)
+    root.update_idletasks()
+    assert len(m._bindids) == 2
+
+    # Re-asserting interactive must not add a second pair of bindings.
+    m.configure(interactive=True)
+    assert len(m._bindids) == 2
+
+    m.configure(interactive=False)
+    assert len(m._bindids) == 0
+
+
+def test_meter_value_trace_released_on_destroy(root):
+    """Destroying a meter detaches its value-variable trace."""
+    m = Meter(root, amountused=10)
+    root.update_idletasks()
+    var = m.amountusedvar
+    assert len(var.trace_info()) == 1
+
+    m.destroy()
+    assert len(var.trace_info()) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Combobox popdown subscription
+# --------------------------------------------------------------------------- #
+def test_combobox_unsubscribes_on_destroy(root):
+    """A combobox releases its Publisher popdown subscription on destroy."""
+    base = Publisher.subscriber_count()
+    cb = ttk.Combobox(root, values=["a", "b"])
+    cb.pack()
+    root.update_idletasks()
+    assert Publisher.subscriber_count() > base
+
+    cb.destroy()
+    root.update_idletasks()
+    assert Publisher.subscriber_count() == base


### PR DESCRIPTION
## What

Workstream B (lifecycle cleanup) from the 2.0 plan — add `destroy()`/unsubscribe
paths so widgets release scheduled callbacks, variable traces, and `Publisher`
subscriptions instead of leaking them or firing on a destroyed widget.

## Changes

- **Canvas `Floodgauge`** — track `variable`/`textvariable` trace ids; remove
  them on `destroy()` and when swapped via `configure()`. Previously every
  `configure(variable=…)` added a trace without removing the old one (unbounded
  accumulation), and an external variable's trace pinned a destroyed widget.
  `destroy()` also cancels the running `after()` animation loop, which otherwise
  kept firing on the dead canvas (raising `TclError`).
- **`Meter`** — `_set_interactive_bind()` unbinds before rebinding so toggling
  `interactive` no longer leaks orphaned indicator binds; `destroy()` detaches
  the `amountusedvar` write trace.
- **`Combobox` popdown** — self-unsubscribe from `Publisher` via a once-bound
  `<Destroy>` handler, so cleanup no longer depends solely on the `Window` global
  `<Destroy>` binding (absent under a vanilla `tk.Tk()` root).

## Tests

New `tests/widgets/test_lifecycle.py` (6 headless regression tests). Full suite:
**18 passed**.

## Scope

Widget-level/additive only. The `Publisher` mechanism rewrite (version-stamped
theme walk) stays **reserved for the engine design session**. `FloodgaugeLegacy`
has the same trace-leak pattern but is slated for deprecation, so it's left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)