### PR TITLE
2.0 PR 1: repaint engine — version-stamped theme walk, delete Publisher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,14 @@ independent cleanup slices are **merged** into `2.0` — deprecated top-level sh
 removed + headless/demo test split (#1068), public/internal split (#1069),
 widget lifecycle-leak fixes (Workstream B, #1070), `FloodgaugeLegacy` runtime
 `DeprecationWarning` (#1071), and the `examples/` `test_`-prefix rename (#1072).
-What remains is the **keystone**: the `style.py` engine repaint / `Publisher`
-elimination (version-stamped theme walk, image-cache cleanup, mixin API,
-singleton posture). It is **reserved for a dedicated design session** — do not
-start it ad hoc. The next session should open that design discussion, working
-from `development/2_0_plan.md` (Workstream A).
+The engine keystone (Workstream A) is now in progress: the design is locked in
+`development/2_0_engine_design.md`, and **PR 1 — the repaint engine** (version
+-stamped theme walk replacing `Publisher`, lazy per-theme style rebuild,
+single-root `RuntimeError`) is **implemented and green** on branch
+`feat/2.0-pr1-repaint-engine` (off `2.0`, not yet merged). Next is **PR 2** —
+the content-addressed image cache — then PR 3+ (mixin API → `style/` split →
+theme/anchor + bootstyle canonical). Proceed PR by PR per the design doc; don't
+exceed a PR's scope without revisiting it.
 
 ## Repository layout
 

--- a/development/2_0_engine_design.md
+++ b/development/2_0_engine_design.md
@@ -1,0 +1,165 @@
+# ttkbootstrap 2.0 — Engine Design (Workstream A keystone)
+
+> Output of the dedicated engine design session (2026-06-25). Pairs with
+> `development/2_0_plan.md` (durable worklist) and `development/2_0_handoff.md`.
+> This is the agreed design for the repaint/image-cache rewrite. Line refs are
+> point-in-time against `style.py` on the `2.0` branch — verify before relying.
+
+## Scope
+
+Workstream A: replace the `Publisher` repaint plumbing and the unbounded image
+cache with bootstack's **mechanisms** (not its API). In-place in `style.py`
+(the `style/` package split is a later PR — locked below). No theme/anchor or
+mixin work in this stream.
+
+## Locked decisions (this session)
+
+1. **Style rebuild = lazy, version-stamped.** Stamp styles like widgets; a style
+   is rebuilt only when a stale *mounted* widget references it. Both repaint and
+   rebuild become O(mounted), not O(all-styles-ever-used).
+2. **Multi-root = enforce single-root with a clear `RuntimeError`.** Closes the
+   silent-no-op trap where the singleton binds to the first root. Full
+   multi-root stays out of 2.0 scope.
+3. **Packaging = engine PR in-place, split later.** Rewrite the repaint/image
+   paths inside the current `style.py` first (clean, behavior-focused diff),
+   then do the `style/` package split + mixin API as follow-on PRs.
+4. **Image cache = content-addressed memoization** (refinement, see below):
+   key on the pixel-determining inputs, not the theme name, so cross-theme
+   -identical assets dedupe and are never re-rendered.
+
+Deferred (do **not** gate this stream): bootstyle strictness default, built-in
+theme drift — those belong to Workstreams D/E.
+
+## Current state (what we're replacing)
+
+`Publisher` (`internal/publisher.py`) does exactly two jobs; the `TTK` channel
+is dead (nothing publishes/subscribes to it):
+
+- **Legacy `tk.*` widgets** subscribe a repaint closure at construction
+  (`style.py` `__init__wrapper` ~`5540`/`5552`); `theme_use` fires
+  `publish_message(Channel.STD)` (~`710`/`716`) to repaint them all.
+- **Combobox popdown** subscribes its own closure (~`5427`), with a
+  destroy-unbind added in Workstream B.
+
+Unsubscribe is split between the `Window` global `<Destroy>` binding
+(`window.py` ~`106`) and the combobox's own binding. Structural defect:
+**`Publisher` holds a strong ref to every styled widget via its closure** — the
+leak class Workstream B patched widget-by-widget but did not root out.
+
+Alongside:
+- `theme_use` → `_create_ttk_styles_on_theme_change` rebuilds **every** registered
+  style on every switch.
+- `theme_images` (per `StyleBuilderTTK`, ~`1282`) never evicts; `theme_use`
+  spins up a **new** builder per theme (~`714`) while old builders + their
+  PhotoImages stay pinned in `_theme_objects`. No cross-theme dedup (names are
+  per-builder/uuid-scoped).
+
+## Repaint model (resolved)
+
+A monotonic `Style._theme_version`, bumped in `theme_use`. Stamps:
+`_style_versions[name]` and `widget._theme_version`. On `theme_use`, after
+`super().theme_use(name)` swaps the Tcl theme DB, run a **DFS over
+`winfo_children()` from the root**; for each widget stamped `< current`:
+
+- **ttk widget** → read its style token; ensure `(current_theme, style)` is fresh
+  in the Tcl DB (rebuild via the builder if stale, then stamp the style); restamp
+  the widget. ttk reflects the reconfig on its next redraw automatically.
+- **tk-legacy widget** → no Tcl style; re-run `update_tk_widget_style(w)` inline.
+  The walk reaches it because it is in `winfo_children()` — **this is what lets us
+  delete the `Publisher` subscription entirely.**
+
+Key points:
+- **Per-theme Tcl style DBs.** ttkbootstrap builds each theme with
+  `theme_create(name, TTK_CLAM)`, so a style configured under theme A is invisible
+  under theme B — that is *why* the legacy code rebuilds on switch. The walk
+  rebuilds `(theme, style)` on demand and stamps it; the monotonic version drives
+  staleness. Theme-return (A→B→A) re-runs A's `configure` calls, which is cheap
+  because images are content-addressed cache hits (below).
+- **No registry, no strong refs.** A widget born at version V stamps V and paints
+  once in its constructor; the `__init__wrapper` keeps the *initial* paint but
+  **drops `Publisher.subscribe`**. Destroyed widgets are simply absent from the
+  tree — the whole subscribe/unsubscribe dance (incl. `window.py:106`) goes away.
+- **Single-root enforcement.** Constructing a second root against an existing
+  `Style` raises `RuntimeError` with a clear message instead of silently
+  no-oping. Tests share one root via the `conftest.py` `root` fixture.
+- **Combobox popdown** folds in as a per-Combobox step in the walk — PRE-FLIGHT
+  CHECK (a): confirm the popdown toplevel is reachable by the root DFS; if not,
+  repaint it explicitly when the walk hits a Combobox.
+- Event-free walk → also fixes the `<Map>`-deferred canvas mis-repaint bug class.
+
+### Wiring to remove / change
+- Delete `Publisher` usage: `style.py` ~`710`/`716` (publish), ~`5427` and ~`5552`
+  (subscribe), `window.py` ~`106` (unsubscribe). Then remove
+  `internal/publisher.py` and its top-level shim once nothing imports it.
+- `theme_use`: bump version + run the walk in place of
+  `_create_ttk_styles_on_theme_change()` + `publish_message`.
+
+## Image cache (content-addressed)
+
+**Memoize the asset builders on their resolved inputs.** Key =
+`(builder-id, *resolved-args)` where args are the pixel-determining values:
+resolved hex color(s), final scaled pixel size, state, geometry (radius, border,
+arrow direction, stripe, …). **Not** the theme name. One shared cache on `Style`.
+
+- Same key anywhere (any theme) → one PhotoImage, built once, shared across theme
+  DBs. The Tcl image **name derives from the key** (`ttkb_<digest>`), so
+  `image create photo` runs only on a miss and multiple styles/themes reference
+  the same name safely.
+- A color/size change → new key → new image rendered lazily on style rebuild; the
+  old image just stops being referenced.
+
+**Default-on.** The cache is the default path, not an opt-in toggle — it is the
+leak/correctness fix, not a perf knob. Escape hatches only: `clear_image_cache()`
+and a debug force-miss (e.g. env flag) for diagnosing render bugs.
+
+**Versioning split.** Content-addressing *subsumes* per-image versioning: an
+image is immutable by its key, so a color/theme change yields a *different* key
+(different image), never an invalidation. The monotonic `_theme_version` stamps
+only the **mutable** things (styles, widgets); images — the **immutable** things
+— are addressed by content. The two mechanisms compose; the version stamp never
+touches image identity.
+
+Consequences:
+- **Theme-return is cheap** — the expensive part (Pillow rendering) is a cache hit;
+  only the (cheap) ttk `configure` calls re-run. Monotonic-version-only suffices.
+- **Default-on raises the stakes on the purity audit (check (b)).** With caching
+  as the default path, *every* builder must be pure w.r.t. its key or users get
+  silent wrong-color assets after a theme switch — so the audit is a hard gate
+  for PR 2, not optional.
+- **Eviction is not timing-coupled.** Nothing is cleared on theme switch. Growth
+  is bounded by *distinct* visual assets across visited themes (deduped), not by
+  widgets-created × themes-visited. PR 2 ships a single content-addressed cache +
+  an explicit `clear_image_cache()`; default-on is the argument for eventually
+  adding **mark-and-sweep-during-the-walk** eviction (touch = keep, unmarked =
+  free) — deferred unless profiling demands it.
+
+**Correctness obligation — PRE-FLIGHT CHECK (b):** every asset builder must be
+*pure with respect to its keyed args*. Audit the ~40 `theme_images[...] =` sites
+(~`1565`–`4873`): any color/size read from `self.colors`/`self.theme` *inside* a
+builder rather than passed as an argument must be lifted into the key, or the
+cache returns a stale image after a theme change. The ~40 sites funnel through a
+`_get_or_create_image(key, render_fn)` helper.
+
+## PR sequence
+
+- **PR 1 — repaint engine (in-place):** version stamp + theme walk; delete
+  `Publisher` (both subscribe sites + `window.py` unsubscribe + publish in
+  `theme_use`); lazy per-theme style rebuild; single-root `RuntimeError`.
+  Behavior-focused; leans on `tests/widgets/test_lifecycle.py` as the regression
+  net. Add a destroy/recreate + theme-switch stress assertion for subscriber/leak
+  count going to zero.
+- **PR 2 — image cache:** route the ~40 image sites through
+  `_get_or_create_image`; single content-addressed cache on `Style`;
+  `clear_image_cache()`; the builder-purity audit. Depends on PR 1's
+  infrastructure but is a separable review.
+- **PR 3+ —** mixin API (Workstream C), then `style/` package split
+  (Workstream G), then theme/anchor model (E) + bootstyle canonical (D) carrying
+  the `_compat` adapters.
+
+## Verification to lean on
+- `tests/widgets/test_lifecycle.py` — destroy/recreate harness; catches
+  repaint/leak regressions.
+- `tests/widget_styles/` — asserts built style values.
+- New for PR 1: assert `Publisher` is gone and that N create/destroy/theme-switch
+  cycles leave no residual per-widget references (the old subscriber-count check,
+  now a tree/stamp check).

--- a/development/2_0_engine_design.md
+++ b/development/2_0_engine_design.md
@@ -140,6 +140,45 @@ builder rather than passed as an argument must be lifted into the key, or the
 cache returns a stale image after a theme change. The ~40 sites funnel through a
 `_get_or_create_image(key, render_fn)` helper.
 
+## Pre-flight check (a) — RESOLVED (PR 1 session)
+
+The combobox popdown is **not** reachable by the root `winfo_children()` DFS.
+At the Tcl level the popdown *is* a child of the combobox
+(`winfo children .!combobox` → `.!combobox.popdown`), but tkinter's Python-side
+`winfo_children()` skips it because the popdown is created lazily by ttk at the
+Tcl level and never registered in tkinter's per-widget `children` dict. So the
+generic walk cannot reach it. **Resolution (as designed):** the walk calls
+`Bootstyle.update_ttk_widget_style` for every ttk widget, and that method now
+repaints the popdown inline when it sees a `TCombobox` (no subscription). Probe
+preserved at scratchpad `probe_popdown.py`.
+
+## PR 1 — DONE (this session)
+
+Implemented on `feat/2.0-pr1-repaint-engine` off `2.0`. Suite: 24 passed.
+- `Style._theme_version` monotonic counter; `theme_use` bumps it then runs
+  `_theme_walk()` (DFS from `self.master`, repaint+restamp stale widgets via
+  `_repaint_widget`: ttk → `update_ttk_widget_style`, tk → `update_tk_widget_style`).
+- `_create_ttk_styles_on_theme_change` (rebuild-every-registered-style) deleted;
+  rebuild is now lazy/O(mounted) driven by `style_exists_in_theme` per visited
+  widget. (`_style_versions` from the design was **not** added — per-theme Tcl
+  style DBs already make `style_exists_in_theme` the staleness signal, so a
+  parallel style-version dict would be a redundant second source of truth.)
+- `Publisher` usage removed from the engine: subscribe sites, the publish calls
+  in `theme_use`, and `window.py`'s `<Destroy>` unsubscribe binding. The
+  `internal/publisher.py` module + its top-level `ttkbootstrap.publisher` shim
+  are **kept** (now unused by core) to honor the "removed in 3.0" deprecation
+  promise on that public path; delete both in 3.0.
+- `autostyle=False` tk widgets now set `_tb_no_autostyle` and the walk skips
+  them — preserves the pre-2.0 "opted-out widget never repaints" behavior that
+  previously fell out of never-subscribing.
+- Single-root: `Window.__init__` calls `_require_single_root` (raises
+  `RuntimeError` if a Style is bound to a different live root); `Window.destroy`
+  now clears the **class** attr `Style.instance` (was a no-op instance attr),
+  so sequential roots work and the singleton rebinds cleanly.
+- Composite widgets (Meter/Floodgauge) repaint via Tk's native `<<ThemeChanged>>`
+  virtual event (fired by `theme_use`), independent of the deleted Publisher —
+  verified still firing.
+
 ## PR sequence
 
 - **PR 1 — repaint engine (in-place):** version stamp + theme walk; delete
@@ -147,7 +186,7 @@ cache returns a stale image after a theme change. The ~40 sites funnel through a
   `theme_use`); lazy per-theme style rebuild; single-root `RuntimeError`.
   Behavior-focused; leans on `tests/widgets/test_lifecycle.py` as the regression
   net. Add a destroy/recreate + theme-switch stress assertion for subscriber/leak
-  count going to zero.
+  count going to zero. **← DONE (see above).**
 - **PR 2 — image cache:** route the ~40 image sites through
   `_get_or_create_image`; single content-addressed cache on `Style`;
   `clear_image_cache()`; the builder-purity audit. Depends on PR 1's

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,7 +3,7 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-06-25._
+_Last updated: 2026-06-25 (engine design session held)._
 
 ## Where we are
 
@@ -54,31 +54,55 @@ Suite: `python -m pytest -q` → **20 passed**, headless, order-independent.
 
 ## The hard rule
 
-**Do not start the `style.py` engine rewrite (the split into a `style/` package,
-the mixin API, the theme/anchor model, the version-stamped theme walk) as ad-hoc
-coding.** The user wants a **dedicated design discussion first**. Independent,
-low-risk cleanup can proceed without it.
+**Do not start the `style.py` engine rewrite as ad-hoc coding.** The design
+discussion has now been held (see below) — the agreed design lives in
+`development/2_0_engine_design.md`. Implementation proceeds **PR by PR per that
+doc**, starting with PR 1; do not exceed PR 1's scope without revisiting the doc.
 
-## Next session: the engine design session
+## Engine design session — DONE (2026-06-25)
 
-All independent slices are **done** (see Merged). The next session is the
-**dedicated design discussion** for the keystone — open it before writing any
-engine code. Suggested agenda:
+The dedicated design discussion is complete. Full design:
+**`development/2_0_engine_design.md`**. Decisions locked this session:
 
-1. **Lock the three open decisions** below (strictness default, multi-root
-   posture, theme-drift) — they shape the engine's public contract.
-2. **Settle the repaint model**: confirm the version-stamped theme walk (DFS
-   `winfo_children()` + `_theme_version` stamp, repaint only stale) replaces
-   `Publisher` wholesale, and decide what happens to the widget-constructor
-   wrappers that subscribe today.
-3. **Decide packaging**: keep one `style.py` vs split into a `style/` package,
-   and whether the mixin API (Workstream C) lands in the same pass or after.
-4. **Sequence it** into reviewable PRs (engine walk + image-cache, then mixin
-   API, then theme/anchor model) rather than one mega-change.
+1. **Style rebuild = lazy, version-stamped** — rebuild a `(theme, style)` only
+   when a stale *mounted* widget references it; O(mounted), not O(all-styles).
+2. **Multi-root = enforce single-root with a clear `RuntimeError`** — close the
+   silent-no-op trap; full multi-root out of 2.0 scope.
+3. **Packaging = engine PR in-place, split later** — rewrite repaint/image paths
+   inside `style.py` first; `style/` package split is a follow-on PR.
+4. **Image cache = content-addressed memoization** — key the asset builders on
+   their pixel-determining inputs (resolved hex, scaled size, state, geometry),
+   NOT the theme name, so cross-theme-identical assets dedupe and never
+   re-render. This also moots theme-return rebuild cost and decouples eviction
+   from theme-switch timing.
 
-Verification already in place to lean on: `tests/widgets/test_lifecycle.py` is a
-destroy/recreate harness that will catch repaint/leak regressions when the
-engine changes, and `tests/widget_styles/` checks built styles.
+Resolved repaint model: monotonic `Style._theme_version`; DFS over
+`winfo_children()` repaints+restamps only stale widgets (ttk → ensure its
+`(theme,style)` fresh; tk-legacy → re-run `update_tk_widget_style` inline);
+the `__init__wrapper` keeps its initial paint but **drops `Publisher.subscribe`**.
+This deletes `Publisher` wholesale (the leak class disappears — no registry, no
+strong refs).
+
+### Agreed PR sequence
+- **PR 1 — repaint engine (in-place):** version stamp + theme walk; delete
+  `Publisher` (subscribe sites `style.py` ~`5427`/`5552`, publish ~`710`/`716`,
+  unsubscribe `window.py` ~`106`); lazy per-theme style rebuild; single-root
+  `RuntimeError`. **← next actionable slice.**
+- **PR 2 — image cache:** route ~40 `theme_images[...]=` sites through
+  `_get_or_create_image`; single content-addressed cache + `clear_image_cache()`;
+  builder-purity audit.
+- **PR 3+ —** mixin API (C), then `style/` split (G), then theme/anchor (E) +
+  bootstyle canonical (D).
+
+### Two pre-flight checks for implementation (not yet settled)
+- (a) Is the **combobox popdown** toplevel reached by the root `winfo_children()`
+  DFS, or does it need an explicit per-Combobox repaint in the walk?
+- (b) **Builder-purity audit**: any asset builder reading color/size from
+  `self.colors`/`self.theme` internally (not via args) must lift that input into
+  the cache key, else stale images survive a theme change.
+
+Verification to lean on: `tests/widgets/test_lifecycle.py` (destroy/recreate
+harness) + `tests/widget_styles/` (built-style values).
 
 ## The keystone (needs the design session)
 
@@ -93,9 +117,11 @@ belongs in the design session, not a quick PR. Wiring today:
 (unsubscribe on `<Destroy>`).
 
 ## Open decisions (from the plan)
+- ~~Multi-root~~ — **LOCKED**: enforce single-root with a clear `RuntimeError`.
 - bootstyle strictness default: warn-by-default + opt-in strict (lean) vs strict.
-- Multi-root: enforce single-root with a clear error (lean) vs defer.
+  (Deferred to Workstream D — does not gate the engine PRs.)
 - Built-in theme drift from auto-ramps (lean: accept) vs pin specific themes.
+  (Deferred to Workstream E — does not gate the engine PRs.)
 
 ## Conventions established this effort
 - `internal/` (no underscore) for private plumbing; warn-shim old public paths,

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,7 +3,7 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-06-25 (engine design session held)._
+_Last updated: 2026-06-25 (engine design session held; design committed `a732faa`)._
 
 ## Where we are
 
@@ -104,17 +104,27 @@ strong refs).
 Verification to lean on: `tests/widgets/test_lifecycle.py` (destroy/recreate
 harness) + `tests/widget_styles/` (built-style values).
 
-## The keystone (needs the design session)
+## Next session: PR 1 — repaint engine (implementation)
 
-**Workstream A — engine repaint.** The opening concrete item is **eliminating
-`Publisher`** (now `internal/publisher.py`): it is solely the legacy-tk-widget +
-combobox-popdown repaint plumbing (only the `STD` channel is used; `TTK` is dead
-code). Replace it with bootstack's **version-stamped theme walk** (DFS
-`winfo_children()`, stamp `_theme_version`, repaint only stale). This rewrites
-core `theme_use` paths and the widget-constructor wrappers in `style.py`, so it
-belongs in the design session, not a quick PR. Wiring today:
-`style.py` ~`709`/`715` (publish), ~`5426`/`5540` (subscribe), `window.py` ~`106`
-(unsubscribe on `<Destroy>`).
+Design is locked and committed; the keystone now moves from design to code.
+**Start a fresh session** — the design lives durably in
+`development/2_0_engine_design.md`, so a new session loses no context and gains a
+full budget + clean slate for a substantial core change.
+
+Suggested opening prompt:
+> Start PR 1 (repaint engine) from `development/2_0_engine_design.md` — branch off
+> `2.0`, begin with the combobox-popdown DFS reachability probe (pre-flight check a).
+
+Scope (do not exceed without revisiting the design doc): version stamp + theme
+walk; delete `Publisher` (subscribe `style.py` ~`5427`/`5552`, publish ~`710`/`716`,
+unsubscribe `window.py` ~`106`); lazy per-theme style rebuild; single-root
+`RuntimeError`. PR 2 (content-addressed image cache) and PR 3+ (mixin → split →
+theme/anchor) follow — see the PR sequence above. The image cache is **default-on**.
+
+First moves: resolve pre-flight check (a) (instrument the DFS to see whether
+`.popdown` appears under the root); then build the walk. Lean on
+`tests/widgets/test_lifecycle.py` as the regression net and add a
+create/destroy/theme-switch assertion that residual per-widget refs hit zero.
 
 ## Open decisions (from the plan)
 - ~~Multi-root~~ — **LOCKED**: enforce single-root with a clear `RuntimeError`.

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,12 +3,18 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-06-25 (engine design session held; design committed `a732faa`)._
+_Last updated: 2026-06-25 (PR 1 — repaint engine — implemented on
+`feat/2.0-pr1-repaint-engine`)._
 
 ## Where we are
 
 Integration branch: **`2.0`** (cut all 2.0 PRs against it, not `master`).
