### PR TITLE
Normalize scaling and asset geometry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,10 @@ Read these, in order, before any 2.0 work:
    - `development/2_0_recolor_assets_design.md` — **recolorable raster widget
      assets** (merged in #1081).
    - `development/2_0_builder_split_design.md` — modular `StyleBuilderTTK`
-     recipe registry (approved, implemented, visually approved, and open as
-     draft PR #1082).
+     recipe registry (approved, implemented, visually approved, and merged as
+     #1082).
+   - `development/2_0_scaling_design.md` — scaling and asset-geometry
+     normalization (approved, implemented, and visually approved).
 
 ### Where things stand (snapshot — confirm against the handoff, it's authoritative)
 
@@ -52,28 +54,33 @@ Integration branch is **`2.0`** (cut all 2.0 PRs against it, NOT `master`).
 Merged into `2.0`: engine repaint + content-addressed image cache (PRs 1–2),
 mixin API replacing the import-time monkey-patch (PR 3), the `style/` package
 split (PR 4), the public asset/layout toolkit (PR 5), the icon engine (PR 6a),
-the glyph-builder migration (PR 6b), and recolorable raster widget assets
-(#1081). Draft PR **#1082** modularizes `StyleBuilderTTK`; its expected suite is
-**147 passed**, all structural/headless gates pass apart from the documented
-local Tcl catalog defect, and its human light↔dark smoke gate passed. After
-#1082, design scaling/asset-geometry normalization first, then a focused
+the glyph-builder migration (PR 6b), recolorable raster widget assets (#1081),
+and the `StyleBuilderTTK` modularization (#1082). The expected suite on `2.0` is
+**147 passed**. Scaling and asset-geometry normalization is implemented on
+`refactor/2.0-scaling`; its 177-test expected suite and structural gates pass
+apart from the documented local Tcl catalog defect. Its human
+100/125/150/200% light↔dark gate passed. After the scaling PR, take a focused
 Workstream E slice for private color ramps plus the minimal builder helpers
 (`active`, `pressed`, `border`, `disabled`, `on_color`). Canonical bootstyle
 grammar (D) remains later and needs its own design pass.
 
-## Current task this handoff: modularize `StyleBuilderTTK`
+## Current task this handoff: prepare the scaling PR
 
-Branch: **`refactor/2.0-builder-modules`**, cut from `2.0` after the recolorable
-raster-assets PR merged as **#1081**; draft PR **#1082** targets `2.0`. The
-2,689-line
-`style/builders_ttk.py` recipe monolith is now a 161-line coordinator plus a
-private frozen decorator registry and 22 widget-family modules.
+Branch: **`refactor/2.0-scaling`**, cut from `2.0` after the builder
+modularization merged as **#1082**. The approved design and implementation are
+in **`development/2_0_scaling_design.md`** and the current working tree. One
+root-bound service now owns logical-to-physical conversion; toolkit assets and
+icons accept logical sizes; manifest v2 separates source pixels from approved
+logical geometry; final image frames are not even-snapped; builder geometry is
+scaled once and guarded structurally.
 
-The approved design and exact verification results are in
-**`development/2_0_builder_split_design.md`**. Headless, structural, and human
-light↔dark smoke gates pass. Preserve the existing
-bootstyle grammar, generated style names, lazy per-theme behavior, and visuals.
-Current action: review and merge #1082.
+Automated result: **176 passed / 1 environment failure** on Python 3.12 because
+this Tcl install cannot read `tk8.6/msgs/nl.msg`; excluding localization gives
+**171 passed**. Warning-free import, 36 fresh-process style imports, Python 3.10
+grammar for 88 files, and 226 forced annotation targets pass. The human
+light↔dark gate passed at 100%, 125%, 150%, and 200%. The branch is ready for
+intentional commit/PR preparation. Color ramps and builder state-color helpers
+remain out of scope.
 
 ## How to work here
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Workstream E slice for private color ramps plus the minimal builder helpers
 (`active`, `pressed`, `border`, `disabled`, `on_color`). Canonical bootstyle
 grammar (D) remains later and needs its own design pass.
 
-## Current task this handoff: prepare the scaling PR
+## Current task this handoff: review and merge scaling PR #1083
 
 Branch: **`refactor/2.0-scaling`**, cut from `2.0` after the builder
 modularization merged as **#1082**. The approved design and implementation are
@@ -79,8 +79,8 @@ this Tcl install cannot read `tk8.6/msgs/nl.msg`; excluding localization gives
 **171 passed**. Warning-free import, 36 fresh-process style imports, Python 3.10
 grammar for 88 files, and 226 forced annotation targets pass. The human
 light↔dark gate passed at 100%, 125%, 150%, and 200%. The branch is ready for
-intentional commit/PR preparation. Color ramps and builder state-color helpers
-remain out of scope.
+review as draft PR **#1083** against `2.0`. Color ramps and builder state-color
+helpers remain out of scope.
 
 ## How to work here
 

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -4,8 +4,8 @@
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
 _Last updated: 2026-06-29 (scaling and asset-geometry normalization approved,
-implemented, and visually approved on `refactor/2.0-scaling`; ready for
-intentional commit/PR preparation.)_
+implemented, and visually approved on `refactor/2.0-scaling`; open as draft PR
+#1083 against `2.0`.)_
 
 ## Where we are
 
@@ -35,9 +35,10 @@ implementation summary immediately below.
 **PR #1082 is MERGED.** `2.0` now includes the 161-line coordinator, frozen
 registry, and 22 widget-family modules. Merge commit: `fa1cede8`.
 
-**Current actionable → prepare the scaling branch commit/PR.** Branch:
-`refactor/2.0-scaling`, cut from `2.0` at `fa1cede8`. Approved design:
-`development/2_0_scaling_design.md`. Automated and human gates pass.
+**Current actionable → review and merge draft PR #1083.** Branch:
+`refactor/2.0-scaling`, cut from `2.0` at `fa1cede8`; implementation commit
+`b491a0be`. Approved design: `development/2_0_scaling_design.md`. Automated and
+human gates pass.
 
 **Next after scaling:** design a focused Workstream E slice: cheap private ramps
 plus only the builder helpers ttkbootstrap needs (`active`, `pressed`,
@@ -46,7 +47,7 @@ plus only the builder helpers ttkbootstrap needs (`active`, `pressed`,
 unless a simple concrete need emerges. Canonical bootstyle grammar (D) follows
 later with its own design pass.
 
-## Scaling and asset geometry — IMPLEMENTED, VISUALLY APPROVED
+## Scaling and asset geometry — DRAFT PR #1083, VISUALLY APPROVED
 
 Approved decisions: public size-bearing `Assets`/Icon APIs take logical UI
 units; `IconRenderer.render()` remains a physical-pixel leaf; final

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,18 +3,18 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-06-29 (`StyleBuilderTTK` modularization implemented and
-visually approved on `refactor/2.0-builder-modules`; all gates pass and the
-branch is open as draft PR #1082 against `2.0`.)_
+_Last updated: 2026-06-29 (scaling and asset-geometry normalization approved,
+implemented, and visually approved on `refactor/2.0-scaling`; ready for
+intentional commit/PR preparation.)_
 
 ## Where we are
 
 Integration branch: **`2.0`** (cut all 2.0 PRs against it, not `master`).
-Expected suite on `2.0`: **104 passed**, headless, order-independent.
-Expected suite after this branch: **147 passed**.
-On this machine Python 3.12 reports **102 passed / 2 unrelated failures** because
-its Tcl install cannot read `tk8.6/msgs/nl.msg` and `tk8.6/msgs/fr.msg`;
-excluding that environment-specific localization module gives **98 passed**.
+Expected suite on `2.0`: **147 passed**, headless, order-independent. Expected
+after the scaling branch: **177 passed**. On this machine Python 3.12 reports
+**176 passed / 1 environment failure** because its Tcl install cannot read
+`tk8.6/msgs/nl.msg`; excluding the six-test localization module gives **171
+passed**.
 
 The engine keystone (Workstream A) is **complete and merged**: PR 1 (repaint,
 #1073) + PR 2 (content-addressed image cache, #1074). **PR 3 — the mixin API
@@ -28,24 +28,58 @@ the style-construction toolkit (Workstream I, Tier 1)** is **merged** (#1077; se
 the geometric/layout cleanup landed, and the public registration path is in. That
 completes the Workstream I icon work for 2.0.
 
-**The recolorable raster-assets PR is MERGED (#1081).** The expected suite is
-now 104 tests and the light↔dark manual gate passed. See the implementation
-summary immediately below.
+**The recolorable raster-assets PR is MERGED (#1081).** At that merge the
+expected suite was 104 tests, and the light↔dark manual gate passed. See the
+implementation summary immediately below.
 
-**Current actionable → review and merge builder-modularization draft PR #1082.**
-The branch is `refactor/2.0-builder-modules`, based on merge commit `080e3d19`. The approved
-design and exact verification results are in
-`development/2_0_builder_split_design.md`.
+**PR #1082 is MERGED.** `2.0` now includes the 161-line coordinator, frozen
+registry, and 22 widget-family modules. Merge commit: `fa1cede8`.
 
-**Next after #1082:** first write and discuss a scaling/asset-geometry design.
-It must unify logical UI units, physical pixels, source-image pixels, rounding,
-and even-snap behavior; restore intended element dimensions (especially the
-scale thumb); and specify 100/125/150/200% tests before implementation. Then
-design a focused Workstream E slice: cheap private ramps plus only the builder
-helpers ttkbootstrap needs (`active`, `pressed`, `border`, `disabled`, and
+**Current actionable → prepare the scaling branch commit/PR.** Branch:
+`refactor/2.0-scaling`, cut from `2.0` at `fa1cede8`. Approved design:
+`development/2_0_scaling_design.md`. Automated and human gates pass.
+
+**Next after scaling:** design a focused Workstream E slice: cheap private ramps
+plus only the builder helpers ttkbootstrap needs (`active`, `pressed`,
+`border`, `disabled`, and
 `on_color`). Keep those helpers on `StyleBuilderTTK`; defer a public palette API
 unless a simple concrete need emerges. Canonical bootstyle grammar (D) follows
 later with its own design pass.
+
+## Scaling and asset geometry — IMPLEMENTED, VISUALLY APPROVED
+
+Approved decisions: public size-bearing `Assets`/Icon APIs take logical UI
+units; `IconRenderer.render()` remains a physical-pixel leaf; final
+layout-facing images keep exact dimensions with no even snap; #1081 geometry is
+locked at checkbox/radio 18×18, switches 38×18, scale thumb 22×22 and track
+12×6, progressbar thickness 8/4/12, and scrollbar thumb 18×8 at 100%.
+
+- New private `style/scaling.py`: one service attached to the Tk root; 96-DPI
+  Windows/X11 and 72-DPI Aqua baselines; nominal quarter-step normalization;
+  round-half-away conversion; direct source-pixel conversion; no global state.
+- `Style`, both builders, public `utility.scale_size`, `Assets`, icons, and
+  recolored rasters share that service. `Window(scaling=...)` remains applied
+  before `Style` and the first lazy build. Windows stays system-DPI-aware;
+  per-monitor-v2/live rebuilds remain out of scope.
+- Size-bearing toolkit inputs are logical. Builders no longer pre-scale asset
+  inputs. `icon_element` also scales numeric border/padding/width/height once.
+  Exact odd image frames are preserved; the icon renderer owns its physical
+  frame normalization.
+- Element manifest v2 records `source_size` separately from approved logical
+  `size`, `border`, and `padding`. Rotations transform logical metadata with the
+  pixels. Cache keys remain based on final physical dimensions and colors.
+- Tk-facing builder padding, borders, focus/insert widths, sash and arrow
+  geometry, progress/floodgauge thickness, Treeview geometry, and legacy-tk
+  widths now scale once. AST guards reject new unscaled numeric builder geometry
+  and pre-scaled logical toolkit inputs.
+- Verification: focused scaling/toolkit/icon/recolor suite **68 passed**;
+  expected full suite **177 tests**; local full result **176 passed / 1 known Tcl
+  `nl.msg` environment failure**; excluding localization **171 passed**.
+  Warning-free import; 36 fresh-process style imports; Python 3.10 parsed 88
+  source/test files; 226 annotation targets force-evaluated. Preview constructs
+  successfully in separate processes at all four factors.
+- Human gate passed (user, 2026-06-29): both preview tabs and flatly↔darkly
+  switching approved at 100%, 125%, 150%, and 200%.
 
 **Recolorable raster widget assets — MERGED #1081, VISUALLY APPROVED.** Source
 branch: `feat/2.0-recolor-elements`. Locked design:
@@ -83,7 +117,7 @@ scrollbar/progressbar now use bootstack-derived templates from
   approved after indicator spacing, progressbar stretch/surface, and scrollbar
   thumb-only/native-trough corrections.
 
-## Builder modularization — IMPLEMENTED, VISUALLY APPROVED
+## Builder modularization — MERGED #1082, VISUALLY APPROVED
 
 Goal: replace the 2,600+ line `style/builders_ttk.py` recipe monolith with a
 private, decorator-backed registry and one module per widget family, following
@@ -109,7 +143,8 @@ Locked scope from the 2026-06-28 discussion:
 
 Implementation summary:
 
-- Draft PR: **#1082**, targeting `2.0`; commit `96bcab40`.
+- Merged PR: **#1082**, targeting `2.0`; merge commit `fa1cede8`
+  (implementation commit `96bcab40`, handoff commit `f8c20dd8`).
 - Approved design: `development/2_0_builder_split_design.md`.
 - `StyleBuilderTTK`: 2,689-line monolith → 161-line per-theme coordinator.
 - Private frozen registry: 36 exact `(variant, widget-family)` keys; explicit

--- a/development/2_0_icons_design.md
+++ b/development/2_0_icons_design.md
@@ -1,5 +1,10 @@
 # ttkbootstrap 2.0 — Icon-Rendered Assets Design (Workstream I, Tier 1.5)
 
+> **Scaling update (2026-06-29):**
+> `development/2_0_scaling_design.md` supersedes this document's historical
+> caller-scaled/even-snap rules. Public icon APIs accept logical UI units;
+> `IconRenderer.render()` remains an exact physical-pixel raster leaf.
+
 > Design pass (2026-06-27). Pairs with `development/2_0_plan.md` (Workstream I),
 > `development/2_0_toolkit_design.md` (PR 5 toolkit this builds on),
 > `development/2_0_engine_design.md` (PR 2 `_get_or_create_image` chokepoint),

--- a/development/2_0_recolor_assets_design.md
+++ b/development/2_0_recolor_assets_design.md
@@ -1,5 +1,10 @@
 # 2.0 — Recolorable raster widget assets (design brief)
 
+> **Scaling update (2026-06-29):**
+> `development/2_0_scaling_design.md` supersedes source-density-derived widget
+> geometry. Manifest v2 records source pixels and approved logical geometry
+> separately and does not even-snap final image frames.
+
 > **Status: IMPLEMENTED + VISUALLY APPROVED (2026-06-28).** The staged
 > `assets/elements/` templates are the source set; the decisions at the end of
 > this document are implemented on `feat/2.0-recolor-elements`.

--- a/development/2_0_scaling_design.md
+++ b/development/2_0_scaling_design.md
@@ -1,0 +1,441 @@
+# ttkbootstrap 2.0 — Scaling and asset-geometry normalization
+
+**Status:** implemented and visually approved on 2026-06-29
+**Branch:** `refactor/2.0-scaling`, from `2.0` at `fa1cede8`
+**Date:** 2026-06-29
+
+## Decision summary
+
+Replace the current scaling formulas with one root-bound service. Every
+measurement has an explicit unit and crosses a unit boundary once:
+
+1. Builder and public size inputs are **logical UI units** at baseline density.
+2. Tk-facing geometry and final image dimensions are **physical pixels**.
+3. Raster-template dimensions are **source-image pixels** and never imply UI
+   size by themselves.
+
+Logical units convert to physical pixels with round-half-up. Manifest assets
+carry an explicit logical target size instead of deriving widget geometry from
+source density. Final image dimensions are not forced even: pixel-grid snapping
+is a rendering concern and must not enlarge ttk layout geometry.
+
+The scale thumb changed from 14 logical pixels immediately before #1081 to
+22px at 100%. Visual review confirmed that 22px is the correct logical baseline;
+the smaller 14px thumb is not being restored. For the other manifest-backed
+widgets, the recommended baseline is the geometry shipped in and visually
+approved with #1081. Historical procedural dimensions remain audit evidence,
+not an implicit reason to revert approved raster geometry.
+
+## Scope and invariants
+
+In scope:
+
+- platform baselines and root DPI-factor detection;
+- `utility.scale_size()` and `StyleBuilderTTK.scale_size()`;
+- one service used by builders, `Assets`, icons, and recolored rasters;
+- procedural asset dimensions, radii, strokes, and render-grid alignment;
+- manifest source size, logical size, border, and padding semantics;
+- Window DPI initialization order;
+- hard-coded geometry in ttk and legacy-tk style builders;
+- automated and human checks at 100%, 125%, 150%, and 200%.
+
+Out of scope:
+
+- color ramps and builder state-color helpers;
+- bootstyle grammar changes;
+- live per-monitor rescaling after a window moves between displays;
+- a new public DPI-management API;
+- font-system redesign, window-geometry semantics, or application widget
+  padding outside the style builders;
+- color, state, element-name, layout, or generated-style-name changes.
+
+Implementation must preserve public names and call signatures, generated ttk
+style names, lazy per-theme construction, cache purity, and warning-free
+imports. Visual changes are limited to geometry corrections approved from this
+design.
+
+## Current-state findings
+
+### Independent and inconsistent formulas
+
+- `utility.scale_size(widget, size)` divides Tk scaling by a fixed non-macOS
+  baseline and truncates with `int`.
+- `StyleBuilderTTK.scale_size(size)` selects an Aqua/non-Aqua baseline and
+  uses `ceil`.
+- `Assets.recolor()` repeats baseline selection, divides by manifest
+  `default_dpi`, rounds half up, and then forces width and height even.
+
+The same logical value can therefore round down, round up, or round up again to
+an even number depending on its consumer.
+
+### Procedural assets and icons
+
+`Assets.circle`, `rounded_rect`, `image`, and `icon` currently require
+already-scaled final pixels, then force each dimension to the next even integer.
+`rect` does not. Public `Icon()` does not scale its default or user size,
+while internal builders pre-scale before `Assets.icon`. This contract makes
+missed and double scaling easy.
+
+### Recolored rasters
+
+The manifest records source width/height and a global 2x density. The renderer
+infers logical size from source pixels. That relationship must be explicit,
+not assumed. For the slider, visual review confirmed that the 44px source is
+a 2x source for a 22px logical thumb.
+
+Border and padding are also recorded as source pixels and rounded separately.
+Image dimensions are even-snapped while metadata is not, so they do not share
+one geometry policy.
+
+### Window initialization
+
+`Window` enables Windows DPI awareness before constructing `Tk`, applies an
+explicit `scaling=` value after root creation, and constructs `Style` last.
+That order is correct. The missing part is one root-bound object reused by all
+later scaling consumers.
+
+### Bootstack lessons
+
+Useful mechanisms to port:
+
+- 96-DPI Windows/Linux and 72-DPI macOS baselines;
+- separate UI and source-image scale concepts;
+- logical and source-measurement helpers;
+- DPI-scaled icons;
+- adaptive supersampling, render-origin alignment, LANCZOS, and sharpening.
+
+Do not port bootstack's process-global `_ScalingState`. ttkbootstrap is tied to
+one Tk root, so scale belongs to that root/interpreter. Bootstack also mixes
+truncation, round, early source rounding, and layout-affecting even snaps; those
+parts should be normalized rather than copied.
+
+## Unit model
+
+### Logical UI units (`lu`)
+
+Theme-authored dimensions at baseline density: padding, borders, indicators,
+progressbar thickness, icon frames, radii, and ttk layout spacing. At 100%,
+`1 lu = 1 px`. Logical units are not Tk points; font point sizes remain under
+Tk's font scaling.
+
+### Physical pixels (`px`)
+
+Integer dimensions passed to Pillow, `PhotoImage`, ttk image elements, canvas
+coordinates, and pixel-valued style options. A value already in physical pixels
+must never pass through `scale_size` again.
+
+Font metrics such as `linespace` are already physical. Screen coordinates and
+the current public `Window(size=...)` contract are also physical/window-manager
+coordinates and remain unchanged.
+
+### Source-image pixels (`spx`)
+
+Coordinates in a vendored PNG. They validate and address the bitmap but do not
+define widget size. A manifest gives each asset a separate logical target size.
+Any retained source border measurement must be labeled and converted without an
+intermediate 1x rounding.
+
+## Root-bound scaling service
+
+Add a private leaf module, proposed as `style/scaling.py`, with no engine
+import. `Style` creates or reuses the service after `ttk.Style.__init__`
+establishes `master` and before the first theme builder runs.
+
+Conceptual interface:
+
+```python
+class Scaling:
+    root
+    windowing_system
+    baseline
+    tk_scaling
+    factor
+
+    def logical(self, value): ...
+    def source(self, value, *, source_scale): ...
+    def image_size(self, logical_size): ...
+    def render_origin(self, value, *, oversample): ...
+```
+
+The exact class name stays private. One instance is attached to the root so
+`Style`, both style builders, `Assets`, icons, recoloring, and the public
+utility observe the same scale. There is no global mutable scale.
+
+`StyleBuilderTTK.scale_size()` remains as a convenience delegate.
+`utility.scale_size(widget, size)` keeps its public two-argument signature and
+delegates through the widget's root. Existing result shapes remain: scalar to
+integer and tuple/list to list.
+
+`Assets(style)` takes the service from `style`; it never redetects a
+baseline. Cache keys continue to contain final physical dimensions, so equal
+pixels deduplicate across themes.
+
+The service reads current Tk scaling when converting rather than keeping an
+independent value. `Window(scaling=...)` still sets Tk before `Style` exists.
+Changing Tk scaling after styles are built remains unsupported because existing
+ttk styles are not rebuilt; document that callers must set it before style
+construction rather than adding live DPI rebuilding here.
+
+## Baselines, detection, and rounding
+
+### Baselines
+
+- `win32` and `x11`: 96 DPI / 72 points = `4/3` pixels per point.
+- `aqua`: 72 DPI / 72 points = `1.0`; Retina backing scale is not multiplied
+  into Tk layout geometry.
+
+Select by Tk's windowing system, not Python's OS name.
+
+### Detection and initialization
+
+1. On Windows, keep the pre-root best-effort system-DPI-awareness behavior.
+   Prefer `SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE)` when available,
+   then fall back to `SetProcessDPIAware`, without raising if awareness was
+   already fixed by the host process. Do not opt into per-monitor-v2 behavior
+   in this workstream because live per-monitor rescaling is explicitly out of
+   scope.
+2. After root creation, `tk scaling` is authoritative. If unavailable, use
+   `winfo_fpixels(1i) / 72`.
+3. Explicit `Window(scaling=x)` remains a Tk pixels-per-point override and is
+   applied before the service binds.
+4. Linux and macOS retain the value configured by Tk/environment. Do not replace
+   it with a device-global Windows percentage.
+
+This avoids bootstack's process-global `GetScaleFactorForDevice(0)` assumption.
+Live per-monitor changes remain out of scope.
+
+### Factor normalization
+
+Tk often reports nominal values with small error, such as `1.333989...`
+instead of `4/3`. Compute `raw = tk_scaling / baseline`; if it is within
+`0.005` of a quarter-step, normalize to that step. Otherwise retain the raw
+factor. This makes 100/125/150/200% deterministic without rejecting custom
+factors.
+
+### Rounding
+
+Positive logical geometry uses round-half-up at the final boundary:
+
+```text
+px = max(minimum, floor(lu * factor + 0.5))
+```
+
+Do not use banker rounding, truncation, or unconditional `ceil`. Zero stays
+zero. Positive border/padding components can request a one-pixel minimum.
+Negative values, where allowed, round symmetrically away from zero at the half.
+
+Source conversion retains fractional precision until its final boundary:
+
+```text
+px = floor((spx / source_scale) * factor + 0.5)
+```
+
+Never round `spx / source_scale` first.
+
+## Rendering and even snapping
+
+**Proposed decision: even snapping must not affect layout geometry.** A requested
+15px image remains 15px, not 16px. `PhotoImage` dimensions determine ttk
+requested geometry and direct-widget image geometry, so changing the final
+canvas is not a rendering-only detail.
+
+Remove the current odd-to-next-even output rule from procedural assets, icons,
+and recolored rasters. Keep:
+
+- adaptive supersampling;
+- draw-origin alignment to final-pixel boundaries in the oversampled canvas;
+- parity-aware centering inside the exact final frame;
+- LANCZOS downscale and existing tuned sharpening.
+
+Internal canvas coordinates may snap; final physical width/height may be odd.
+Cache keys use the exact final dimensions. Tests explicitly prove odd intended
+dimensions remain odd.
+
+The coordinate contract is explicit: logical frame geometry converts to final
+physical pixels first; an oversampled canvas then multiplies those dimensions
+by the oversample factor. A final-pixel edge at coordinate `p` is therefore
+`p * oversample` in draw-callback space. A helper that receives an already
+oversampled coordinate may round it to the nearest multiple of `oversample`.
+It must not round or enlarge the final image frame. This avoids the ambiguous
+phrase `snap the origin`, which otherwise permits opposite implementations.
+
+## Asset-geometry audit and approval table
+
+These are frame/layout dimensions at nominal 100%, not necessarily visible ink:
+
+| Asset | Immediately before #1081 | Current result | Finding / proposal |
+|---|---:|---:|---|
+| Checkbox | 20×20 | 18×18 | **Recommend 18×18**: retain the #1081 raster frame that passed visual review. |
+| Radio | 20×20 | 18×18 | **Recommend 18×18**: retain the #1081 annulus that passed visual review. |
+| Round/square switch | 32×20 image, 36 element width | 38×18 | **Recommend 38×18**: retain the approved raster frame; the old separate element width is not part of the new asset contract. |
+| Scale thumb | 14×14 | 22×22 | Visual review approved **22×22** as the correct baseline. |
+| Scale track | 40×5 | 12×6 inferred frame | Visual review approved **6 logical pixels** of cross-axis thickness; 12px is the repeat-tile length. |
+| Standard progressbar | 10 thickness | 8 thickness | **Recommend 8**: retain the #1081 raster thickness that passed the corrected stretch/surface review. |
+| Thin progressbar | did not exist | 4 thickness | New approved style; retain 4 unless review says otherwise. |
+| Striped progressbar | 12 thickness | 12, then fractional-scale even snap | Baseline preserved; remove output even snap. |
+| Scrollbar thumb | 28×9 | 18×8 | **Recommend 18×8**: #1081 intentionally changed to an arrowless thumb/native-trough contract and passed visual review; the old arrow-bearing geometry is not its baseline. |
+
+This recommendation treats #1081's human light↔dark gate as approval of the
+nominal geometry actually shown, including the follow-up progressbar and
+scrollbar corrections. A new side-by-side gate is warranted only if that prior
+approval did not cover size, or if the four-scale review exposes a concrete
+alignment or hit-area problem. It is safer than silently restoring unrelated
+dimensions from the superseded icon/procedural layouts.
+
+The recolor design said scaled sizes would be preserved, but the manifest
+inferred them from source pixels. Use a versioned manifest with separate units:
+
+```json
+{
+  file: slider-handle.png,
+  source_size: [44, 44],
+  size: [22, 22],
+  border: 0,
+  padding: 0
+}
+```
+
+`source_size` is `spx` and validates the file. `size`, `border`, and
+`padding` are `lu`. Source scale may remain as provenance but no longer
+determines widget geometry. Transforms rotate logical geometry and metadata with
+the pixels.
+
+The approved scale baseline is a 22px thumb and 6px track thickness. Historical
+geometry remains useful for regression analysis, but does not override the
+visually approved baseline.
+
+## Assets, icons, and public contracts
+
+To enforce “scale exactly once,” size-bearing toolkit calls should accept
+logical units and let their bound service convert:
+
+- `Assets.circle`, `rect`, `rounded_rect`, `image`, and `icon`;
+- public `Icon` and `icon_element`;
+- `Assets.recolor` through logical manifest metadata.
+
+Names, signatures, return types, and cache behavior do not change. This corrects
+the unit semantics of APIs introduced on the unreleased 2.0 branch. Internal
+builders stop pre-scaling before these calls. Documentation says to pass logical
+sizes directly and use `utility.scale_size` only when an external Tk/Pillow API
+needs physical pixels.
+
+`IconRenderer.render()` remains the low-level raster leaf and continues to take
+an exact physical-pixel frame. Public `Icon()` and `Assets.icon()` perform the
+single logical-to-physical conversion before calling it. Keeping this boundary
+physical prevents the renderer from depending on a Tk root and preserves its
+standalone import/test role.
+
+For `icon_element()`, numeric `border`, `padding`, `width`, and `height` options
+are logical units and cross the same boundary once. The lower-level generic
+`image_element()` continues to accept final Tk geometry because manifest-backed
+callers pass its already-scaled metadata directly.
+
+Procedural radius, width, and similar geometry are logical too. Custom
+`Assets.image` callbacks still draw on their supplied supersampled physical
+canvas; that boundary is explicitly rendering-space.
+
+The alternative is to preserve the current “already physical” toolkit size
+contract and pre-scale at every caller. It is source compatible but cannot
+prevent missed/double scaling. The logical-input contract is recommended and
+requires explicit approval because it corrects current 2.0 documentation.
+
+## Builder geometry audit
+
+Classify each measurement:
+
+- **Scale once:** ttk padding, arrow padding/size, sash thickness, progressbar
+  and floodgauge thickness, row padding, element dimensions, border/focus width,
+  insertion-cursor width, and logical spacers.
+- **Already physical:** font metrics and metadata returned by the service.
+- **Tk-scaled elsewhere:** font point sizes.
+- **Rendering space:** Pillow draw-callback coordinates.
+- **Not measurements:** zero, `sticky`, `expand`, `side`, and booleans.
+
+Current literals include `(10, 5)`, `(6, 5)`, `5`, and `(2, 2)`
+paddings; 1/2px border and focus widths; 50px floodgauge thickness; Treeview
+padding; toolbutton arrow geometry; and legacy-tk highlight/insert widths.
+Convert them from logical units through the coordinator/service. Keep named
+constants near recipes when a number carries widget-specific intent.
+
+Add a structural test that flags new numeric geometry options in builders unless
+they pass through scaling, are zero, come from font metrics/manifest metadata,
+or carry an explicit physical-pixel annotation.
+
+## Required test matrix
+
+| Nominal scale | Factor | 22 lu | 20 lu | 6 lu | 1 lu |
+|---:|---:|---:|---:|---:|---:|
+| 100% | 1.00 | 22 | 20 | 6 | 1 |
+| 125% | 1.25 | 28 | 25 | 8 | 1 |
+| 150% | 1.50 | 33 | 30 | 9 | 2 |
+| 200% | 2.00 | 44 | 40 | 12 | 2 |
+
+Automated tests:
+
+1. Aqua/non-Aqua baseline selection and floating-noise normalization.
+2. Scalar/tuple/list conversion, result shape, zero/minimum behavior, and
+   half-up boundaries at all four factors.
+3. Source conversion without intermediate rounding.
+4. Procedural rect, anti-aliased shape, and custom-image dimensions; odd
+   results remain odd.
+5. Icon frame dimensions and cache keys at all factors.
+6. Every manifest asset's image dimensions, rotations, border, and padding
+   against the approved logical table.
+7. Recolor cache dedupe and theme-switch no-stale behavior.
+8. Representative builder geometry: button and field padding/border, sash,
+   progressbar/floodgauge thickness, and a legacy-tk width.
+9. `Window(scaling=...)` applies before the first lazy style/asset build; the
+   public utility and builder observe the same service.
+10. Warning-free import, standalone imports, Python 3.10 parse, and Python 3.14
+    annotation force evaluation.
+
+Tests continue to use the shared `root` fixture, restore `tk scaling`, and
+avoid a second Window. Factor-independent arithmetic can use a fake Tk adapter;
+root-bound integration cases use unique assets/style names so lazy state does
+not leak between parameter cases.
+
+Human gate on Windows at 100/125/150/200%, one light and one dark theme:
+
+- scale thumb/track alignment and drag hit area;
+- checkbox, radio, and switches beside normal text;
+- standard/thin/striped progressbars;
+- standard/round scrollbars and minimum thumb length;
+- buttons, entries, combobox/spinbox arrows, Notebook tabs, Treeview rows,
+  panedwindow sash, date icon, and sizegrip;
+- light↔dark switching at each factor with no geometry jump.
+
+Record the approved logical table in tests so replacing a source asset cannot
+silently change widget size.
+
+## Implemented sequence
+
+1. Add the private service and delegate both existing scale helpers.
+2. Bind it in `Style` and preserve Window initialization order.
+3. Normalize `Assets` and icon units; remove final even-size snapping while
+   retaining render-grid alignment.
+4. Version the recolor manifest with explicit source/logical geometry and apply
+   the approved table.
+5. Migrate hard-coded ttk and legacy-tk builder geometry once; add the structural
+   guard.
+6. Run the full headless/structural gates, then the four-scale human gate.
+
+No color-ramp/helper work belongs in this branch.
+
+Automated implementation results: focused scaling/toolkit/icon/recolor suite
+68 passed; expected full suite 177 tests; local Python 3.12 result 176 passed
+with the existing Tcl `nl.msg` environment failure; excluding localization 171
+passed. Warning-free import, 36 fresh-process style imports, Python 3.10 grammar
+for 88 source/test files, and 226 forced annotation targets pass. Human
+light↔dark inspection passed at 100%, 125%, 150%, and 200% on 2026-06-29.
+
+## Approved decisions
+
+Approved by the user on 2026-06-29:
+
+1. Size-bearing 2.0 `Assets`/Icon APIs accept logical UI units;
+   `IconRenderer.render()` remains a physical-pixel leaf.
+2. Layout-facing images keep their exact final dimensions. Rendering uses the
+   explicit oversampled grid alignment above, with no final even-size snap.
+3. The logical baseline table is locked: checkbox/radio 18×18, switches 38×18,
+   scale thumb 22×22 and track tile 12×6, standard/thin/striped progressbar
+   thickness 8/4/12, and scrollbar thumb 18×8 at 100%.

--- a/development/2_0_scaling_design.md
+++ b/development/2_0_scaling_design.md
@@ -2,6 +2,7 @@
 
 **Status:** implemented and visually approved on 2026-06-29
 **Branch:** `refactor/2.0-scaling`, from `2.0` at `fa1cede8`
+**Draft PR:** #1083 against `2.0`
 **Date:** 2026-06-29
 
 ## Decision summary

--- a/development/2_0_toolkit_design.md
+++ b/development/2_0_toolkit_design.md
@@ -1,5 +1,10 @@
 # ttkbootstrap 2.0 — Style-Construction Toolkit Design (Workstream I, Tier 1)
 
+> **Scaling update (2026-06-29):**
+> `development/2_0_scaling_design.md` supersedes this document's historical
+> final-pixel input and even-size-snap rules. Size-bearing `Assets` APIs now
+> accept logical UI units and preserve exact scaled output dimensions.
+
 > Output of the Workstream I design pass (2026-06-25). Pairs with
 > `development/2_0_plan.md` (durable worklist, Workstream I at lines ~246–284),
 > `development/2_0_handoff.md` (session state), and the engine design

--- a/examples/recolor_assets_preview.py
+++ b/examples/recolor_assets_preview.py
@@ -1,23 +1,37 @@
-"""Visual gate for the 2.0 recolorable ttk element assets.
+"""Visual gate for 2.0 scaling and recolorable ttk element assets.
 
-Run with `python examples/recolor_assets_preview.py`, then switch between the
-light and dark themes and inspect normal, selected, disabled, and oriented
-variants of every migrated widget family.
+Run once per nominal scale, then switch between the light and dark themes:
+
+`python examples/recolor_assets_preview.py --scale 1.25`
+
+Supported factors are 1.0, 1.25, 1.5, and 2.0. Inspect normal, selected,
+disabled, and oriented raster variants on the Assets tab and representative
+Tk-facing builder geometry on the Geometry tab.
 """
+import argparse
+import platform
 import tkinter as tk
 
 import ttkbootstrap as ttk
 
 
 class Preview:
-    def __init__(self, app):
+    def __init__(self, app, factor):
         self.app = app
+        self.factor = factor
         self.style = app.style
         self.variables = []
         self.body = ttk.Frame(app, padding=16)
         self.body.pack(fill="both", expand=True)
         self._build_header()
-        self._build_widgets()
+        tabs = ttk.Notebook(self.body)
+        tabs.pack(fill="both", expand=True)
+        assets = ttk.Frame(tabs, padding=8)
+        geometry = ttk.Frame(tabs, padding=8)
+        tabs.add(assets, text="Assets")
+        tabs.add(geometry, text="Geometry")
+        self._build_widgets(assets)
+        self._build_geometry(geometry)
 
     def _build_header(self):
         header = ttk.Frame(self.body)
@@ -29,9 +43,9 @@ class Preview:
         self.switch.pack(side="right")
         self._refresh_header()
 
-    def _build_widgets(self):
+    def _build_widgets(self, parent):
         indicators = ttk.Labelframe(
-            self.body, text="Indicators", padding=12)
+            parent, text="Indicators", padding=12)
         indicators.pack(fill="x", pady=6)
         for column, color in enumerate(("primary", "success", "warning", "light")):
             group = ttk.Frame(indicators)
@@ -61,7 +75,7 @@ class Preview:
             disabled.state(["disabled", "selected"])
 
         motion = ttk.Labelframe(
-            self.body, text="Scale / scrollbar", padding=12)
+            parent, text="Scale / scrollbar", padding=12)
         motion.pack(fill="both", expand=True, pady=6)
         ttk.Scale(motion, from_=0, to=100, value=55,
                   bootstyle="primary").pack(fill="x", pady=8)
@@ -86,10 +100,48 @@ class Preview:
                 progress, value=65, bootstyle=style_name).pack(
                     fill="x", pady=(2, 10))
 
+    def _build_geometry(self, parent):
+        buttons = ttk.Labelframe(parent, text="Buttons and fields", padding=12)
+        buttons.pack(fill="x", pady=6)
+        ttk.Button(buttons, text="Primary", bootstyle="primary").grid(
+            row=0, column=0, padx=6, pady=6)
+        ttk.Button(buttons, text="Outline", bootstyle="success-outline").grid(
+            row=0, column=1, padx=6, pady=6)
+        ttk.DateEntry(buttons, bootstyle="primary").grid(
+            row=0, column=2, padx=6, pady=6)
+        ttk.Entry(buttons).grid(row=1, column=0, padx=6, pady=6, sticky="ew")
+        ttk.Combobox(buttons, values=("Combobox", "Second value")).grid(
+            row=1, column=1, padx=6, pady=6, sticky="ew")
+        ttk.Spinbox(buttons, from_=0, to=10).grid(
+            row=1, column=2, padx=6, pady=6, sticky="ew")
+        for column in range(3):
+            buttons.columnconfigure(column, weight=1)
+
+        panes = ttk.Panedwindow(parent, orient="horizontal")
+        panes.pack(fill="x", pady=8)
+        left = ttk.Frame(panes, padding=12, bootstyle="light")
+        right = ttk.Frame(panes, padding=12, bootstyle="secondary")
+        ttk.Label(left, text="Panedwindow left").pack()
+        ttk.Label(right, text="Panedwindow right", bootstyle="inverse").pack()
+        panes.add(left, weight=1)
+        panes.add(right, weight=1)
+
+        tree = ttk.Treeview(
+            parent, columns=("value",), show="tree headings", height=5)
+        tree.heading("#0", text="Treeview")
+        tree.heading("value", text="Value")
+        tree.column("#0", width=180)
+        tree.column("value", width=180)
+        for index in range(4):
+            tree.insert("", "end", text=f"Row {index + 1}", values=(index * 25,))
+        tree.pack(fill="both", expand=True, pady=8)
+        ttk.Sizegrip(parent).pack(anchor="se")
+
     def _refresh_header(self):
         current = self.style.theme.name
         other = "darkly" if current == "flatly" else "flatly"
-        self.title.configure(text=f"Recolorable element assets — {current}")
+        percent = round(self.factor * 100)
+        self.title.configure(text=f"Scaling preview — {percent}% — {current}")
         self.switch.configure(text=f"Switch to {other}")
 
     def _toggle_theme(self):
@@ -99,8 +151,13 @@ class Preview:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--scale", type=float, choices=(1.0, 1.25, 1.5, 2.0), default=1.0)
+    args = parser.parse_args()
+    baseline = 1.0 if platform.system() == "Darwin" else 4 / 3
     app = ttk.Window(
-        title="ttkbootstrap 2.0 — recolorable assets",
-        themename="flatly", size=(820, 720))
-    Preview(app)
+        title="ttkbootstrap 2.0 — scaling preview",
+        themename="flatly", size=(900, 760), scaling=baseline * args.scale)
+    Preview(app, args.scale)
     app.mainloop()

--- a/src/ttkbootstrap/assets/elements/README.md
+++ b/src/ttkbootstrap/assets/elements/README.md
@@ -8,6 +8,7 @@ structural channels, magenta is an optional third fill channel, and alpha stays
 transparent. Magenta is currently used only for the slider handle center; it is
 not a focus channel. There is no cyan/teal channel.
 
-`manifest.json` records source dimensions, source DPI, and ttk image-element
-border/padding metadata. Horizontal sources may be flipped or quarter-turned at
-render time; transformed pixels and metadata always use the same transform.
+`manifest.json` records source-pixel dimensions separately from logical UI
+size and logical ttk border/padding metadata. Horizontal sources may be flipped
+or quarter-turned at render time; transformed pixels and metadata always use the
+same transform.

--- a/src/ttkbootstrap/assets/elements/manifest.json
+++ b/src/ttkbootstrap/assets/elements/manifest.json
@@ -1,17 +1,17 @@
 {
-  "version": 1,
-  "default_dpi": 2.0,
+  "version": 2,
+  "default_source_scale": 2.0,
   "images": {
-    "checkbox_checked": {"file": "checkbox-checked.png", "width": 36, "height": 36, "border": 0, "padding": 0},
-    "checkbox_unchecked": {"file": "checkbox-unchecked.png", "width": 36, "height": 36, "border": 0, "padding": 0},
-    "checkbox_indeterminate": {"file": "checkbox-indeterminate.png", "width": 36, "height": 36, "border": 0, "padding": 0},
-    "radiobutton": {"file": "radio.png", "width": 36, "height": 36, "border": 0, "padding": 0},
-    "switch_round": {"file": "switch-round.png", "width": 76, "height": 36, "border": 0, "padding": 0},
-    "switch_square": {"file": "switch-square.png", "width": 76, "height": 36, "border": 0, "padding": 0},
-    "slider_handle": {"file": "slider-handle.png", "width": 44, "height": 44, "border": 0, "padding": 0},
-    "slider_track": {"file": "slider-track.png", "width": 24, "height": 12, "border": [4, 0], "padding": 0},
-    "progressbar_default": {"file": "progressbar-default.png", "width": 32, "height": 16, "border": [8, 0], "padding": 0},
-    "progressbar_thin": {"file": "progressbar-thin.png", "width": 16, "height": 8, "border": [4, 0], "padding": 0},
-    "scrollbar_thumb": {"file": "scrollbar-thumb.png", "width": 36, "height": 16, "border": [8, 0], "padding": 0}
+    "checkbox_checked": {"file": "checkbox-checked.png", "source_size": [36, 36], "size": [18, 18], "border": 0, "padding": 0},
+    "checkbox_unchecked": {"file": "checkbox-unchecked.png", "source_size": [36, 36], "size": [18, 18], "border": 0, "padding": 0},
+    "checkbox_indeterminate": {"file": "checkbox-indeterminate.png", "source_size": [36, 36], "size": [18, 18], "border": 0, "padding": 0},
+    "radiobutton": {"file": "radio.png", "source_size": [36, 36], "size": [18, 18], "border": 0, "padding": 0},
+    "switch_round": {"file": "switch-round.png", "source_size": [76, 36], "size": [38, 18], "border": 0, "padding": 0},
+    "switch_square": {"file": "switch-square.png", "source_size": [76, 36], "size": [38, 18], "border": 0, "padding": 0},
+    "slider_handle": {"file": "slider-handle.png", "source_size": [44, 44], "size": [22, 22], "border": 0, "padding": 0},
+    "slider_track": {"file": "slider-track.png", "source_size": [24, 12], "size": [12, 6], "border": [2, 0], "padding": 0},
+    "progressbar_default": {"file": "progressbar-default.png", "source_size": [32, 16], "size": [16, 8], "border": [4, 0], "padding": 0},
+    "progressbar_thin": {"file": "progressbar-thin.png", "source_size": [16, 8], "size": [8, 4], "border": [2, 0], "padding": 0},
+    "scrollbar_thumb": {"file": "scrollbar-thumb.png", "source_size": [36, 16], "size": [18, 8], "border": [4, 0], "padding": 0}
   }
 }

--- a/src/ttkbootstrap/style/assets.py
+++ b/src/ttkbootstrap/style/assets.py
@@ -7,34 +7,14 @@ render an asset *and* derive its cache key from the same inputs, so a key can
 never drift from the pixels it names -- the purity hazard PR 2's whole audit
 existed to manage.
 
-The renderer ports bootstack's snap-at-the-source pipeline: even-pixel-snap the
-final size, adaptive supersample (3x/2x/1x by size), LANCZOS downscale, then an
-UnsharpMask to restore edge crispness. The result is crisper, DPI-stable assets
--- callers pass only the logical (already DPI-scaled) size; the oversample factor
-and the snap are internal and adaptive.
+The renderer uses adaptive supersampling, LANCZOS downscaling, and sharpening
+while preserving exact root-scaled output dimensions. Callers pass logical UI
+sizes.
 """
 from PIL import Image, ImageDraw, ImageFilter, ImageTk
 from PIL.Image import Resampling
 
 from ttkbootstrap.style.elements import RecolorRenderer, RecolorResult
-
-
-def _wh(size):
-    """Normalize `size` (int -> square, or `(w, h)`) to an int `(w, h)` tuple."""
-    if isinstance(size, (int, float)):
-        return (int(size), int(size))
-    return (int(size[0]), int(size[1]))
-
-
-def _even(n):
-    """Snap a pixel length up to the next even integer.
-
-    bootstack's fractional-DPI fix: an even final size avoids the half-pixel
-    LANCZOS blur seen at 125%/150% scaling. Applied to the anti-aliased recipes
-    only -- `rect` has no edges to blur and keeps its exact size.
-    """
-    return n if n % 2 == 0 else n + 1
-
 
 def _oversample(w, h):
     """Adaptive supersample factor by the larger dimension (bootstack: 3/2/1)."""
@@ -47,9 +27,9 @@ def _oversample(w, h):
 
 
 def _render(size, draw_fn):
-    """Render `draw_fn` onto an oversampled canvas, then snap-downscale + sharpen.
+    """Render `draw_fn` onto an oversampled canvas, then downscale and sharpen.
 
-    `size` is the even-snapped final `(w, h)`. `draw_fn(draw, w, h)` draws onto an
+    `size` is the exact final physical `(w, h)`. `draw_fn(draw, w, h)` draws onto an
     `ImageDraw.Draw` over the oversampled `(w, h)` canvas (final size x the
     adaptive factor), so any coordinates are expressed relative to the canvas it
     is handed. After the LANCZOS downscale an UnsharpMask restores edge
@@ -75,20 +55,20 @@ class Assets:
     manage). Builders reach a shared instance via `self.assets`; public users
     construct `Assets(Style.get_instance())`.
 
-    Sizes are the final widget pixel size (already DPI-scaled by the caller, e.g.
-    via `scale_size`); the anti-aliased recipes even-pixel-snap and supersample
-    internally, so two logical sizes that snap equal share one image. Every
+    Sizes are logical UI units converted once by the root-bound scaling service;
+    final image dimensions are exact and may be odd. Every
     method returns the Tcl image name (the `_get_or_create_image` contract), and
     the resolved colors are *in* the key, so cross-theme-identical assets dedupe.
     """
 
     def __init__(self, style):
         self.style = style
+        self.scaling = style.scaling
 
     def circle(self, fill, size, *, outline=None, width=0):
-        """A filled (optionally outlined) circle. `width` is in final pixels."""
-        size = _wh(size)
-        size = (_even(size[0]), _even(size[1]))
+        """A filled circle; `size` and `width` are logical UI units."""
+        size = self.scaling.image_size(size)
+        width = self.scaling.logical(width, minimum=1 if width > 0 else 0)
         key = ("circle", fill, size, outline, width)
 
         def factory():
@@ -100,9 +80,10 @@ class Assets:
         return self.style._get_or_create_image(key, factory)
 
     def rounded_rect(self, fill, size, radius, *, outline=None, width=0):
-        """A rounded rectangle. `radius` and `width` are in final pixels."""
-        size = _wh(size)
-        size = (_even(size[0]), _even(size[1]))
+        """A rounded rectangle with geometry in logical UI units."""
+        size = self.scaling.image_size(size)
+        radius = self.scaling.logical(radius)
+        width = self.scaling.logical(width, minimum=1 if width > 0 else 0)
         key = ("rounded_rect", fill, size, radius, outline, width)
 
         def factory():
@@ -118,7 +99,7 @@ class Assets:
 
     def rect(self, fill, size):
         """A solid axis-aligned rectangle (no anti-aliasing, no size snap)."""
-        size = _wh(size)
+        size = self.scaling.image_size(size)
         key = ("rect", fill, size)
         return self.style._get_or_create_image(
             key, lambda: ImageTk.PhotoImage(Image.new("RGB", size, fill)))
@@ -126,9 +107,9 @@ class Assets:
     def icon(self, name, size, color):
         """Render a Bootstrap Icons glyph as a cached widget asset.
 
-        `size` is the final (DPI-scaled) pixel size; `color` is a resolved color
+        `size` is the logical UI size; `color` is a resolved color
         string. Returns the Tcl image name (the same contract as the shape
-        recipes). The key is `("icon", name, snapped_size, color)` -- theme
+        recipes). The key is `("icon", name, physical_size, color)` -- theme
         -independent by construction (the resolved color is *in* the key), so two
         themes that resolve a glyph to the same color share one image.
 
@@ -138,8 +119,7 @@ class Assets:
         """
         from ttkbootstrap.style.icons import IconRenderer
 
-        size = _wh(size)
-        size = (_even(size[0]), _even(size[1]))
+        size = self.scaling.image_size(size)
         key = ("icon", name, size, color)
         return self.style._get_or_create_image(
             key, lambda: ImageTk.PhotoImage(IconRenderer.render(name, size, color)))
@@ -153,14 +133,10 @@ class Assets:
         turn; dimensions and border/padding metadata transform with the pixels.
 
         Returns a `RecolorResult` containing the Tcl image name and scaled
-        manifest metadata. The manifest's 2x source dimensions are converted to
-        the current Tk image scale internally, so callers do not pass a size.
+        logical manifest metadata. Source-image dimensions only validate the
+        vendored PNG; callers do not pass a size.
         """
-        winsys = self.style.master.tk.call("tk", "windowingsystem")
-        baseline = 1.000492368291482 if winsys == "aqua" else 1.33398982438864281
-        tk_scaling = float(self.style.master.tk.call("tk", "scaling"))
-        scale = (tk_scaling / baseline) / RecolorRenderer.source_dpi()
-        meta = RecolorRenderer.metadata(name, scale, transform)
+        meta = RecolorRenderer.metadata(name, self.scaling, transform)
         size = (meta.width, meta.height)
         key = ("recolor", name, size, white, black, magenta, transform)
         image = self.style._get_or_create_image(
@@ -175,12 +151,11 @@ class Assets:
 
         `draw_fn(draw, w, h)` draws onto the oversampled `(w, h)` canvas, so the
         old hand-fit canvas constants become `w`-relative expressions. The key is
-        `(draw_fn.__qualname__, snapped_size, *key_parts)` -- list in `key_parts`
+        `(draw_fn.__qualname__, physical_size, *key_parts)` -- list in `key_parts`
         every color/value the draw closes over; they sit *beside* the draw so the
         key cannot silently drift from it, and the `__qualname__` keeps two
         different draws from colliding on equal `key_parts`.
         """
-        size = _wh(size)
-        size = (_even(size[0]), _even(size[1]))
+        size = self.scaling.image_size(size)
         key = (draw_fn.__qualname__, size, *key_parts)
         return self.style._get_or_create_image(key, lambda: _render(size, draw_fn))

--- a/src/ttkbootstrap/style/builders/button.py
+++ b/src/ttkbootstrap/style/builders/button.py
@@ -19,14 +19,14 @@ def build_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "TButton"
+    ttk_class = "TButton"
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         foreground = builder.colors.get_foreground(PRIMARY)
         background = builder.colors.primary
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         foreground = builder.colors.get_foreground(colorname)
         background = builder.colors.get(colorname)
 
@@ -44,9 +44,9 @@ def build_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         darkcolor=background,
         lightcolor=background,
         relief=tk.RAISED,
-        focusthickness=1,
+        focusthickness=builder.scale_size(1),
         focuscolor=foreground,
-        padding=(10, 5),
+        padding=builder.scale_size((10, 5)),
         anchor=tk.CENTER,
     )
     builder.style.map(
@@ -85,15 +85,15 @@ def build_outline_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "Outline.TButton"
+    ttk_class = "Outline.TButton"
 
     disabled_fg = Colors.make_transparent(0.30, builder.colors.fg, builder.colors.bg)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         colorname = PRIMARY
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
 
     foreground = builder.colors.get(colorname)
     background = builder.colors.get_foreground(colorname)
@@ -110,9 +110,9 @@ def build_outline_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         darkcolor=builder.colors.bg,
         lightcolor=builder.colors.bg,
         relief=tk.RAISED,
-        focusthickness=1,
+        focusthickness=builder.scale_size(1),
         focuscolor=foreground,
-        padding=(10, 5),
+        padding=builder.scale_size((10, 5)),
         anchor=tk.CENTER,
     )
     builder.style.map(
@@ -184,14 +184,14 @@ def build_link_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         darkcolor=builder.colors.bg,
         lightcolor=builder.colors.bg,
         relief=tk.RAISED,
-        focusthickness=1,
+        focusthickness=builder.scale_size(1),
         focuscolor=foreground,
         anchor=tk.CENTER,
-        padding=(10, 5),
+        padding=builder.scale_size((10, 5)),
     )
     builder.style.map(
         ttk_style,
-        shiftrelief=[("pressed !disabled", -1)],
+        shiftrelief=[("pressed !disabled", builder.scale_size(-1))],
         foreground=[
             ("disabled", disabled_fg),
             ("pressed !disabled", pressed),
@@ -256,7 +256,7 @@ def build_date_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         btn_foreground = Colors.get_foreground(builder.colors, colorname)
 
     # Calendar icon in the button foreground color.
-    size = builder.scale_size([21, 22])
+    size = [21, 22]
     img_normal = builder.assets.icon("calendar3", size, btn_foreground)
 
     pressed = Colors.update_hsv(background, vd=-0.1)
@@ -272,7 +272,7 @@ def build_date_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         relief=tk.RAISED,
         focusthickness=0,
         focuscolor=foreground,
-        padding=(2, 2),
+        padding=builder.scale_size((2, 2)),
         anchor=tk.CENTER,
         image=img_normal,
     )

--- a/src/ttkbootstrap/style/builders/calendar.py
+++ b/src/ttkbootstrap/style/builders/calendar.py
@@ -22,15 +22,15 @@ def build_calendar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             The color label used to style the widget.
     """
 
-    style_class = "TCalendar"
+    ttk_class = "TCalendar"
 
     if any([colorname == DEFAULT, colorname == ""]):
         prime_color = builder.colors.primary
-        ttk_style = style_class
+        ttk_style = ttk_class
         chevron_style = "Chevron.TButton"
     else:
         prime_color = builder.colors.get(colorname)
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         chevron_style = f"Chevron.{colorname}.TButton"
 
     if builder.is_light_theme:
@@ -48,10 +48,10 @@ def build_calendar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         darkcolor=builder.colors.bg,
         lightcolor=builder.colors.bg,
         relief=tk.RAISED,
-        focusthickness=1,
+        focusthickness=builder.scale_size(1),
         focuscolor=builder.colors.fg,
-        borderwidth=1,
-        padding=(10, 5),
+        borderwidth=builder.scale_size(1),
+        padding=builder.scale_size((10, 5)),
         anchor=tk.CENTER,
     )
     layout(builder.style, ttk_style,

--- a/src/ttkbootstrap/style/builders/checkbutton.py
+++ b/src/ttkbootstrap/style/builders/checkbutton.py
@@ -60,9 +60,7 @@ def build_checkbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 
     spacer_name = f"{sn.ttk_style}.spacer"
 
-    image_element(
-        builder.style, spacer_name,
-        default=indicator_spacer(builder), sticky=EW)
+    image_element(builder.style, spacer_name, default=indicator_spacer(builder), sticky=EW)
 
     layout(builder.style, sn.ttk_style, El("Checkbutton.padding", sticky=NSEW, children=[
         El(f"{sn.ttk_style}.indicator", side=LEFT, sticky=""),

--- a/src/ttkbootstrap/style/builders/combobox.py
+++ b/src/ttkbootstrap/style/builders/combobox.py
@@ -20,7 +20,7 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label to use as the primary widget color.
     """
-    style_class = "TCombobox"
+    ttk_class = "TCombobox"
 
     if builder.is_light_theme:
         disabled_fg = builder.colors.border
@@ -32,11 +32,11 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         readonly = border_color
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         element = f"{ttk_style.replace('TC', 'C')}"
         focus_color = builder.colors.primary
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         element = f"{ttk_style.replace('TC', 'C')}"
         focus_color = builder.colors.get(colorname)
 
@@ -74,7 +74,7 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         background=builder.colors.inputbg,
         insertcolor=builder.colors.inputfg,
         relief=tk.FLAT,
-        padding=5,
+        padding=builder.scale_size(5),
     )
     builder.style.map(
         ttk_style,

--- a/src/ttkbootstrap/style/builders/entry.py
+++ b/src/ttkbootstrap/style/builders/entry.py
@@ -16,7 +16,7 @@ def build_entry_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "TEntry"
+    ttk_class = "TEntry"
 
     # general default colors
     if builder.is_light_theme:
@@ -30,11 +30,11 @@ def build_entry_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 
     if any([colorname == DEFAULT, not colorname]):
         # default style
-        ttk_style = style_class
+        ttk_style = ttk_class
         focus_color = builder.colors.primary
     else:
         # colored style
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         focus_color = builder.colors.get(colorname)
         border_color = focus_color
 
@@ -46,7 +46,7 @@ def build_entry_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         fieldbackground=builder.colors.inputbg,
         foreground=builder.colors.inputfg,
         insertcolor=builder.colors.inputfg,
-        padding=5,
+        padding=builder.scale_size(5),
     )
     builder.style.map(
         ttk_style,

--- a/src/ttkbootstrap/style/builders/floodgauge.py
+++ b/src/ttkbootstrap/style/builders/floodgauge.py
@@ -22,17 +22,17 @@ def build_floodgauge_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    horizontal_style_class = "Horizontal.TFloodgauge"
-    vertical_style_class = "Vertical.TFloodgauge"
+    h_ttk_class = "Horizontal.TFloodgauge"
+    v_ttk_class = "Vertical.TFloodgauge"
     flood_font = "-size 14"
 
     if any([colorname == DEFAULT, colorname == ""]):
-        h_ttk_style = horizontal_style_class
-        v_ttk_style = vertical_style_class
+        h_ttk_style = h_ttk_class
+        v_ttk_style = v_ttk_class
         background = builder.colors.primary
     else:
-        h_ttk_style = f"{colorname}.{horizontal_style_class}"
-        v_ttk_style = f"{colorname}.{vertical_style_class}"
+        h_ttk_style = f"{colorname}.{h_ttk_class}"
+        v_ttk_style = f"{colorname}.{v_ttk_class}"
         background = builder.colors.get(colorname)
 
     if colorname == LIGHT:
@@ -52,8 +52,8 @@ def build_floodgauge_style(builder: StyleBuilderTTK, colorname=DEFAULT):
                El("Floodgauge.label", sticky="")]))
     builder.configure(
         h_ttk_style,
-        thickness=50,
-        borderwidth=1,
+        thickness=builder.scale_size(50),
+        borderwidth=builder.scale_size(1),
         bordercolor=background,
         lightcolor=background,
         pbarrelief=tk.FLAT,
@@ -74,8 +74,8 @@ def build_floodgauge_style(builder: StyleBuilderTTK, colorname=DEFAULT):
                El("Floodgauge.label", sticky="")]))
     builder.configure(
         v_ttk_style,
-        thickness=50,
-        borderwidth=1,
+        thickness=builder.scale_size(50),
+        borderwidth=builder.scale_size(1),
         bordercolor=background,
         lightcolor=background,
         pbarrelief=tk.FLAT,

--- a/src/ttkbootstrap/style/builders/frame.py
+++ b/src/ttkbootstrap/style/builders/frame.py
@@ -16,13 +16,13 @@ def build_frame_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "TFrame"
+    ttk_class = "TFrame"
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         background = builder.colors.bg
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         background = builder.colors.get(colorname)
 
     builder.configure(ttk_style, background=background)

--- a/src/ttkbootstrap/style/builders/label.py
+++ b/src/ttkbootstrap/style/builders/label.py
@@ -18,16 +18,16 @@ def build_meter_subtxt_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "Metersubtxt.TLabel"
+    ttk_class = "Metersubtxt.TLabel"
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         if builder.is_light_theme:
             foreground = builder.colors.secondary
         else:
             foreground = builder.colors.light
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         foreground = builder.colors.get(colorname)
 
     background = builder.colors.bg
@@ -54,7 +54,7 @@ def build_meter_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             The color label used to style the widget.
     """
 
-    style_class = "Meter.TLabel"
+    ttk_class = "Meter.TLabel"
 
     # text color = `foreground`
     # trough color = `space`
@@ -68,11 +68,11 @@ def build_meter_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         trough_color = Colors.update_hsv(builder.colors.selectbg, vd=-0.2)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         background = builder.colors.bg
         textcolor = builder.colors.primary
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         textcolor = builder.colors.get(colorname)
         background = builder.colors.bg
 
@@ -97,14 +97,14 @@ def build_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "TLabel"
+    ttk_class = "TLabel"
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         foreground = builder.colors.fg
         background = builder.colors.bg
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         foreground = builder.colors.get(colorname)
         background = builder.colors.bg
 
@@ -130,14 +130,14 @@ def build_inverse_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "Inverse.TLabel"
+    ttk_class = "Inverse.TLabel"
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         background = builder.colors.fg
         foreground = builder.colors.bg
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         background = builder.colors.get(colorname)
         foreground = builder.colors.get_foreground(colorname)
 

--- a/src/ttkbootstrap/style/builders/labelframe.py
+++ b/src/ttkbootstrap/style/builders/labelframe.py
@@ -18,13 +18,13 @@ def build_labelframe_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "TLabelframe"
+    ttk_class = "TLabelframe"
 
     background = builder.colors.bg
 
     if any([colorname == DEFAULT, colorname == ""]):
         foreground = builder.colors.fg
-        ttk_style = style_class
+        ttk_style = ttk_class
 
         if builder.is_light_theme:
             border_color = builder.colors.border
@@ -34,7 +34,7 @@ def build_labelframe_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     else:
         foreground = builder.colors.get(colorname)
         border_color = foreground
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
 
     # create widget style
     builder.configure(
@@ -45,7 +45,7 @@ def build_labelframe_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     builder.configure(
         ttk_style,
         relief=tk.RAISED,
-        borderwidth=1,
+        borderwidth=builder.scale_size(1),
         bordercolor=border_color,
         lightcolor=background,
         darkcolor=background,

--- a/src/ttkbootstrap/style/builders/menubutton.py
+++ b/src/ttkbootstrap/style/builders/menubutton.py
@@ -21,14 +21,14 @@ def build_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "TMenubutton"
+    ttk_class = "TMenubutton"
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         background = builder.colors.primary
         foreground = builder.colors.get_foreground(PRIMARY)
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
         background = builder.colors.get(colorname)
         foreground = builder.colors.get_foreground(colorname)
 
@@ -47,7 +47,7 @@ def build_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         relief=tk.RAISED,
         focusthickness=0,
         focuscolor=builder.colors.selectfg,
-        padding=(10, 5),
+        padding=builder.scale_size((10, 5)),
     )
     builder.style.map(
         ttk_style,
@@ -118,15 +118,15 @@ def build_outline_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "Outline.TMenubutton"
+    ttk_class = "Outline.TMenubutton"
 
     disabled_fg = Colors.make_transparent(0.30, builder.colors.fg, builder.colors.bg)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = style_class
+        ttk_style = ttk_class
         colorname = PRIMARY
     else:
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
 
     foreground = builder.colors.get(colorname)
     background = builder.colors.get_foreground(colorname)
@@ -145,7 +145,7 @@ def build_outline_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         relief=tk.RAISED,
         focusthickness=0,
         focuscolor=foreground,
-        padding=(10, 5),
+        padding=builder.scale_size((10, 5)),
     )
     builder.style.map(
         ttk_style,

--- a/src/ttkbootstrap/style/builders/notebook.py
+++ b/src/ttkbootstrap/style/builders/notebook.py
@@ -16,7 +16,7 @@ def build_notebook_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    style_class = "TNotebook"
+    ttk_class = "TNotebook"
 
     if builder.is_light_theme:
         border_color = builder.colors.border
@@ -28,11 +28,11 @@ def build_notebook_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     if any([colorname == DEFAULT, colorname == ""]):
         background = builder.colors.inputbg
         select_fg = builder.colors.fg
-        ttk_style = style_class
+        ttk_style = ttk_class
     else:
         select_fg = builder.colors.get_foreground(colorname)
         background = builder.colors.get(colorname)
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = f"{colorname}.{ttk_class}"
 
     ttk_style_tab = f"{ttk_style}.Tab"
 
@@ -43,10 +43,13 @@ def build_notebook_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         bordercolor=border_color,
         lightcolor=builder.colors.bg,
         darkcolor=builder.colors.bg,
-        tabmargins=(0, 1, 1, 0),
+        tabmargins=builder.scale_size((0, 1, 1, 0)),
     )
     builder.configure(
-        ttk_style_tab, focuscolor="", foreground=foreground, padding=(6, 5)
+        ttk_style_tab,
+        focuscolor="",
+        foreground=foreground,
+        padding=builder.scale_size((6, 5)),
     )
     builder.style.map(
         ttk_style_tab,
@@ -62,7 +65,10 @@ def build_notebook_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             ("selected", border_color),
             ("!selected", border_color),
         ],
-        padding=[("selected", (6, 5)), ("!selected", (6, 5))],
+        padding=[
+            ("selected", builder.scale_size((6, 5))),
+            ("!selected", builder.scale_size((6, 5))),
+        ],
         foreground=[("selected", foreground), ("!selected", select_fg)],
     )
 

--- a/src/ttkbootstrap/style/builders/panedwindow.py
+++ b/src/ttkbootstrap/style/builders/panedwindow.py
@@ -16,8 +16,8 @@ def build_panedwindow_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    h_style_class = "Horizontal.TPanedwindow"
-    v_style_class = "Vertical.TPanedwindow"
+    h_ttk_class = "Horizontal.TPanedwindow"
+    v_ttk_class = "Vertical.TPanedwindow"
 
     if builder.is_light_theme:
         default_color = builder.colors.border
@@ -26,12 +26,12 @@ def build_panedwindow_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 
     if any([colorname == DEFAULT, colorname == ""]):
         sash_color = default_color
-        h_ttk_style = h_style_class
-        v_ttk_style = v_style_class
+        h_ttk_style = h_ttk_class
+        v_ttk_style = v_ttk_class
     else:
         sash_color = builder.colors.get(colorname)
-        h_ttk_style = f"{colorname}.{h_style_class}"
-        v_ttk_style = f"{colorname}.{v_style_class}"
+        h_ttk_style = f"{colorname}.{h_ttk_class}"
+        v_ttk_style = f"{colorname}.{v_ttk_class}"
 
     builder.configure(
         "Sash", gripcount=0, sashthickness=builder.scale_size(2)

--- a/src/ttkbootstrap/style/builders/progressbar.py
+++ b/src/ttkbootstrap/style/builders/progressbar.py
@@ -9,7 +9,7 @@ from ttkbootstrap.style.theme import Colors
 from ttkbootstrap.style.builders.registry import register_builder
 
 
-def _create_striped_progressbar_assets(builder, thickness, colorname=DEFAULT):
+def _create_striped_progressbar_assets(builder, colorname=DEFAULT):
     """Create the striped progressbar image and return as a
     `PhotoImage`
 
@@ -54,8 +54,8 @@ def _create_striped_progressbar_assets(builder, thickness, colorname=DEFAULT):
         d.polygon([(0, h), (0, 0.52 * h), (0.52 * w, 0), (w, 0)], fill=bar_color)
         d.polygon([(0.52 * w, h), (w, 0.52 * h), (w, h)], fill=bar_color)
 
-    h_name = a.image((thickness, thickness), draw_h, bar_color, bar_color_light)
-    v_name = a.image((thickness, thickness), draw_v, bar_color, bar_color_light)
+    h_name = a.image((12, 12), draw_h, bar_color, bar_color_light)
+    v_name = a.image((12, 12), draw_v, bar_color, bar_color_light)
     return h_name, v_name
 
 
@@ -70,17 +70,17 @@ def build_striped_progressbar_style(builder: StyleBuilderTTK, colorname=DEFAULT)
         colorname (str):
             The primary widget color label.
     """
-    h_style_class = "Striped.Horizontal.TProgressbar"
-    v_style_class = "Striped.Vertical.TProgressbar"
+    h_ttk_class = "Striped.Horizontal.TProgressbar"
+    v_ttk_class = "Striped.Vertical.TProgressbar"
 
     thickness = builder.scale_size(12)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        h_ttk_style = h_style_class
-        v_ttk_style = v_style_class
+        h_ttk_style = h_ttk_class
+        v_ttk_style = v_ttk_class
     else:
-        h_ttk_style = f"{colorname}.{h_style_class}"
-        v_ttk_style = f"{colorname}.{v_style_class}"
+        h_ttk_style = f"{colorname}.{h_ttk_class}"
+        v_ttk_style = f"{colorname}.{v_ttk_class}"
 
     if builder.is_light_theme:
         if colorname == LIGHT:
@@ -94,7 +94,7 @@ def build_striped_progressbar_style(builder: StyleBuilderTTK, colorname=DEFAULT)
         border_color = trough_color
 
     # ( horizontal, vertical )
-    images = _create_striped_progressbar_assets(builder, thickness, colorname)
+    images = _create_striped_progressbar_assets(builder, colorname)
 
     # horizontal progressbar
     h_element = h_ttk_style.replace(".TP", ".P")
@@ -113,7 +113,7 @@ def build_striped_progressbar_style(builder: StyleBuilderTTK, colorname=DEFAULT)
         troughcolor=trough_color,
         thickness=thickness,
         bordercolor=border_color,
-        borderwidth=1,
+        borderwidth=builder.scale_size(1),
     )
 
     # vertical progressbar
@@ -133,7 +133,7 @@ def build_striped_progressbar_style(builder: StyleBuilderTTK, colorname=DEFAULT)
         troughcolor=trough_color,
         bordercolor=border_color,
         thickness=thickness,
-        borderwidth=1,
+        borderwidth=builder.scale_size(1),
     )
     builder.register_ttkstyle(h_ttk_style)
     builder.register_ttkstyle(v_ttk_style)

--- a/src/ttkbootstrap/style/builders/radiobutton.py
+++ b/src/ttkbootstrap/style/builders/radiobutton.py
@@ -39,12 +39,9 @@ def build_radiobutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 
     a = builder.assets
     selected = a.recolor("radiobutton", white=accent, black=accent)
-    unselected = a.recolor(
-        "radiobutton", white=builder.colors.bg, black=fg_muted)
-    disabled_selected = a.recolor(
-        "radiobutton", white=disabled, black=disabled)
-    disabled_unselected = a.recolor(
-        "radiobutton", white=builder.colors.bg, black=disabled)
+    unselected = a.recolor("radiobutton", white=builder.colors.bg, black=fg_muted)
+    disabled_selected = a.recolor("radiobutton", white=disabled, black=disabled)
+    disabled_unselected = a.recolor("radiobutton", white=builder.colors.bg, black=disabled)
     image_element(
         builder.style, f"{sn.ttk_style}.indicator", default=selected.image,
         states={
@@ -54,9 +51,7 @@ def build_radiobutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         },
         border=selected.meta.border, padding=selected.meta.padding, sticky=W)
     spacer_name = f"{sn.ttk_style}.spacer"
-    image_element(
-        builder.style, spacer_name,
-        default=indicator_spacer(builder), sticky=EW)
+    image_element(builder.style, spacer_name, default=indicator_spacer(builder), sticky=EW)
     layout(
         builder.style, sn.ttk_style,
         El("Radiobutton.padding", sticky=NSEW, children=[
@@ -64,4 +59,5 @@ def build_radiobutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             El(spacer_name, side=LEFT),
             El("Radiobutton.focus", side=LEFT, sticky="", children=[
                 El("Radiobutton.label", sticky=NSEW)])]))
+
     builder.register_ttkstyle(sn.ttk_style)

--- a/src/ttkbootstrap/style/builders/sizegrip.py
+++ b/src/ttkbootstrap/style/builders/sizegrip.py
@@ -33,7 +33,7 @@ def build_sizegrip_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 
     # Visual-check item: `grip-horizontal` vs a corner-grip glyph -- settle
     # on the human spot-check.
-    size = builder.scale_size(16)
+    size = 16
     image = builder.assets.icon("grip-horizontal", size, grip_color)
 
     builder.style.element_create(

--- a/src/ttkbootstrap/style/builders/spinbox.py
+++ b/src/ttkbootstrap/style/builders/spinbox.py
@@ -88,7 +88,7 @@ def build_spinbox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         background=builder.colors.inputbg,
         relief=tk.FLAT,
         insertcolor=builder.colors.inputfg,
-        padding=(10, 5),
+        padding=builder.scale_size((10, 5)),
     )
 
     builder.style.map(

--- a/src/ttkbootstrap/style/builders/toggle.py
+++ b/src/ttkbootstrap/style/builders/toggle.py
@@ -68,16 +68,10 @@ def build_round_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         background=[("selected", builder.colors.bg)],
     )
     a = builder.assets
-    on = a.recolor(
-        "switch_round", white=accent, black=builder.colors.bg)
-    off = a.recolor(
-        "switch_round", white=fg_muted, black=builder.colors.bg,
-        transform="flip-x")
-    disabled_on = a.recolor(
-        "switch_round", white=disabled_fg, black=builder.colors.bg)
-    disabled_off = a.recolor(
-        "switch_round", white=disabled_fg, black=builder.colors.bg,
-        transform="flip-x")
+    on = a.recolor("switch_round", white=accent, black=builder.colors.bg)
+    off = a.recolor("switch_round", white=fg_muted, black=builder.colors.bg, transform="flip-x")
+    disabled_on = a.recolor("switch_round", white=disabled_fg, black=builder.colors.bg)
+    disabled_off = a.recolor("switch_round", white=disabled_fg, black=builder.colors.bg, transform="flip-x")
     spacer_name = f"{ttk_style}.spacer"
     try:
         image_element(
@@ -138,9 +132,7 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     else:
         accent = builder.colors.get(colorname)
 
-    builder.configure(
-        ttk_style, relief=tk.FLAT, borderwidth=0, foreground=builder.colors.fg
-    )
+    builder.configure(ttk_style, relief=tk.FLAT, borderwidth=0, foreground=builder.colors.fg)
     builder.style.map(
         ttk_style,
         foreground=[("disabled", disabled_fg)],
@@ -150,16 +142,10 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         ],
     )
     a = builder.assets
-    on = a.recolor(
-        "switch_square", white=accent, black=builder.colors.bg)
-    off = a.recolor(
-        "switch_square", white=fg_muted, black=builder.colors.bg,
-        transform="flip-x")
-    disabled_on = a.recolor(
-        "switch_square", white=disabled_fg, black=builder.colors.bg)
-    disabled_off = a.recolor(
-        "switch_square", white=disabled_fg, black=builder.colors.bg,
-        transform="flip-x")
+    on = a.recolor("switch_square", white=accent, black=builder.colors.bg)
+    off = a.recolor("switch_square", white=fg_muted, black=builder.colors.bg, transform="flip-x")
+    disabled_on = a.recolor("switch_square", white=disabled_fg, black=builder.colors.bg)
+    disabled_off = a.recolor("switch_square", white=disabled_fg, black=builder.colors.bg, transform="flip-x")
     spacer_name = f"{ttk_style}.spacer"
     image_element(
         builder.style, f"{ttk_style}.indicator", default=on.image,

--- a/src/ttkbootstrap/style/builders/toolbutton.py
+++ b/src/ttkbootstrap/style/builders/toolbutton.py
@@ -47,9 +47,9 @@ def build_toolbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         darkcolor=toggle_off,
         lightcolor=toggle_off,
         relief=tk.RAISED,
-        focusthickness=1,
+        focusthickness=builder.scale_size(1),
         focuscolor=foreground,
-        padding=(10, 5),
+        padding=builder.scale_size((10, 5)),
         anchor=tk.CENTER,
     )
     builder.style.map(
@@ -133,11 +133,11 @@ def build_outline_toolbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         relief=tk.RAISED,
         focusthickness=0,
         focuscolor=foreground,
-        padding=(10, 5),
+        padding=builder.scale_size((10, 5)),
         anchor=tk.CENTER,
         arrowcolor=foreground,
-        arrowpadding=(0, 0, 15, 0),
-        arrowsize=3,
+        arrowpadding=builder.scale_size((0, 0, 15, 0)),
+        arrowsize=builder.scale_size(3),
     )
     builder.style.map(
         ttk_style,

--- a/src/ttkbootstrap/style/builders/treeview.py
+++ b/src/ttkbootstrap/style/builders/treeview.py
@@ -59,11 +59,11 @@ def build_table_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         background=background,
         foreground=foreground,
         relief=RAISED,
-        borderwidth=1,
+        borderwidth=builder.scale_size(1),
         darkcolor=background,
         bordercolor=border_color,
         lightcolor=background,
-        padding=5,
+        padding=builder.scale_size(5),
     )
     builder.style.map(
         header_style,
@@ -86,7 +86,7 @@ def build_table_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         bordercolor=border_color,
         lightcolor=builder.colors.inputbg,
         darkcolor=builder.colors.inputbg,
-        borderwidth=2,
+        borderwidth=builder.scale_size(2),
         padding=0,
         rowheight=row_height,
         relief=tk.RAISED,
@@ -100,7 +100,7 @@ def build_table_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         ],
     )
     layout(builder.style, body_style,
-           El("Button.border", sticky=tk.NSEW, border="1", children=[
+           El("Button.border", sticky=tk.NSEW, border=builder.scale_size(1), children=[
                El("Treeview.padding", sticky=tk.NSEW, children=[
                    El("Treeview.treearea", sticky=tk.NSEW)])]))
 
@@ -158,7 +158,7 @@ def build_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         background=background,
         foreground=foreground,
         relief=tk.FLAT,
-        padding=5,
+        padding=builder.scale_size(5),
     )
     builder.style.map(
         header_style,
@@ -174,7 +174,7 @@ def build_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         bordercolor=border_color,
         lightcolor=builder.colors.inputbg,
         darkcolor=builder.colors.inputbg,
-        borderwidth=2,
+        borderwidth=builder.scale_size(2),
         padding=0,
         rowheight=row_height,
         relief=tk.RAISED,
@@ -196,7 +196,7 @@ def build_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         darkcolor=[("focus", focus_color)],
     )
     layout(builder.style, body_style,
-           El("Button.border", sticky=tk.NSEW, border="1", children=[
+           El("Button.border", sticky=tk.NSEW, border=builder.scale_size(1), children=[
                El("Treeview.padding", sticky=tk.NSEW, children=[
                    El("Treeview.treearea", sticky=tk.NSEW)])]))
 

--- a/src/ttkbootstrap/style/builders/utils.py
+++ b/src/ttkbootstrap/style/builders/utils.py
@@ -2,7 +2,7 @@
 
 def indicator_spacer(builder):
     """Return the shared transparent image used between indicator and label."""
-    size = builder.scale_size((6, 1))
+    size = (6, 1)
 
     def draw_spacer(_draw, _width, _height):
         pass
@@ -30,7 +30,7 @@ def simple_arrow_assets(builder, arrowcolor: str, disabledcolor: str, activecolo
         image names in the order (up, down, left, right).
     """
     a = builder.assets
-    size = builder.scale_size([13, 11])
+    size = [13, 11]
 
     def make_arrows(color):
         up = a.icon("caret-up-fill", size, color)

--- a/src/ttkbootstrap/style/builders_tk.py
+++ b/src/ttkbootstrap/style/builders_tk.py
@@ -179,13 +179,13 @@ class StyleBuilderTK:
 
         widget.configure(
             relief=tk.FLAT,
-            highlightthickness=1,
+            highlightthickness=self.style.scaling.logical(1),
             foreground=self.colors.inputfg,
             highlightbackground=bordercolor,
             highlightcolor=self.colors.primary,
             background=self.colors.inputbg,
             insertbackground=self.colors.inputfg,
-            insertwidth=1,
+            insertwidth=self.style.scaling.logical(1),
         )
 
     def update_scale_style(self, widget: tk.Scale):
@@ -208,7 +208,7 @@ class StyleBuilderTK:
             sliderrelief=tk.FLAT,
             borderwidth=0,
             activebackground=activecolor,
-            highlightthickness=1,
+            highlightthickness=self.style.scaling.logical(1),
             highlightcolor=bordercolor,
             highlightbackground=bordercolor,
             troughcolor=self.colors.inputbg,
@@ -229,14 +229,14 @@ class StyleBuilderTK:
 
         widget.configure(
             relief=tk.FLAT,
-            highlightthickness=1,
+            highlightthickness=self.style.scaling.logical(1),
             foreground=self.colors.inputfg,
             highlightbackground=bordercolor,
             highlightcolor=self.colors.primary,
             background=self.colors.inputbg,
             buttonbackground=self.colors.inputbg,
             insertbackground=self.colors.inputfg,
-            insertwidth=1,
+            insertwidth=self.style.scaling.logical(1),
             # these options should work, but do not have any affect
             buttonuprelief=tk.FLAT,
             buttondownrelief=tk.SUNKEN,
@@ -262,7 +262,7 @@ class StyleBuilderTK:
             selectforeground=self.colors.selectfg,
             highlightcolor=self.colors.primary,
             highlightbackground=bordercolor,
-            highlightthickness=1,
+            highlightthickness=self.style.scaling.logical(1),
             activestyle="none",
             relief=tk.FLAT,
         )
@@ -319,7 +319,7 @@ class StyleBuilderTK:
         widget.configure(
             highlightcolor=bordercolor,
             foreground=self.colors.fg,
-            borderwidth=1,
+            borderwidth=self.style.scaling.logical(1),
             highlightthickness=0,
             background=self.colors.bg,
         )
@@ -350,10 +350,10 @@ class StyleBuilderTK:
             insertbackground=self.colors.inputfg,
             selectbackground=self.colors.selectbg,
             selectforeground=self.colors.selectfg,
-            insertwidth=1,
-            highlightthickness=1,
+            insertwidth=self.style.scaling.logical(1),
+            highlightthickness=self.style.scaling.logical(1),
             relief=tk.FLAT,
-            padx=5,
-            pady=5,
+            padx=self.style.scaling.logical(5),
+            pady=self.style.scaling.logical(5),
             # font="TkDefaultFont",
         )

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -1,6 +1,5 @@
 """Per-theme coordinator for private ttk widget-family style recipes."""
 
-from math import ceil
 from tkinter import ttk
 
 from ttkbootstrap.constants import *
@@ -60,20 +59,8 @@ class StyleBuilderTTK:
         self.style._build_configure(style, **options)
 
     def scale_size(self, size):
-        """Scale an integer or sequence using Tk's active scaling factor."""
-        winsys = self.style.master.tk.call("tk", "windowingsystem")
-        if winsys == "aqua":
-            baseline = 1.000492368291482
-        else:
-            baseline = 1.33398982438864281
-        scaling = self.style.master.tk.call("tk", "scaling")
-        factor = scaling / baseline
-
-        if isinstance(size, (int, float)):
-            return ceil(size * factor)
-        if isinstance(size, (tuple, list)):
-            return [ceil(x * factor) for x in size]
-        return None
+        """Convert logical UI units using the root-bound scaling service."""
+        return self.style.scaling.logical(size)
 
     def build_style(
         self,
@@ -129,7 +116,7 @@ class StyleBuilderTTK:
             selectforeground=self.colors.selectfg,
             selectbackground=self.colors.selectbg,
             fieldbg=self.colors.bg,
-            borderwidth=1,
+            borderwidth=self.scale_size(1),
             focuscolor="",
         )
 
@@ -151,7 +138,7 @@ class StyleBuilderTTK:
             background="#fffddd",
             foreground="#333",
             bordercolor="#888",
-            borderwidth=1,
+            borderwidth=self.scale_size(1),
             darkcolor="#fffddd",
             lightcolor="#fffddd",
             relief=RAISED,

--- a/src/ttkbootstrap/style/elements.py
+++ b/src/ttkbootstrap/style/elements.py
@@ -65,7 +65,7 @@ class RecolorRenderer:
 
     @classmethod
     def source_dpi(cls):
-        return float(cls._load_manifest().get("default_dpi", 2.0))
+        return float(cls._load_manifest().get("default_source_scale", 2.0))
 
     @classmethod
     def _source(cls, name):
@@ -75,8 +75,7 @@ class RecolorRenderer:
             path = _ELEMENTS_DIR / info["file"]
             with Image.open(path) as source:
                 image = source.convert("RGBA")
-            expected = (int(info.get("width", image.width)),
-                        int(info.get("height", image.height)))
+            expected = tuple(info.get("source_size", image.size))
             if image.size != expected:
                 raise ValueError(
                     f"element asset {name!r} is {image.size}, manifest says {expected}"
@@ -113,33 +112,29 @@ class RecolorRenderer:
         return values
 
     @staticmethod
-    def _scale_spec(value, scale):
+    def _scale_spec(value, scaling):
         def scaled(item):
-            return max(1, int(item * scale + 0.5)) if item > 0 else 0
+            return scaling.logical(item, minimum=1) if item > 0 else 0
 
         if isinstance(value, int):
             return scaled(value)
         return tuple(scaled(item) for item in value)
 
     @classmethod
-    def metadata(cls, name, scale, transform=None):
+    def metadata(cls, name, scaling, transform=None):
         cls._validate_transform(transform)
         info = cls.info(name)
-        width, height = int(info["width"]), int(info["height"])
+        width, height = info["size"]
         if transform in ("rotate-90", "rotate-270"):
             width, height = height, width
-
-        def even(value):
-            value = max(1, int(value * scale + 0.5))
-            return value if value % 2 == 0 else value + 1
 
         border = cls._rotate_spec(info.get("border", 0), transform)
         padding = cls._rotate_spec(info.get("padding", 0), transform)
         return ElementMeta(
-            width=even(width),
-            height=even(height),
-            border=cls._scale_spec(border, scale),
-            padding=cls._scale_spec(padding, scale),
+            width=scaling.logical(width, minimum=1),
+            height=scaling.logical(height, minimum=1),
+            border=cls._scale_spec(border, scaling),
+            padding=cls._scale_spec(padding, scaling),
         )
 
     @staticmethod

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -13,6 +13,7 @@ from ttkbootstrap.constants import *
 from ttkbootstrap.themes.standard import STANDARD_THEMES
 
 from ttkbootstrap.style.theme import ThemeDefinition
+from ttkbootstrap.style.scaling import Scaling
 from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
 
 try:
@@ -87,6 +88,7 @@ class Style(ttk.Style):
         self._load_themes()
         self._dynamic_foreground = False
         super().__init__()
+        self.scaling = Scaling.for_widget(self.master)
 
         Style.instance = self
         self.theme_use(theme)

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from PIL import Image, ImageDraw, ImageFilter, ImageFont
 from PIL.Image import Resampling
 
-from ttkbootstrap.style.assets import Assets, _wh
+from ttkbootstrap.style.assets import Assets
 from ttkbootstrap.style.layout import statespec, image_element
 
 
@@ -44,6 +44,13 @@ _ICONS_DIR = Path(__file__).parent.parent / "assets" / "icons"
 # center in a square frame.
 _ICON_Y_BIAS = 0.02
 _ICON_PAD_FACTOR = 0.10
+
+
+def _physical_size(size):
+    """Normalize an exact physical scalar or pair to `(width, height)`."""
+    if isinstance(size, (int, float)):
+        return int(size), int(size)
+    return int(size[0]), int(size[1])
 
 
 def _icon_oversample(w, h):
@@ -135,7 +142,7 @@ class IconRenderer:
         Raises `ValueError` for a name absent from the Bootstrap Icons glyphmap
         (a typo fails loudly rather than rendering a blank image).
         """
-        w, h = _wh(size)
+        w, h = _physical_size(size)
         _, glyphmap = cls._load_assets()
         glyph = glyphmap.get(name)
         if glyph is None:
@@ -236,8 +243,8 @@ def Icon(name, size=16, color=None):
             An unknown name raises `ValueError`.
 
         size (int | tuple[int, int]):
-            The final pixel size (already DPI-scaled by the caller). Snapped to an
-            even size internally.
+            The logical UI size. It is converted once by the root-bound service;
+            final dimensions may be odd.
 
         color (str):
             A bootstyle keyword ("primary", "success", "fg", ...) resolved against
@@ -306,8 +313,9 @@ def icon_element(style, name, *, size, default, states=None, **options):
     ```
 
     `states` is an ordered dict; ttk matches its specs first-match-wins, so the
-    insertion order *is* the match order. `options` (border, sticky, width, ...)
-    pass through to `element_create`.
+    insertion order *is* the match order. Numeric `border`, `padding`, `width`,
+    and `height` options are logical UI units and convert with the image frame;
+    other options pass through to `element_create`.
     """
     if "." not in name:
         raise ValueError(
@@ -315,6 +323,10 @@ def icon_element(style, name, *, size, default, states=None, **options):
             f"looked up on the ttkstyle prefix), got {name!r}")
     ttkstyle = name.rsplit(".", 1)[0]
     assets = Assets(style)
+    for option in ("border", "padding", "width", "height"):
+        value = options.get(option)
+        if isinstance(value, (int, float, tuple, list)):
+            options[option] = assets.scaling.logical(value, minimum=1)
 
     default_name = _spec_name(default)
     if default_name is None:

--- a/src/ttkbootstrap/style/scaling.py
+++ b/src/ttkbootstrap/style/scaling.py
@@ -1,0 +1,106 @@
+"""Private root-bound scaling primitives for ttkbootstrap.
+
+Theme recipes use logical UI units. This service converts them exactly once to
+the physical pixels consumed by Tk and Pillow.
+"""
+from math import ceil, floor
+
+
+_QUARTER_STEP_TOLERANCE = 0.005
+_ROOT_ATTRIBUTE = "_ttkbootstrap_scaling"
+
+
+def _round_half_away(value: float) -> int:
+    """Round halves away from zero without Python's banker rounding."""
+    if value >= 0:
+        return floor(value + 0.5)
+    return ceil(value - 0.5)
+
+
+class Scaling:
+    """Convert logical UI units for one Tk root/interpreter."""
+
+    def __init__(self, root):
+        self.root = root
+
+    @classmethod
+    def for_widget(cls, widget):
+        """Return the service attached to `widget`'s root."""
+        root_getter = getattr(widget, "_root", None)
+        root = root_getter() if callable(root_getter) else widget
+        service = getattr(root, _ROOT_ATTRIBUTE, None)
+        if service is None:
+            service = cls(root)
+            setattr(root, _ROOT_ATTRIBUTE, service)
+        return service
+
+    @property
+    def windowing_system(self) -> str:
+        return str(self.root.tk.call("tk", "windowingsystem"))
+
+    @property
+    def baseline(self) -> float:
+        return 1.0 if self.windowing_system == "aqua" else 4 / 3
+
+    @property
+    def tk_scaling(self) -> float:
+        try:
+            return float(self.root.tk.call("tk", "scaling"))
+        except Exception:
+            return float(self.root.winfo_fpixels("1i")) / 72
+
+    @property
+    def factor(self) -> float:
+        raw = self.tk_scaling / self.baseline
+        quarter = round(raw * 4) / 4
+        if abs(raw - quarter) <= _QUARTER_STEP_TOLERANCE:
+            return quarter
+        return raw
+
+    def logical(self, value, *, minimum: int = 0):
+        """Convert logical UI units to physical pixels.
+
+        Scalars return an integer. Tuple and list inputs retain the historical
+        public `scale_size` result shape and return a list.
+        """
+
+        def convert(item, factor):
+            if item == 0:
+                return 0
+            result = _round_half_away(float(item) * factor)
+            return max(minimum, result) if item > 0 else result
+
+        if isinstance(value, (int, float)):
+            return convert(value, self.factor)
+        if isinstance(value, (tuple, list)):
+            factor = self.factor
+            return [convert(item, factor) for item in value]
+        return None
+
+    def source(self, value, *, source_scale: float, minimum: int = 0):
+        """Convert source-image pixels directly to physical pixels."""
+        if source_scale <= 0:
+            raise ValueError("source_scale must be greater than zero")
+        if isinstance(value, (int, float)):
+            return self.logical(float(value) / source_scale, minimum=minimum)
+        if isinstance(value, (tuple, list)):
+            logical = [float(item) / source_scale for item in value]
+            return self.logical(logical, minimum=minimum)
+        return None
+
+    def image_size(self, size) -> tuple[int, int]:
+        """Convert a logical scalar or pair to physical `(width, height)`."""
+        if isinstance(size, (int, float)):
+            edge = self.logical(size, minimum=1)
+            return edge, edge
+        if isinstance(size, (tuple, list)) and len(size) == 2:
+            width, height = self.logical(size, minimum=1)
+            return width, height
+        raise TypeError(f"size must be a number or two-item sequence, got {size!r}")
+
+    @staticmethod
+    def render_origin(value: float, *, oversample: int) -> int:
+        """Align an oversampled coordinate to the final-pixel grid."""
+        if oversample < 1:
+            raise ValueError("oversample must be at least 1")
+        return _round_half_away(value / oversample) * oversample

--- a/src/ttkbootstrap/utility.py
+++ b/src/ttkbootstrap/utility.py
@@ -87,42 +87,46 @@ def enable_high_dpi_awareness(root=None, scaling=None):
             widgets will resize themselves dynamically to accommodate 
             the new scaling factor.
     """
+    # Keep the existing system-DPI-aware behavior. Per-monitor-v2 awareness
+    # requires live style rebuilding when a window crosses displays, which is
+    # outside ttkbootstrap's current scaling contract.
     try:
         from ctypes import windll
-        windll.user32.SetProcessDPIAware()
-    except:
+        try:
+            windll.shcore.SetProcessDpiAwareness(1)
+        except Exception:
+            windll.user32.SetProcessDPIAware()
+    except Exception:
         pass
 
     try:
-        if root and scaling:
+        if root is not None and scaling is not None:
             root.tk.call('tk', 'scaling', scaling)
-    except:
+    except Exception:
         pass
 
 
 def scale_size(widget, size):
     """Scale the size based on the scaling factor of tkinter. 
     This is used most frequently to adjust the assets for 
-    image-based widget layouts and font sizes.
+    image-based widget layouts and pixel-valued geometry.
+
+    `size` is expressed in logical UI units. Conversion uses the scaling
+    service attached to the widget's root and rounds half away from zero.
 
     Parameters:
 
         widget (Widget):
             The widget object.
 
-        size (Union[int, List, Tuple]):
-            A single integer or an iterable of integers
+        size (int | float | list | tuple):
+            A number or sequence of numbers in logical UI units.
 
     Returns:
 
-        Union[int, List]:
+        int | list:
             An integer or list of integers representing the new size.
     """
-    BASELINE = 1.33398982438864281
-    scaling = widget.tk.call('tk', 'scaling')
-    factor = scaling / BASELINE
+    from ttkbootstrap.style.scaling import Scaling
 
-    if isinstance(size, int):
-        return int(size * factor)
-    elif isinstance(size, tuple) or isinstance(size, list):
-        return [int(x * factor) for x in size]
+    return Scaling.for_widget(widget).logical(size)

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,0 +1,493 @@
+"""Root-bound scaling and asset-geometry regression tests."""
+import ast
+from math import floor
+from pathlib import Path
+
+import pytest
+
+from ttkbootstrap import utility
+from ttkbootstrap.style.assets import Assets
+from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
+from ttkbootstrap.style.elements import RecolorRenderer
+from ttkbootstrap.style.scaling import Scaling
+
+
+class _FakeTk:
+    def __init__(self, windowing_system, scaling):
+        self.windowing_system = windowing_system
+        self.scaling = scaling
+
+    def call(self, *args):
+        if args == ("tk", "windowingsystem"):
+            return self.windowing_system
+        if args == ("tk", "scaling"):
+            return self.scaling
+        raise AssertionError(args)
+
+
+class _FakeRoot:
+    def __init__(self, windowing_system, scaling):
+        self.tk = _FakeTk(windowing_system, scaling)
+
+    def _root(self):
+        return self
+
+    def winfo_fpixels(self, value):
+        assert value == "1i"
+        return self.tk.scaling * 72
+
+
+@pytest.mark.parametrize(
+    ("factor", "expected"),
+    [
+        (1.00, (22, 20, 6, 1)),
+        (1.25, (28, 25, 8, 1)),
+        (1.50, (33, 30, 9, 2)),
+        (2.00, (44, 40, 12, 2)),
+    ],
+)
+def test_logical_matrix_uses_round_half_up(factor, expected):
+    scaling = Scaling(_FakeRoot("win32", (4 / 3) * factor))
+    assert tuple(scaling.logical(value) for value in (22, 20, 6, 1)) == expected
+    assert scaling.logical((22, 6)) == [expected[0], expected[2]]
+
+
+@pytest.mark.parametrize(
+    ("windowing_system", "baseline"),
+    [("win32", 4 / 3), ("x11", 4 / 3), ("aqua", 1.0)],
+)
+def test_platform_baseline_and_nominal_noise(windowing_system, baseline):
+    scaling = Scaling(_FakeRoot(windowing_system, baseline * 1.00049))
+    assert scaling.baseline == baseline
+    assert scaling.factor == 1.0
+
+
+def test_source_conversion_rounds_only_at_final_boundary():
+    scaling = Scaling(_FakeRoot("x11", (4 / 3) * 1.25))
+    assert scaling.source(5, source_scale=2) == 3
+    assert scaling.source((5, 8), source_scale=2) == [3, 5]
+
+
+def test_zero_minimum_negative_and_sequence_contracts():
+    scaling = Scaling(_FakeRoot("x11", 4 / 3))
+    assert scaling.logical(0, minimum=1) == 0
+    assert scaling.logical(0.1, minimum=1) == 1
+    assert scaling.logical(0.5) == 1
+    assert scaling.logical(-0.5) == -1
+    assert scaling.logical((1, 2)) == [1, 2]
+    assert scaling.logical([1, 2]) == [1, 2]
+    assert scaling.logical("1") is None
+
+
+def test_custom_factor_is_not_forced_to_quarter_step():
+    scaling = Scaling(_FakeRoot("x11", (4 / 3) * 1.31))
+    assert scaling.factor == pytest.approx(1.31)
+
+
+def test_tk_scaling_falls_back_to_screen_pixels_per_inch():
+    root = _FakeRoot("x11", 1.75)
+    original_call = root.tk.call
+
+    def call(*args):
+        if args == ("tk", "scaling"):
+            raise RuntimeError("unavailable")
+        return original_call(*args)
+
+    root.tk.call = call
+    assert Scaling(root).tk_scaling == 1.75
+
+
+def test_source_scale_and_render_origin_validation():
+    scaling = Scaling(_FakeRoot("x11", 4 / 3))
+    with pytest.raises(ValueError, match="source_scale"):
+        scaling.source(1, source_scale=0)
+    assert scaling.render_origin(4.5, oversample=3) == 6
+    assert scaling.render_origin(-4.5, oversample=3) == -6
+    with pytest.raises(ValueError, match="oversample"):
+        scaling.render_origin(1, oversample=0)
+
+
+def test_image_size_contract():
+    scaling = Scaling(_FakeRoot("x11", 4 / 3))
+    assert scaling.image_size(15) == (15, 15)
+    assert scaling.image_size((15, 9)) == (15, 9)
+    with pytest.raises(TypeError, match="two-item sequence"):
+        scaling.image_size((1, 2, 3))
+
+
+def test_public_utility_reuses_root_service():
+    root = _FakeRoot("x11", (4 / 3) * 1.5)
+    service = Scaling.for_widget(root)
+    assert Scaling.for_widget(root) is service
+    assert utility.scale_size(root, [22, 6]) == [33, 9]
+
+
+def test_style_builder_utility_and_assets_share_root_service(root):
+    builder = StyleBuilderTTK(build=False)
+    assert builder.style.scaling is Scaling.for_widget(root)
+    assert builder.assets.scaling is builder.style.scaling
+
+
+def test_window_and_style_initialize_scaling_before_style_builds():
+    package = Path(__file__).parents[1] / "src" / "ttkbootstrap"
+    window_source = (package / "window.py").read_text(encoding="utf-8")
+    init_source = window_source[window_source.index("class Window"):]
+    assert init_source.index("utility.enable_high_dpi_awareness()") < init_source.index(
+        "super().__init__(**kwargs)"
+    )
+    assert init_source.index("super().__init__(**kwargs)") < init_source.index(
+        "utility.enable_high_dpi_awareness(self, scaling)"
+    ) < init_source.index("self._style = Style(themename)")
+
+    engine_source = (package / "style" / "engine.py").read_text(encoding="utf-8")
+    style_init = engine_source[engine_source.index("class Style"):]
+    assert style_init.index("super().__init__()") < style_init.index(
+        "self.scaling = Scaling.for_widget(self.master)"
+    ) < style_init.index("self.theme_use(theme)")
+
+
+APPROVED_MANIFEST_GEOMETRY = {
+    "checkbox_checked": ((18, 18), 0, 0),
+    "checkbox_unchecked": ((18, 18), 0, 0),
+    "checkbox_indeterminate": ((18, 18), 0, 0),
+    "radiobutton": ((18, 18), 0, 0),
+    "switch_round": ((38, 18), 0, 0),
+    "switch_square": ((38, 18), 0, 0),
+    "slider_handle": ((22, 22), 0, 0),
+    "slider_track": ((12, 6), (2, 0), 0),
+    "progressbar_default": ((16, 8), (4, 0), 0),
+    "progressbar_thin": ((8, 4), (2, 0), 0),
+    "scrollbar_thumb": ((18, 8), (4, 0), 0),
+}
+
+
+def _scaled(value, factor):
+    def one(item):
+        return floor(item * factor + 0.5) if item > 0 else 0
+
+    if isinstance(value, int):
+        return one(value)
+    return tuple(one(item) for item in value)
+
+
+def test_manifest_records_approved_logical_geometry():
+    assert set(RecolorRenderer._load_manifest()["images"]) == set(
+        APPROVED_MANIFEST_GEOMETRY
+    )
+    for name, (size, border, padding) in APPROVED_MANIFEST_GEOMETRY.items():
+        info = RecolorRenderer.info(name)
+        assert tuple(info["size"]) == size
+        assert tuple(info["source_size"]) == RecolorRenderer._source(name).size
+        actual_border = info["border"]
+        actual_border = (
+            tuple(actual_border)
+            if isinstance(actual_border, list)
+            else actual_border
+        )
+        assert actual_border == border
+        assert info["padding"] == padding
+
+
+@pytest.mark.parametrize("factor", [1.00, 1.25, 1.50, 2.00])
+def test_manifest_geometry_and_image_matrix(root, factor):
+    tk = root.tk
+    before = float(tk.call("tk", "scaling"))
+    try:
+        tk.call("tk", "scaling", root.style.scaling.baseline * factor)
+        assets = Assets(root.style)
+        for name, (logical_size, logical_border, logical_padding) in (
+            APPROVED_MANIFEST_GEOMETRY.items()
+        ):
+            result = assets.recolor(
+                name,
+                white="#ffffff",
+                black="#111111",
+                magenta="#336699",
+            )
+            expected_size = _scaled(logical_size, factor)
+            assert (result.meta.width, result.meta.height) == expected_size
+            assert result.meta.border == _scaled(logical_border, factor)
+            assert result.meta.padding == _scaled(logical_padding, factor)
+            assert int(tk.call("image", "width", result.image)) == expected_size[0]
+            assert int(tk.call("image", "height", result.image)) == expected_size[1]
+
+        rotated = assets.recolor(
+            "slider_track",
+            white="#222222",
+            black="#222222",
+            transform="rotate-90",
+        )
+        assert (rotated.meta.width, rotated.meta.height) == _scaled((6, 12), factor)
+        assert rotated.meta.border == _scaled((0, 2), factor)
+    finally:
+        tk.call("tk", "scaling", before)
+
+
+@pytest.mark.parametrize(
+    ("factor", "expected"),
+    [(1.00, 15), (1.25, 19), (1.50, 23), (2.00, 30)],
+)
+def test_procedural_and_icon_frames_scale_once_and_keep_exact_size(
+    root, factor, expected
+):
+    tk = root.tk
+    before = float(tk.call("tk", "scaling"))
+
+    def empty(_draw, _width, _height):
+        pass
+
+    try:
+        tk.call("tk", "scaling", root.style.scaling.baseline * factor)
+        assets = Assets(root.style)
+        names = (
+            assets.circle("#123456", 15),
+            assets.rect("#234567", 15),
+            assets.image(15, empty, "scaling-matrix"),
+            assets.icon("square", 15, "#345678"),
+        )
+        for name in names:
+            assert int(tk.call("image", "width", name)) == expected
+            assert int(tk.call("image", "height", name)) == expected
+    finally:
+        tk.call("tk", "scaling", before)
+
+
+def test_representative_builder_geometry_scales_once(root):
+    import tkinter as tk
+
+    from ttkbootstrap.style.builders.button import build_button_style
+    from ttkbootstrap.style.builders.entry import build_entry_style
+    from ttkbootstrap.style.builders.floodgauge import build_floodgauge_style
+    from ttkbootstrap.style.builders.panedwindow import build_panedwindow_style
+
+    style = root.style
+    tkapp = root.tk
+    before = float(tkapp.call("tk", "scaling"))
+    builder = StyleBuilderTTK(build=False)
+    recipes = (
+        build_button_style,
+        build_entry_style,
+        build_panedwindow_style,
+        build_floodgauge_style,
+    )
+    try:
+        tkapp.call("tk", "scaling", style.scaling.baseline * 1.5)
+        for recipe in recipes:
+            recipe(builder, "danger")
+
+        assert style.configure("danger.TButton", "padding") == "15 8"
+        assert int(style.configure("danger.TButton", "focusthickness")) == 2
+        assert int(style.configure("danger.TEntry", "padding")) == 8
+        assert int(style.configure("Sash", "sashthickness")) == 3
+        assert int(
+            style.configure("danger.Horizontal.TFloodgauge", "thickness")
+        ) == 75
+
+        text = tk.Text(root)
+        builder.builder_tk.update_text_style(text)
+        assert int(text.cget("insertwidth")) == 2
+        assert int(text.cget("padx")) == 8
+    finally:
+        tkapp.call("tk", "scaling", before)
+        for recipe in recipes[:-1]:
+            recipe(builder, "danger")
+        for ttk_style in (
+            "danger.Horizontal.TFloodgauge",
+            "danger.Vertical.TFloodgauge",
+        ):
+            builder.configure(
+                ttk_style,
+                thickness=builder.scale_size(50),
+                borderwidth=builder.scale_size(1),
+            )
+
+
+GEOMETRY_OPTIONS = {
+    "arrowpadding",
+    "arrowsize",
+    "border",
+    "borderwidth",
+    "focusthickness",
+    "handlepad",
+    "handlesize",
+    "height",
+    "highlightthickness",
+    "insertwidth",
+    "padding",
+    "padx",
+    "pady",
+    "rowheight",
+    "sashpad",
+    "sashthickness",
+    "sashwidth",
+    "shiftrelief",
+    "tabmargins",
+    "thickness",
+    "width",
+}
+ASSET_METHODS = {"circle", "icon", "image", "rect", "rounded_rect"}
+
+
+def _contains_scaling_call(node):
+    return any(
+        isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Attribute)
+        and child.func.attr in {"logical", "scale_size"}
+        for child in ast.walk(node)
+    )
+
+
+def _contains_nonzero_literal(node):
+    if isinstance(node, ast.Subscript):
+        return _contains_nonzero_literal(node.value)
+    if isinstance(node, ast.Constant):
+        return (
+            isinstance(node.value, (int, float))
+            and not isinstance(node.value, bool)
+            and node.value != 0
+        )
+    return any(
+        _contains_nonzero_literal(child)
+        for child in ast.iter_child_nodes(node)
+    )
+
+
+def _builder_paths():
+    root = Path(__file__).parents[1] / "src" / "ttkbootstrap" / "style"
+    return [
+        root / "builders_tk.py",
+        root / "builders_ttk.py",
+        *(root / "builders").glob("*.py"),
+    ]
+
+
+def _function_scopes(tree):
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+
+
+def _assignments(scope):
+    values = {}
+    for node in ast.walk(scope):
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name):
+                values.setdefault(target.id, []).append((node.lineno, node.value))
+    return values
+
+
+def _resolve_name(node, assignments, lineno):
+    if not isinstance(node, ast.Name):
+        return node
+    candidates = [
+        (line, value)
+        for line, value in assignments.get(node.id, [])
+        if line < lineno
+    ]
+    return max(candidates, default=(0, node))[1]
+
+
+def _is_logical_toolkit_call(call):
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr in ASSET_METHODS
+    ) or (
+        isinstance(call.func, ast.Name)
+        and call.func.id == "icon_element"
+    )
+
+
+def test_builder_numeric_geometry_is_scaled_or_already_physical():
+    violations = []
+    for path in _builder_paths():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for scope in _function_scopes(tree):
+            assignments = _assignments(scope)
+            calls = (
+                node for node in ast.walk(scope) if isinstance(node, ast.Call)
+            )
+            for call in calls:
+                if _is_logical_toolkit_call(call):
+                    continue
+                for keyword in call.keywords:
+                    value = _resolve_name(keyword.value, assignments, call.lineno)
+                    if (
+                        keyword.arg in GEOMETRY_OPTIONS
+                        and _contains_nonzero_literal(value)
+                        and not _contains_scaling_call(value)
+                    ):
+                        violations.append(f"{path.name}:{call.lineno}:{keyword.arg}")
+    assert not violations, "unscaled literal builder geometry: " + ", ".join(
+        violations
+    )
+
+
+def test_builder_asset_inputs_are_logical_not_pre_scaled():
+    violations = []
+    logical_positions = {
+        "circle": (1,),
+        "icon": (1,),
+        "image": (0,),
+        "rect": (1,),
+        "rounded_rect": (1, 2),
+    }
+    logical_keywords = {
+        "circle": {"size", "width"},
+        "icon": {"size"},
+        "image": {"size"},
+        "rect": {"size"},
+        "rounded_rect": {"size", "radius", "width"},
+    }
+    for path in _builder_paths():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for scope in _function_scopes(tree):
+            assignments = _assignments(scope)
+            calls = (
+                node for node in ast.walk(scope) if isinstance(node, ast.Call)
+            )
+            for call in calls:
+                if isinstance(call.func, ast.Name) and call.func.id == "icon_element":
+                    logical_values = [
+                        keyword.value
+                        for keyword in call.keywords
+                        if keyword.arg in {"size", "border", "padding", "width", "height"}
+                    ]
+                    for value in logical_values:
+                        value = _resolve_name(value, assignments, call.lineno)
+                        if _contains_scaling_call(value):
+                            violations.append(
+                                f"{path.name}:{call.lineno}:icon_element"
+                            )
+                    continue
+                if (
+                    not isinstance(call.func, ast.Attribute)
+                    or call.func.attr not in ASSET_METHODS
+                ):
+                    continue
+                values = [
+                    call.args[index]
+                    for index in logical_positions[call.func.attr]
+                    if len(call.args) > index
+                ]
+                values.extend(
+                    keyword.value
+                    for keyword in call.keywords
+                    if keyword.arg in logical_keywords[call.func.attr]
+                )
+                for value in values:
+                    value = _resolve_name(value, assignments, call.lineno)
+                    if _contains_scaling_call(value):
+                        violations.append(
+                            f"{path.name}:{call.lineno}:{call.func.attr}"
+                        )
+    assert not violations, "pre-scaled toolkit asset size: " + ", ".join(
+        violations
+    )

--- a/tests/test_style_package.py
+++ b/tests/test_style_package.py
@@ -31,6 +31,7 @@ PUBLIC_NAMES = [
 
 SUBMODULES = [
     "ttkbootstrap.style.theme",
+    "ttkbootstrap.style.scaling",
     "ttkbootstrap.style.builders_tk",
     "ttkbootstrap.style.builders_ttk",
     "ttkbootstrap.style.engine",

--- a/tests/test_toolkit.py
+++ b/tests/test_toolkit.py
@@ -4,9 +4,8 @@ Covers the public helpers in `ttkbootstrap.style.assets` / `.layout`:
 
 - the shape recipes derive a complete, color-bearing cache key (so identical
   inputs dedupe and a single differing color is a different image);
-- the even-pixel snap (an odd logical size and the next even one resolve to the
-  same image, and the rendered image is even-sized) -- bootstack's fractional-DPI
-  fix; `rect` is exempt and keeps its exact size;
+- exact layout-facing dimensions: odd logical sizes remain odd and receive
+  distinct cache entries;
 - the `image` escape hatch keys on its declared `*key_parts`;
 - `El` lowers to ttk's nested `(name, opts)` tuple form;
 - `statespec` validates the state grammar (and raises on a typo);
@@ -113,13 +112,13 @@ def test_circle_outline_and_width_in_key(root):
     assert plain != outlined
 
 
-def test_even_size_snap(root):
+def test_odd_size_stays_exact(root):
     a = Assets(root.style)
     odd = a.circle("#123456", 15)
     even = a.circle("#123456", 16)
-    assert odd == even       # 15 snaps up to 16 -> same image/key
+    assert odd != even
     img = _cached_image(root.style, odd)
-    assert (img.width(), img.height()) == (16, 16)  # rendered size is even
+    assert (img.width(), img.height()) == (15, 15)
 
 
 def test_rect_keeps_exact_size(root):

--- a/tests/widget_styles/test_icons.py
+++ b/tests/widget_styles/test_icons.py
@@ -3,7 +3,7 @@
 Covers the glyph renderer and its public surface in `ttkbootstrap.style.icons`:
 
 - `IconRenderer.render` rasterizes a known glyph to a non-empty RGBA of the
-  requested (even-snapped) size, and centers a metrics-present glyph in its frame;
+  requested exact size, and centers a metrics-present glyph in its frame;
 - an unknown glyph name fails loudly (a typo is not a blank image);
 - `Assets.icon` / `Icon` derive a complete, color-bearing cache key, so identical
   `(name, size, color)` dedupe to one Tcl image and a single differing color is a
@@ -33,7 +33,7 @@ def _cached_image(style, name):
 # --------------------------------------------------------------------------- #
 # Renderer (pure -- no Tk root)
 # --------------------------------------------------------------------------- #
-def test_render_known_glyph_is_nonempty_rgba_of_even_size():
+def test_render_known_glyph_is_nonempty_rgba_of_requested_size():
     img = IconRenderer.render("check-square-fill", (20, 20), "#3498db")
     assert img.mode == "RGBA"
     assert img.size == (20, 20)
@@ -100,13 +100,44 @@ def test_icon_key_completeness(root):
     assert n1 != n3          # one differing color -> different key -> different name
 
 
-def test_icon_even_snaps_size(root):
+def test_icon_odd_size_stays_exact(root):
     a = Assets(root.style)
     odd = a.icon("square", 15, "#000000")
     even = a.icon("square", 16, "#000000")
-    assert odd == even       # 15 snaps up to 16 -> same image/key
+    assert odd != even
     img = _cached_image(root.style, odd)
-    assert (img.width(), img.height()) == (16, 16)
+    assert (img.width(), img.height()) == (15, 15)
+
+
+def test_icon_element_scales_geometry_options_once(root, monkeypatch):
+    import ttkbootstrap.style.icons as icons
+
+    captured = {}
+
+    def capture(_style, _name, **options):
+        captured.update(options)
+
+    monkeypatch.setattr(icons, "image_element", capture)
+    tk = root.tk
+    before = float(tk.call("tk", "scaling"))
+    try:
+        tk.call("tk", "scaling", root.style.scaling.baseline * 1.5)
+        icons.icon_element(
+            root.style,
+            "Scaling.TWidget.icon",
+            size=15,
+            default={"name": "square", "color": "#123456"},
+            border=1,
+            padding=(0, 2),
+            width=20,
+        )
+        image = _cached_image(root.style, captured["default"])
+        assert (image.width(), image.height()) == (23, 23)
+        assert captured["border"] == 2
+        assert captured["padding"] == [0, 3]
+        assert captured["width"] == 30
+    finally:
+        tk.call("tk", "scaling", before)
 
 
 def test_icon_atom_resolves_color_keyword(root):

--- a/tests/widget_styles/test_recolor_assets.py
+++ b/tests/widget_styles/test_recolor_assets.py
@@ -28,7 +28,7 @@ def test_magenta_is_an_optional_fill_channel():
     assert image.getpixel((21, 10)) == (0x12, 0x34, 0x56, 255)
 
 
-def test_flip_and_rotation_transform_pixels_and_metadata():
+def test_flip_and_rotation_transform_pixels_and_metadata(root):
     normal = RecolorRenderer.render(
         "switch_round", (76, 36), white="#ff0000", black="#00ff00")
     flipped = RecolorRenderer.render(
@@ -37,9 +37,9 @@ def test_flip_and_rotation_transform_pixels_and_metadata():
     assert normal.getpixel((19, 18)) == flipped.getpixel((56, 18))
     assert normal.getpixel((57, 18)) == flipped.getpixel((18, 18))
 
-    horizontal = RecolorRenderer.metadata("progressbar_default", 0.5)
+    horizontal = RecolorRenderer.metadata("progressbar_default", root.style.scaling)
     vertical = RecolorRenderer.metadata(
-        "progressbar_default", 0.5, "rotate-90")
+        "progressbar_default", root.style.scaling, "rotate-90")
     assert (horizontal.width, horizontal.height, horizontal.border) == (16, 8, (4, 0))
     assert (vertical.width, vertical.height, vertical.border) == (8, 16, (0, 4))
 


### PR DESCRIPTION
## Summary

- add one root-bound scaling service with explicit logical UI, physical-pixel, and source-image unit boundaries
- normalize platform baselines, quarter-step detection, and round-half-away conversion
- make size-bearing Assets and Icon APIs accept logical units and preserve exact final dimensions without even snapping
- version the recolorable-element manifest so source dimensions and approved logical geometry are independent
- scale ttk and legacy-tk builder geometry exactly once, with structural regression guards
- add the 100/125/150/200% test matrix and an interactive two-tab scaling preview
- update the 2.0 design and cross-machine handoff documentation

## Why

Scaling was split across three inconsistent formulas: truncation in the public utility, ceiling in the ttk builder, and source-density inference plus even snapping in recolored assets. The same logical value could therefore produce different physical geometry depending on its consumer, and source PNG dimensions could silently change widget layout.

This consolidates conversion behind the Tk root and makes each unit boundary explicit. It preserves bootstyle grammar, generated style names, lazy construction, cache purity, and the visually approved #1081 baseline geometry.

## Impact

This corrects the unreleased 2.0 toolkit size contract: public size-bearing asset/icon inputs are logical UI units. Low-level IconRenderer.render remains a physical-pixel leaf. Layout-facing images retain exact scaled dimensions, including odd sizes.

## Validation

- focused scaling/toolkit/icon/recolor suite: 68 passed
- full local suite: 176 passed, with one existing environment failure because this Tcl installation cannot read tk8.6/msgs/nl.msg
- suite excluding localization: 171 passed
- warning-free import
- 36 fresh-process style imports
- Python 3.10 grammar parse: 88 source/test files
- forced annotation evaluation: 226 targets
- human flatly/darkly visual gate passed at 100%, 125%, 150%, and 200%