### PR TITLE
Migrate glyph builders onto the icon engine + toolkit cleanup (2.0 PR 6b)

### DIFF
--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -72,6 +72,26 @@ import, standalone cycle guard + PEP 649 sweep clean.
   separator + striped-progressbar tile alignment; round vs square scrollbar
   thumb shape.
 
+### Spot-check round 2 — DONE (2026-06-28, commits `a8a5f5d`, `9590798`)
+From the user's first visual pass: toggle sized up to the glyph's true ~1.6:1
+aspect (`[24,15]→[32,20]`, element width 28→36); date button → `calendar3`;
+combobox/spinbox arrows switched from outline `chevron-*` to solid `caret-*-fill`
++ right `-padding(6)`; **menubutton** (solid + outline) native clam triangle →
+`caret-down-fill` image indicator (new `_build_menubutton_arrow` helper; outline
+recolors on hover, solid doesn't); **datepicker header** `◀/▶` text →
+`caret-left/right-fill` images in the bar's contrasting fg. Suite 92, warning-free.
+
+### ⚠️ OPEN FOLLOW-UP — visual polish (deferred 2026-06-28, user)
+PR 6b is functionally complete and good enough to continue, **but the user wants
+another visual-polish pass before final merge — NOT yet merge-ready.** Likely
+candidates (confirm against a fresh `python -m ttkbootstrap` + a date picker):
+menubutton caret **size/right-padding** (currently the `[13,11]` caret + 10px pad,
+up from the tiny native `arrowsize=4` — may read large); datepicker arrow size
+(14px) next to the bold title; toggle final sizing; any remaining glyph picks
+(`grip-horizontal` sizegrip, LIGHT-on-light readability). Treat this as the
+remaining gate item: do the polish pass, re-spot-check, *then* update this handoff
+to "ready to merge" and merge to `2.0`.
+
 ## PR 6a — MERGED (2026-06-27, #1079, Workstream I Tier 1.5 — icon engine)
 
 Merged into `2.0` (was `feat/2.0-pr6a-icon-engine`). Engine only — touches **no**

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -25,12 +25,13 @@ the style-construction toolkit (Workstream I, Tier 1)** is **merged** (#1077; se
 "PR 5" below). **PR 6a — the icon engine (Workstream I, Tier 1.5)** is **merged**
 (#1079; see "PR 6a — MERGED" below).
 
-**Current slice → PR 6b is CODE-COMPLETE on `feat/2.0-pr6b-glyph-builders`
-(NOT merged).** The merge gate is the **human visual spot-check** (light↔dark) —
-run `python -m ttkbootstrap` (the widget gallery has a theme dropdown) and eyeball
-the migrated indicators; settle the open glyph picks (below) against it. Once it
-reads well, merge to `2.0`. After 6b: Workstream E (theme/anchor model) + D
-(bootstyle canonical grammar); Tier-2 toolkit follows E.
+**Current slice → PR 6b is merge-ready; a PR is open against `2.0`** (branch
+`feat/2.0-pr6b-glyph-builders`). Two human spot-check rounds done (light↔dark via
+`python -m ttkbootstrap`); the bones (icon engine wired into every glyph builder +
+geometric/layout cleanup + public registration path) are in. Remaining visual
+polish is deferred to a **follow-up PR** (see "FOLLOW-UP" below). After 6b:
+Workstream E (theme/anchor model) + D (bootstyle canonical grammar); Tier-2
+toolkit follows E.
 
 ## PR 6b — CODE-COMPLETE (2026-06-28, `feat/2.0-pr6b-glyph-builders`, NOT merged)
 
@@ -81,16 +82,16 @@ combobox/spinbox arrows switched from outline `chevron-*` to solid `caret-*-fill
 recolors on hover, solid doesn't); **datepicker header** `◀/▶` text →
 `caret-left/right-fill` images in the bar's contrasting fg. Suite 92, warning-free.
 
-### ⚠️ OPEN FOLLOW-UP — visual polish (deferred 2026-06-28, user)
-PR 6b is functionally complete and good enough to continue, **but the user wants
-another visual-polish pass before final merge — NOT yet merge-ready.** Likely
-candidates (confirm against a fresh `python -m ttkbootstrap` + a date picker):
-menubutton caret **size/right-padding** (currently the `[13,11]` caret + 10px pad,
-up from the tiny native `arrowsize=4` — may read large); datepicker arrow size
-(14px) next to the bold title; toggle final sizing; any remaining glyph picks
-(`grip-horizontal` sizegrip, LIGHT-on-light readability). Treat this as the
-remaining gate item: do the polish pass, re-spot-check, *then* update this handoff
-to "ready to merge" and merge to `2.0`.
+### FOLLOW-UP (deferred to a separate PR) — visual polish
+**Decision (user, 2026-06-28): PR 6b's job was the *bones* — the icon engine
+wired into every glyph builder + the geometric/layout cleanup + the public
+registration path. That is done, so PR 6b is merge-ready and a PR is open against
+`2.0`. The remaining work is value/asset tweaking, deferred to a follow-up PR.**
+Polish candidates (eyeball a fresh `python -m ttkbootstrap` + a date picker):
+menubutton caret **size/right-padding** (currently `[13,11]` caret + 10px pad, up
+from the tiny native `arrowsize=4` — may read large); datepicker arrow size (14px)
+next to the bold title; toggle final sizing; remaining glyph picks
+(`grip-horizontal` sizegrip, LIGHT-on-light readability).
 
 ## PR 6a — MERGED (2026-06-27, #1079, Workstream I Tier 1.5 — icon engine)
 

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,11 +3,14 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-06-27 (Workstream I — **PR 6a, the icon engine, MERGED**
-(#1079): vendored Bootstrap Icons font + `style/icons.py` (`IconRenderer`) +
-`Assets.icon` + public `Icon`/`icon_element`. Engine-only, no builders touched.
-Suite **89 passed**. Render tuning + `record-circle-fill` settled via a live
-visual spot-check; see "PR 6a — MERGED" below. Next: PR 6b.)_
+_Last updated: 2026-06-28 (Workstream I — **PR 6b CODE-COMPLETE on
+`feat/2.0-pr6b-glyph-builders`, NOT merged — pending a human visual
+spot-check**. Glyph builders (check/radio/toggle×2/date/arrows/sizegrip) migrated
+onto `a.icon`/`icon_element`; the held branch's geometric/layout cleanup
+re-applied; the PR-6a public style-registration finding fixed
+(`register_style` + `layout()` auto-registers). Suite **92 passed**,
+warning-free import, cycle guard + PEP 649 sweep clean. See "PR 6b —
+CODE-COMPLETE" below for the spot-check checklist + open glyph picks.)_
 
 ## Where we are
 
@@ -22,13 +25,52 @@ the style-construction toolkit (Workstream I, Tier 1)** is **merged** (#1077; se
 "PR 5" below). **PR 6a — the icon engine (Workstream I, Tier 1.5)** is **merged**
 (#1079; see "PR 6a — MERGED" below).
 
-**Next actionable slice → PR 6b (migrate glyph builders + land the held
-geometric/layout cleanup).** This is the visible change: check/radio/switch/date/
-arrows/sizegrip onto `a.icon`/`icon_element`, plus the kept geometric/`layout`/
-`image_element` migrations from the held branch. **Gate the merge on a human
-visual spot-check** (light↔dark) and **add the public style-registration path**
-the PR-6a review surfaced (see below). After 6b: Workstream E (theme/anchor
-model) + D (bootstyle canonical grammar); Tier-2 toolkit follows E.
+**Current slice → PR 6b is CODE-COMPLETE on `feat/2.0-pr6b-glyph-builders`
+(NOT merged).** The merge gate is the **human visual spot-check** (light↔dark) —
+run `python -m ttkbootstrap` (the widget gallery has a theme dropdown) and eyeball
+the migrated indicators; settle the open glyph picks (below) against it. Once it
+reads well, merge to `2.0`. After 6b: Workstream E (theme/anchor model) + D
+(bootstyle canonical grammar); Tier-2 toolkit follows E.
+
+## PR 6b — CODE-COMPLETE (2026-06-28, `feat/2.0-pr6b-glyph-builders`, NOT merged)
+
+Built hybrid: Opus settled the public API + the held-branch keep/drop split and
+implemented the registration path; a Sonnet agent did the mechanical glyph/layout
+migration against the locked `development/2_0_icons_design.md`; Opus reviewed the
+diff. Three commits; suite **92 passed**, warning-free import, font not loaded at
+import, standalone cycle guard + PEP 649 sweep clean.
+
+- **`f282262` — public style-registration path** (the PR-6a finding). New
+  `register_style(style, ttkstyle)` in `style/layout.py`; **`layout()` now
+  auto-registers** the style it applies (defining a layout is what gives a style
+  its identity — mirrors ttk's own `style.layout`), so a toolkit-built style
+  whose terminal step is `layout()` resolves via `style="..."` with no extra
+  step. Re-exported from `ttkbootstrap.style` + top-level. +3 tests.
+- **`435ec23` — Part A: glyph builders → icons** (−715/+155). check/radio/
+  round-toggle/square-toggle/date/arrows/sizegrip migrated onto `icon_element`/
+  `a.icon` per the design's glyph+color tables; the six `create_*_assets` glyph
+  methods deleted; `ImageFont`/`Transpose` imports removed. Toggles are **one
+  look** (`toggle-on`/`toggle-off`; square is a visual alias). Radio on =
+  `record-circle-fill`. Existing state-color math + scaled sizes preserved.
+  **Deviation (correct):** element names use the full `{ttkstyle}.indicator`
+  prefix (not `sn.element`) so `icon_element`'s foreground lookup targets the
+  configured style — matches PR 5's radiobutton convention.
+- **`b63db19` — Part B: geometric/layout cleanup** (−353/+150). Separator,
+  progressbar (+stripes), scrollbars (round/square), combobox, floodgauge,
+  spinbox, treeview, calendar layouts re-applied onto `rect`/`rounded_rect`/
+  `image`/`image_element`/`layout`/`El`/`state_map` (re-applied fresh from the
+  held branch as reference — not cherry-picked; the file had drifted).
+
+- **Open glyph picks — settle on the spot-check:** `calendar-event` (date) vs
+  `calendar`; `grip-horizontal` (sizegrip) vs a corner-grip glyph; LIGHT-on-light
+  knockout readability (existing contrast logic preserved as a safety net);
+  toggle aspect ratio (rendered at `[24,15]`). Change a pick by editing the one
+  glyph name in the builder.
+- **Spot-check checklist:** check/radio/toggle indicators across all states
+  (esp. disabled = muted) on a light theme and a dark theme; combobox/spinbox/
+  scrollbar chevrons (normal/active/disabled); date button calendar; sizegrip;
+  separator + striped-progressbar tile alignment; round vs square scrollbar
+  thumb shape.
 
 ## PR 6a — MERGED (2026-06-27, #1079, Workstream I Tier 1.5 — icon engine)
 

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -61,7 +61,7 @@ from ttkbootstrap.style import (
     bootify, apply_bootstyle, enable_global_api,
     # Style-construction toolkit (Workstream I): the public "build your own
     # style" surface, dogfooded by the builders.
-    Assets, El, layout, image_element, statespec, state_map, StyleName,
+    Assets, El, layout, register_style, image_element, statespec, state_map, StyleName,
     # Icon-rendered assets: glyph atoms + per-state icon element sugar.
     Icon, icon_element,
 )
@@ -219,6 +219,7 @@ __all__ = [
     "Assets",
     "El",
     "layout",
+    "register_style",
     "image_element",
     "statespec",
     "state_map",

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -140,6 +140,11 @@ class DatePickerDialog:
         self.title.configure(bootstyle=f"{self.bootstyle}-inverse")
         self.prev_period.configure(style=f"Chevron.{self.bootstyle}.TButton")
         self.next_period.configure(style=f"Chevron.{self.bootstyle}.TButton")
+        # caret-fill nav arrows, in the title bar's contrasting foreground color
+        # (matches the filled-triangle arrows used elsewhere in the app)
+        arrow_color = ttk.Style.get_instance().colors.get_foreground(self.bootstyle)
+        self.prev_period.configure(image=ttk.Icon("caret-left-fill", 14, arrow_color))
+        self.next_period.configure(image=ttk.Icon("caret-right-fill", 14, arrow_color))
 
     def _draw_calendar(self) -> None:
         self._update_widget_bootstyle()
@@ -189,7 +194,7 @@ class DatePickerDialog:
     def _draw_titlebar(self) -> None:
         """Draw the calendar title bar and navigation controls."""
         # create and pack the title and action buttons
-        self.prev_period = ttk.Button(master=self.frm_title, text="◀", command=self.on_prev_month)
+        self.prev_period = ttk.Button(master=self.frm_title, command=self.on_prev_month)
         self.prev_period.pack(side=LEFT)
 
         self.title = ttk.Label(
@@ -200,7 +205,7 @@ class DatePickerDialog:
         )
         self.title.pack(side=LEFT, fill=X, expand=YES)
 
-        self.next_period = ttk.Button(master=self.frm_title, text="▶", command=self.on_next_month)
+        self.next_period = ttk.Button(master=self.frm_title, command=self.on_next_month)
         self.next_period.pack(side=LEFT)
 
         # bind "year" callbacks to action buttons

--- a/src/ttkbootstrap/style/__init__.py
+++ b/src/ttkbootstrap/style/__init__.py
@@ -23,6 +23,7 @@ from ttkbootstrap.style.assets import Assets
 from ttkbootstrap.style.layout import (
     El,
     layout,
+    register_style,
     image_element,
     statespec,
     state_map,
@@ -47,6 +48,7 @@ __all__ = [
     "Assets",
     "El",
     "layout",
+    "register_style",
     "image_element",
     "statespec",
     "state_map",

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -8,13 +8,14 @@ import tkinter as tk
 from math import ceil
 from tkinter import font, ttk
 
-from PIL import Image, ImageDraw, ImageFont, ImageTk
-from PIL.Image import Resampling, Transpose
+from PIL import Image, ImageDraw, ImageTk
+from PIL.Image import Resampling
 
 from ttkbootstrap.constants import *
 from ttkbootstrap.style.theme import Colors, ThemeDefinition
 from ttkbootstrap.style.builders_tk import StyleBuilderTK
 from ttkbootstrap.style.assets import Assets
+from ttkbootstrap.style.icons import icon_element
 from ttkbootstrap.style.layout import (
     El, layout, image_element, state_map, StyleName,
 )
@@ -805,52 +806,36 @@ class StyleBuilderTTK:
         self.style._register_ttkstyle(v_ttkstyle)
 
     def create_simple_arrow_assets(self, arrowcolor: str, disabledcolor: str, activecolor: str, y_offset: int = 0):
-        """
-        Create simple arrow assets (small triangles) that can be used for various widgets.
-        Originally created to replace Combobox.downarrow to fix layout issues in python 3.13.
-        Also used for the Spinbox widget.
+        """Create chevron arrow assets using Bootstrap Icons glyphs.
+
+        Used for Combobox and Spinbox indicators. Replaces the old hand-drawn
+        triangles with `chevron-up/down/left/right` for a lighter, modern
+        open-arrow weight (RESOLVED: chevron over caret-*-fill per the icons
+        design).
+
+        The `y_offset` parameter is accepted for API compatibility but is no
+        longer used (it was specific to the old hand-drawn triangle approach).
 
         Args:
             arrowcolor: The color value to use as the arrow fill color.
             disabledcolor: A second color value to use when the arrow is disabled.
             activecolor: A third color value to use when the arrow has focus.
-            y_offset: (optional) The vertical padding to apply to the arrow images (useful in spinnboxes).
+            y_offset: Accepted for API compatibility; ignored.
         Returns:
-            A nested tuple containing the names of the created arrow images in the order (up, down, left, right)
-            for each color.
+            A nested tuple (normal, disabled, active), each a 4-tuple of Tcl
+            image names in the order (up, down, left, right).
         """
+        a = self.assets
+        size = self.scale_size([13, 11])
 
-        def draw_simple_arrow(color: str, y_offset: int = 0):
-            size = self.scale_size([13, 11])
+        def make_arrows(color):
+            up = a.icon("chevron-up", size, color)
+            down = a.icon("chevron-down", size, color)
+            left = a.icon("chevron-left", size, color)
+            right = a.icon("chevron-right", size, color)
+            return up, down, left, right
 
-            def render(rotate):
-                # arrow (triangle) pointing up, offset by y_offset, then rotated
-                img = Image.new("RGBA", (13, 11))
-                ImageDraw.Draw(img).polygon(
-                    [(3, 6 + y_offset), (9, 6 + y_offset), (6, 3 + y_offset)],
-                    fill=color,
-                )
-                img = img.resize(size, Resampling.BICUBIC)
-                if rotate:
-                    img = img.rotate(rotate)
-                return ImageTk.PhotoImage(img)
-
-            base = ("arrow.simple", color, y_offset, tuple(size))
-            up_name = self.style._get_or_create_image(
-                base + ("up",), lambda: render(0))
-            down_name = self.style._get_or_create_image(
-                base + ("down",), lambda: render(180))
-            left_name = self.style._get_or_create_image(
-                base + ("left",), lambda: render(90))
-            right_name = self.style._get_or_create_image(
-                base + ("right",), lambda: render(-90))
-            return up_name, down_name, left_name, right_name
-
-        normal_names = draw_simple_arrow(arrowcolor, y_offset=y_offset)
-        pressed_names = draw_simple_arrow(disabledcolor, y_offset=y_offset)
-        active_names = draw_simple_arrow(activecolor, y_offset=y_offset)
-
-        return normal_names, pressed_names, active_names
+        return make_arrows(arrowcolor), make_arrows(disabledcolor), make_arrows(activecolor)
 
     def create_arrow_assets(self, arrowcolor, pressed, active):
         """Create arrow assets used for various widget buttons.
@@ -1910,97 +1895,6 @@ class StyleBuilderTTK:
         # register ttkstyle
         self.style._register_ttkstyle(ttkstyle)
 
-    def create_square_toggle_assets(self, colorname=DEFAULT):
-        """Create the image assets used to build a square toggle
-        style.
-
-        Parameters:
-
-            colorname (str):
-                The color label used to style the widget.
-
-        Returns:
-
-            tuple[str]:
-                A tuple of PhotoImage names.
-        """
-        size = self.scale_size([24, 15])
-        if any([colorname == DEFAULT, colorname == ""]):
-            colorname = PRIMARY
-
-        # set default style color values
-        prime_color = self.colors.get(colorname)
-        on_border = prime_color
-        on_indicator = self.colors.selectfg
-        on_fill = prime_color
-        off_fill = self.colors.bg
-        disabled_fg = Colors.make_transparent(0.3, self.colors.fg, self.colors.bg)
-        off_border = Colors.make_transparent(0.4, self.colors.fg, self.colors.bg)
-        off_indicator = Colors.make_transparent(0.4, self.colors.fg, self.colors.bg)
-
-        # override defaults for light and dark colors
-        if colorname == LIGHT:
-            on_border = self.colors.dark
-            on_indicator = on_border
-        elif colorname == DARK:
-            on_border = self.colors.light
-            on_indicator = on_border
-
-        def make_off():
-            img = Image.new("RGBA", (226, 130))
-            draw = ImageDraw.Draw(img)
-            draw.rectangle(
-                xy=[1, 1, 225, 129], outline=off_border, width=6, fill=off_fill
-            )
-            draw.rectangle([18, 18, 110, 110], fill=off_indicator)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_on():
-            img = Image.new("RGBA", (226, 130))
-            draw = ImageDraw.Draw(img)
-            draw.rectangle(
-                xy=[1, 1, 225, 129], outline=on_border, width=6, fill=on_fill
-            )
-            draw.rectangle([18, 18, 110, 110], fill=on_indicator)
-            img = img.transpose(Transpose.ROTATE_180)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_disabled():
-            img = Image.new("RGBA", (226, 130))
-            draw = ImageDraw.Draw(img)
-            draw.rectangle([1, 1, 225, 129], outline=disabled_fg, width=6)
-            draw.rectangle([18, 18, 110, 110], fill=disabled_fg)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_on_disabled():
-            img = Image.new("RGBA", (226, 130))
-            draw = ImageDraw.Draw(img)
-            draw.rectangle(
-                xy=[1, 1, 225, 129], outline=disabled_fg, width=6, fill=off_fill
-            )
-            draw.rectangle([18, 18, 110, 110], fill=disabled_fg)
-            img = img.transpose(Transpose.ROTATE_180)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        off_name = self.style._get_or_create_image(
-            ("toggle.square.off", off_border, off_fill, off_indicator, tuple(size)),
-            make_off,
-        )
-        on_name = self.style._get_or_create_image(
-            ("toggle.square.on", on_border, on_fill, on_indicator, tuple(size)),
-            make_on,
-        )
-        disabled_name = self.style._get_or_create_image(
-            ("toggle.square.disabled", disabled_fg, tuple(size)),
-            make_disabled,
-        )
-        on_disabled_name = self.style._get_or_create_image(
-            ("toggle.square.on_disabled", disabled_fg, off_fill, tuple(size)),
-            make_on_disabled,
-        )
-
-        return off_name, on_name, disabled_name, on_disabled_name
-
     def create_toggle_style(self, colorname=DEFAULT):
         """Create a round toggle style for the ttk.Checkbutton widget.
 
@@ -2009,112 +1903,6 @@ class StyleBuilderTTK:
             colorname (str):
         """
         self.create_round_toggle_style(colorname)
-
-    def create_round_toggle_assets(self, colorname=DEFAULT):
-        """Create image assets for the round toggle style.
-
-        Parameters:
-
-            colorname (str):
-                The color label assigned to the colors property.
-
-        Returns:
-
-            tuple[str]:
-                A tuple of PhotoImage names.
-        """
-        size = self.scale_size([24, 15])
-
-        if any([colorname == DEFAULT, colorname == ""]):
-            colorname = PRIMARY
-
-        # set default style color values
-        prime_color = self.colors.get(colorname)
-        on_border = prime_color
-        on_indicator = self.colors.selectfg
-        on_fill = prime_color
-        off_fill = self.colors.bg
-
-        disabled_fg = Colors.make_transparent(0.3, self.colors.fg, self.colors.bg)
-        off_border = Colors.make_transparent(0.4, self.colors.fg, self.colors.bg)
-        off_indicator = Colors.make_transparent(0.4, self.colors.fg, self.colors.bg)
-
-        # override defaults for light and dark colors
-        if colorname == LIGHT:
-            on_border = self.colors.dark
-            on_indicator = on_border
-        elif colorname == DARK:
-            on_border = self.colors.light
-            on_indicator = on_border
-
-        def make_off():
-            img = Image.new("RGBA", (226, 130))
-            draw = ImageDraw.Draw(img)
-            draw.rounded_rectangle(
-                xy=[1, 1, 225, 129],
-                radius=(128 / 2),
-                outline=off_border,
-                width=6,
-                fill=off_fill,
-            )
-            draw.ellipse([20, 18, 112, 110], fill=off_indicator)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_on():
-            img = Image.new("RGBA", (226, 130))
-            draw = ImageDraw.Draw(img)
-            draw.rounded_rectangle(
-                xy=[1, 1, 225, 129],
-                radius=(128 / 2),
-                outline=on_border,
-                width=6,
-                fill=on_fill,
-            )
-            draw.ellipse([20, 18, 112, 110], fill=on_indicator)
-            img = img.transpose(Transpose.ROTATE_180)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_on_disabled():
-            img = Image.new("RGBA", (226, 130))
-            draw = ImageDraw.Draw(img)
-            draw.rounded_rectangle(
-                xy=[1, 1, 225, 129],
-                radius=(128 / 2),
-                outline=disabled_fg,
-                width=6,
-                fill=off_fill,
-            )
-            draw.ellipse([20, 18, 112, 110], fill=disabled_fg)
-            img = img.transpose(Transpose.ROTATE_180)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_disabled():
-            img = Image.new("RGBA", (226, 130))
-            draw = ImageDraw.Draw(img)
-            draw.rounded_rectangle(
-                xy=[1, 1, 225, 129], radius=(128 / 2), outline=disabled_fg, width=6
-            )
-            draw.ellipse([20, 18, 112, 110], fill=disabled_fg)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        off_name = self.style._get_or_create_image(
-            ("toggle.round.off", off_border, off_fill, off_indicator, tuple(size)),
-            make_off,
-        )
-        on_name = self.style._get_or_create_image(
-            ("toggle.round.on", on_border, on_fill, on_indicator, tuple(size)),
-            make_on,
-        )
-        on_disabled_name = self.style._get_or_create_image(
-            ("toggle.round.on_disabled", disabled_fg, off_fill, tuple(size)),
-            make_on_disabled,
-        )
-        disabled_name = self.style._get_or_create_image(
-            ("toggle.round.disabled", disabled_fg, tuple(size)),
-            make_disabled,
-        )
-
-        return off_name, on_name, disabled_name, on_disabled_name
 
     def create_round_toggle_style(self, colorname=DEFAULT):
         """Create a round toggle style for the ttk.Checkbutton widget.
@@ -2125,8 +1913,8 @@ class StyleBuilderTTK:
                 The color label used to style the widget.
         """
         STYLE = "Round.Toggle"
-
         disabled_fg = Colors.make_transparent(0.30, self.colors.fg, self.colors.bg)
+        fg_muted = Colors.make_transparent(0.40, self.colors.fg, self.colors.bg)
 
         if any([colorname == DEFAULT, colorname == ""]):
             ttkstyle = STYLE
@@ -2134,29 +1922,19 @@ class StyleBuilderTTK:
         else:
             ttkstyle = f"{colorname}.{STYLE}"
 
-        # ( off, on, disabled )
-        images = self.create_round_toggle_assets(colorname)
+        # Resolve the "on" accent; LIGHT/DARK on their own background need a
+        # contrasting indicator (visual-check item: verify toggle aspect ratio
+        # and LIGHT-on-light on the human spot-check).
+        if colorname == LIGHT:
+            accent = self.colors.dark
+        elif colorname == DARK:
+            accent = self.colors.light
+        else:
+            accent = self.colors.get(colorname)
 
-        try:
-            width = self.scale_size(28)
-            borderpad = self.scale_size(4)
-            self.style.element_create(
-                f"{ttkstyle}.indicator",
-                "image",
-                images[1],
-                ("disabled selected", images[3]),
-                ("disabled", images[2]),
-                ("!selected", images[0]),
-                width=width,
-                border=borderpad,
-                sticky=tk.W,
-            )
-        except:
-            """This method is used as the default Toggle style, so it
-            is neccessary to catch Tcl Errors when it tries to create
-            and element that was already created by the Toggle or
-            Round Toggle style"""
-            pass
+        # Toggle icons are wider than tall (approx 1.6:1); keep the same
+        # logical size the old hand-drawn assets used so geometry is unchanged.
+        toggle_size = self.scale_size([24, 15])
 
         self.style._build_configure(
             ttkstyle,
@@ -2171,102 +1949,62 @@ class StyleBuilderTTK:
             foreground=[("disabled", disabled_fg)],
             background=[("selected", self.colors.bg)],
         )
-        self.style.layout(
-            ttkstyle,
-            [
-                (
-                    "Toolbutton.border",
-                    {
-                        "sticky": tk.NSEW,
-                        "children": [
-                            (
-                                "Toolbutton.padding",
-                                {
-                                    "sticky": tk.NSEW,
-                                    "children": [
-                                        (
-                                            f"{ttkstyle}.indicator",
-                                            {"side": tk.LEFT},
-                                        ),
-                                        (
-                                            "Toolbutton.label",
-                                            {"side": tk.LEFT},
-                                        ),
-                                    ],
-                                },
-                            )
-                        ],
-                    },
-                )
-            ],
-        )
+        try:
+            icon_element(self.style, f"{ttkstyle}.indicator", size=toggle_size,
+                default={"name": "toggle-on", "color": accent},
+                states={
+                    "disabled selected": {"name": "toggle-on",  "color": disabled_fg},
+                    "disabled":          {"name": "toggle-off", "color": disabled_fg},
+                    "!selected":         {"name": "toggle-off", "color": fg_muted},
+                },
+                width=self.scale_size(28), border=self.scale_size(4), sticky=W)
+        except Exception:
+            """This method is used as the default Toggle style, so it is
+            necessary to catch Tcl errors when it tries to create an element
+            that was already created by the Toggle or Round Toggle style."""
+            pass
+
+        layout(self.style, ttkstyle,
+            El("Toolbutton.border", sticky=NSEW, children=[
+                El("Toolbutton.padding", sticky=NSEW, children=[
+                    El(f"{ttkstyle}.indicator", side=LEFT),
+                    El("Toolbutton.label", side=LEFT)])]))
         # register ttkstyle
         self.style._register_ttkstyle(ttkstyle)
 
     def create_square_toggle_style(self, colorname=DEFAULT):
         """Create a square toggle style for the ttk.Checkbutton widget.
 
+        Note: as of 2.0 both round and square toggles render the same Bootstrap
+        Icons toggle glyphs (`toggle-on`/`toggle-off`). The `square-toggle`
+        bootstyle keyword remains for back-compat but produces the same rounded
+        indicator as `round-toggle`.
+
         Parameters:
 
             colorname (str):
                 The color label used to style the widget.
         """
-
         STYLE = "Square.Toggle"
-
         disabled_fg = Colors.make_transparent(0.30, self.colors.fg, self.colors.bg)
+        fg_muted = Colors.make_transparent(0.40, self.colors.fg, self.colors.bg)
 
         if any([colorname == DEFAULT, colorname == ""]):
             ttkstyle = STYLE
+            colorname = PRIMARY
         else:
             ttkstyle = f"{colorname}.{STYLE}"
 
-        # ( off, on, disabled )
-        images = self.create_square_toggle_assets(colorname)
+        # Resolve the "on" accent (same logic as round-toggle).
+        if colorname == LIGHT:
+            accent = self.colors.dark
+        elif colorname == DARK:
+            accent = self.colors.light
+        else:
+            accent = self.colors.get(colorname)
 
-        width = self.scale_size(28)
-        borderpad = self.scale_size(4)
+        toggle_size = self.scale_size([24, 15])
 
-        self.style.element_create(
-            f"{ttkstyle}.indicator",
-            "image",
-            images[1],
-            ("disabled selected", images[3]),
-            ("disabled", images[2]),
-            ("!selected", images[0]),
-            width=width,
-            border=borderpad,
-            sticky=tk.W,
-        )
-        self.style.layout(
-            ttkstyle,
-            [
-                (
-                    "Toolbutton.border",
-                    {
-                        "sticky": tk.NSEW,
-                        "children": [
-                            (
-                                "Toolbutton.padding",
-                                {
-                                    "sticky": tk.NSEW,
-                                    "children": [
-                                        (
-                                            f"{ttkstyle}.indicator",
-                                            {"side": tk.LEFT},
-                                        ),
-                                        (
-                                            "Toolbutton.label",
-                                            {"side": tk.LEFT},
-                                        ),
-                                    ],
-                                },
-                            )
-                        ],
-                    },
-                )
-            ],
-        )
         self.style._build_configure(
             ttkstyle, relief=tk.FLAT, borderwidth=0, foreground=self.colors.fg
         )
@@ -2278,6 +2016,19 @@ class StyleBuilderTTK:
                 ("!selected", self.colors.bg),
             ],
         )
+        icon_element(self.style, f"{ttkstyle}.indicator", size=toggle_size,
+            default={"name": "toggle-on", "color": accent},
+            states={
+                "disabled selected": {"name": "toggle-on",  "color": disabled_fg},
+                "disabled":          {"name": "toggle-off", "color": disabled_fg},
+                "!selected":         {"name": "toggle-off", "color": fg_muted},
+            },
+            width=self.scale_size(28), border=self.scale_size(4), sticky=W)
+        layout(self.style, ttkstyle,
+            El("Toolbutton.border", sticky=NSEW, children=[
+                El("Toolbutton.padding", sticky=NSEW, children=[
+                    El(f"{ttkstyle}.indicator", side=LEFT),
+                    El("Toolbutton.label", side=LEFT)])]))
         # register ttkstyle
         self.style._register_ttkstyle(ttkstyle)
 
@@ -2502,58 +2253,6 @@ class StyleBuilderTTK:
         # register ttkstyle
         self.style._register_ttkstyle(ttkstyle)
 
-    def create_radiobutton_assets(self, colorname=DEFAULT):
-        """Create the image assets used to build the radiobutton style.
-
-        Parameters:
-
-            colorname (str):
-
-        Returns:
-
-            tuple[str]:
-                A tuple of PhotoImage names
-        """
-        a = self.assets
-        on_fill = self.colors.get(colorname)
-        off_fill = self.colors.bg
-        on_indicator = self.colors.selectfg
-        size = self.scale_size([14, 14])
-        off_border = Colors.make_transparent(0.4, self.colors.fg, self.colors.bg)
-        disabled = Colors.make_transparent(0.3, self.colors.fg, self.colors.bg)
-
-        if self.is_light_theme and colorname == LIGHT:
-            on_indicator = self.colors.dark
-
-        # geometry differs (outline vs filled) for the light-on-light case
-        light_outline = colorname == LIGHT and self.is_light_theme
-
-        # Concentric "on" / "on_disabled" states need a composite draw, so they
-        # use the `image` escape hatch -- the colors each draw closes over are
-        # listed beside it as key parts (so the key can't drift from the pixels).
-        def draw_on(d, w, h):
-            if light_outline:
-                d.ellipse((0, 0, w - 1, h - 1), outline=off_border, width=round(w * 0.045))
-            else:
-                d.ellipse((0, 0, w - 1, h - 1), fill=on_fill)
-            d.ellipse((w * 0.30, h * 0.30, w * 0.70, h * 0.70), fill=on_indicator)
-
-        def draw_on_disabled(d, w, h):
-            if light_outline:
-                d.ellipse((0, 0, w - 1, h - 1), outline=off_border, width=round(w * 0.045))
-            else:
-                d.ellipse((0, 0, w - 1, h - 1), fill=disabled)
-            d.ellipse((w * 0.30, h * 0.30, w * 0.70, h * 0.70), fill=off_fill)
-
-        # the unselected "off" / "disabled" states are a single outlined circle
-        ring = max(1, round(size[0] * 0.045))
-        off_name = a.circle(off_fill, size, outline=off_border, width=ring)
-        disabled_name = a.circle(off_fill, size, outline=disabled, width=ring)
-        on_name = a.image(size, draw_on, light_outline, on_fill, on_indicator, off_border)
-        on_disabled_name = a.image(size, draw_on_disabled, light_outline, disabled, off_fill, off_border)
-
-        return off_name, on_name, disabled_name, on_disabled_name
-
     def create_radiobutton_style(self, colorname=DEFAULT):
         """Create a style for the ttk.Radiobutton widget.
 
@@ -2562,19 +2261,33 @@ class StyleBuilderTTK:
             colorname (str):
                 The color label used to style the widget.
         """
-
         sn = StyleName("TRadiobutton", colorname)
-        disabled_fg = Colors.make_transparent(0.30, self.colors.fg, self.colors.bg)
+        fg = self.colors.fg
+        disabled = Colors.make_transparent(0.30, fg, self.colors.bg)
+        fg_muted = Colors.make_transparent(0.40, fg, self.colors.bg)
 
-        # ( off, on, disabled, on_disabled )
-        images = self.create_radiobutton_assets(sn.colorname)
-        image_element(
-            self.style, f"{sn.ttkstyle}.indicator", default=images[1],
-            states={"disabled selected": images[3], "disabled": images[2],
-                    "!selected": images[0]},
+        # Resolve the "on" accent; LIGHT/DARK on their own background need a
+        # contrasting indicator so the knockout interior stays readable
+        # (visual-check item: verify LIGHT-on-light reads on the human spot-check).
+        if sn.colorname == LIGHT and self.is_light_theme:
+            accent = self.colors.dark
+        elif sn.colorname == DARK and not self.is_light_theme:
+            accent = self.colors.light
+        else:
+            accent = self.colors.get(sn.colorname)
+
+        # Foreground map FIRST -- color-less icon specs resolve against it.
+        self.style._build_configure(sn.ttkstyle, foreground=fg)
+        state_map(self.style, sn.ttkstyle, foreground={"disabled": disabled})
+
+        icon_element(self.style, f"{sn.ttkstyle}.indicator", size=self.scale_size(20),
+            default={"name": "record-circle-fill", "color": accent},
+            states={
+                "disabled selected": "record-circle-fill",   # follows fg(disabled)
+                "disabled":          "circle",               # follows fg(disabled)
+                "!selected":         {"name": "circle", "color": fg_muted},
+            },
             width=self.scale_size(20), border=self.scale_size(4), sticky=W)
-        state_map(self.style, sn.ttkstyle, foreground={"disabled": disabled_fg})
-        self.style._build_configure(sn.ttkstyle)
         layout(
             self.style, sn.ttkstyle,
             El("Radiobutton.padding", sticky=NSEW, children=[
@@ -2582,60 +2295,6 @@ class StyleBuilderTTK:
                 El("Radiobutton.focus", side=LEFT, sticky="", children=[
                     El("Radiobutton.label", sticky=NSEW)])]))
         self.style._register_ttkstyle(sn.ttkstyle)
-
-    def create_date_button_assets(self, foreground):
-        """Create the image assets used to build the date button
-        style. This button style applied to the button in the
-        ttkbootstrap.widgets.DateEntry.
-
-        Parameters:
-
-            foreground (str):
-                The color value used to draw the calendar image.
-
-        Returns:
-
-            str:
-                The PhotoImage name.
-        """
-        size = self.scale_size([21, 22])
-
-        def render():
-            fill = foreground
-            image = Image.new("RGBA", (210, 220))
-            draw = ImageDraw.Draw(image)
-
-            draw.rounded_rectangle(
-                [10, 30, 200, 210], radius=20, outline=fill, width=10
-            )
-
-            calendar_image_coordinates = [
-                # page spirals
-                [40, 10, 50, 50],
-                [100, 10, 110, 50],
-                [160, 10, 170, 50],
-                # row 1
-                [70, 90, 90, 110],
-                [110, 90, 130, 110],
-                [150, 90, 170, 110],
-                # row 2
-                [30, 130, 50, 150],
-                [70, 130, 90, 150],
-                [110, 130, 130, 150],
-                [150, 130, 170, 150],
-                # row 3
-                [30, 170, 50, 190],
-                [70, 170, 90, 190],
-                [110, 170, 130, 190],
-            ]
-            for xy in calendar_image_coordinates:
-                draw.rectangle(xy=xy, fill=fill)
-
-            return ImageTk.PhotoImage(image.resize(size, Resampling.LANCZOS))
-
-        return self.style._get_or_create_image(
-            ("date_button", foreground, tuple(size)), render
-        )
 
     def create_date_button_style(self, colorname=DEFAULT):
         """Create a date button style for the ttk.Button widget.
@@ -2663,7 +2322,11 @@ class StyleBuilderTTK:
             background = self.colors.get(colorname)
             btn_foreground = Colors.get_foreground(self.colors, colorname)
 
-        img_normal = self.create_date_button_assets(btn_foreground)
+        # Calendar icon in the button foreground color.
+        # Visual-check item: `calendar-event` vs `calendar` -- settle on the
+        # human spot-check.
+        size = self.scale_size([21, 22])
+        img_normal = self.assets.icon("calendar-event", size, btn_foreground)
 
         pressed = Colors.update_hsv(background, vd=-0.1)
         hover = Colors.update_hsv(background, vd=0.10)
@@ -2702,7 +2365,6 @@ class StyleBuilderTTK:
                 ("hover !disabled", hover),
             ],
         )
-
         self.style._register_ttkstyle(ttkstyle)
 
     def create_calendar_style(self, colorname=DEFAULT):
@@ -2998,219 +2660,44 @@ class StyleBuilderTTK:
             colorname (str):
                 The color label used to style the widget.
         """
-        STYLE = "TCheckbutton"
+        sn = StyleName("TCheckbutton", colorname)
+        size = self.scale_size(20)
+        fg = self.colors.fg
+        disabled = Colors.make_transparent(0.3, fg, self.colors.bg)
+        fg_muted = Colors.make_transparent(0.4, fg, self.colors.bg)
 
-        disabled_fg = Colors.make_transparent(0.3, self.colors.fg, self.colors.bg)
-
-        if any([colorname == DEFAULT, colorname == ""]):
-            colorname = PRIMARY
-            ttkstyle = STYLE
+        # Resolve the "on" accent; LIGHT/DARK on their own background need a
+        # contrasting indicator so the knockout interior stays readable
+        # (visual-check item: verify LIGHT-on-light reads on the human spot-check).
+        if sn.colorname == LIGHT and self.is_light_theme:
+            accent = self.colors.dark
+        elif sn.colorname == DARK and not self.is_light_theme:
+            accent = self.colors.light
         else:
-            ttkstyle = f"{colorname}.TCheckbutton"
+            accent = self.colors.get(sn.colorname)
 
-        # ( off, on, disabled )
-        images = self.create_checkbutton_assets(colorname)
+        # Foreground map FIRST -- color-less icon specs resolve against it.
+        self.style._build_configure(sn.ttkstyle, foreground=fg)
+        state_map(self.style, sn.ttkstyle, foreground={"disabled": disabled})
 
-        element = ttkstyle.replace(".TC", ".C")
-        width = self.scale_size(20)
-        borderpad = self.scale_size(4)
-        self.style.element_create(
-            f"{element}.indicator",
-            "image",
-            images[1],
-            ("disabled selected", images[4]),
-            ("disabled alternate", images[5]),
-            ("disabled", images[2]),
-            ("alternate", images[3]),
-            ("!selected", images[0]),
-            width=width,
-            border=borderpad,
-            sticky=tk.W,
-        )
-        self.style._build_configure(ttkstyle, foreground=self.colors.fg)
-        self.style.map(ttkstyle, foreground=[("disabled", disabled_fg)])
-        self.style.layout(
-            ttkstyle,
-            [
-                (
-                    "Checkbutton.padding",
-                    {
-                        "children": [
-                            (
-                                f"{element}.indicator",
-                                {"side": tk.LEFT, "sticky": ""},
-                            ),
-                            (
-                                "Checkbutton.focus",
-                                {
-                                    "children": [
-                                        (
-                                            "Checkbutton.label",
-                                            {"sticky": tk.NSEW},
-                                        )
-                                    ],
-                                    "side": tk.LEFT,
-                                    "sticky": "",
-                                },
-                            ),
-                        ],
-                        "sticky": tk.NSEW,
-                    },
-                )
-            ],
-        )
+        # Element name carries the ttkstyle prefix so `icon_element`'s
+        # foreground lookup targets the style we just configured.
+        icon_element(self.style, f"{sn.ttkstyle}.indicator", size=size,
+            default={"name": "check-square-fill", "color": accent},
+            states={
+                "disabled selected":  "check-square-fill",   # follows fg(disabled)
+                "disabled alternate": "dash-square-fill",    # follows fg(disabled)
+                "disabled":           "square",              # follows fg(disabled)
+                "alternate":          {"name": "dash-square-fill", "color": accent},
+                "!selected":          {"name": "square", "color": fg_muted},
+            },
+            border=self.scale_size(4), sticky=W)
+        layout(self.style, sn.ttkstyle, El("Checkbutton.padding", sticky=NSEW, children=[
+            El(f"{sn.ttkstyle}.indicator", side=LEFT, sticky=""),
+            El("Checkbutton.focus", side=LEFT, sticky="", children=[
+                El("Checkbutton.label", sticky=NSEW)])]))
         # register ttkstyle
-        self.style._register_ttkstyle(ttkstyle)
-
-    def create_checkbutton_assets(self, colorname=DEFAULT):
-        """Create the image assets used to build the standard
-        checkbutton style.
-
-        Parameters:
-
-            colorname (str):
-                The color label used to style the widget.
-
-        Returns:
-
-            tuple[str]:
-                A tuple of PhotoImage names.
-        """
-        # set platform specific checkfont
-        winsys = self.style.tk.call("tk", "windowingsystem")
-        indicator = "✓"
-        if winsys == "win32":
-            # Windows font
-            fnt = ImageFont.truetype("seguisym.ttf", 120)
-            font_offset = -20
-            # TODO consider using ImageFont.getsize for offsets
-        elif winsys == "x11":
-            # Linux fonts
-            try:
-                # this should be available on most Linux distros
-                fnt = ImageFont.truetype("FreeSerif.ttf", 130)
-                font_offset = 10
-            except:
-                try:
-                    # this should be available as a backup on Linux 
-                    # distros that don't have the FreeSerif.ttf file
-                    fnt = ImageFont.truetype("DejaVuSans.ttf", 160)
-                    font_offset = -15
-                except:
-                    # If all else fails, use the default ImageFont
-                    # this won't actually show anything in practice 
-                    # because of how I'm scaling the image, but it 
-                    # will prevent the program from crashing. I need 
-                    # a better solution for a missing font
-                    fnt = ImageFont.load_default()
-                    font_offset = 0
-                    indicator = "x"
-        else:
-            # Mac OS font
-            fnt = ImageFont.truetype("LucidaGrande.ttc", 120)
-            font_offset = -10
-
-        prime_color = self.colors.get(colorname)
-        on_border = prime_color
-        on_fill = prime_color
-        off_fill = self.colors.bg
-        off_border = self.colors.selectbg
-        off_border = Colors.make_transparent(0.4, self.colors.fg, self.colors.bg)
-        disabled_fg = Colors.make_transparent(0.3, self.colors.fg, self.colors.bg)
-
-        if colorname == LIGHT:
-            check_color = self.colors.dark
-            on_border = check_color
-        elif colorname == DARK:
-            check_color = self.colors.light
-            on_border = check_color
-        else:
-            check_color = self.colors.selectfg
-
-        size = self.scale_size([14, 14])
-        # Font choice is OS-fixed for the process; `indicator`/`font_offset`
-        # capture which fallback was selected so text glyphs key correctly.
-        glyph = (indicator, font_offset)
-
-        def make_off():
-            img = Image.new("RGBA", (134, 134))
-            ImageDraw.Draw(img).rounded_rectangle(
-                [2, 2, 132, 132], radius=16, outline=off_border, width=6,
-                fill=off_fill,
-            )
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_on():
-            img = Image.new("RGBA", (134, 134))
-            draw = ImageDraw.Draw(img)
-            draw.rounded_rectangle(
-                [2, 2, 132, 132], radius=16, fill=on_fill, outline=on_border,
-                width=3,
-            )
-            draw.text((20, font_offset), indicator, font=fnt, fill=check_color)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_on_disabled():
-            img = Image.new("RGBA", (134, 134))
-            draw = ImageDraw.Draw(img)
-            draw.rounded_rectangle(
-                [2, 2, 132, 132], radius=16, fill=disabled_fg,
-                outline=disabled_fg, width=3,
-            )
-            draw.text((20, font_offset), indicator, font=fnt, fill=off_fill)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_alt():
-            img = Image.new("RGBA", (134, 134))
-            draw = ImageDraw.Draw(img)
-            draw.rounded_rectangle(
-                [2, 2, 132, 132], radius=16, fill=on_fill, outline=on_border,
-                width=3,
-            )
-            draw.line([36, 67, 100, 67], fill=check_color, width=12)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_alt_disabled():
-            img = Image.new("RGBA", (134, 134))
-            draw = ImageDraw.Draw(img)
-            draw.rounded_rectangle(
-                [2, 2, 132, 132], radius=16, fill=disabled_fg,
-                outline=disabled_fg, width=3,
-            )
-            draw.line([36, 67, 100, 67], fill=off_fill, width=12)
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        def make_disabled():
-            img = Image.new("RGBA", (134, 134))
-            ImageDraw.Draw(img).rounded_rectangle(
-                [2, 2, 132, 132], radius=16, outline=disabled_fg, width=3
-            )
-            return ImageTk.PhotoImage(img.resize(size, Resampling.LANCZOS))
-
-        off_name = self.style._get_or_create_image(
-            ("checkbutton.off", off_border, off_fill, tuple(size)), make_off
-        )
-        on_name = self.style._get_or_create_image(
-            ("checkbutton.on", on_fill, on_border, check_color, glyph, tuple(size)),
-            make_on,
-        )
-        on_dis_name = self.style._get_or_create_image(
-            ("checkbutton.on_disabled", disabled_fg, off_fill, glyph, tuple(size)),
-            make_on_disabled,
-        )
-        alt_name = self.style._get_or_create_image(
-            ("checkbutton.alt", on_fill, on_border, check_color, tuple(size)),
-            make_alt,
-        )
-        alt_dis_name = self.style._get_or_create_image(
-            ("checkbutton.alt_disabled", disabled_fg, off_fill, tuple(size)),
-            make_alt_disabled,
-        )
-        disabled_name = self.style._get_or_create_image(
-            ("checkbutton.disabled", disabled_fg, tuple(size)), make_disabled
-        )
-
-        return off_name, on_name, disabled_name, alt_name, on_dis_name, alt_dis_name
+        self.style._register_ttkstyle(sn.ttkstyle)
 
     def create_menubutton_style(self, colorname=DEFAULT):
         """Create a solid style for the ttk.Menubutton widget.
@@ -3447,56 +2934,6 @@ class StyleBuilderTTK:
         self.style._register_ttkstyle(h_ttkstyle)
         self.style._register_ttkstyle(v_ttkstyle)
 
-    def create_sizegrip_assets(self, color):
-        """Create image assets used to build the sizegrip style.
-
-        Parameters:
-
-            color (str):
-                The color _value_ used to draw the image.
-
-        Returns:
-
-            str:
-                The PhotoImage name.
-        """
-
-        box = self.scale_size(1)
-        pad = box * 2
-        chunk = box + pad  # 4
-
-        w = chunk * 3 + pad  # 14
-        h = chunk * 3 + pad  # 14
-
-        size = [w, h]
-
-        def render():
-            im = Image.new("RGBA", size)
-            draw = ImageDraw.Draw(im)
-
-            draw.rectangle((chunk * 2 + pad, pad, chunk * 3, chunk), fill=color)
-            draw.rectangle(
-                (chunk * 2 + pad, chunk + pad, chunk * 3, chunk * 2), fill=color
-            )
-            draw.rectangle(
-                (chunk * 2 + pad, chunk * 2 + pad, chunk * 3, chunk * 3),
-                fill=color,
-            )
-
-            draw.rectangle(
-                (chunk + pad, chunk + pad, chunk * 2, chunk * 2), fill=color
-            )
-            draw.rectangle(
-                (chunk + pad, chunk * 2 + pad, chunk * 2, chunk * 3), fill=color
-            )
-
-            draw.rectangle((pad, chunk * 2 + pad, chunk, chunk * 3), fill=color)
-            return ImageTk.PhotoImage(im)
-
-        return self.style._get_or_create_image(
-            ("sizegrip", color, tuple(size)), render
-        )
-
     def create_sizegrip_style(self, colorname=DEFAULT):
         """Create a style for the ttk.Sizegrip widget.
 
@@ -3518,7 +2955,10 @@ class StyleBuilderTTK:
             ttkstyle = f"{colorname}.{STYLE}"
             grip_color = self.colors.get(colorname)
 
-        image = self.create_sizegrip_assets(grip_color)
+        # Visual-check item: `grip-horizontal` vs a corner-grip glyph -- settle
+        # on the human spot-check.
+        size = self.scale_size(16)
+        image = self.assets.icon("grip-horizontal", size, grip_color)
 
         self.style.element_create(
             f"{ttkstyle}.Sizegrip.sizegrip", "image", image

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -2381,9 +2381,6 @@ class StyleBuilderTTK:
             bordercolor=background,
             darkcolor=background,
             lightcolor=background,
-            arrowsize=self.scale_size(4),
-            arrowcolor=foreground,
-            arrowpadding=(0, 0, 15, 0),
             relief=tk.RAISED,
             focusthickness=0,
             focuscolor=self.colors.selectfg,
@@ -2391,7 +2388,6 @@ class StyleBuilderTTK:
         )
         self.style.map(
             ttkstyle,
-            arrowcolor=[("disabled", disabled_fg)],
             foreground=[("disabled", disabled_fg)],
             background=[
                 ("disabled", disabled_bg),
@@ -2414,8 +2410,36 @@ class StyleBuilderTTK:
                 ("hover !disabled", hover),
             ],
         )
+        # caret-down-fill indicator (replaces the native clam triangle); the
+        # solid menubutton arrow keeps one color (only the background changes on
+        # hover), so just a normal + disabled image.
+        self._build_menubutton_arrow(ttkstyle, foreground, disabled_fg, foreground)
         # register ttkstyle
         self.style._register_ttkstyle(ttkstyle)
+
+    def _build_menubutton_arrow(self, ttkstyle, normal, disabled, active):
+        """Build the caret-down indicator element + layout for a Menubutton style.
+
+        Replaces ttk's native `Menubutton.indicator` triangle with a Bootstrap
+        `caret-down-fill` image element so the menubutton arrow matches the
+        caret-fill arrows used elsewhere. `normal`/`disabled`/`active` are the
+        arrow colors per state (`active` == `normal` when the arrow does not
+        recolor on hover/press).
+        """
+        arrows = self.create_simple_arrow_assets(normal, disabled, active)
+        down, down_disabled, down_active = arrows[0][1], arrows[1][1], arrows[2][1]
+        image_element(
+            self.style, f"{ttkstyle}.indicator", default=down,
+            states={"disabled": down_disabled,
+                    "pressed !disabled": down_active,
+                    "hover !disabled": down_active},
+            sticky="", padding=(0, 0, self.scale_size(10), 0))
+        layout(self.style, ttkstyle,
+            El("Menubutton.border", sticky=NSEW, children=[
+                El("Menubutton.focus", sticky=NSEW, children=[
+                    El(f"{ttkstyle}.indicator", side=tk.RIGHT, sticky=""),
+                    El("Menubutton.padding", sticky=tk.EW, children=[
+                        El("Menubutton.label", side=LEFT, sticky="")])])]))
 
     def create_outline_menubutton_style(self, colorname=DEFAULT):
         """Create an outline button style for the ttk.Menubutton widget
@@ -2453,9 +2477,6 @@ class StyleBuilderTTK:
             focusthickness=0,
             focuscolor=foreground,
             padding=(10, 5),
-            arrowcolor=foreground,
-            arrowpadding=(0, 0, 15, 0),
-            arrowsize=self.scale_size(4),
         )
         self.style.map(
             ttkstyle,
@@ -2481,12 +2502,10 @@ class StyleBuilderTTK:
                 ("pressed !disabled", pressed),
                 ("hover !disabled", hover),
             ],
-            arrowcolor=[
-                ("disabled", disabled_fg),
-                ("pressed", foreground_pressed),
-                ("hover", foreground_pressed),
-            ],
         )
+        # caret-down-fill indicator; the outline arrow recolors on hover/press
+        # (foreground -> the contrasting fill color), so pass that as `active`.
+        self._build_menubutton_arrow(ttkstyle, foreground, disabled_fg, foreground_pressed)
         # register ttkstyle
         self.style._register_ttkstyle(ttkstyle)
 

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -208,15 +208,12 @@ class StyleBuilderTTK:
         downarrow_image = arrow_images[0][1]
         downarrow_disabled_image = arrow_images[1][1]
         downarrow_focused_image = arrow_images[2][1]
-        self.style.element_create(
-            f"{element}.downarrow",
-            "image",
-            downarrow_image,
-            ("disabled", downarrow_disabled_image),
-            ("pressed !disabled", downarrow_focused_image),
-            ("focus !disabled", downarrow_focused_image),
-            ("hover !disabled", downarrow_focused_image),
-        )
+        image_element(
+            self.style, f"{element}.downarrow", default=downarrow_image,
+            states={"disabled": downarrow_disabled_image,
+                    "pressed !disabled": downarrow_focused_image,
+                    "focus !disabled": downarrow_focused_image,
+                    "hover !disabled": downarrow_focused_image})
         #  self.style.element_create(f"{element}.downarrow", "from", TTK_DEFAULT)  # doesn't work in python 3.13
         self.style.element_create(f"{element}.padding", "from", TTK_CLAM)
         self.style.element_create(f"{element}.textarea", "from", TTK_CLAM)
@@ -259,37 +256,11 @@ class StyleBuilderTTK:
                 ("readonly", readonly),
             ],
         )
-        self.style.layout(
-            ttkstyle,
-            [
-                (
-                    "combo.Spinbox.field",
-                    {
-                        "side": tk.TOP,
-                        "sticky": tk.EW,
-                        "children": [
-                            (
-                                "Combobox.downarrow",
-                                {"side": tk.RIGHT, "sticky": tk.S},
-                            ),
-                            (
-                                "Combobox.padding",
-                                {
-                                    "expand": "1",
-                                    "sticky": tk.NSEW,
-                                    "children": [
-                                        (
-                                            "Combobox.textarea",
-                                            {"sticky": tk.NSEW},
-                                        )
-                                    ],
-                                },
-                            ),
-                        ],
-                    },
-                )
-            ],
-        )
+        layout(self.style, ttkstyle,
+               El("combo.Spinbox.field", side=tk.TOP, sticky=tk.EW, children=[
+                   El("Combobox.downarrow", side=tk.RIGHT, sticky=tk.S),
+                   El("Combobox.padding", expand="1", sticky=tk.NSEW, children=[
+                       El("Combobox.textarea", sticky=tk.NSEW)])]))
         self.style._register_ttkstyle(ttkstyle)
         try:
             self.create_scrollbar_style()
@@ -326,28 +297,21 @@ class StyleBuilderTTK:
             h_ttkstyle = f"{colorname}.{HSTYLE}"
             v_ttkstyle = f"{colorname}.{VSTYLE}"
 
+        a = self.assets
+
         # horizontal separator
         h_element = h_ttkstyle.replace(".TS", ".S")
-        h_name = self.style._get_or_create_image(
-            ("separator", background, tuple(hsize)),
-            lambda: ImageTk.PhotoImage(Image.new("RGB", hsize, background)),
-        )
-
+        h_name = a.rect(background, hsize)
         self.style.element_create(f"{h_element}.separator", "image", h_name)
-        self.style.layout(
-            h_ttkstyle, [(f"{h_element}.separator", {"sticky": tk.EW})]
-        )
+        layout(self.style, h_ttkstyle,
+               El(f"{h_element}.separator", sticky=tk.EW))
 
         # vertical separator
         v_element = v_ttkstyle.replace(".TS", ".S")
-        v_name = self.style._get_or_create_image(
-            ("separator", background, tuple(vsize)),
-            lambda: ImageTk.PhotoImage(Image.new("RGB", vsize, background)),
-        )
+        v_name = a.rect(background, vsize)
         self.style.element_create(f"{v_element}.separator", "image", v_name)
-        self.style.layout(
-            v_ttkstyle, [(f"{v_element}.separator", {"sticky": tk.NS})]
-        )
+        layout(self.style, v_ttkstyle,
+               El(f"{v_element}.separator", sticky=tk.NS))
         self.style._register_ttkstyle(h_ttkstyle)
         self.style._register_ttkstyle(v_ttkstyle)
 
@@ -380,28 +344,24 @@ class StyleBuilderTTK:
             value_delta = 0.1
 
         barcolor_light = Colors.update_hsv(barcolor, sd=-0.2, vd=value_delta)
+        a = self.assets
 
-        def make_striped(rotate):
-            img = Image.new("RGBA", (100, 100), barcolor_light)
-            draw = ImageDraw.Draw(img)
-            draw.polygon(
-                xy=[(0, 0), (48, 0), (100, 52), (100, 100)],
-                fill=barcolor,
-            )
-            draw.polygon(xy=[(0, 52), (48, 100), (0, 100)], fill=barcolor)
-            resized = img.resize((thickness, thickness), Resampling.LANCZOS)
-            if rotate:
-                resized = resized.rotate(90)
-            return ImageTk.PhotoImage(resized)
+        # Diagonal stripe pattern over a barcolor_light field; the original
+        # polygons were hand-fit to a 100-unit canvas, re-expressed here as
+        # w/h-relative ratios. The vertical variant is the horizontal one
+        # rotated 90 deg CCW.
+        def draw_h(d, w, h):
+            d.rectangle((0, 0, w, h), fill=barcolor_light)
+            d.polygon([(0, 0), (0.48 * w, 0), (w, 0.52 * h), (w, h)], fill=barcolor)
+            d.polygon([(0, 0.52 * h), (0.48 * w, h), (0, h)], fill=barcolor)
 
-        h_name = self.style._get_or_create_image(
-            ("progressbar.striped", barcolor, barcolor_light, thickness, "h"),
-            lambda: make_striped(False),
-        )
-        v_name = self.style._get_or_create_image(
-            ("progressbar.striped", barcolor, barcolor_light, thickness, "v"),
-            lambda: make_striped(True),
-        )
+        def draw_v(d, w, h):
+            d.rectangle((0, 0, w, h), fill=barcolor_light)
+            d.polygon([(0, h), (0, 0.52 * h), (0.52 * w, 0), (w, 0)], fill=barcolor)
+            d.polygon([(0.52 * w, h), (w, 0.52 * h), (w, h)], fill=barcolor)
+
+        h_name = a.image((thickness, thickness), draw_h, barcolor, barcolor_light)
+        v_name = a.image((thickness, thickness), draw_v, barcolor, barcolor_light)
         return h_name, v_name
 
     def create_striped_progressbar_style(self, colorname=DEFAULT):
@@ -447,23 +407,9 @@ class StyleBuilderTTK:
             width=thickness,
             sticky=tk.EW,
         )
-        self.style.layout(
-            h_ttkstyle,
-            [
-                (
-                    f"{h_element}.trough",
-                    {
-                        "sticky": tk.NSEW,
-                        "children": [
-                            (
-                                f"{h_element}.pbar",
-                                {"side": tk.LEFT, "sticky": tk.NS},
-                            )
-                        ],
-                    },
-                )
-            ],
-        )
+        layout(self.style, h_ttkstyle,
+               El(f"{h_element}.trough", sticky=tk.NSEW, children=[
+                   El(f"{h_element}.pbar", side=tk.LEFT, sticky=tk.NS)]))
         self.style._build_configure(
             h_ttkstyle,
             troughcolor=troughcolor,
@@ -481,23 +427,9 @@ class StyleBuilderTTK:
             width=thickness,
             sticky=tk.NS,
         )
-        self.style.layout(
-            v_ttkstyle,
-            [
-                (
-                    f"{v_element}.trough",
-                    {
-                        "sticky": tk.NSEW,
-                        "children": [
-                            (
-                                f"{v_element}.pbar",
-                                {"side": tk.BOTTOM, "sticky": tk.EW},
-                            )
-                        ],
-                    },
-                )
-            ],
-        )
+        layout(self.style, v_ttkstyle,
+               El(f"{v_element}.trough", sticky=tk.NSEW, children=[
+                   El(f"{v_element}.pbar", side=tk.BOTTOM, sticky=tk.EW)]))
         self.style._build_configure(
             v_ttkstyle,
             troughcolor=troughcolor,
@@ -571,20 +503,9 @@ class StyleBuilderTTK:
             self.style.element_create(trough_element, "from", TTK_CLAM)
             self.style.element_create(pbar_element, "from", TTK_DEFAULT)
 
-        self.style.layout(
-            h_ttkstyle,
-            [
-                (
-                    trough_element,
-                    {
-                        "sticky": "nswe",
-                        "children": [
-                            (pbar_element, {"side": "left", "sticky": "ns"})
-                        ],
-                    },
-                )
-            ],
-        )
+        layout(self.style, h_ttkstyle,
+               El(trough_element, sticky="nswe", children=[
+                   El(pbar_element, side="left", sticky="ns")]))
         self.style._build_configure(h_ttkstyle, background=background)
 
         # vertical progressbar
@@ -595,20 +516,9 @@ class StyleBuilderTTK:
             self.style.element_create(trough_element, "from", TTK_CLAM)
             self.style.element_create(pbar_element, "from", TTK_DEFAULT)
             self.style._build_configure(v_ttkstyle, background=background)
-        self.style.layout(
-            v_ttkstyle,
-            [
-                (
-                    trough_element,
-                    {
-                        "sticky": "nswe",
-                        "children": [
-                            (pbar_element, {"side": "bottom", "sticky": "we"})
-                        ],
-                    },
-                )
-            ],
-        )
+        layout(self.style, v_ttkstyle,
+               El(trough_element, sticky="nswe", children=[
+                   El(pbar_element, side="bottom", sticky="we")]))
 
         # register ttkstyles
         self.style._register_ttkstyle(h_ttkstyle)
@@ -739,21 +649,10 @@ class StyleBuilderTTK:
         h_element = h_ttkstyle.replace(".TF", ".F")
         self.style.element_create(f"{h_element}.trough", "from", TTK_CLAM)
         self.style.element_create(f"{h_element}.pbar", "from", TTK_DEFAULT)
-        self.style.layout(
-            h_ttkstyle,
-            [
-                (
-                    f"{h_element}.trough",
-                    {
-                        "children": [
-                            (f"{h_element}.pbar", {"sticky": tk.NS}),
-                            ("Floodgauge.label", {"sticky": ""}),
-                        ],
-                        "sticky": tk.NSEW,
-                    },
-                )
-            ],
-        )
+        layout(self.style, h_ttkstyle,
+               El(f"{h_element}.trough", sticky=tk.NSEW, children=[
+                   El(f"{h_element}.pbar", sticky=tk.NS),
+                   El("Floodgauge.label", sticky="")]))
         self.style._build_configure(
             h_ttkstyle,
             thickness=50,
@@ -772,21 +671,10 @@ class StyleBuilderTTK:
         v_element = v_ttkstyle.replace(".TF", ".F")
         self.style.element_create(f"{v_element}.trough", "from", TTK_CLAM)
         self.style.element_create(f"{v_element}.pbar", "from", TTK_DEFAULT)
-        self.style.layout(
-            v_ttkstyle,
-            [
-                (
-                    f"{v_element}.trough",
-                    {
-                        "children": [
-                            (f"{v_element}.pbar", {"sticky": tk.EW}),
-                            ("Floodgauge.label", {"sticky": ""}),
-                        ],
-                        "sticky": tk.NSEW,
-                    },
-                )
-            ],
-        )
+        layout(self.style, v_ttkstyle,
+               El(f"{v_element}.trough", sticky=tk.NSEW, children=[
+                   El(f"{v_element}.pbar", sticky=tk.EW),
+                   El("Floodgauge.label", sticky="")]))
         self.style._build_configure(
             v_ttkstyle,
             thickness=50,
@@ -907,33 +795,23 @@ class StyleBuilderTTK:
                 The color value to use when the thumb is active or
                 hovered.
         """
+        a = self.assets
         vsize = self.scale_size([9, 28])
         hsize = self.scale_size([28, 9])
 
-        def rounded_rect(size, fill):
-            def render():
-                x = size[0] * 10
-                y = size[1] * 10
-                img = Image.new("RGBA", (x, y))
-                draw = ImageDraw.Draw(img)
-                radius = min([x, y]) // 2
-                draw.rounded_rectangle([0, 0, x - 1, y - 1], radius, fill)
-                return ImageTk.PhotoImage(
-                    img.resize(size, Resampling.BICUBIC)
-                )
-
-            return self.style._get_or_create_image(
-                ("scrollbar.round", fill, tuple(size)), render
-            )
+        # A fully-rounded "pill": radius = half the short axis (the old draw
+        # used a 10x canvas with radius min//2, downscaled -- same shape).
+        def pill(size, fill):
+            return a.rounded_rect(fill, size, min(size) / 2)
 
         # create images
-        h_normal_img = rounded_rect(hsize, thumbcolor)
-        h_pressed_img = rounded_rect(hsize, pressed)
-        h_active_img = rounded_rect(hsize, active)
+        h_normal_img = pill(hsize, thumbcolor)
+        h_pressed_img = pill(hsize, pressed)
+        h_active_img = pill(hsize, active)
 
-        v_normal_img = rounded_rect(vsize, thumbcolor)
-        v_pressed_img = rounded_rect(vsize, pressed)
-        v_active_img = rounded_rect(vsize, active)
+        v_normal_img = pill(vsize, thumbcolor)
+        v_pressed_img = pill(vsize, pressed)
+        v_active_img = pill(vsize, active)
 
         return (
             h_normal_img,
@@ -996,45 +874,18 @@ class StyleBuilderTTK:
             relief=tk.FLAT,
             borderwidth=0,
         )
-        self.style.element_create(
-            f"{h_ttkstyle}.thumb",
-            "image",
-            scroll_images[0],
-            ("pressed", scroll_images[1]),
-            ("active", scroll_images[2]),
-            border=self.scale_size(9),
-            padding=0,
-            sticky=tk.EW,
-        )
-        self.style.layout(
-            h_ttkstyle,
-            [
-                (
-                    "Horizontal.Scrollbar.trough",
-                    {
-                        "sticky": "we",
-                        "children": [
-                            (
-                                "Horizontal.Scrollbar.leftarrow",
-                                {"side": "left", "sticky": ""},
-                            ),
-                            (
-                                "Horizontal.Scrollbar.rightarrow",
-                                {"side": "right", "sticky": ""},
-                            ),
-                            (
-                                f"{h_ttkstyle}.thumb",
-                                {"expand": "1", "sticky": "nswe"},
-                            ),
-                        ],
-                    },
-                )
-            ],
-        )
+        image_element(
+            self.style, f"{h_ttkstyle}.thumb", default=scroll_images[0],
+            states={"pressed": scroll_images[1], "active": scroll_images[2]},
+            border=self.scale_size(9), padding=0, sticky=tk.EW)
+        layout(self.style, h_ttkstyle,
+               El("Horizontal.Scrollbar.trough", sticky="we", children=[
+                   El("Horizontal.Scrollbar.leftarrow", side="left", sticky=""),
+                   El("Horizontal.Scrollbar.rightarrow", side="right", sticky=""),
+                   El(f"{h_ttkstyle}.thumb", expand="1", sticky="nswe")]))
         self.style._build_configure(h_ttkstyle, arrowcolor=background)
-        self.style.map(
-            h_ttkstyle, arrowcolor=[("pressed", pressed), ("active", active)]
-        )
+        state_map(self.style, h_ttkstyle,
+                  arrowcolor={"pressed": pressed, "active": active})
 
         # vertical scrollbar
         self.style._build_configure(
@@ -1048,45 +899,18 @@ class StyleBuilderTTK:
             background=troughcolor,
             relief=tk.FLAT,
         )
-        self.style.element_create(
-            f"{v_ttkstyle}.thumb",
-            "image",
-            scroll_images[3],
-            ("pressed", scroll_images[4]),
-            ("active", scroll_images[5]),
-            border=self.scale_size(9),
-            padding=0,
-            sticky=tk.NS,
-        )
-        self.style.layout(
-            v_ttkstyle,
-            [
-                (
-                    "Vertical.Scrollbar.trough",
-                    {
-                        "sticky": "ns",
-                        "children": [
-                            (
-                                "Vertical.Scrollbar.uparrow",
-                                {"side": "top", "sticky": ""},
-                            ),
-                            (
-                                "Vertical.Scrollbar.downarrow",
-                                {"side": "bottom", "sticky": ""},
-                            ),
-                            (
-                                f"{v_ttkstyle}.thumb",
-                                {"expand": "1", "sticky": "nswe"},
-                            ),
-                        ],
-                    },
-                )
-            ],
-        )
+        image_element(
+            self.style, f"{v_ttkstyle}.thumb", default=scroll_images[3],
+            states={"pressed": scroll_images[4], "active": scroll_images[5]},
+            border=self.scale_size(9), padding=0, sticky=tk.NS)
+        layout(self.style, v_ttkstyle,
+               El("Vertical.Scrollbar.trough", sticky="ns", children=[
+                   El("Vertical.Scrollbar.uparrow", side="top", sticky=""),
+                   El("Vertical.Scrollbar.downarrow", side="bottom", sticky=""),
+                   El(f"{v_ttkstyle}.thumb", expand="1", sticky="nswe")]))
         self.style._build_configure(v_ttkstyle, arrowcolor=background)
-        self.style.map(
-            v_ttkstyle, arrowcolor=[("pressed", pressed), ("active", active)]
-        )
+        state_map(self.style, v_ttkstyle,
+                  arrowcolor={"pressed": pressed, "active": active})
 
         # register ttkstyles
         self.style._register_ttkstyle(h_ttkstyle)
@@ -1108,30 +932,19 @@ class StyleBuilderTTK:
                 The color value to use when the thumb is active or
                 hovered.
         """
+        a = self.assets
         vsize = self.scale_size([9, 28])
         hsize = self.scale_size([28, 9])
 
-        def draw_rect(size, fill):
-            def render():
-                x = size[0] * 10
-                y = size[1] * 10
-                img = Image.new("RGBA", (x, y), fill)
-                return ImageTk.PhotoImage(
-                    img.resize(size), Resampling.BICUBIC
-                )
+        # Solid-fill rectangles (the old 10x oversample + resize was a no-op
+        # for a flat fill).
+        h_normal_img = a.rect(thumbcolor, hsize)
+        h_pressed_img = a.rect(pressed, hsize)
+        h_active_img = a.rect(active, hsize)
 
-            return self.style._get_or_create_image(
-                ("scrollbar.rect", fill, tuple(size)), render
-            )
-
-        # create images
-        h_normal_img = draw_rect(hsize, thumbcolor)
-        h_pressed_img = draw_rect(hsize, pressed)
-        h_active_img = draw_rect(hsize, active)
-
-        v_normal_img = draw_rect(vsize, thumbcolor)
-        v_pressed_img = draw_rect(vsize, pressed)
-        v_active_img = draw_rect(vsize, active)
+        v_normal_img = a.rect(thumbcolor, vsize)
+        v_pressed_img = a.rect(pressed, vsize)
+        v_active_img = a.rect(active, vsize)
 
         return (
             h_normal_img,
@@ -1194,44 +1007,18 @@ class StyleBuilderTTK:
             relief=tk.FLAT,
             borderwidth=0,
         )
-        self.style.element_create(
-            f"{h_ttkstyle}.thumb",
-            "image",
-            scroll_images[0],
-            ("pressed", scroll_images[1]),
-            ("active", scroll_images[2]),
-            border=(3, 0),
-            sticky=tk.NSEW,
-        )
-        self.style.layout(
-            h_ttkstyle,
-            [
-                (
-                    "Horizontal.Scrollbar.trough",
-                    {
-                        "sticky": "we",
-                        "children": [
-                            (
-                                "Horizontal.Scrollbar.leftarrow",
-                                {"side": "left", "sticky": ""},
-                            ),
-                            (
-                                "Horizontal.Scrollbar.rightarrow",
-                                {"side": "right", "sticky": ""},
-                            ),
-                            (
-                                f"{h_ttkstyle}.thumb",
-                                {"expand": "1", "sticky": "nswe"},
-                            ),
-                        ],
-                    },
-                )
-            ],
-        )
+        image_element(
+            self.style, f"{h_ttkstyle}.thumb", default=scroll_images[0],
+            states={"pressed": scroll_images[1], "active": scroll_images[2]},
+            border=(3, 0), sticky=tk.NSEW)
+        layout(self.style, h_ttkstyle,
+               El("Horizontal.Scrollbar.trough", sticky="we", children=[
+                   El("Horizontal.Scrollbar.leftarrow", side="left", sticky=""),
+                   El("Horizontal.Scrollbar.rightarrow", side="right", sticky=""),
+                   El(f"{h_ttkstyle}.thumb", expand="1", sticky="nswe")]))
         self.style._build_configure(h_ttkstyle, arrowcolor=background)
-        self.style.map(
-            h_ttkstyle, arrowcolor=[("pressed", pressed), ("active", active)]
-        )
+        state_map(self.style, h_ttkstyle,
+                  arrowcolor={"pressed": pressed, "active": active})
 
         # vertical scrollbar
         self.style._build_configure(
@@ -1246,44 +1033,18 @@ class StyleBuilderTTK:
             relief=tk.FLAT,
             borderwidth=0,
         )
-        self.style.element_create(
-            f"{v_ttkstyle}.thumb",
-            "image",
-            scroll_images[3],
-            ("pressed", scroll_images[4]),
-            ("active", scroll_images[5]),
-            border=(0, 3),
-            sticky=tk.NSEW,
-        )
-        self.style.layout(
-            v_ttkstyle,
-            [
-                (
-                    "Vertical.Scrollbar.trough",
-                    {
-                        "sticky": "ns",
-                        "children": [
-                            (
-                                "Vertical.Scrollbar.uparrow",
-                                {"side": "top", "sticky": ""},
-                            ),
-                            (
-                                "Vertical.Scrollbar.downarrow",
-                                {"side": "bottom", "sticky": ""},
-                            ),
-                            (
-                                f"{v_ttkstyle}.thumb",
-                                {"expand": "1", "sticky": "nswe"},
-                            ),
-                        ],
-                    },
-                )
-            ],
-        )
+        image_element(
+            self.style, f"{v_ttkstyle}.thumb", default=scroll_images[3],
+            states={"pressed": scroll_images[4], "active": scroll_images[5]},
+            border=(0, 3), sticky=tk.NSEW)
+        layout(self.style, v_ttkstyle,
+               El("Vertical.Scrollbar.trough", sticky="ns", children=[
+                   El("Vertical.Scrollbar.uparrow", side="top", sticky=""),
+                   El("Vertical.Scrollbar.downarrow", side="bottom", sticky=""),
+                   El(f"{v_ttkstyle}.thumb", expand="1", sticky="nswe")]))
         self.style._build_configure(v_ttkstyle, arrowcolor=background)
-        self.style.map(
-            v_ttkstyle, arrowcolor=[("pressed", pressed), ("active", active)]
-        )
+        state_map(self.style, v_ttkstyle,
+                  arrowcolor={"pressed": pressed, "active": active})
 
         # register ttkstyles
         self.style._register_ttkstyle(h_ttkstyle)
@@ -1334,68 +1095,23 @@ class StyleBuilderTTK:
         downarrow_disabled_image = arrow_images[1][1]
         downarrow_focus_image = arrow_images[2][1]
 
-        self.style.element_create(
-            f"{element}.uparrow",
-            "image",
-            uparrow_image,
-            ("disabled", uparrow_disabled_image),
-            ("pressed !disabled", uparrow_focus_image),
-            ("hover !disabled", uparrow_focus_image),
-        )
-        self.style.element_create(
-            f"{element}.downarrow",
-            "image",
-            downarrow_image,
-            ("disabled", downarrow_disabled_image),
-            ("pressed !disabled", downarrow_focus_image),
-            ("hover !disabled", downarrow_focus_image),
-        )
-        self.style.layout(
-            ttkstyle,
-            [
-                (
-                    f"{element}.field",
-                    {
-                        "side": tk.TOP,
-                        "sticky": tk.EW,
-                        "children": [
-                            (
-                                "null",
-                                {
-                                    "side": tk.RIGHT,
-                                    "sticky": "",
-                                    "children": [
-                                        (
-                                            f"{element}.uparrow",
-                                            {"side": tk.TOP, "sticky": tk.E},
-                                        ),
-                                        (
-                                            f"{element}.downarrow",
-                                            {
-                                                "side": tk.BOTTOM,
-                                                "sticky": tk.E,
-                                            },
-                                        ),
-                                    ],
-                                },
-                            ),
-                            (
-                                f"{element}.padding",
-                                {
-                                    "sticky": tk.NSEW,
-                                    "children": [
-                                        (
-                                            f"{element}.textarea",
-                                            {"sticky": tk.NSEW},
-                                        )
-                                    ],
-                                },
-                            ),
-                        ],
-                    },
-                )
-            ],
-        )
+        image_element(
+            self.style, f"{element}.uparrow", default=uparrow_image,
+            states={"disabled": uparrow_disabled_image,
+                    "pressed !disabled": uparrow_focus_image,
+                    "hover !disabled": uparrow_focus_image})
+        image_element(
+            self.style, f"{element}.downarrow", default=downarrow_image,
+            states={"disabled": downarrow_disabled_image,
+                    "pressed !disabled": downarrow_focus_image,
+                    "hover !disabled": downarrow_focus_image})
+        layout(self.style, ttkstyle,
+               El(f"{element}.field", side=tk.TOP, sticky=tk.EW, children=[
+                   El("null", side=tk.RIGHT, sticky="", children=[
+                       El(f"{element}.uparrow", side=tk.TOP, sticky=tk.E),
+                       El(f"{element}.downarrow", side=tk.BOTTOM, sticky=tk.E)]),
+                   El(f"{element}.padding", sticky=tk.NSEW, children=[
+                       El(f"{element}.textarea", sticky=tk.NSEW)])]))
         self.style._build_configure(
             ttkstyle,
             bordercolor=bordercolor,
@@ -1519,32 +1235,10 @@ class StyleBuilderTTK:
                 ("selected", self.colors.selectfg),
             ],
         )
-        self.style.layout(
-            body_style,
-            [
-                (
-                    "Button.border",
-                    {
-                        "sticky": tk.NSEW,
-                        "border": "1",
-                        "children": [
-                            (
-                                "Treeview.padding",
-                                {
-                                    "sticky": tk.NSEW,
-                                    "children": [
-                                        (
-                                            "Treeview.treearea",
-                                            {"sticky": tk.NSEW},
-                                        )
-                                    ],
-                                },
-                            )
-                        ],
-                    },
-                )
-            ],
-        )
+        layout(self.style, body_style,
+               El("Button.border", sticky=tk.NSEW, border="1", children=[
+                   El("Treeview.padding", sticky=tk.NSEW, children=[
+                       El("Treeview.treearea", sticky=tk.NSEW)])]))
         # register ttkstyles
         self.style._register_ttkstyle(body_style)
 
@@ -1632,32 +1326,10 @@ class StyleBuilderTTK:
             lightcolor=[("focus", focuscolor)],
             darkcolor=[("focus", focuscolor)],
         )
-        self.style.layout(
-            body_style,
-            [
-                (
-                    "Button.border",
-                    {
-                        "sticky": tk.NSEW,
-                        "border": "1",
-                        "children": [
-                            (
-                                "Treeview.padding",
-                                {
-                                    "sticky": tk.NSEW,
-                                    "children": [
-                                        (
-                                            "Treeview.treearea",
-                                            {"sticky": tk.NSEW},
-                                        )
-                                    ],
-                                },
-                            )
-                        ],
-                    },
-                )
-            ],
-        )
+        layout(self.style, body_style,
+               El("Button.border", sticky=tk.NSEW, border="1", children=[
+                   El("Treeview.padding", sticky=tk.NSEW, children=[
+                       El("Treeview.treearea", sticky=tk.NSEW)])]))
 
         try:
             self.style.element_create("Treeitem.indicator", "from", TTK_ALT)
@@ -2409,36 +2081,11 @@ class StyleBuilderTTK:
             padding=(10, 5),
             anchor=tk.CENTER,
         )
-        self.style.layout(
-            ttkstyle,
-            [
-                (
-                    "Toolbutton.border",
-                    {
-                        "sticky": tk.NSEW,
-                        "children": [
-                            (
-                                "Toolbutton.focus",
-                                {
-                                    "sticky": tk.NSEW,
-                                    "children": [
-                                        (
-                                            "Toolbutton.padding",
-                                            {
-                                                "sticky": tk.NSEW,
-                                                "children": [
-                                                    ("Toolbutton.label", {"sticky": tk.NSEW})
-                                                ],
-                                            },
-                                        )
-                                    ],
-                                },
-                            )
-                        ],
-                    },
-                )
-            ],
-        )
+        layout(self.style, ttkstyle,
+               El("Toolbutton.border", sticky=tk.NSEW, children=[
+                   El("Toolbutton.focus", sticky=tk.NSEW, children=[
+                       El("Toolbutton.padding", sticky=tk.NSEW, children=[
+                           El("Toolbutton.label", sticky=tk.NSEW)])])]))
 
         self.style.map(
             ttkstyle,

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -213,7 +213,9 @@ class StyleBuilderTTK:
             states={"disabled": downarrow_disabled_image,
                     "pressed !disabled": downarrow_focused_image,
                     "focus !disabled": downarrow_focused_image,
-                    "hover !disabled": downarrow_focused_image})
+                    "hover !disabled": downarrow_focused_image},
+            # right padding so the caret isn't flush against the border
+            padding=(0, 0, self.scale_size(6), 0))
         #  self.style.element_create(f"{element}.downarrow", "from", TTK_DEFAULT)  # doesn't work in python 3.13
         self.style.element_create(f"{element}.padding", "from", TTK_CLAM)
         self.style.element_create(f"{element}.textarea", "from", TTK_CLAM)
@@ -694,12 +696,11 @@ class StyleBuilderTTK:
         self.style._register_ttkstyle(v_ttkstyle)
 
     def create_simple_arrow_assets(self, arrowcolor: str, disabledcolor: str, activecolor: str, y_offset: int = 0):
-        """Create chevron arrow assets using Bootstrap Icons glyphs.
+        """Create caret arrow assets using Bootstrap Icons glyphs.
 
-        Used for Combobox and Spinbox indicators. Replaces the old hand-drawn
-        triangles with `chevron-up/down/left/right` for a lighter, modern
-        open-arrow weight (RESOLVED: chevron over caret-*-fill per the icons
-        design).
+        Used for Combobox and Spinbox indicators. Uses the solid `caret-*-fill`
+        triangles so the indicators read consistently with the filled-triangle
+        arrows elsewhere in the app (menubutton, datepicker header).
 
         The `y_offset` parameter is accepted for API compatibility but is no
         longer used (it was specific to the old hand-drawn triangle approach).
@@ -717,10 +718,10 @@ class StyleBuilderTTK:
         size = self.scale_size([13, 11])
 
         def make_arrows(color):
-            up = a.icon("chevron-up", size, color)
-            down = a.icon("chevron-down", size, color)
-            left = a.icon("chevron-left", size, color)
-            right = a.icon("chevron-right", size, color)
+            up = a.icon("caret-up-fill", size, color)
+            down = a.icon("caret-down-fill", size, color)
+            left = a.icon("caret-left-fill", size, color)
+            right = a.icon("caret-right-fill", size, color)
             return up, down, left, right
 
         return make_arrows(arrowcolor), make_arrows(disabledcolor), make_arrows(activecolor)
@@ -1095,16 +1096,20 @@ class StyleBuilderTTK:
         downarrow_disabled_image = arrow_images[1][1]
         downarrow_focus_image = arrow_images[2][1]
 
+        # right padding so the carets aren't flush against the border
+        arrow_pad = (0, 0, self.scale_size(6), 0)
         image_element(
             self.style, f"{element}.uparrow", default=uparrow_image,
             states={"disabled": uparrow_disabled_image,
                     "pressed !disabled": uparrow_focus_image,
-                    "hover !disabled": uparrow_focus_image})
+                    "hover !disabled": uparrow_focus_image},
+            padding=arrow_pad)
         image_element(
             self.style, f"{element}.downarrow", default=downarrow_image,
             states={"disabled": downarrow_disabled_image,
                     "pressed !disabled": downarrow_focus_image,
-                    "hover !disabled": downarrow_focus_image})
+                    "hover !disabled": downarrow_focus_image},
+            padding=arrow_pad)
         layout(self.style, ttkstyle,
                El(f"{element}.field", side=tk.TOP, sticky=tk.EW, children=[
                    El("null", side=tk.RIGHT, sticky="", children=[
@@ -1604,9 +1609,10 @@ class StyleBuilderTTK:
         else:
             accent = self.colors.get(colorname)
 
-        # Toggle icons are wider than tall (approx 1.6:1); keep the same
-        # logical size the old hand-drawn assets used so geometry is unchanged.
-        toggle_size = self.scale_size([24, 15])
+        # Toggle glyphs are ~1.6:1 (w:h); match that aspect so the pill fills the
+        # frame without slack. Sized up from the old hand-drawn assets for a more
+        # legible switch.
+        toggle_size = self.scale_size([32, 20])
 
         self.style._build_configure(
             ttkstyle,
@@ -1629,7 +1635,7 @@ class StyleBuilderTTK:
                     "disabled":          {"name": "toggle-off", "color": disabled_fg},
                     "!selected":         {"name": "toggle-off", "color": fg_muted},
                 },
-                width=self.scale_size(28), border=self.scale_size(4), sticky=W)
+                width=self.scale_size(36), border=self.scale_size(4), sticky=W)
         except Exception:
             """This method is used as the default Toggle style, so it is
             necessary to catch Tcl errors when it tries to create an element
@@ -1675,7 +1681,7 @@ class StyleBuilderTTK:
         else:
             accent = self.colors.get(colorname)
 
-        toggle_size = self.scale_size([24, 15])
+        toggle_size = self.scale_size([32, 20])
 
         self.style._build_configure(
             ttkstyle, relief=tk.FLAT, borderwidth=0, foreground=self.colors.fg
@@ -1695,7 +1701,7 @@ class StyleBuilderTTK:
                 "disabled":          {"name": "toggle-off", "color": disabled_fg},
                 "!selected":         {"name": "toggle-off", "color": fg_muted},
             },
-            width=self.scale_size(28), border=self.scale_size(4), sticky=W)
+            width=self.scale_size(36), border=self.scale_size(4), sticky=W)
         layout(self.style, ttkstyle,
             El("Toolbutton.border", sticky=NSEW, children=[
                 El("Toolbutton.padding", sticky=NSEW, children=[
@@ -1995,10 +2001,8 @@ class StyleBuilderTTK:
             btn_foreground = Colors.get_foreground(self.colors, colorname)
 
         # Calendar icon in the button foreground color.
-        # Visual-check item: `calendar-event` vs `calendar` -- settle on the
-        # human spot-check.
         size = self.scale_size([21, 22])
-        img_normal = self.assets.icon("calendar-event", size, btn_foreground)
+        img_normal = self.assets.icon("calendar3", size, btn_foreground)
 
         pressed = Colors.update_hsv(background, vd=-0.1)
         hover = Colors.update_hsv(background, vd=0.10)

--- a/src/ttkbootstrap/style/layout.py
+++ b/src/ttkbootstrap/style/layout.py
@@ -88,13 +88,42 @@ class El:
         return (self.name, options)
 
 
+def register_style(style, ttkstyle):
+    """Register a hand-built ttk style name with the ttkbootstrap engine.
+
+    A custom style applied to a ttkbootstrap widget via `style="My.TButton"` is
+    **silently re-resolved to its base style** unless the engine knows the name --
+    `bootstyle` resolution only honors `style=` for a *registered* style. Building
+    a style with the toolkit (`element_create`/`image_element`/`icon_element`/
+    `map`) does not register it on its own; call this (or `layout()`, which calls
+    it for you) so `style="<ttkstyle>"` resolves to what you built.
+
+    ```python
+    state_map(style, "My.TButton", background={"pressed": "#333"})
+    register_style(style, "My.TButton")   # now style="My.TButton" resolves
+    ```
+
+    Registration is per *active* theme (it mirrors the built-in builders). A
+    hand-built style is not auto-rebuilt on a theme switch, so re-build + re
+    -register it if you change themes -- engine-managed theme-follow for custom
+    styles is a separate effort.
+    """
+    style._register_ttkstyle(ttkstyle)
+
+
 def layout(style, ttkstyle, root):
     """Apply an `El` (or list of `El`s) as the layout for `ttkstyle`.
 
-    Pure structural sugar over `style.layout(ttkstyle, [...])`.
+    Structural sugar over `style.layout(ttkstyle, [...])`. Defining a layout is
+    what gives a style its identity, so this also **registers** `ttkstyle` with
+    the engine (via `register_style`) -- a hand-built style whose terminal step is
+    `layout()` resolves through `style="<ttkstyle>"` with no extra step. (Built-in
+    builders that also call `_register_ttkstyle` explicitly are unaffected --
+    registration is an idempotent set add.)
     """
     roots = [root] if isinstance(root, El) else list(root)
     style.layout(ttkstyle, [element.spec() for element in roots])
+    register_style(style, ttkstyle)
 
 
 def image_element(style, name, *, default, states=None, **options):

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -20,7 +20,8 @@ import pytest
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import PRIMARY
 from ttkbootstrap.style import (
-    Assets, El, layout, image_element, statespec, state_map, StyleName,
+    Assets, El, layout, register_style, image_element, statespec, state_map,
+    StyleName,
 )
 
 
@@ -165,3 +166,40 @@ def test_layout_applies_el_tree(root):
     root.update_idletasks()
     spec = root.style.layout("success.TRadiobutton")
     assert spec  # a non-empty, applied layout
+
+
+# --------------------------------------------------------------------------- #
+# Public style registration (the PR-6a finding: a hand-built style applied via
+# style="..." is silently re-resolved to its base unless registered)
+# --------------------------------------------------------------------------- #
+def test_register_style_marks_style_known(root):
+    style = root.style
+    name = "Custom.TButton"
+    assert not style.style_exists_in_theme(name)
+    register_style(style, name)
+    assert style.style_exists_in_theme(name)
+
+
+def test_layout_auto_registers(root):
+    # layout() is the terminal step of a hand-built style; it should register the
+    # name itself so style="..." resolves with no extra call.
+    style = root.style
+    name = "Auto.TButton"
+    assert not style.style_exists_in_theme(name)
+    layout(style, name, El("Button.padding", sticky="nsew", children=[
+        El("Button.label", sticky="nsew")]))
+    assert style.style_exists_in_theme(name)
+
+
+def test_registered_style_is_honored_via_style_kwarg(root):
+    # The finding end-to-end: BootMixin honors style="X" only for a registered
+    # style, else it re-resolves to the base. A toolkit-built style whose terminal
+    # step is layout() must therefore survive on the widget unchanged.
+    style = root.style
+    name = "Fancy.TButton"
+    layout(style, name, El("Button.padding", sticky="nsew", children=[
+        El("Button.label", sticky="nsew")]))
+    btn = ttk.Button(root, style=name)
+    btn.pack()
+    root.update_idletasks()
+    assert btn.cget("style") == name


### PR DESCRIPTION
Wires the PR-6a icon engine into the widget builders and lands the held toolkit
cleanup. The **bones** of the visible 2.0 refresh; remaining value/asset tweaking
is a deferred follow-up (see end). Per `development/2_0_icons_design.md`.

## What's in it

**Public style-registration path** (fixes the PR-6a review finding — a hand-built
style applied via `style="X"` was silently re-resolved to its base unless
registered with the private `_register_ttkstyle`):
- `register_style(style, ttkstyle)` in `style/layout.py`, and `layout()` now
  auto-registers the style it applies (defining a layout is what gives a style its
  identity — mirrors ttk's own `style.layout`). Re-exported from
  `ttkbootstrap.style` + top-level.

**Part A — glyph builders → icons** (`icon_element` / `Assets.icon`):
check/radio/round-toggle/square-toggle/date/arrows/sizegrip migrated onto the
Bootstrap Icons glyphs per the design's glyph+color tables; the six
`create_*_assets` glyph methods deleted; `ImageFont`/`Transpose` imports removed.
Toggles are one look (`toggle-on`/`toggle-off`; square is a visual alias); radio
on = `record-circle-fill`. Existing state-color math + scaled sizes preserved.

**Part B — geometric/layout cleanup**: separator, progressbar (+stripes),
scrollbars, combobox, floodgauge, spinbox, treeview, calendar layouts re-applied
onto `rect`/`rounded_rect`/`image`/`image_element`/`layout`/`El`/`state_map`.

**Spot-check tuning** (two human light↔dark passes): toggle sized to its true
~1.6:1 aspect and scaled up; date button → `calendar3`; combobox/spinbox arrows →
solid `caret-*-fill` + right `-padding`; **menubutton** (solid + outline) native
clam triangle → `caret-down-fill` image indicator; **datepicker header** `◀/▶`
text → `caret-left/right-fill` images.

## Gates
- `python -m pytest -q` → **92 passed** (headless), warning-free import, font not
  loaded at import, standalone-import cycle guard + PEP 649 annotation sweep clean.
- Reviewed diff (Opus); built hybrid with a Sonnet agent doing the mechanical
  migration against the locked design.

## Deferred to a follow-up PR (not a gate here)
Visual polish only — menubutton caret size/right-padding, datepicker arrow size,
sizegrip glyph (`grip-horizontal`), LIGHT-on-light readability. Tracked in
`development/2_0_handoff.md` → "FOLLOW-UP (deferred to a separate PR)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)