-Suite: `python -m pytest -q` → **20 passed**, headless, order-independent.
+Suite: `python -m pytest -q` → **24 passed**, headless, order-independent.
+
+PR 1 (the engine keystone) is **implemented and green** on branch
+`feat/2.0-pr1-repaint-engine` (off `2.0`); not yet merged. Details in
+`development/2_0_engine_design.md` ("PR 1 — DONE"). Next actionable slice is
+**PR 2 — content-addressed image cache**.
 
 ### Merged into `2.0`
 - **#1068** — Tier-0 cleanup:
@@ -104,27 +110,41 @@ strong refs).
 Verification to lean on: `tests/widgets/test_lifecycle.py` (destroy/recreate
 harness) + `tests/widget_styles/` (built-style values).
 
-## Next session: PR 1 — repaint engine (implementation)
+## PR 1 — DONE (2026-06-25)
 
-Design is locked and committed; the keystone now moves from design to code.
-**Start a fresh session** — the design lives durably in
-`development/2_0_engine_design.md`, so a new session loses no context and gains a
-full budget + clean slate for a substantial core change.
+Implemented on `feat/2.0-pr1-repaint-engine` (off `2.0`); suite **24 passed**.
+Full write-up + the pre-flight (a) resolution in
+`development/2_0_engine_design.md`. Headlines:
+- Monotonic `Style._theme_version`; `theme_use` bumps it then runs `_theme_walk`
+  (DFS from the root, repaint+restamp only stale widgets). Deleted
+  `_create_ttk_styles_on_theme_change`; rebuild is now lazy/O(mounted).
+- `Publisher` removed from the engine (no subscribe/publish/unsubscribe). Module
+  + the `ttkbootstrap.publisher` shim kept unused until the 3.0 removal date.
+- Combobox popdown repainted inline in `update_ttk_widget_style` (pre-flight (a):
+  the popdown is **not** reachable by the Python `winfo_children()` DFS).
+- `autostyle=False` tk widgets set `_tb_no_autostyle`; the walk skips them.
+- Single-root enforced: `Window.__init__` → `_require_single_root` raises a clear
+  `RuntimeError`; `Window.destroy` now clears the class-level `Style.instance`.
+- New tests in `tests/widgets/test_lifecycle.py`: no-Publisher-subscriptions,
+  walk stamps/repaints mounted widgets, theme-switch-cycle leak check,
+  autostyle-skip, single-root raise.
 
