### PR TITLE
Style-construction toolkit (2.0 PR 5, Workstream I Tier 1)

### DIFF
--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,8 +3,9 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-06-25 (PR 4 — `style/` package split (Workstream G) —
-merged into `2.0`, #1076)._
+_Last updated: 2026-06-25 (Workstream I — style-construction toolkit — **PR 5
+implemented on the working tree** per `development/2_0_toolkit_design.md`; suite
+**75 passed**; not yet branched/PR'd/merged)._
 
 ## Where we are
 
@@ -14,8 +15,9 @@ Suite: `python -m pytest -q` → **61 passed**, headless, order-independent.
 The engine keystone (Workstream A) is **complete and merged**: PR 1 (repaint,
 #1073) + PR 2 (content-addressed image cache, #1074). **PR 3 — the mixin API
 (Workstream C)** is **merged** (#1075). **PR 4 — the `style/` package split
-(Workstream G)** is **merged** (#1076; pure move, see "PR 4" below). Next
-actionable slice is the **style-construction toolkit (Workstream I)**.
+(Workstream G)** is **merged** (#1076; pure move, see "PR 4" below). The
+**style-construction toolkit (Workstream I)** design pass is **done** (see
+"Workstream I" below); next actionable slice is **PR 5** — implementing it.
 
 ### Merged into `2.0`
 - **#1068** — Tier-0 cleanup:
@@ -228,13 +230,89 @@ Workstream I toolkit is a separate follow-on PR. Merged into `2.0` (was
   force-evaluation sweep. **Reuse it for E/D code moves.** Details in the design
   doc's "Implementation — DONE" section.
 
-## Next: Workstream I (style-construction toolkit), then E + D
+## PR 5 — IMPLEMENTED (2026-06-25, on working tree; not yet merged)
 
-The `style/` package now has a stable home for the **public** `image_asset` /
-`layout()` toolkit (Workstream I), which wraps PR 2's `_get_or_create_image`
-chokepoint and lands in `style/assets.py` + `style/layout.py` — its own design
-pass (new public surface). Then the theme/anchor model (E) + bootstyle canonical
-grammar (D), carrying the `_compat` adapters.
+Workstream I Tier-1 toolkit, per `development/2_0_toolkit_design.md`. Suggested
+branch `feat/2.0-pr5-toolkit` (cut against `2.0`). Suite: **75 passed** (was 61;
++14 in `tests/test_toolkit.py`). Headlines:
+
+- **New `style/assets.py`** — `Assets(style)` facade over PR 2's
+  `Style._get_or_create_image`. Recipes `circle`/`rect`/`rounded_rect` + the
+  `image(size, draw_fn, *key_parts)` escape hatch. The cache key is *derived
+  from the render inputs* (resolved hex + snapped size + geometry), so it cannot
+  drift from the pixels — the hazard PR 2's purity audit managed by hand. Ports
+  bootstack's snap-at-the-source pipeline: even-pixel-snap the size, adaptive
+  oversample (3×/2×/1× by size), LANCZOS + `UnsharpMask`. No public
+  `oversample`/`inset` knobs. `rect` is solid-fill (no AA, no snap → keeps exact
+  size, e.g. the 40×5 scale track).
+- **New `style/layout.py`** — `El`/`layout` (lowers an `El` tree to ttk's nested
+  `(name, opts)` form; children via constructor kwarg, not bootstack's fluent
+  positional parenting), `image_element` (named, validated state→image map),
+  `statespec`/`state_map` (validate the `!neg`/space-AND grammar against
+  `TTK_STATES` — the Workstream D loud-failure seam; keep the token set here),
+  `StyleName` (absorbs the `DEFAULT/""`→PRIMARY, `f"{color}.{STYLE}"`, and
+  `.TS→.S` element-name dance).
+- **Acceptance test met**: `create_scale_assets`/`create_scale_style` and
+  `create_radiobutton_assets`/`create_radiobutton_style` migrated onto the
+  toolkit — shorter and clearer (radio style 69→29 lines incl. docstring; the
+  30-line layout pyramid → 5 readable lines). Behavior-preserved: layouts query
+  identical to the originals (`expand`=`'1'`, `sticky`=`'nswe'`, same element
+  names + radio pyramid, same `foreground`/disabled map). The migrated radio
+  keeps the original `sticky=""` on indicator/focus (the design's example
+  omitted it; kept for behavior-exactness).
+- **Public surface** re-exported from `style/__init__.py` *and* top-level
+  `ttkbootstrap` (`Assets`, `El`, `layout`, `image_element`, `statespec`,
+  `state_map`, `StyleName`); `import ttkbootstrap` stays warning-free.
+- **`test_image_cache.py` helper** updated: the scale thumb's key tag moved from
+  `"scale.thumb"` to the recipe's `("circle", fill, size, None, 0)`; assertions
+  unchanged (still color-at-pixel, robust to the snapped-pipeline AA change).
+- **Gates re-run**: standalone-import cycle guard (assets/layout import alone;
+  they're leaves — assets→PIL, layout→constants, no engine edge) and the PEP 649
+  annotation force-evaluation sweep (3.14) over the two new modules + migrated
+  builders — both clean.
+- **Remaining before merge**: a spot visual diff on scale/radio/check to confirm
+  the snapped pipeline reads equal-or-better (sharper/DPI-stable, not color
+  drift) — can't run a GUI headless here. Then branch + PR against `2.0`.
+- **Deferred (out of PR 5 scope)**: migrating the *remaining* ~25 asset / ~25
+  layout sites onto the toolkit (mechanical, same shapes repeated) — design doc
+  step 4, a fast-follow. Tier 2 (`state_colors` from ramp steps; composite
+  recipes) waits on Workstream E.
+
+## Workstream I — DESIGN PASS DONE (2026-06-25), implementation done (see "PR 5")
+
+Design pass held (per the hard rule — new public surface, like the engine/split
+got one). Full design: **`development/2_0_toolkit_design.md`**. The next session
+**implements PR 5 from that doc**; do not exceed its scope without revisiting it.
+
+Tier-1 toolkit lands in **`style/assets.py`** (`Assets` facade: `circle`/`rect`/
+`rounded_rect` shape recipes + an `image(size, draw_fn, *key_parts)` escape hatch,
+all wrapping PR 2's `_get_or_create_image`) + **`style/layout.py`** (`layout()`/
+`El`, `image_element`, `statespec`/`state_map`, `StyleName`). Re-exported from
+`style/__init__.py` and top-level `ttkbootstrap` (public custom-style API).
+
+Decisions locked this session:
+- **PR scope = one PR** (assets + layout together; the acceptance test spans both).
+- **The key is derived from the recipe, never hand-written** — kills the
+  hand-built-key purity hazard that PR 2's whole audit existed to manage.
+- **Fidelity = adopt bootstack's snap-at-the-source pipeline** (not the earlier
+  (A)/(B) drift tradeoff). Per user steer, mined `bootstack/src` and ported four
+  mechanisms into `Assets`: round the DPI factor; **even-pixel-snap** the final
+  size before keying/rendering (kills fractional-DPI LANCZOS blur); **adaptive
+  oversample** (3×/2×/1× by size) + snap draw origin to oversample multiples;
+  LANCZOS + `UnsharpMask`. Result is *crisper, DPI-stable* assets, not color drift
+  → PR 2's color-at-pixel purity tests still pass. No public `oversample`/`inset`
+  knobs. (bootstack refs in the design doc's fidelity section.)
+- **`El`/`image_element` mirror bootstack's `Element.spec()`/`ElementImage.build()`**
+  (same author, keep models in sync), with two deliberate divergences: constructor
+  `children=[...]` (not fluent positional parenting) and validating `statespec`
+  (the Workstream D loud-failure seam).
+
+Acceptance test pre-validated in the doc: `create_scale_assets` ~64→~22 lines,
+`create_radiobutton_style` ~67→~18, both clearer. Carry the **PEP 649 annotation
+force-evaluation sweep** into the new modules + migrated builders (3.14 gotcha).
+
+Then E (theme/anchor model) + D (bootstyle canonical grammar), carrying the
+`_compat` adapters. Tier-2 toolkit (`state_colors` from ramp steps) follows E.
 
 ## Open decisions (from the plan)
 - ~~Multi-root~~ — **LOCKED**: enforce single-root with a clear `RuntimeError`.

--- a/development/2_0_toolkit_design.md
+++ b/development/2_0_toolkit_design.md
@@ -1,0 +1,467 @@
+# ttkbootstrap 2.0 — Style-Construction Toolkit Design (Workstream I, Tier 1)
+
+> Output of the Workstream I design pass (2026-06-25). Pairs with
+> `development/2_0_plan.md` (durable worklist, Workstream I at lines ~246–284),
+> `development/2_0_handoff.md` (session state), and the engine design
+> (`development/2_0_engine_design.md` — PR 2 built the `_get_or_create_image`
+> chokepoint this toolkit wraps). Line refs are point-in-time against the
+> `style/` package on the `2.0` branch — verify before relying.
+
+## Scope
+
+Workstream I, **Tier 1 only**: the mechanical, low-risk public helpers that make
+image/state-based ttk styles tractable, and that de-duplicate the asset/layout
+boilerplate in `builders_ttk.py`. Tier 2 (`state_colors` from ramp steps,
+composite recipes) depends on the semantic-anchor model (Workstream E) and is
+**out of scope** here.
+
+This is a design pass first, per the established discipline (engine, split, and
+mixin work each got one). **No code moves until the API shape below is signed
+off.** The toolkit is a **new public API surface** — the delivery vehicle for
+"make custom styles easy" — so it earns the same up-front design as the engine.
+
+The toolkit lands in **`style/assets.py`** (image construction) and
+**`style/layout.py`** (layout/element/statespec/name helpers). Neither file
+exists yet (the split deliberately did not pre-create them).
+
+## The acceptance test (from the plan)
+
+> Rewriting `create_scale_assets` / `create_radiobutton_style` on the toolkit
+> must come out **shorter and clearer**, or the abstraction is wrong.
+
+This doc designs the API *against* those two builders and shows the before/after
+(see "Acceptance test — proof" below). They were chosen well: between them they
+exercise every Tier-1 primitive — shape-recipe assets, a custom composite draw,
+a state→image element map, a nested layout pyramid, and the colorname/`.TS`
+name dance.
+
+## The warts, catalogued from current code
+
+Surveyed across `builders_ttk.py` (30 `Image.new` sites, ~40 `_get_or_create_image`
+calls, ~25 `layout()` pyramids). The recurring shapes:
+
+1. **Per-asset SSAA boilerplate.** Every image draw is
+   `Image.new("RGBA", (OVERSAMPLE, OVERSAMPLE))` → draw → `ImageTk.PhotoImage(
+   img.resize(size, Resampling.LANCZOS))`, repeated ~25× verbatim. The
+   oversample canvas is an inconsistent magic number per family — `(100,100)`,
+   `(134,134)`, `(226,130)`, `(210,220)`, `(13,11)`, `(11,11)` — with draw
+   coordinates hand-fitted to *that* canvas (`[1,1,133,133]`, `[40,40,94,94]`,
+   ellipse `(0,0,95,95)` on a 100-px canvas).
+
+2. **Hand-built cache keys that must mirror the closure.** Every
+   `_get_or_create_image(("radio.on", light_outline, on_fill, on_indicator,
+   off_border, tuple(size)), make_on)` call re-lists, by hand, exactly the values
+   `make_on` closes over. **The entire PR 2 purity audit (pre-flight check (b))
+   existed to get these keys right** — a key that drifts from the draw silently
+   returns a stale-color image after a theme switch. This is the toolkit's
+   highest-value target: make the key *fall out of* the render description so it
+   cannot drift.
+
+3. **Positional bare-string image statespecs.** `element_create(name, "image",
+   default, ("disabled", img), ("pressed", img), ...)` — order-significant
+   tuples with unvalidated state strings.
+
+4. **Nested layout tuple/dict pyramids.** A 3-level indicator/focus/label tree is
+   ~30 lines of `(name, {"children": [(name, {"sticky": ...}), ...]})`
+   (radiobutton ~`2682`, scale ~`715`).
+
+5. **Name/orientation surgery + the `DEFAULT/""` dance.** Every builder opens with
+   `if any([colorname == DEFAULT, colorname == ""])` and threads
+   `f"{colorname}.{STYLE}"` plus `h_ttkstyle.replace(".TS", ".S")` to derive the
+   element prefix.
+
+## Design principle
+
+**Thin helpers, not a DSL.** The toolkit is a *new public compat surface* — every
+symbol is something we must keep working through 2.x. Keep it small and
+orthogonal: each helper does one mechanical job, composes with raw ttk calls
+(you can mix toolkit and `style.element_create` freely), and adds no runtime
+state of its own beyond the existing `Style._image_cache`.
+
+**The key is derived, never hand-written.** The single biggest correctness win:
+a render's cache key is computed from the inputs that determine its pixels, so it
+is impossible to write a draw whose key omits a color it uses. Shape recipes make
+this automatic; the escape hatch makes it explicit-but-adjacent (the key parts
+sit in the same call as the draw, not 15 lines away).
+
+## `style/assets.py` — image construction
+
+A small `Assets(style)` facade bound to the engine's cache. Builders reach it via
+a cached `self.assets` property; public users construct `Assets(Style.get_instance())`.
+
+### Shape recipes (renderer + key in one)
+
+These cover the bulk of assets (any single filled/outlined primitive). The recipe
+*is* both the renderer and the key — you cannot under-specify the key:
+
+```python
+a = Assets(style)              # internally: self.assets
+
+a.circle(fill, size, *, outline=None, width=0)
+a.rect(fill, size)                                   # solid fill, no AA needed
+a.rounded_rect(fill, size, radius, *, outline=None, width=0)
+```
+
+- `size` is the **final widget pixel size** (already DPI-scaled by the caller;
+  int → square, or `(w, h)`). The recipe owns the **snapped SSAA pipeline ported
+  from bootstack** (see the resolved fidelity section): even-pixel-snap the size,
+  pick the adaptive oversample factor (3×/2×/1× by size), draw on the
+  `snapped_size × oversample` canvas, snap the draw origin to oversample multiples,
+  `LANCZOS` downscale, `UnsharpMask`, wrap in `PhotoImage`. **No `oversample`
+  parameter on the public signature** — it's internal and adaptive.
+- Returns the Tcl image name (same contract as `_get_or_create_image`).
+- The key is built internally as `("circle", fill, snapped_size, outline, width)`
+  etc. — **complete by construction, theme-independent** (resolved hex is in the
+  key, so cross-theme-identical assets dedupe; this is exactly PR 2's invariant,
+  now enforced by the recipe instead of by audit). The *snapped* size is in the
+  key, so two logical sizes that snap equal share one image.
+
+### General escape hatch (custom composite draws)
+
+For the handful of multi-shape draws (radio "on" = concentric circles, the
+date-button calendar, striped polygons, arrow glyphs), an explicit draw with an
+explicit-but-adjacent key:
+
+```python
+a.image(size, draw_fn, *key_parts)
+```
+
+- `draw_fn(draw, w, h)` receives a fresh `ImageDraw.Draw` over the oversampled
+  `(w, h)` canvas (where `w, h` is the snapped size × the adaptive oversample); it
+  draws relative to `w, h` (so the magic `134`/`94`/`40` oversample constants
+  become `w`-relative expressions, killing wart #1's coordinate coupling). The
+  snap + downscale + `UnsharpMask` happen around `draw_fn` exactly as in the
+  recipes.
+- Key = `(draw_fn.__qualname__, snapped_size, *key_parts)`. The caller still
+  lists the colors the draw uses in `*key_parts`, **but they sit in the same call
+  as the draw**, not in a detached tuple — and the `__qualname__` distinguishes
+  draws so two different shapes never collide on equal key_parts.
+- Still removes `Image.new` / `.resize(LANCZOS)` / `PhotoImage` /
+  separate-`_get_or_create_image` boilerplate even where a recipe doesn't fit.
+
+`a.rect` skips oversampling (axis-aligned solid fill has no edges to anti-alias —
+matches today's `Image.new("RGB", size, color)` exactly).
+
+### How it wraps PR 2
+
+`Assets` is a thin layer over `Style._get_or_create_image(key, factory)`:
+
+```python
+class Assets:
+    def __init__(self, style): self.style = style
+    def circle(self, fill, size, *, outline=None, width=0, oversample=8):
+        size = _wh(size)
+        key = ("circle", fill, size, outline, width)
+        return self.style._get_or_create_image(key, lambda: _draw_circle(...))
+```
+
+`_get_or_create_image` stays the private chokepoint and the single source of cache
+truth; `Assets` is the public, ergonomic, key-safe front door to it. No second
+cache, no behavior change to the cache itself.
+
+## `style/layout.py` — layout, elements, statespecs, names
+
+### `layout()` + `El` — the layout-pyramid killer
+
+```python
+from ttkbootstrap.style.layout import layout, El
+
+layout(style, ttkstyle,
+    El("Radiobutton.padding", sticky=NSEW, children=[
+        El(f"{ttkstyle}.indicator", side=LEFT),
+        El("Radiobutton.focus", side=LEFT, children=[
+            El("Radiobutton.label", sticky=NSEW),
+        ]),
+    ]),
+)
+```
+
+`El(name, *, side=, sticky=, expand=, border=, children=[])` carries the ttk
+element options as keywords; `layout()` lowers the `El` tree to ttk's
+`(name, {opts, "children": [...]})` nested form and calls `style.layout(...)`.
+Pure structural sugar — the biggest readability win, zero behavioral surface.
+
+### `image_element()` — named, validated state→image map
+
+```python
+image_element(style, f"{ttkstyle}.indicator", default=on,
+    states={"disabled selected": on_disabled,
+            "disabled": on_disabled_alt,
+            "!selected": off},
+    width=width, border=border, sticky=W)
+```
+
+Wraps `element_create(..., "image", default, *statespecs, **opts)`. `states` is an
+**ordered** dict (ttk statespecs are first-match-wins; dict insertion order is the
+match order, made explicit). Each key is validated via `statespec` below — a typo
+like `"diabled"` fails loudly instead of silently never matching (the natural home
+for Workstream D's loud-failure validation).
+
+### `statespec` / `state_map()` — grammar validation
+
+```python
+statespec("disabled selected")     # -> ("disabled", "selected")  (validated)
+statespec("!selected")             # -> ("!selected",)
+state_map(disabled=disabled_fg)    # -> [("disabled", disabled_fg)]  for style.map
+```
+
+Validates the `!negation` + space-AND grammar against the known ttk/bootstyle
+state tokens; raises on unknown tokens. `state_map()` is the `style.map(...)`
+analog (replaces bare `foreground=[("disabled", fg)]` lists). Loud-failure
+validation here is the seam shared with Workstream D — keep the token set in one
+place both can import.
+
+### `StyleName` — the `DEFAULT/""` + `.TS→.S` absorber
+
+```python
+sn = StyleName("TScale", colorname, orient="Horizontal")
+sn.colorname    # PRIMARY when input was DEFAULT/"" (per-widget default), else as given
+sn.ttkstyle     # "Horizontal.TScale" or "primary.Horizontal.TScale"
+sn.element      # "Horizontal.Scale"  (drops the T from the ttk class token)
+```
+
+Absorbs `if any([colorname == DEFAULT, colorname == ""])`, the
+`f"{colorname}.{STYLE}"` prefixing, the `.replace(".TS", ".S")` element-name
+derivation, and the "default colorname → PRIMARY" rule that ~30 builders repeat.
+Lowest-risk, most-mechanical primitive; orthogonal to the image/layout helpers.
+
+### Alignment with bootstack's `Element` / `ElementImage`
+
+bootstack already ships these analogs (`style/element.py:6-174`), which is a
+maintenance asset — the same author keeps both mental models in sync:
+
+- `El` ≈ bootstack's **`Element(name, *, expand, side, sticky, border)`** with a
+  recursive **`.spec()`** that lowers to the ttk `(name, {opts, "children":[...]})`
+  tuple/dict. Port the `.spec()` lowering directly.
+- `image_element` ≈ bootstack's **`ElementImage(...).state_specs([...]).build()`**,
+  which returns `(name, args, options)` for `element_create`. Port the `build()`
+  arg assembly.
+
+Two **deliberate divergences** (keep ttkbootstrap's simpler shape, note why):
+
+- Use a **constructor `children=[...]` kwarg**, not bootstack's fluent
+  `.children([...])`. bootstack's `children()` parents siblings positionally
+  (`elements[i-1]`), which is fragile; the kwarg form is unambiguous and reads as
+  the tree it builds.
+- Keep `statespec`/`state_map` as **validating** helpers (loud failure on unknown
+  tokens — the Workstream D seam). bootstack's state maps are plain
+  `(state, value)` lists with no validation; ttkbootstrap adds the check.
+
+## Acceptance test — proof
+
+### `create_scale_assets` (assets): ~64 lines → ~22
+
+The `make_thumb` closure, the six `_get_or_create_image` calls with hand-built
+keys, and every `Image.new` / `.resize(LANCZOS)` / `PhotoImage` disappear:
+
+```python
+def create_scale_assets(self, colorname=DEFAULT, size=14):
+    size = self.scale_size(size)
+    a = self.assets
+    if self.is_light_theme:
+        disabled = self.colors.border
+        track = self.colors.bg if colorname == LIGHT else self.colors.light
+    else:
+        disabled = self.colors.selectbg
+        track = Colors.update_hsv(self.colors.selectbg, vd=-0.2)
+    normal = self.colors.primary if colorname in (DEFAULT, "") \
+        else self.colors.get(colorname)
+    pressed = Colors.update_hsv(normal, vd=-0.1)
+    hover = Colors.update_hsv(normal, vd=0.1)
+    h_size, v_size = self.scale_size((40, 5)), self.scale_size((5, 40))
+    return (
+        a.circle(normal,   size),
+        a.circle(pressed,  size),
+        a.circle(hover,    size),
+        a.circle(disabled, size),
+        a.rect(track, h_size),
+        a.rect(track, v_size),
+    )
+```
+
+The state-color *math* stays (that's the builder's real content); the **plumbing**
+is gone. Each `a.circle(c, size)` keys on `("circle", c, (size,size), None, 0)` —
+no hand-written key, no purity hazard.
+
+### `create_radiobutton_style` (style): ~67 lines → ~18
+
+```python
+def create_radiobutton_style(self, colorname=DEFAULT):
+    sn = StyleName("TRadiobutton", colorname)
+    disabled_fg = Colors.make_transparent(0.30, self.colors.fg, self.colors.bg)
+    off, on, disabled, on_disabled = self.create_radiobutton_assets(sn.colorname)
+    image_element(self.style, f"{sn.ttkstyle}.indicator", default=on,
+        states={"disabled selected": on_disabled,
+                "disabled": disabled,
+                "!selected": off},
+        width=self.scale_size(20), border=self.scale_size(4), sticky=W)
+    state_map(self.style, sn.ttkstyle, foreground={"disabled": disabled_fg})
+    self.style._build_configure(sn.ttkstyle)
+    layout(self.style, sn.ttkstyle,
+        El("Radiobutton.padding", sticky=NSEW, children=[
+            El(f"{sn.ttkstyle}.indicator", side=LEFT),
+            El("Radiobutton.focus", side=LEFT, children=[
+                El("Radiobutton.label", sticky=NSEW)])]))
+    self.style._register_ttkstyle(sn.ttkstyle)
+```
+
+The 30-line layout pyramid → 5 readable lines; the positional statespecs → a named
+dict; the colorname/element dance → one `StyleName`. **Both targets pass: shorter
+and clearer.** The `create_radiobutton_assets` companion uses `a.circle` for the
+off/disabled states and `a.image(size, draw_on, light_outline, on_fill,
+on_indicator, off_border)` for the two concentric-circle "on" states — its key
+parts now sit beside the draw.
+
+## Public exposure
+
+The toolkit is public (dogfooded internally + the headline "build your own style"
+API). Re-export plan:
+
+- `style/__init__.py` re-exports `Assets`, `image_element`, `layout`, `El`,
+  `statespec`, `state_map`, `StyleName` (alongside the existing surface), so
+  `from ttkbootstrap.style import Assets, layout, El` works.
+- Top-level `ttkbootstrap` re-exports the same names for custom-style authoring
+  (the import block at `__init__.py:59`). Keep `import ttkbootstrap` warning-free.
+- The submodules `style.assets` / `style.layout` are the canonical homes;
+  `style.engine._get_or_create_image` stays private.
+
+## Layering / import safety
+
+`assets.py` and `layout.py` sit **above** `engine.py` in the package layering
+(they consume `Style`), **below** `bootstyle.py` is not required — they are leaves
+that nothing in the core imports at module top-level:
+
+- `assets.py` top-level imports: `from math import ceil` (or reuse), PIL bits
+  (`Image, ImageDraw, ImageTk, Resampling`). It needs a `Style` **instance** at
+  call time (passed in), not the class at import time → **no top-level edge to
+  `engine`**, so no cycle. Mirror the split's function-local-back-edge discipline
+  if a class import is ever needed.
+- `layout.py` top-level imports: `tkinter` constants only; it calls methods on the
+  `style` instance passed in. No engine import.
+- `builders_ttk.py` gains `from .assets import Assets` and
+  `from .layout import layout, El, image_element, statespec, state_map, StyleName`
+  — these are **downward** (builders → toolkit-leaves that don't import builders),
+  import-safe. Verify with the standalone-import cycle guard from the split.
+
+**Carry the PEP 649 annotation force-evaluation sweep** (split design doc's
+notable finding): the dev interpreter is 3.14, where a missing annotation-only
+import imports clean and only `NameError`s on `__annotations__` access. Run the
+sweep over the two new modules + the migrated builders.
+
+## The one open decision — pixel fidelity of migrated builders
+
+The shape recipes are **good defaults, not bit-exact replicas** of today's draws.
+Concrete divergences the recipes would introduce:
+
+- Scale thumb draws ellipse `(0,0,95,95)` on a 100-px canvas — a deliberate ~5%
+  margin. `a.circle` draws full-bleed unless given an inset.
+- Radio/check use a `134`-px canvas with `[1,1,133,133]` insets and a fixed
+  oversample ratio; recipes use a uniform `oversample` factor.
+
+These are **sub-pixel anti-aliasing / edge differences**, not color changes. PR 2's
+purity tests assert *which color a key pixel is* (robust to AA), not whole-image
+equality — so they would still pass. The question is whether to:
+
+- **(A) Accept sub-pixel AA drift** (recommended) — same latitude Workstream E
+  already takes on theme-palette drift; keeps the recipes clean (no per-site
+  inset/oversample knobs leaking the old magic numbers back in). Add an optional
+  `inset=`/`oversample=` only where a specific widget visibly regresses.
+- **(B) Preserve pixels exactly** — recipes grow `inset`/absolute-canvas params so
+  each migrated builder reproduces its current draw byte-for-byte. Faithful, but
+  drags wart #1's magic constants into the public API and dilutes the "clearer"
+  win.
+
+Recommend **(A)**, with a pre-migration check that `tests/widget_styles/
+test_image_cache.py` (and any visual assertion) tests *color-at-pixel*, not image
+equality — and a spot visual diff on scale + radio + check before merge.
+
+A second, smaller scope question (lower stakes): **land Tier 1 in one PR, or split
+assets vs layout?** **LOCKED: one PR** — they're co-designed, the acceptance test
+spans both, and the migration of a builder touches both at once. It's larger than
+the pure split but every changed builder is regression-netted by the existing
+style-value + image-cache suites.
+
+### RESOLVED — bootstack's snap-at-the-source pipeline dissolves the (A)/(B) split
+
+User guidance (2026-06-25): *"bootstack figured out a way to keep from doing
+sub-pixel adjustments by rounding the scaling and also some other tricks. Might be
+worth a look there to avoid having to re-invent the wheel."* Mined bootstack
+(`src/bootstack`); it confirms the steer and gives us a **better** answer than
+either (A) or (B): don't *manage* drift, **eliminate it at the source** by snapping
+sizes to whole/even pixels before rendering. With that pipeline the recipes produce
+crisper assets than today's hand-fit canvases, and "fidelity" stops being a knob.
+
+The four mechanisms to port verbatim into `Assets` (file refs into bootstack):
+
+1. **Round the DPI factor, never truncate** (`_runtime/utility.py:250-268`,
+   `scale_icon_size` → `max(base, round(base * ui_scale))`). ttkbootstrap's current
+   `scale_size` (`builders_ttk.py:72`) uses `ceil` — already rounds *up*, but the
+   real fix is the next step.
+2. **Even-pixel snap the final size before keying/rendering**
+   (`_core/images.py:364`, `style/utility.py:516`):
+   `size = size if size % 2 == 0 else size + 1`. This is the trick that kills the
+   half-pixel LANCZOS blur at fractional DPI (125 %, 150 %). The snap happens inside
+   the recipe, so the cache key uses the snapped size → identical logical sizes
+   dedupe and land crisp.
+3. **Adaptive supersample, then snap the draw origin to oversample multiples**
+   (`_core/images.py:393-406`): `3×` for `<32 px`, `2×` for `<64 px`, `1×` for
+   `≥64 px`; draw origin rounded to a multiple of the oversample factor so the glyph
+   lands on whole pixels after downscale. Replaces the per-builder magic canvases
+   (`100`/`134`/`226`) with one principled factor.
+4. **LANCZOS downscale + `UnsharpMask` to restore edge crispness**
+   (`_core/images.py:459-461`, `style/utility.py:137`):
+   `img.resize(size, LANCZOS).filter(ImageFilter.UnsharpMask(radius=0.6,
+   percent=60, threshold=0))`. The sharpen is what makes the snapped result read
+   crisper than the current bare-LANCZOS output.
+
+**Decision (LOCKED): adopt bootstack's snapped pipeline** (a stronger form of (A)).
+The migrated assets will differ from today at the pixel level — *by being sharper
+and DPI-stable* — not by drifting color. PR 2's purity tests assert color-at-pixel
+(robust to this), so they pass; add a spot visual diff on scale/radio/check to
+confirm the quality is equal-or-better. No per-recipe `inset`/`oversample` knobs
+leak into the public API — option (B) is dropped. The recipe owns the snap +
+adaptive-oversample + unsharp internally; callers pass only the logical size.
+
+One caveat to carry into implementation: a few existing draws encode a deliberate
+margin in their canvas (scale thumb's `(0,0,95,95)` on a 100-px canvas ≈ 5 % inset).
+Where a recipe's full-bleed default changes a widget's *visual weight* (not just its
+AA), reproduce the margin as a documented constant inside that recipe's default —
+not as a public knob.
+
+## PR scope & sequencing
+
+One PR (`feat/2.0-pr5-toolkit`), per the recommendation above:
+
+1. Add `style/assets.py` (`Assets` + recipes + `image`) and `style/layout.py`
+   (`layout`/`El`/`image_element`/`statespec`/`state_map`/`StyleName`).
+2. Re-export from `style/__init__.py` and top-level `ttkbootstrap`.
+3. Migrate the **two acceptance-test builders** (`create_scale_*`,
+   `create_radiobutton_*`) first as the proof; land them, confirm suite + visual.
+4. Migrate the remaining asset/layout sites opportunistically (separate commits
+   within the PR, or a fast-follow PR if the diff gets large) — the recipes are
+   the same shapes repeated, so this is mechanical once the two proofs land.
+5. New tests: recipe key-completeness (same inputs → same name; one differing
+   color → different name), **even-size snap** (an odd logical size and the
+   next even one resolve to the same image/key; the rendered size is even),
+   `El`→ttk-tuple lowering (matches the hand-written nested form), `statespec`
+   validation (good + raises-on-typo), `StyleName` (`DEFAULT/""`→PRIMARY,
+   `.TS→.S`, color-prefix). Keep `import ttkbootstrap` warning-free.
+
+Tier 2 (`state_colors` from ramp steps; composite recipes) is deferred to after
+Workstream E, as the plan sequences it.
+
+## Verification plan
+
+- `python -m pytest -q` → still **61 passed** plus the new toolkit tests.
+- Acceptance: the two migrated builders are shorter (line count) and pass the
+  existing style-value + `test_image_cache.py` assertions unchanged.
+- Cache invariant preserved: a theme round-trip still holds `_image_cache` flat
+  (the recipe keys are theme-independent by construction).
+- Snapped pipeline (ported from bootstack): rendered asset sizes are even; a spot
+  visual diff on scale/radio/check confirms equal-or-better crispness vs today
+  (sharper, DPI-stable — not color drift). `test_image_cache.py` color-at-pixel
+  assertions pass unchanged.
+- Standalone-import cycle guard for `style.assets` / `style.layout`; PEP 649
+  annotation force-evaluation sweep over the new modules + migrated builders.
+- `import ttkbootstrap` warning-free; the new public names import from both
+  `ttkbootstrap` and `ttkbootstrap.style`.

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -59,6 +59,9 @@ from tkinter.ttk import (
 from ttkbootstrap.style import (
     Bootstyle, Style, BootMixin, AutoStyleMixin,
     bootify, apply_bootstyle, enable_global_api,
+    # Style-construction toolkit (Workstream I): the public "build your own
+    # style" surface, dogfooded by the builders.
+    Assets, El, layout, image_element, statespec, state_map, StyleName,
 )
 
 
@@ -209,6 +212,15 @@ __all__ = [
     "bootify",
     "apply_bootstyle",
     "enable_global_api",
+
+    # Style-construction toolkit
+    "Assets",
+    "El",
+    "layout",
+    "image_element",
+    "statespec",
+    "state_map",
+    "StyleName",
 
     # Windows
     "Toplevel",

--- a/src/ttkbootstrap/style/__init__.py
+++ b/src/ttkbootstrap/style/__init__.py
@@ -19,6 +19,15 @@ from ttkbootstrap.style.bootstyle import (
     apply_bootstyle,
     enable_global_api,
 )
+from ttkbootstrap.style.assets import Assets
+from ttkbootstrap.style.layout import (
+    El,
+    layout,
+    image_element,
+    statespec,
+    state_map,
+    StyleName,
+)
 
 __all__ = [
     "Colors",
@@ -33,4 +42,12 @@ __all__ = [
     "bootify",
     "apply_bootstyle",
     "enable_global_api",
+    # Style-construction toolkit (Workstream I)
+    "Assets",
+    "El",
+    "layout",
+    "image_element",
+    "statespec",
+    "state_map",
+    "StyleName",
 ]

--- a/src/ttkbootstrap/style/assets.py
+++ b/src/ttkbootstrap/style/assets.py
@@ -1,0 +1,137 @@
+"""Public image-construction toolkit for ttkbootstrap styles.
+
+`Assets(style)` is the ergonomic, key-safe front door to the engine's
+content-addressed image cache (`Style._get_or_create_image`). The shape recipes
+(`circle`/`rect`/`rounded_rect`) and the general `image()` escape hatch each
+render an asset *and* derive its cache key from the same inputs, so a key can
+never drift from the pixels it names -- the purity hazard PR 2's whole audit
+existed to manage.
+
+The renderer ports bootstack's snap-at-the-source pipeline: even-pixel-snap the
+final size, adaptive supersample (3x/2x/1x by size), LANCZOS downscale, then an
+UnsharpMask to restore edge crispness. The result is crisper, DPI-stable assets
+-- callers pass only the logical (already DPI-scaled) size; the oversample factor
+and the snap are internal and adaptive.
+"""
+from PIL import Image, ImageDraw, ImageFilter, ImageTk
+from PIL.Image import Resampling
+
+
+def _wh(size):
+    """Normalize `size` (int -> square, or `(w, h)`) to an int `(w, h)` tuple."""
+    if isinstance(size, (int, float)):
+        return (int(size), int(size))
+    return (int(size[0]), int(size[1]))
+
+
+def _even(n):
+    """Snap a pixel length up to the next even integer.
+
+    bootstack's fractional-DPI fix: an even final size avoids the half-pixel
+    LANCZOS blur seen at 125%/150% scaling. Applied to the anti-aliased recipes
+    only -- `rect` has no edges to blur and keeps its exact size.
+    """
+    return n if n % 2 == 0 else n + 1
+
+
+def _oversample(w, h):
+    """Adaptive supersample factor by the larger dimension (bootstack: 3/2/1)."""
+    longest = max(w, h)
+    if longest < 32:
+        return 3
+    elif longest < 64:
+        return 2
+    return 1
+
+
+def _render(size, draw_fn):
+    """Render `draw_fn` onto an oversampled canvas, then snap-downscale + sharpen.
+
+    `size` is the even-snapped final `(w, h)`. `draw_fn(draw, w, h)` draws onto an
+    `ImageDraw.Draw` over the oversampled `(w, h)` canvas (final size x the
+    adaptive factor), so any coordinates are expressed relative to the canvas it
+    is handed. After the LANCZOS downscale an UnsharpMask restores edge
+    crispness. Returns a `PhotoImage`.
+    """
+    w, h = size
+    factor = _oversample(w, h)
+    cw, ch = w * factor, h * factor
+    img = Image.new("RGBA", (cw, ch))
+    draw_fn(ImageDraw.Draw(img), cw, ch)
+    if factor > 1:
+        img = img.resize((w, h), Resampling.LANCZOS)
+        img = img.filter(ImageFilter.UnsharpMask(radius=0.6, percent=60, threshold=0))
+    return ImageTk.PhotoImage(img)
+
+
+class Assets:
+    """Key-safe image construction over the engine's content-addressed cache.
+
+    `Assets(style)` wraps `Style._get_or_create_image`: each method renders an
+    asset *and* derives its cache key from the same render inputs, so the key
+    cannot drift from the pixels (the purity hazard PR 2's audit existed to
+    manage). Builders reach a shared instance via `self.assets`; public users
+    construct `Assets(Style.get_instance())`.
+
+    Sizes are the final widget pixel size (already DPI-scaled by the caller, e.g.
+    via `scale_size`); the anti-aliased recipes even-pixel-snap and supersample
+    internally, so two logical sizes that snap equal share one image. Every
+    method returns the Tcl image name (the `_get_or_create_image` contract), and
+    the resolved colors are *in* the key, so cross-theme-identical assets dedupe.
+    """
+
+    def __init__(self, style):
+        self.style = style
+
+    def circle(self, fill, size, *, outline=None, width=0):
+        """A filled (optionally outlined) circle. `width` is in final pixels."""
+        size = _wh(size)
+        size = (_even(size[0]), _even(size[1]))
+        key = ("circle", fill, size, outline, width)
+
+        def factory():
+            def draw(d, w, h):
+                ow = round(width * w / size[0]) if width else 0
+                d.ellipse((0, 0, w - 1, h - 1), fill=fill, outline=outline, width=ow)
+            return _render(size, draw)
+
+        return self.style._get_or_create_image(key, factory)
+
+    def rounded_rect(self, fill, size, radius, *, outline=None, width=0):
+        """A rounded rectangle. `radius` and `width` are in final pixels."""
+        size = _wh(size)
+        size = (_even(size[0]), _even(size[1]))
+        key = ("rounded_rect", fill, size, radius, outline, width)
+
+        def factory():
+            def draw(d, w, h):
+                factor = w / size[0]
+                r = round(radius * factor)
+                ow = round(width * factor) if width else 0
+                d.rounded_rectangle((0, 0, w - 1, h - 1), radius=r, fill=fill,
+                                    outline=outline, width=ow)
+            return _render(size, draw)
+
+        return self.style._get_or_create_image(key, factory)
+
+    def rect(self, fill, size):
+        """A solid axis-aligned rectangle (no anti-aliasing, no size snap)."""
+        size = _wh(size)
+        key = ("rect", fill, size)
+        return self.style._get_or_create_image(
+            key, lambda: ImageTk.PhotoImage(Image.new("RGB", size, fill)))
+
+    def image(self, size, draw_fn, *key_parts):
+        """Escape hatch for custom composite draws (concentric circles, glyphs).
+
+        `draw_fn(draw, w, h)` draws onto the oversampled `(w, h)` canvas, so the
+        old hand-fit canvas constants become `w`-relative expressions. The key is
+        `(draw_fn.__qualname__, snapped_size, *key_parts)` -- list in `key_parts`
+        every color/value the draw closes over; they sit *beside* the draw so the
+        key cannot silently drift from it, and the `__qualname__` keeps two
+        different draws from colliding on equal `key_parts`.
+        """
+        size = _wh(size)
+        size = (_even(size[0]), _even(size[1]))
+        key = (draw_fn.__qualname__, size, *key_parts)
+        return self.style._get_or_create_image(key, lambda: _render(size, draw_fn))

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -14,6 +14,10 @@ from PIL.Image import Resampling, Transpose
 from ttkbootstrap.constants import *
 from ttkbootstrap.style.theme import Colors, ThemeDefinition
 from ttkbootstrap.style.builders_tk import StyleBuilderTK
+from ttkbootstrap.style.assets import Assets
+from ttkbootstrap.style.layout import (
+    El, layout, image_element, state_map, StyleName,
+)
 
 
 class StyleBuilderTTK:
@@ -68,6 +72,19 @@ class StyleBuilderTTK:
         """If the current theme is _light_, returns `True`, otherwise
         returns `False`."""
         return self.style.theme.type == LIGHT
+
+    @property
+    def assets(self) -> Assets:
+        """A key-safe `Assets` facade bound to the engine image cache.
+
+        Lazily constructed once per builder; the underlying cache lives on the
+        shared `Style` singleton, so dedup is process-wide regardless of which
+        builder created an asset.
+        """
+        cached = self.__dict__.get("_assets")
+        if cached is None:
+            cached = self.__dict__["_assets"] = Assets(self.style)
+        return cached
 
     def scale_size(self, size):
         """Scale the size of images and other assets based on the
@@ -617,12 +634,10 @@ class StyleBuilderTTK:
                 layout when building the style.
         """
         size = self.scale_size(size)
+        a = self.assets
         if self.is_light_theme:
             disabled_color = self.colors.border
-            if colorname == LIGHT:
-                track_color = self.colors.bg
-            else:
-                track_color = self.colors.light
+            track_color = self.colors.bg if colorname == LIGHT else self.colors.light
         else:
             disabled_color = self.colors.selectbg
             track_color = Colors.update_hsv(self.colors.selectbg, vd=-0.2)
@@ -631,54 +646,20 @@ class StyleBuilderTTK:
             normal_color = self.colors.primary
         else:
             normal_color = self.colors.get(colorname)
-
         pressed_color = Colors.update_hsv(normal_color, vd=-0.1)
         hover_color = Colors.update_hsv(normal_color, vd=0.1)
-
-        def make_thumb(fill):
-            img = Image.new("RGBA", (100, 100))
-            ImageDraw.Draw(img).ellipse((0, 0, 95, 95), fill=fill)
-            return ImageTk.PhotoImage(
-                img.resize((size, size), Resampling.LANCZOS)
-            )
 
         h_size = self.scale_size((40, 5))
         v_size = self.scale_size((5, 40))
 
-        # thumb states (same geometry; keyed by fill color + size)
-        normal_name = self.style._get_or_create_image(
-            ("scale.thumb", normal_color, size),
-            lambda: make_thumb(normal_color),
-        )
-        pressed_name = self.style._get_or_create_image(
-            ("scale.thumb", pressed_color, size),
-            lambda: make_thumb(pressed_color),
-        )
-        hover_name = self.style._get_or_create_image(
-            ("scale.thumb", hover_color, size),
-            lambda: make_thumb(hover_color),
-        )
-        disabled_name = self.style._get_or_create_image(
-            ("scale.thumb", disabled_color, size),
-            lambda: make_thumb(disabled_color),
-        )
-        # tracks (solid fill)
-        h_track_name = self.style._get_or_create_image(
-            ("scale.track", track_color, tuple(h_size)),
-            lambda: ImageTk.PhotoImage(Image.new("RGB", h_size, track_color)),
-        )
-        v_track_name = self.style._get_or_create_image(
-            ("scale.track", track_color, tuple(v_size)),
-            lambda: ImageTk.PhotoImage(Image.new("RGB", v_size, track_color)),
-        )
-
+        # ( normal, pressed, hover, disabled thumbs; horizontal, vertical track )
         return (
-            normal_name,
-            pressed_name,
-            hover_name,
-            disabled_name,
-            h_track_name,
-            v_track_name,
+            a.circle(normal_color, size),
+            a.circle(pressed_color, size),
+            a.circle(hover_color, size),
+            a.circle(disabled_color, size),
+            a.rect(track_color, h_size),
+            a.rect(track_color, v_size),
         )
 
     def create_scale_style(self, colorname=DEFAULT):
@@ -689,81 +670,39 @@ class StyleBuilderTTK:
             colorname (str):
                 The color label used to style the widget.
         """
-        STYLE = "TScale"
-
-        if any([colorname == DEFAULT, colorname == ""]):
-            h_ttkstyle = f"Horizontal.{STYLE}"
-            v_ttkstyle = f"Vertical.{STYLE}"
-        else:
-            h_ttkstyle = f"{colorname}.Horizontal.{STYLE}"
-            v_ttkstyle = f"{colorname}.Vertical.{STYLE}"
+        h = StyleName("TScale", colorname, orient="Horizontal")
+        v = StyleName("TScale", colorname, orient="Vertical")
 
         # ( normal, pressed, hover, disabled, htrack, vtrack )
         images = self.create_scale_assets(colorname)
 
         # horizontal scale
-        h_element = h_ttkstyle.replace(".TS", ".S")
-        self.style.element_create(
-            f"{h_element}.slider",
-            "image",
-            images[0],
-            ("disabled", images[3]),
-            ("pressed", images[1]),
-            ("hover", images[2]),
-        )
-        self.style.element_create(f"{h_element}.track", "image", images[4])
-        self.style.layout(
-            h_ttkstyle,
-            [
-                (
-                    f"{h_element}.focus",
-                    {
-                        "expand": "1",
-                        "sticky": tk.NSEW,
-                        "children": [
-                            (f"{h_element}.track", {"sticky": tk.EW}),
-                            (
-                                f"{h_element}.slider",
-                                {"side": tk.LEFT, "sticky": ""},
-                            ),
-                        ],
-                    },
-                )
-            ],
-        )
+        image_element(
+            self.style, f"{h.element}.slider", default=images[0],
+            states={"disabled": images[3], "pressed": images[1],
+                    "hover": images[2]})
+        self.style.element_create(f"{h.element}.track", "image", images[4])
+        layout(
+            self.style, h.ttkstyle,
+            El(f"{h.element}.focus", expand=1, sticky=NSEW, children=[
+                El(f"{h.element}.track", sticky=EW),
+                El(f"{h.element}.slider", side=LEFT, sticky="")]))
+
         # vertical scale
-        v_element = v_ttkstyle.replace(".TS", ".S")
-        self.style.element_create(
-            f"{v_element}.slider",
-            "image",
-            images[0],
-            ("disabled", images[3]),
-            ("pressed", images[1]),
-            ("hover", images[2]),
-        )
-        self.style.element_create(f"{v_element}.track", "image", images[5])
-        self.style.layout(
-            v_ttkstyle,
-            [
-                (
-                    f"{v_element}.focus",
-                    {
-                        "expand": "1",
-                        "sticky": tk.NSEW,
-                        "children": [
-                            (f"{v_element}.track", {"sticky": tk.NS}),
-                            (
-                                f"{v_element}.slider",
-                                {"side": tk.TOP, "sticky": ""},
-                            ),
-                        ],
-                    },
-                )
-            ],
-        )
+        image_element(
+            self.style, f"{v.element}.slider", default=images[0],
+            states={"disabled": images[3], "pressed": images[1],
+                    "hover": images[2]})
+        self.style.element_create(f"{v.element}.track", "image", images[5])
+        layout(
+            self.style, v.ttkstyle,
+            El(f"{v.element}.focus", expand=1, sticky=NSEW, children=[
+                El(f"{v.element}.track", sticky=NS),
+                El(f"{v.element}.slider", side=TOP, sticky="")]))
+
         # register ttkstyles
-        self.style._register_ttkstyle(h_ttkstyle)
-        self.style._register_ttkstyle(v_ttkstyle)
+        self.style._register_ttkstyle(h.ttkstyle)
+        self.style._register_ttkstyle(v.ttkstyle)
 
     def create_floodgauge_style(self, colorname=DEFAULT):
         """Create a ttk style for the ttkbootstrap.widgets.Floodgauge
@@ -2575,71 +2514,43 @@ class StyleBuilderTTK:
             tuple[str]:
                 A tuple of PhotoImage names
         """
-        prime_color = self.colors.get(colorname)
-        on_fill = prime_color
+        a = self.assets
+        on_fill = self.colors.get(colorname)
         off_fill = self.colors.bg
         on_indicator = self.colors.selectfg
         size = self.scale_size([14, 14])
         off_border = Colors.make_transparent(0.4, self.colors.fg, self.colors.bg)
         disabled = Colors.make_transparent(0.3, self.colors.fg, self.colors.bg)
 
-        if self.is_light_theme:
-            if colorname == LIGHT:
-                on_indicator = self.colors.dark
+        if self.is_light_theme and colorname == LIGHT:
+            on_indicator = self.colors.dark
 
         # geometry differs (outline vs filled) for the light-on-light case
         light_outline = colorname == LIGHT and self.is_light_theme
 
-        def make_off():
-            img = Image.new("RGBA", (134, 134))
-            ImageDraw.Draw(img).ellipse(
-                xy=[1, 1, 133, 133], outline=off_border, width=6, fill=off_fill
-            )
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_on():
-            img = Image.new("RGBA", (134, 134))
-            draw = ImageDraw.Draw(img)
+        # Concentric "on" / "on_disabled" states need a composite draw, so they
+        # use the `image` escape hatch -- the colors each draw closes over are
+        # listed beside it as key parts (so the key can't drift from the pixels).
+        def draw_on(d, w, h):
             if light_outline:
-                draw.ellipse(xy=[1, 1, 133, 133], outline=off_border, width=6)
+                d.ellipse((0, 0, w - 1, h - 1), outline=off_border, width=round(w * 0.045))
             else:
-                draw.ellipse(xy=[1, 1, 133, 133], fill=on_fill)
-            draw.ellipse([40, 40, 94, 94], fill=on_indicator)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
+                d.ellipse((0, 0, w - 1, h - 1), fill=on_fill)
+            d.ellipse((w * 0.30, h * 0.30, w * 0.70, h * 0.70), fill=on_indicator)
 
-        def make_on_disabled():
-            img = Image.new("RGBA", (134, 134))
-            draw = ImageDraw.Draw(img)
+        def draw_on_disabled(d, w, h):
             if light_outline:
-                draw.ellipse(xy=[1, 1, 133, 133], outline=off_border, width=6)
+                d.ellipse((0, 0, w - 1, h - 1), outline=off_border, width=round(w * 0.045))
             else:
-                draw.ellipse(xy=[1, 1, 133, 133], fill=disabled)
-            draw.ellipse([40, 40, 94, 94], fill=off_fill)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
+                d.ellipse((0, 0, w - 1, h - 1), fill=disabled)
+            d.ellipse((w * 0.30, h * 0.30, w * 0.70, h * 0.70), fill=off_fill)
 
-        def make_disabled():
-            img = Image.new("RGBA", (134, 134))
-            ImageDraw.Draw(img).ellipse(
-                xy=[1, 1, 133, 133], outline=disabled, width=3, fill=off_fill
-            )
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        off_name = self.style._get_or_create_image(
-            ("radio.off", off_border, off_fill, tuple(size)), make_off
-        )
-        on_name = self.style._get_or_create_image(
-            ("radio.on", light_outline, on_fill, on_indicator, off_border,
-             tuple(size)),
-            make_on,
-        )
-        on_disabled_name = self.style._get_or_create_image(
-            ("radio.on_disabled", light_outline, off_border, disabled, off_fill,
-             tuple(size)),
-            make_on_disabled,
-        )
-        disabled_name = self.style._get_or_create_image(
-            ("radio.disabled", disabled, off_fill, tuple(size)), make_disabled
-        )
+        # the unselected "off" / "disabled" states are a single outlined circle
+        ring = max(1, round(size[0] * 0.045))
+        off_name = a.circle(off_fill, size, outline=off_border, width=ring)
+        disabled_name = a.circle(off_fill, size, outline=disabled, width=ring)
+        on_name = a.image(size, draw_on, light_outline, on_fill, on_indicator, off_border)
+        on_disabled_name = a.image(size, draw_on_disabled, light_outline, disabled, off_fill, off_border)
 
         return off_name, on_name, disabled_name, on_disabled_name
 
@@ -2652,65 +2563,25 @@ class StyleBuilderTTK:
                 The color label used to style the widget.
         """
 
-        STYLE = "TRadiobutton"
-
+        sn = StyleName("TRadiobutton", colorname)
         disabled_fg = Colors.make_transparent(0.30, self.colors.fg, self.colors.bg)
 
-        if any([colorname == DEFAULT, colorname == ""]):
-            ttkstyle = STYLE
-            colorname = PRIMARY
-        else:
-            ttkstyle = f"{colorname}.{STYLE}"
-
-        # ( off, on, disabled )
-        images = self.create_radiobutton_assets(colorname)
-        width = self.scale_size(20)
-        borderpad = self.scale_size(4)
-        self.style.element_create(
-            f"{ttkstyle}.indicator",
-            "image",
-            images[1],
-            ("disabled selected", images[3]),
-            ("disabled", images[2]),
-            ("!selected", images[0]),
-            width=width,
-            border=borderpad,
-            sticky=tk.W,
-        )
-        self.style.map(ttkstyle, foreground=[("disabled", disabled_fg)])
-        self.style._build_configure(ttkstyle)
-        self.style.layout(
-            ttkstyle,
-            [
-                (
-                    "Radiobutton.padding",
-                    {
-                        "children": [
-                            (
-                                f"{ttkstyle}.indicator",
-                                {"side": tk.LEFT, "sticky": ""},
-                            ),
-                            (
-                                "Radiobutton.focus",
-                                {
-                                    "children": [
-                                        (
-                                            "Radiobutton.label",
-                                            {"sticky": tk.NSEW},
-                                        )
-                                    ],
-                                    "side": tk.LEFT,
-                                    "sticky": "",
-                                },
-                            ),
-                        ],
-                        "sticky": tk.NSEW,
-                    },
-                )
-            ],
-        )
-        # register ttkstyle
-        self.style._register_ttkstyle(ttkstyle)
+        # ( off, on, disabled, on_disabled )
+        images = self.create_radiobutton_assets(sn.colorname)
+        image_element(
+            self.style, f"{sn.ttkstyle}.indicator", default=images[1],
+            states={"disabled selected": images[3], "disabled": images[2],
+                    "!selected": images[0]},
+            width=self.scale_size(20), border=self.scale_size(4), sticky=W)
+        state_map(self.style, sn.ttkstyle, foreground={"disabled": disabled_fg})
+        self.style._build_configure(sn.ttkstyle)
+        layout(
+            self.style, sn.ttkstyle,
+            El("Radiobutton.padding", sticky=NSEW, children=[
+                El(f"{sn.ttkstyle}.indicator", side=LEFT, sticky=""),
+                El("Radiobutton.focus", side=LEFT, sticky="", children=[
+                    El("Radiobutton.label", sticky=NSEW)])]))
+        self.style._register_ttkstyle(sn.ttkstyle)
 
     def create_date_button_assets(self, foreground):
         """Create the image assets used to build the date button

--- a/src/ttkbootstrap/style/layout.py
+++ b/src/ttkbootstrap/style/layout.py
@@ -1,0 +1,180 @@
+"""Public layout / element / statespec / name helpers for ttkbootstrap styles.
+
+Small, composable helpers that absorb the boilerplate every style builder
+repeats: the nested layout tuple/dict pyramids (`El` + `layout`), image element
+state->image maps (`image_element`), `style.map` state maps (`state_map`), the
+`!negation`/space-AND state grammar validation (`statespec`), and the
+colorname/orientation/`.TS->.S` name surgery (`StyleName`).
+
+They are thin wrappers, not a DSL: each does one mechanical job, holds no state
+of its own, calls methods on the `Style` instance passed in, and composes freely
+with raw `style.element_create`/`style.layout`/`style.map` calls. Top-level
+imports are tkinter constants only -- no engine edge, so these stay leaves in
+the package layering.
+"""
+from ttkbootstrap.constants import DEFAULT, PRIMARY
+
+
+# The canonical ttk widget state tokens. `statespec`/`state_map` validate against
+# this set so a typo ("diabled") fails loudly at style-build time instead of
+# silently never matching. This is the loud-failure seam shared with Workstream D
+# -- keep the token set here, in one place, for both to import.
+TTK_STATES = frozenset({
+    "active", "alternate", "background", "disabled", "focus", "hover",
+    "invalid", "pressed", "readonly", "selected",
+})
+
+
+def statespec(spec):
+    """Validate a ttk state string and split it into a tuple of tokens.
+
+    Tokens are space-separated; each may be negated with a leading `!`
+    ("!selected"). An unknown token raises `ValueError`.
+
+    ```python
+    statespec("disabled selected")  # -> ("disabled", "selected")
+    statespec("!selected")          # -> ("!selected",)
+    ```
+    """
+    tokens = tuple(spec.split())
+    for token in tokens:
+        base = token[1:] if token.startswith("!") else token
+        if base not in TTK_STATES:
+            raise ValueError(
+                f"unknown widget state {token!r}; valid tokens are "
+                f"{', '.join(sorted(TTK_STATES))} (optionally '!'-negated)"
+            )
+    return tokens
+
+
+class El:
+    """A ttk layout element: a name, layout options, and child `El`s.
+
+    `layout()` lowers an `El` tree to ttk's nested `(name, {opts, "children":
+    [...]})` form. Mirrors bootstack's `Element.spec()`, but takes children as a
+    constructor `children=[...]` kwarg (unambiguous; reads as the tree it builds)
+    rather than fluent positional parenting.
+
+    ```python
+    El("Radiobutton.padding", sticky=NSEW, children=[
+        El(f"{ttkstyle}.indicator", side=LEFT),
+        El("Radiobutton.focus", side=LEFT, children=[
+            El("Radiobutton.label", sticky=NSEW)])])
+    ```
+    """
+
+    __slots__ = ("name", "options", "children")
+
+    def __init__(self, name, *, side=None, sticky=None, expand=None,
+                 border=None, children=None):
+        self.name = name
+        self.children = list(children) if children else []
+        options = {}
+        if side is not None:
+            options["side"] = side
+        if sticky is not None:
+            options["sticky"] = sticky
+        if expand is not None:
+            options["expand"] = expand
+        if border is not None:
+            options["border"] = border
+        self.options = options
+
+    def spec(self):
+        """Lower this element (and its subtree) to a ttk `(name, opts)` tuple."""
+        options = dict(self.options)
+        if self.children:
+            options["children"] = [child.spec() for child in self.children]
+        return (self.name, options)
+
+
+def layout(style, ttkstyle, root):
+    """Apply an `El` (or list of `El`s) as the layout for `ttkstyle`.
+
+    Pure structural sugar over `style.layout(ttkstyle, [...])`.
+    """
+    roots = [root] if isinstance(root, El) else list(root)
+    style.layout(ttkstyle, [element.spec() for element in roots])
+
+
+def image_element(style, name, *, default, states=None, **options):
+    """Create an image element with a validated, ordered state->image map.
+
+    Wraps `style.element_create(name, "image", default, *statespecs, **options)`.
+    `states` is an ordered dict `{state_string: image}`; ttk matches statespecs
+    first-match-wins, so the dict's insertion order *is* the match order, made
+    explicit. Each state string is validated by `statespec` (a typo raises
+    instead of silently never matching). `options` (width, border, sticky, ...)
+    pass through to `element_create`.
+
+    ```python
+    image_element(style, f"{ttkstyle}.indicator", default=on,
+        states={"disabled selected": on_disabled, "disabled": disabled,
+                "!selected": off},
+        width=20, border=4, sticky=W)
+    ```
+    """
+    args = [default]
+    if states:
+        for state_string, image in states.items():
+            args.append((*statespec(state_string), image))
+    style.element_create(name, "image", *args, **options)
+
+
+def state_map(style, ttkstyle, **options):
+    """Validated `style.map` analog.
+
+    Each keyword is a ttk option (e.g. `foreground=`) whose value is an ordered
+    dict `{state_string: value}` (or an iterable of `(state_string, value)`
+    pairs). State strings are validated by `statespec`. Replaces bare
+    `foreground=[("disabled", fg)]` lists.
+
+    ```python
+    state_map(style, ttkstyle, foreground={"disabled": disabled_fg})
+    ```
+    """
+    mapping = {}
+    for option, spec in options.items():
+        items = spec.items() if isinstance(spec, dict) else spec
+        mapping[option] = [(*statespec(state_string), value)
+                           for state_string, value in items]
+    style.map(ttkstyle, **mapping)
+
+
+class StyleName:
+    """Absorbs the colorname / orientation / `.TS->.S` name surgery builders repeat.
+
+    From a ttk class token ("TScale", "TRadiobutton"), the requested colorname,
+    and an optional orientation it derives the three names every builder opens
+    with:
+
+      .colorname  PRIMARY when the input is DEFAULT/"" (the per-widget default),
+                  else the input unchanged.
+      .ttkstyle   the full ttk style name ("Horizontal.TScale",
+                  "info.Horizontal.TScale", "TRadiobutton", ...).
+      .element    the element-name prefix with the class token's leading "T"
+                  dropped ("info.Horizontal.TScale" -> "info.Horizontal.Scale"),
+                  matching the old `h_ttkstyle.replace(".TS", ".S")` dance.
+
+    ```python
+    sn = StyleName("TScale", colorname, orient="Horizontal")
+    sn.colorname    # PRIMARY when colorname was DEFAULT/"", else as given
+    sn.ttkstyle     # "Horizontal.TScale" or "primary.Horizontal.TScale"
+    sn.element      # "Horizontal.Scale"
+    ```
+    """
+
+    __slots__ = ("colorname", "ttkstyle", "element")
+
+    def __init__(self, ttkclass, colorname=DEFAULT, orient=None):
+        is_default = colorname in (DEFAULT, "")
+        self.colorname = PRIMARY if is_default else colorname
+
+        orient_prefix = f"{orient}." if orient else ""
+        if is_default:
+            self.ttkstyle = f"{orient_prefix}{ttkclass}"
+        else:
+            self.ttkstyle = f"{colorname}.{orient_prefix}{ttkclass}"
+
+        element_class = ttkclass[1:] if ttkclass.startswith("T") else ttkclass
+        self.element = self.ttkstyle.replace(ttkclass, element_class)

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -1,0 +1,167 @@
+"""Style-construction toolkit tests (2.0 Workstream I / PR 5).
+
+Covers the public helpers in `ttkbootstrap.style.assets` / `.layout`:
+
+- the shape recipes derive a complete, color-bearing cache key (so identical
+  inputs dedupe and a single differing color is a different image);
+- the even-pixel snap (an odd logical size and the next even one resolve to the
+  same image, and the rendered image is even-sized) -- bootstack's fractional-DPI
+  fix; `rect` is exempt and keeps its exact size;
+- the `image` escape hatch keys on its declared `*key_parts`;
+- `El` lowers to ttk's nested `(name, opts)` tuple form;
+- `statespec` validates the state grammar (and raises on a typo);
+- `StyleName` performs the DEFAULT/""->PRIMARY, `.TS->.S`, color-prefix dance.
+
+The new public names import warning-free from both `ttkbootstrap` and
+`ttkbootstrap.style`.
+"""
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import PRIMARY
+from ttkbootstrap.style import (
+    Assets, El, layout, image_element, statespec, state_map, StyleName,
+)
+
+
+def _cached_image(style, name):
+    """The cached PhotoImage whose Tcl name is `name` (or None)."""
+    for _key, (cached_name, image) in style._image_cache.items():
+        if cached_name == name:
+            return image
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no Tk root required)
+# --------------------------------------------------------------------------- #
+def test_statespec_splits_and_validates():
+    assert statespec("disabled selected") == ("disabled", "selected")
+    assert statespec("!selected") == ("!selected",)
+    assert statespec("hover !disabled") == ("hover", "!disabled")
+    assert statespec("") == ()
+
+
+def test_statespec_raises_on_typo():
+    with pytest.raises(ValueError):
+        statespec("diabled")
+    with pytest.raises(ValueError):
+        statespec("!notastate")
+    with pytest.raises(ValueError):
+        statespec("disabled seelcted")
+
+
+def test_el_lowers_to_ttk_tuple():
+    tree = El("Radiobutton.padding", sticky="nsew", children=[
+        El("X.indicator", side="left", sticky=""),
+        El("Radiobutton.focus", side="left", sticky="", children=[
+            El("Radiobutton.label", sticky="nsew")])])
+    assert tree.spec() == (
+        "Radiobutton.padding",
+        {"sticky": "nsew", "children": [
+            ("X.indicator", {"side": "left", "sticky": ""}),
+            ("Radiobutton.focus", {"side": "left", "sticky": "", "children": [
+                ("Radiobutton.label", {"sticky": "nsew"})]})]})
+
+
+def test_el_expand_and_border_options():
+    assert El("a", expand=1).spec() == ("a", {"expand": 1})
+    assert El("a", border=4).spec() == ("a", {"border": 4})
+    assert El("a").spec() == ("a", {})
+
+
+def test_stylename_default_to_primary():
+    sn = StyleName("TRadiobutton")
+    assert sn.colorname == PRIMARY
+    assert sn.ttkstyle == "TRadiobutton"
+    assert sn.element == "Radiobutton"
+
+    empty = StyleName("TRadiobutton", "")
+    assert empty.colorname == PRIMARY
+    assert empty.ttkstyle == "TRadiobutton"
+
+
+def test_stylename_color_and_orient():
+    sn = StyleName("TScale", "info", orient="Horizontal")
+    assert sn.colorname == "info"
+    assert sn.ttkstyle == "info.Horizontal.TScale"
+    assert sn.element == "info.Horizontal.Scale"  # .TS -> .S
+
+    default = StyleName("TScale", orient="Horizontal")
+    assert default.ttkstyle == "Horizontal.TScale"
+    assert default.element == "Horizontal.Scale"
+
+
+# --------------------------------------------------------------------------- #
+# Recipes against the live image cache (need a root)
+# --------------------------------------------------------------------------- #
+def test_circle_key_completeness(root):
+    a = Assets(root.style)
+    n1 = a.circle("#ff0000", 16)
+    n2 = a.circle("#ff0000", 16)
+    n3 = a.circle("#00ff00", 16)
+    assert n1 == n2          # identical inputs -> cache hit -> same image name
+    assert n1 != n3          # one differing color -> different key -> different name
+
+
+def test_circle_outline_and_width_in_key(root):
+    a = Assets(root.style)
+    plain = a.circle("#ff0000", 16)
+    outlined = a.circle("#ff0000", 16, outline="#000000", width=2)
+    assert plain != outlined
+
+
+def test_even_size_snap(root):
+    a = Assets(root.style)
+    odd = a.circle("#123456", 15)
+    even = a.circle("#123456", 16)
+    assert odd == even       # 15 snaps up to 16 -> same image/key
+    img = _cached_image(root.style, odd)
+    assert (img.width(), img.height()) == (16, 16)  # rendered size is even
+
+
+def test_rect_keeps_exact_size(root):
+    a = Assets(root.style)
+    name = a.rect("#abcdef", (40, 5))
+    img = _cached_image(root.style, name)
+    # solid fill has no edges to blur, so it is exempt from the even snap
+    assert (img.width(), img.height()) == (40, 5)
+
+
+def test_image_escape_hatch_keys_on_parts(root):
+    a = Assets(root.style)
+
+    def draw(d, w, h):
+        d.ellipse((0, 0, w - 1, h - 1), fill="#111111")
+
+    n1 = a.image(16, draw, "#111111")
+    n2 = a.image(16, draw, "#111111")
+    n3 = a.image(16, draw, "#222222")
+    assert n1 == n2          # same qualname + key parts -> dedup
+    assert n1 != n3          # differing key part -> different image
+
+
+# --------------------------------------------------------------------------- #
+# Element / map wrappers against a real style
+# --------------------------------------------------------------------------- #
+def test_image_element_validates_states(root):
+    a = Assets(root.style)
+    img = a.circle("#ffffff", 16)
+    with pytest.raises(ValueError):
+        image_element(root.style, "Bad.indicator", default=img,
+                      states={"diabled": img})
+
+
+def test_state_map_validates_states(root):
+    with pytest.raises(ValueError):
+        state_map(root.style, "TButton", foreground={"diabled": "#000000"})
+
+
+def test_layout_applies_el_tree(root):
+    # building a radiobutton exercises image_element + state_map + layout end to
+    # end; the style must register and round-trip through ttk's layout query.
+    rb = ttk.Radiobutton(root, bootstyle="success")
+    rb.pack()
+    root.update_idletasks()
+    spec = root.style.layout("success.TRadiobutton")
+    assert spec  # a non-empty, applied layout

--- a/tests/widget_styles/test_image_cache.py
+++ b/tests/widget_styles/test_image_cache.py
@@ -13,9 +13,14 @@ import ttkbootstrap as ttk
 
 
 def _scale_thumb(style, primary):
-    """Return the cached (name, PhotoImage) for the scale thumb of `primary`."""
+    """Return the cached (name, PhotoImage) for the scale thumb of `primary`.
+
+    The thumb is now built via the toolkit's `Assets.circle` recipe (Workstream
+    I / PR 5), so its key is `("circle", fill, size, outline, width)`; the normal
+    thumb is the unoutlined circle filled with the theme primary.
+    """
     for key, value in style._image_cache.items():
-        if key[0] == "scale.thumb" and key[1] == primary:
+        if key[0] == "circle" and key[1] == primary and key[3] is None:
             return value
     return None
 


### PR DESCRIPTION
Implements Workstream I (Tier 1) — the style-construction toolkit — per `development/2_0_toolkit_design.md`. The delivery vehicle for "make custom styles easy": a small, orthogonal set of public helpers that make image/state-based ttk styles tractable and de-duplicate the asset/layout boilerplate in `builders_ttk`.

## What's new

**`style/assets.py` — `Assets(style)`**, a key-safe front door to PR 2's content-addressed image cache (`Style._get_or_create_image`).
- Shape recipes `circle` / `rect` / `rounded_rect` + a general `image(size, draw_fn, *key_parts)` escape hatch.
- **The key is derived from the render inputs, never hand-written** — so a draw whose key omits a color it uses is impossible (the exact hazard PR 2's purity audit existed to manage).
- Ports bootstack's **snap-at-the-source pipeline**: even-pixel-snap the final size, adaptive oversample (3×/2×/1× by size), LANCZOS downscale + `UnsharpMask`. Result is crisper, DPI-stable assets — no public `oversample`/`inset` knobs. `rect` is solid-fill (no AA, no snap; keeps its exact size, e.g. the 40×5 scale track).

**`style/layout.py` — layout/element/name helpers.**
- `El` + `layout` — lower an element tree to ttk's nested `(name, {opts, "children":[...]})` form (children via a constructor kwarg, not bootstack's fluent positional parenting).
- `image_element` — named, ordered, **validated** state→image map.
- `statespec` / `state_map` — validate the `!negation`/space-AND grammar against `TTK_STATES`, raising on a typo instead of silently never matching (the Workstream D loud-failure seam; token set kept in one place).
- `StyleName` — absorbs the `DEFAULT/""`→PRIMARY, `f"{color}.{STYLE}"`, and `.TS→.S` name surgery ~30 builders repeat.

## Acceptance test (from the plan)

Migrated the two chosen builders onto the toolkit as the proof — both come out **shorter and clearer**:
- `create_scale_assets` / `create_scale_style`
- `create_radiobutton_assets` / `create_radiobutton_style` (the 30-line layout pyramid → 5 readable lines)

**Behavior-preserved**: queried layouts are identical to the originals (same `expand`/`sticky`/element names, same radio pyramid, same disabled-`foreground` map).

## Public exposure
Re-exported from `ttkbootstrap.style` **and** top-level `ttkbootstrap` (`Assets`, `El`, `layout`, `image_element`, `statespec`, `state_map`, `StyleName`). `import ttkbootstrap` stays warning-free.

## Tests / gates
- Suite: **75 passed** (was 61; +14 in `tests/test_toolkit.py` — recipe key-completeness, even-size snap, escape-hatch keying, `El` lowering, `statespec` validation, `StyleName`).
- `test_image_cache.py` helper updated for the scale thumb's new `("circle", …)` key; assertions unchanged (still color-at-pixel, robust to the snapped-pipeline AA change).
- Standalone-import cycle guard (assets→PIL, layout→constants — both leaves, no engine edge) and the PEP 649 (3.14) annotation force-evaluation sweep over the new modules + migrated builders: clean.

## Remaining before merge
- A spot **visual diff** on scale/radio/check to confirm the snapped pipeline reads equal-or-better (sharper/DPI-stable, not color drift) — couldn't run a GUI in the headless dev env.

## Out of scope (fast-follow)
- Migrating the remaining ~50 asset/layout sites (mechanical; same shapes repeated — design doc step 4).
- Tier 2 (`state_colors` from ramp steps; composite recipes) — waits on Workstream E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)