### PR TITLE
Add runtime DeprecationWarning to FloodgaugeLegacy (2.0)

### DIFF
--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -8,7 +8,7 @@ _Last updated: 2026-06-25._
 ## Where we are
 
 Integration branch: **`2.0`** (cut all 2.0 PRs against it, not `master`).
-Suite: `python -m pytest -q` → **18 passed**, headless, order-independent.
+Suite: `python -m pytest -q` → **20 passed**, headless, order-independent.
 
 ### Merged into `2.0`
 - **#1068** — Tier-0 cleanup:
@@ -41,8 +41,12 @@ Suite: `python -m pytest -q` → **18 passed**, headless, order-independent.
     on the `Window` global `<Destroy>` binding (absent under a vanilla `tk.Tk()`).
   - New `tests/widgets/test_lifecycle.py` (6 headless regression tests).
   - **Not done (left for the engine session):** the `Publisher` mechanism itself
-    (keystone, below). `FloodgaugeLegacy` has the same trace-leak pattern but is
-    slated for deprecation — left alone.
+    (keystone, below).
+- **`FloodgaugeLegacy` deprecation** — instantiating it now emits a runtime
+  `DeprecationWarning` (3.0 removal); was docstring-only. Canvas `Floodgauge`
+  stays warning-free, and so does `import ttkbootstrap` (warning fires on init,
+  not import). New `tests/widgets/test_deprecations.py` (2 tests). Its lifecycle
+  trace leaks were left as-is — the widget is on the way out.
 
 ## The hard rule
 
@@ -53,15 +57,11 @@ low-risk cleanup can proceed without it.
 
 ## Suggested next slices (independent, no design session needed)
 
-1. **`FloodgaugeLegacy`** — plan lists it for outright 2.0 removal, but it only
-   has a docstring deprecation (never a runtime `DeprecationWarning`). User's
-   lean: **add a `DeprecationWarning` in 2.0, remove in 3.0** rather than delete
-   cold. Exported from `__init__.py`, `widgets/__init__.py`, `__init__.pyi`,
-   defined in `widgets/floodgauge.py`.
-2. **Wart:** ~30 demos in `examples/` still carry `test_` prefixes (no longer
+1. **Wart:** ~30 demos in `examples/` still carry `test_` prefixes (no longer
    collected, just misleading names). Trivial rename.
 
-(Workstream B widget-level lifecycle leaks — **done**, see Merged section above.)
+(Workstream B lifecycle leaks and the `FloodgaugeLegacy` deprecation — **done**,
+see Merged section above.)
 
 ## The keystone (needs the design session)
 

--- a/src/ttkbootstrap/widgets/floodgauge.py
+++ b/src/ttkbootstrap/widgets/floodgauge.py
@@ -31,6 +31,7 @@ Example:
     root.mainloop()
     ```
 """
+import warnings
 from tkinter import Event, Misc, TclError
 from typing import Any, Optional, Union
 
@@ -473,8 +474,9 @@ class Floodgauge(Canvas):
 
 class FloodgaugeLegacy(Progressbar):
     """
-    DEPRECATED: This widget is retained for backward compatibility. You may
-    use this is you have an issues with the canvas-based widget.
+    DEPRECATED: This widget is retained for backward compatibility and will be
+    removed in 3.0. Instantiating it emits a `DeprecationWarning`. Use the
+    canvas-based `Floodgauge` instead.
 
     Use the canvas-based `Floodgauge` widget instead for:
     - Full control over styling and draw order
@@ -565,6 +567,13 @@ class FloodgaugeLegacy(Progressbar):
             **kwargs:
                 Other configuration options from the option database.
         """
+        warnings.warn(
+            "FloodgaugeLegacy is deprecated and will be removed in 3.0; "
+            "use the canvas-based ttkbootstrap.Floodgauge instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         # progress bar value variables
         if 'variable' in kwargs:
             self._variable = kwargs.pop('variable')

--- a/tests/widgets/test_deprecations.py
+++ b/tests/widgets/test_deprecations.py
@@ -1,0 +1,25 @@
+"""Deprecation-warning regression tests (2.0).
+
+Long-deprecated widgets that are kept through 2.x (removed in 3.0) must emit a
+runtime `DeprecationWarning` when used, not merely document it in a docstring.
+
+Runnable headlessly with pytest.
+"""
+import warnings
+
+import pytest
+
+from ttkbootstrap.widgets.floodgauge import Floodgauge, FloodgaugeLegacy
+
+
+def test_floodgauge_legacy_warns_on_init(root):
+    """Instantiating FloodgaugeLegacy emits a DeprecationWarning naming 3.0."""
+    with pytest.warns(DeprecationWarning, match="removed in 3.0"):
+        FloodgaugeLegacy(root)
+
+
+def test_canvas_floodgauge_does_not_warn(root):
+    """The canonical canvas Floodgauge must not warn."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        Floodgauge(root)


### PR DESCRIPTION
## What

`FloodgaugeLegacy` was deprecated in its docstring only. This emits a real
`DeprecationWarning` on instantiation (naming the 3.0 removal), so users still
on the legacy `ttk.Progressbar`-based widget get a runtime signal to migrate to
the canvas-based `Floodgauge`.

## Behavior

- Warning fires in `__init__` (`stacklevel=2`), pointing at the caller.
- `import ttkbootstrap` stays **warning-free** (verified with `-W error`).
- The canonical canvas `Floodgauge` does **not** warn.

## Tests

New `tests/widgets/test_deprecations.py` (2 tests) — legacy warns / canvas
doesn't. Full suite: **20 passed**.

## Scope

Per the 2.0 plan's tiered-deprecation policy: things newly standardized in 2.0
warn-and-keep through 2.x, removed in 3.0. `FloodgaugeLegacy`'s own lifecycle
trace leaks are intentionally left as-is since the widget is on the way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)