-Suggested opening prompt:
-> Start PR 1 (repaint engine) from `development/2_0_engine_design.md` — branch off
-> `2.0`, begin with the combobox-popdown DFS reachability probe (pre-flight check a).
+To merge: PR `feat/2.0-pr1-repaint-engine` → `2.0`.
 
-Scope (do not exceed without revisiting the design doc): version stamp + theme
-walk; delete `Publisher` (subscribe `style.py` ~`5427`/`5552`, publish ~`710`/`716`,
-unsubscribe `window.py` ~`106`); lazy per-theme style rebuild; single-root
-`RuntimeError`. PR 2 (content-addressed image cache) and PR 3+ (mixin → split →
-theme/anchor) follow — see the PR sequence above. The image cache is **default-on**.
+## Next session: PR 2 — content-addressed image cache
 
-First moves: resolve pre-flight check (a) (instrument the DFS to see whether
-`.popdown` appears under the root); then build the walk. Lean on
-`tests/widgets/test_lifecycle.py` as the regression net and add a
-create/destroy/theme-switch assertion that residual per-widget refs hit zero.
+Scope (from `development/2_0_engine_design.md`, "Image cache"): route the ~40
+`theme_images[...] =` sites (~`1565`–`4873`) through a `_get_or_create_image(key,
+render_fn)` helper backed by a single content-addressed cache on `Style`; add
+`clear_image_cache()`; cache is **default-on**.
+
+First move: **pre-flight check (b) — builder-purity audit.** Every asset builder
+must be pure w.r.t. its keyed args; any color/size read from
+`self.colors`/`self.theme` *inside* a builder (not passed as an arg) must be
+lifted into the cache key, or the cache returns a stale image after a theme
+switch. With the cache default-on this is a hard gate, not optional. Lean on
+`tests/widgets/test_lifecycle.py` + `tests/widget_styles/` and add an assertion
+that a theme switch yields the correct (new) asset pixels, not a stale cache hit.
 
 ## Open decisions (from the plan)
 - ~~Multi-root~~ — **LOCKED**: enforce single-root with a clear `RuntimeError`.

--- a/development/2_0_plan.md
+++ b/development/2_0_plan.md
@@ -243,9 +243,45 @@ Restructure (keep mkdocs + mkdocstrings; adopt the *IA*, not Sphinx):
   declarative `Theme` API and addressable ramp tokens.
 - Widget pages: visual-first, light+dark screenshots, lead with semantic styling.
 
----
+### I. Style-construction toolkit (public + dogfooded internally)
 
-## Sequencing
+Public helpers that make building image/state-based ttk styles tractable — the
+delivery vehicle for "make custom styles easy," and the same code that
+de-duplicates the ~40 hand-written asset/layout sites in `style.py`. Modeled on
+bootstack's layout + image-layout builders. **Acceptance test:** rewriting
+`create_scale_assets`/`create_radiobutton_style` on the toolkit must come out
+shorter and clearer, or the abstraction is wrong.
+
+Warts it targets (observed in `style.py`): per-state asset boilerplate
+(`Image.new`→draw→`PhotoImage(resize)`→`get_image_name`→`theme_images[]`, 4× per
+family, e.g. ~`1883–1934`, ~`3837–3880`); hand-coded supersample/downscale with
+inconsistent oversample canvases + magic coords; positional image-element state
+tuples with bare statespecs (~`3911`); hand-nested layout tuple/dict pyramids
+(~`1976`, ~`3920`); bare-string `map` statespecs (~`3793`); name/orientation
+surgery + the `DEFAULT/""` dance; ad-hoc `update_hsv(±0.1)` state colors.
+
+- **Tier 1 (mechanical, low-risk):**
+  - `image_asset(key, render_fn, *, size, oversample)` — supersample-draw +
+    LANCZOS downscale + cache + return name. **This is the same chokepoint as the
+    content-addressed image cache (Workstream A / PR 2)** — `render_fn` is pure,
+    `key` is the memo key. Shape recipes on top: `circle/rounded_rect/rect_asset`.
+  - `image_element(name, default=, states={spec: img}, **opts)` — named, validated
+    state→image map over `element_create(..., "image", ...)`.
+  - `layout()` builder — nested `El(name, side=, sticky=, children=[...])` →
+    ttk's tuple/dict tree (bootstack layout analog; biggest readability win).
+  - `statespec`/`when` + `state_map()` — validate the `!`/AND grammar vs bare
+    strings; the natural home for loud-failure validation (cf. Workstream D).
+  - `StyleName(base, color, orient)` → `.ttkstyle`/`.element`; absorbs the
+    `DEFAULT/""` + `.TS→.S` rules.
+- **Tier 2 (opinionated, after E):** `state_colors(base)` from ramp steps
+  (depends on the semantic-anchor model) replacing scattered `update_hsv`;
+  composite recipes (indicator, thumb+track) built on Tier 1.
+
+Sequencing: **land Tier 1 with the `style/` split (Workstream G)** — both touch
+the same 40 sites; building helpers + migrating builders in one pass avoids
+double-churn, and the helpers get a stable home (`style/assets.py`,
+`style/layout.py`). Keep it thin (helpers, not a DSL); it is a new *public*
+compat surface, so small + orthogonal. Tier 2 follows E.
 
 1. **(this) Plan documented** on `docs/2.0-plan`.
 2. **Maintenance release from `master`** for the recently merged fixes

--- a/src/ttkbootstrap/style.py
+++ b/src/ttkbootstrap/style.py
@@ -18,7 +18,7 @@ Key Features:
     - Custom theme creation and management
     - Widget-specific style boosting (outline, link, toggle, etc.)
     - Color utilities for HSV manipulation
-    - Publisher-subscriber pattern for theme change notifications
+    - Version-stamped theme walk for theme change repaints
     - Support for user-defined themes
 
 Color Keywords:
@@ -58,7 +58,7 @@ import re
 import tkinter as tk
 from math import ceil
 from tkinter import TclError, font, ttk
-from typing import Any, Callable
+from typing import Any
 
 from PIL import Image, ImageColor, ImageDraw, ImageFont, ImageTk
 from PIL.Image import Resampling, Transpose
@@ -66,7 +66,6 @@ from PIL.Image import Resampling, Transpose
 from ttkbootstrap import colorutils
 from ttkbootstrap.internal import utility as util
 from ttkbootstrap.constants import *
-from ttkbootstrap.internal.publisher import Channel, Publisher
 from ttkbootstrap.themes.standard import STANDARD_THEMES
 
 try:
@@ -600,6 +599,11 @@ class Style(ttk.Style):
         self._style_registry = set()  # all styles used
         self._theme_styles = {}  # styles used in theme
         self._theme_names = set()
+        # Monotonic counter bumped on every theme switch. The theme walk
+        # repaints (and restamps) only widgets stamped older than this, so a
+        # widget is repainted at most once per switch. Replaces the old
+        # Publisher broadcast.
+        self._theme_version = 0
         self._load_themes()
         self._dynamic_foreground = False
         super().__init__()
@@ -706,16 +710,22 @@ class Style(ttk.Style):
         if themename in existing_themes:
             self.theme = self._theme_definitions.get(themename)
             super().theme_use(themename)
-            self._create_ttk_styles_on_theme_change()
-            Publisher.publish_message(Channel.STD)
         # setup a new theme
         elif themename in self._theme_names:
             self.theme = self._theme_definitions.get(themename)
+            # Creating the builder also runs theme_create + theme_use for the
+            # new theme and builds its default (".") styles.
             self._theme_objects[themename] = StyleBuilderTTK()
-            self._create_ttk_styles_on_theme_change()
-            Publisher.publish_message(Channel.STD)
         else:
             raise TclError(themename, "is not a valid theme.")
+
+        # Repaint the live widget tree for the new theme. Each theme has its
+        # own clam-derived Tcl style DB, so a style configured under one theme
+        # is invisible under another; the walk rebuilds the (theme, style)
+        # pairs that mounted widgets actually reference -- O(mounted), not
+        # O(all-styles-ever-used) -- and restyles legacy tk widgets inline.
+        self._theme_version += 1
+        self._theme_walk()
 
     def theme_create(self, themename: str, parent: str = None, settings: dict = None) -> None:
         """
@@ -891,15 +901,54 @@ class Style(ttk.Style):
         theme = self.theme.name
         self._theme_styles[theme].add(ttkstyle)
 
-    def _create_ttk_styles_on_theme_change(self):
-        """Create existing styles when the theme changes"""
-        for ttkstyle in self._style_registry:
-            if not self.style_exists_in_theme(ttkstyle):
-                color = Bootstyle.ttkstyle_widget_color(ttkstyle)
-                method_name = Bootstyle.ttkstyle_method_name(string=ttkstyle)
-                builder: StyleBuilderTTK = self._get_builder()
-                method: Callable = builder.name_to_method(method_name)
-                method(builder, color)
+    def _theme_walk(self):
+        """Repaint the live widget tree for the current theme.
+
+        Depth-first over `winfo_children()` from the root, repainting only
+        widgets stamped older than `_theme_version` (so each widget is touched
+        at most once per switch). ttk widgets get their `(theme, style)`
+        rebuilt on demand; legacy tk widgets are restyled inline. Because the
+        walk reaches every mounted widget through the tree, it replaces both
+        the Publisher broadcast (legacy tk widgets) and the
+        rebuild-every-registered-style scan (ttk widgets).
+        """
+        root = self.master
+        if root is None:
+            return
+
+        version = self._theme_version
+        stack = [root]
+        while stack:
+            widget = stack.pop()
+            # Honor autostyle=False: such widgets opted out of theming and are
+            # never repainted, but their (autostyled) descendants still are.
+            if not getattr(widget, "_tb_no_autostyle", False):
+                if getattr(widget, "_theme_version", None) != version:
+                    self._repaint_widget(widget)
+                    try:
+                        widget._theme_version = version
+                    except (AttributeError, TypeError):
+                        # Builtin/extension widgets that forbid new attributes
+                        # are simply repainted on every switch -- correct, just
+                        # not skippable.
+                        pass
+            try:
+                stack.extend(widget.winfo_children())
+            except TclError:
+                pass
+
+    def _repaint_widget(self, widget):
+        """Restyle a single widget for the current theme.
+
+        ttk widgets ensure their style exists under the active theme (rebuilt
+        lazily by the builder if stale); legacy tk widgets re-run their tk
+        update method. The combobox popdown -- a Tcl toplevel the DFS cannot
+        reach -- is refreshed inside `update_ttk_widget_style`.
+        """
+        if isinstance(widget, ttk.Widget):
+            Bootstyle.update_ttk_widget_style(widget)
+        else:
+            Bootstyle.update_tk_widget_style(widget)
 
     def load_user_theme(self, theme: ThemeDefinition):
         """Load a user theme definition"""
@@ -5319,6 +5368,9 @@ class Bootstyle:
                         self, "default", **kwargs
                     )
                     self.configure(style=ttkstyle)
+                # Stamp the widget current so the next theme walk only repaints
+                # it once the theme actually changes.
+                Bootstyle.stamp_theme_version(self)
             except AttributeError:
                 # Third-party widgets (e.g. tkcalendar.Calendar) override
                 # configure() and may access instance attributes that are not
@@ -5418,32 +5470,15 @@ class Bootstyle:
                 return style_string
             builder_method(builder, widget_color)
 
-        # subscribe popdown style to theme changes
+        # Repaint the combobox popdown. It is a Tcl-level toplevel that the
+        # theme walk's winfo_children() DFS cannot reach, so it is refreshed
+        # here instead -- the walk calls this method for every ttk widget on a
+        # theme change, which keeps the popdown in sync without a subscription.
         try:
             if widget.winfo_class() == "TCombobox":
                 builder: StyleBuilderTTK = style._get_builder()
-                winfo_id = hex(widget.winfo_id())
-                winfo_pathname = widget.winfo_pathname(winfo_id)
-                Publisher.subscribe(
-                    name=winfo_pathname,
-                    func=lambda w=widget: builder.update_combobox_popdown_style(
-                        w
-                    ),
-                    channel=Channel.STD,
-                )
-                # Drop the subscription when the combobox is destroyed, even
-                # when not using a ttkbootstrap Window (whose global <Destroy>
-                # binding would otherwise be the only thing that unsubscribes).
-                # Bind once; this resolver runs on every style update.
-                if not getattr(widget, "_tb_popdown_unsub_bound", False):
-                    widget.bind(
-                        "<Destroy>",
-                        lambda e, n=winfo_pathname: Publisher.unsubscribe(n),
-                        add="+",
-                    )
-                    widget._tb_popdown_unsub_bound = True
                 builder.update_combobox_popdown_style(widget)
-        except:
+        except (AttributeError, TclError):
             pass
 
         return ttkstyle
@@ -5503,6 +5538,23 @@ class Bootstyle:
             widget.__init__ = _init
 
     @staticmethod
+    def stamp_theme_version(widget):
+        """Stamp a widget with the current theme version.
+
+        Freshly built widgets are already painted for the active theme, so
+        stamping them lets the next theme walk skip them until the theme
+        actually changes. No-ops cleanly before a `Style` exists or for
+        widgets that forbid new attributes.
+        """
+        style = Style.get_instance()
+        if style is None:
+            return
+        try:
+            widget._theme_version = style._theme_version
+        except (AttributeError, TypeError):
+            pass
+
+    @staticmethod
     def update_tk_widget_style(widget):
         """Lookup the widget name and call the appropriate update
         method
@@ -5549,11 +5601,14 @@ class Bootstyle:
             func(self, *args, **kwargs)
 
             if autostyle:
-                Publisher.subscribe(
-                    name=str(self),
-                    func=lambda w=self: Bootstyle.update_tk_widget_style(w),
-                    channel=Channel.STD,
-                )
                 Bootstyle.update_tk_widget_style(self)
+                # Stamp the widget current so the next theme walk only
+                # repaints it once the theme actually changes.
+                Bootstyle.stamp_theme_version(self)
+            else:
+                # Opt out of theming entirely: the theme walk must skip this
+                # widget on switch, matching the pre-2.0 behavior where an
+                # unstyled widget never subscribed for repaints.
+                self._tb_no_autostyle = True
 
         return __init__wrapper

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -49,7 +49,6 @@ from typing import Any, Optional, Tuple, Union
 from ttkbootstrap import utility
 from ttkbootstrap.constants import *
 from ttkbootstrap.icons import Icon
-from ttkbootstrap.internal.publisher import Publisher
 from ttkbootstrap.style import Style
 
 
@@ -66,6 +65,34 @@ def get_default_root(what: Optional[str] = None) -> tkinter.Tk:
         root = tkinter.Tk()
         assert tkinter._default_root is root
     return tkinter._default_root
+
+
+def _require_single_root(new_root: tkinter.Misc) -> None:
+    """Raise if a Style is already bound to a different, still-live root.
+
+    The Style engine is a process-wide singleton tied to the first root that
+    created it; a second concurrent root silently no-ops all theming. Enforce
+    a single root with a clear error. Destroying the existing root clears the
+    singleton, so sequential roots (e.g. one app after another) are allowed.
+    """
+    existing = Style.get_instance()
+    if existing is None:
+        return
+    other = getattr(existing, "master", None)
+    if other is None or other is new_root:
+        return
+    try:
+        still_alive = bool(other.winfo_exists())
+    except tkinter.TclError:
+        still_alive = False
+    if still_alive:
+        raise RuntimeError(
+            "ttkbootstrap supports a single application root window. A Style "
+            "is already bound to an existing live root; create one "
+            "Window/Tk per process and reuse it (or destroy the existing "
+            "root before creating a new one). Multi-root support is out of "
+            "scope."
+        )
 
 
 def apply_class_bindings(window: tkinter.Widget) -> None:
@@ -103,7 +130,6 @@ def apply_class_bindings(window: tkinter.Widget) -> None:
 def apply_all_bindings(window: tkinter.Widget) -> None:
     """Add bindings to all widgets in the application"""
     window.bind_all('<Map>', on_map_child, '+')
-    window.bind_all('<Destroy>', lambda e: Publisher.unsubscribe(e.widget))
 
 
 def on_visibility(event: tkinter.Event) -> None:
@@ -272,6 +298,11 @@ class Window(tkinter.Tk):
                 Any other keyword arguments that are passed through to tkinter.Tk() constructor
                 List of available keywords available at: https://docs.python.org/3/library/tkinter.html#tkinter.Tk
         """
+        # ttkbootstrap supports a single application root. The Style engine is
+        # a process-wide singleton bound to the first root; a second live root
+        # would silently no-op all theming. Fail loudly before any side effects.
+        _require_single_root(self)
+
         if hdpi:
             utility.enable_high_dpi_awareness()
 
@@ -343,7 +374,9 @@ class Window(tkinter.Tk):
 
     def destroy(self) -> None:
         """Destroy the window and all its children."""
-        self._style.instance = None
+        # Clear the process-wide singleton (a class attribute) so a later root
+        # rebinds the Style cleanly instead of reusing this destroyed one.
+        Style.instance = None
         super().destroy()
 
     def place_window_center(self) -> None:

--- a/tests/widgets/test_lifecycle.py
+++ b/tests/widgets/test_lifecycle.py
@@ -1,12 +1,22 @@
-"""Lifecycle/leak regression tests (2.0 Workstream B).
+"""Lifecycle/leak regression tests (2.0 Workstreams A & B).
 
-Widgets that schedule `after()` loops, add variable traces, or subscribe to
-the `Publisher` must release those resources when they are reconfigured or
-destroyed. Otherwise a destroyed widget keeps firing callbacks (raising
-`TclError`) or is kept alive by an external variable's trace.
+Widgets that schedule `after()` loops or add variable traces must release
+those resources when they are reconfigured or destroyed. Otherwise a destroyed
+widget keeps firing callbacks (raising `TclError`) or is kept alive by an
+external variable's trace.
+
+Workstream A (the engine repaint rewrite) also removed the `Publisher`: the
+theme walk now repaints the live widget tree directly, so nothing subscribes a
+per-widget closure at construction (the old leak class). The combobox tests
+below assert that the engine holds no `Publisher` subscriptions and that a
+theme switch still repaints every mounted widget via the version-stamped walk.
 
 Runnable headlessly with pytest.
 """
+import tkinter as tk
+
+import pytest
+
 import ttkbootstrap as ttk
 from ttkbootstrap.internal.publisher import Publisher
 from ttkbootstrap.widgets.floodgauge import Floodgauge
@@ -82,16 +92,104 @@ def test_meter_value_trace_released_on_destroy(root):
 
 
 # --------------------------------------------------------------------------- #
-# Combobox popdown subscription
+# Engine repaint walk (Workstream A) — Publisher elimination
 # --------------------------------------------------------------------------- #
-def test_combobox_unsubscribes_on_destroy(root):
-    """A combobox releases its Publisher popdown subscription on destroy."""
-    base = Publisher.subscriber_count()
-    cb = ttk.Combobox(root, values=["a", "b"])
-    cb.pack()
-    root.update_idletasks()
-    assert Publisher.subscriber_count() > base
+def test_engine_holds_no_publisher_subscriptions(root):
+    """The engine no longer subscribes per-widget closures to the Publisher.
 
-    cb.destroy()
+    The old leak class was a strong ref held by a Publisher closure for every
+    styled widget. Creating widgets (incl. a combobox, the last subscriber)
+    must leave the subscriber count untouched.
+    """
+    base = Publisher.subscriber_count()
+    widgets = [
+        ttk.Button(root, bootstyle="primary"),
+        ttk.Combobox(root, values=["a", "b"]),
+        ttk.Frame(root),
+    ]
+    for w in widgets:
+        w.pack()
     root.update_idletasks()
-    assert Publisher.subscriber_count() == base
+    assert Publisher.subscriber_count() == base == 0
+
+
+def test_theme_walk_stamps_and_repaints_mounted_widgets(root):
+    """A theme switch repaints the live tree and restamps every widget."""
+    style = root.style
+    btn = ttk.Button(root, bootstyle="primary")
+    frame = ttk.Frame(root)
+    nested = ttk.Label(frame, bootstyle="info")
+    cb = ttk.Combobox(root, values=["a", "b"])
+    for w in (btn, frame, cb):
+        w.pack()
+    nested.pack()
+    root.update_idletasks()
+
+    start = style.theme.name
+    other = "darkly" if start != "darkly" else "cosmo"
+    bg_before = style.lookup("primary.TButton", "background")
+
+    style.theme_use(other)
+    root.update_idletasks()
+
+    # every mounted widget, including a deeply nested one, is now current
+    version = style._theme_version
+    for w in (btn, frame, nested, cb):
+        assert getattr(w, "_theme_version", None) == version
+
+    # the (theme, style) pair was actually rebuilt for the new theme
+    assert style.lookup("primary.TButton", "background") != bg_before
+
+
+def test_autostyle_false_widget_skipped_by_walk(root):
+    """A tk widget created with autostyle=False is never touched by the walk."""
+    style = root.style
+    start = style.theme.name
+    other = "darkly" if start != "darkly" else "cosmo"
+
+    plain = tk.Label(root, autostyle=False, background="#abcdef")
+    styled = tk.Label(root)
+    plain.pack()
+    styled.pack()
+    root.update_idletasks()
+    styled_before = styled.cget("background")
+
+    style.theme_use(other)
+    root.update_idletasks()
+
+    # opted-out widget keeps its manual color and is never stamped
+    assert plain.cget("background") == "#abcdef"
+    assert not hasattr(plain, "_theme_version")
+    # a normal autostyled widget still repaints
+    assert styled.cget("background") != styled_before
+
+
+def test_theme_switch_cycles_do_not_leak_subscribers(root):
+    """Repeated create/destroy/theme-switch cycles leave no residual refs."""
+    style = root.style
+    start = style.theme.name
+    other = "darkly" if start != "darkly" else "cosmo"
+
+    for _ in range(5):
+        w = ttk.Combobox(root, values=["a", "b"])
+        w.pack()
+        root.update_idletasks()
+        style.theme_use(other)
+        style.theme_use(start)
+        w.destroy()
+        root.update_idletasks()
+
+    assert Publisher.subscriber_count() == 0
+
+
+# --------------------------------------------------------------------------- #
+# Single-root enforcement (Workstream A)
+# --------------------------------------------------------------------------- #
+def test_second_live_root_raises(root):
+    """Creating a second root while one is live raises a clear RuntimeError.
+
+    The guard fires before the second Tk interpreter is built, so the shared
+    session root and Style singleton are left untouched.
+    """
+    with pytest.raises(RuntimeError, match="single application root"):
+        ttk.Window()


### PR DESCRIPTION
First PR of Workstream A (engine keystone), per `development/2_0_engine_design.md`. Replaces the `Publisher`-subscriber repaint plumbing and the rebuild-every-registered-style scan with a version-stamped walk over the live widget tree. Behavior-focused, in-place in `style.py` (the `style/` package split is a later PR). Image cache is **PR 2**.

## What changed

**`style.py` — repaint engine**
- Monotonic `Style._theme_version`; `theme_use` bumps it then runs `_theme_walk()` — a DFS from the root that repaints + restamps only stale widgets (`_repaint_widget`: ttk → `update_ttk_widget_style`, tk → `update_tk_widget_style`).
- Deleted `_create_ttk_styles_on_theme_change` (rebuild *every* registered style). Style rebuild is now lazy / **O(mounted)**, driven by `style_exists_in_theme` per visited widget.
- Removed all `Publisher` usage from the engine — the leak class (strong refs to every styled widget via subscription closures). `internal/publisher.py` + the public `ttkbootstrap.publisher` shim are **kept unused** to honor their "removed in 3.0" promise.
- Combobox popdown is repainted inline in `update_ttk_widget_style` (it's a Tcl toplevel the Python `winfo_children()` DFS can't reach — pre-flight check (a)).
- `autostyle=False` tk widgets set `_tb_no_autostyle`; the walk skips them, preserving the pre-2.0 "opted-out widget never repaints" behavior that previously came from never subscribing.

**`window.py` — single-root posture**
- `_require_single_root` raises a clear `RuntimeError` if a `Style` is already bound to a different *live* root (closes the silent-no-op trap). Full multi-root stays out of scope.
- Fixed `Window.destroy` to clear the **class** attribute `Style.instance` (was a no-op instance attr), so sequential roots rebind cleanly.

## Verification
- `python -m pytest -q` → **24 passed**, headless, order-independent (was 20; +5 new engine tests, −1 Publisher-coupled test).
- New tests in `tests/widgets/test_lifecycle.py`: no Publisher subscriptions, walk stamps/repaints mounted widgets (incl. nested + Toplevel), theme-switch-cycle leak check, autostyle skip, single-root raise.
- Confirmed ttk/tk widgets, combobox popdown, and composite widgets (Meter/Floodgauge, via Tk's native `<<ThemeChanged>>`) all recolor on theme switch; theme-return restores colors; singleton resets on destroy.

## Design note
Did **not** add the `_style_versions` dict from the design doc — per-theme Tcl style DBs already make `style_exists_in_theme` the staleness signal, so a parallel style-version map would be a redundant second source of truth. Recorded in `development/2_0_engine_design.md`.

## Next
PR 2 — content-addressed image cache (starts with pre-flight check (b), the builder-purity audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)