### PR TITLE
Private color ramps and StyleBuilderTTK color helpers

### DIFF
--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -5,9 +5,11 @@
 
 _Last updated: 2026-07-01 (focused Workstream E private ramps and builder
 color helpers implemented on `refactor/2.0-color-helpers`; `on_color` retuned to
-a white-preferred, saturation-aware policy after visual feedback; automated
-gates pass. Theme appearance approved; a quick re-confirm of the retuned vivid
-accents remains before merge.)_
+a white-preferred, saturation-aware policy after visual feedback. pytest
+installed and the suite ACTUALLY RUN this session — 188 passed / 1 known Tcl
+`nl.msg` env failure; two stale `test_color_helpers` assertions corrected (see
+below). Six-theme human visual gate PASSED. Branch is merge-ready — open the PR
+against `2.0`.)_
 
 ## Where we are
 
@@ -39,14 +41,26 @@ registry, and 22 widget-family modules. Merge commit: `fa1cede8`.
 **PR #1083 is MERGED.** Scaling and asset-geometry normalization landed on
 `2.0` as merge commit `c1f9ed73`; its automated and four-scale human gates pass.
 
-**Current actionable → run the color-helper human visual gate.** Branch:
+**Current actionable → open the color-helper PR against `2.0`.** Branch:
 `refactor/2.0-color-helpers`, cut from `2.0` at `c1f9ed73`. Approved design:
-`development/2_0_color_helpers_design.md`. Run
-`python examples/color_states_preview.py`, exercise the five color columns,
-and switch through flatly/minty/morph/darkly/solar/vapor. Automated gates pass.
-Canonical bootstyle grammar (D) remains later and needs its own design pass.
+`development/2_0_color_helpers_design.md`. The six-theme human visual gate
+(`python examples/color_states_preview.py`) PASSED (user, 2026-07-01). Automated
+gates pass (188/1). Canonical bootstyle grammar (D) remains later and needs its
+own design pass.
 
-## Private color ramps and builder helpers — IMPLEMENTED, VISUAL GATE PENDING
+**pytest gap closed + two stale tests fixed (2026-07-01).** The prior session's
+env had no pytest, so `test_color_helpers` was written but never run. Installing
+it surfaced two assertions written against the OLD clam-face pattern
+(`bordercolor`/`darkcolor`/`lightcolor` = face, faking flatness under
+`relief=RAISED`) that no longer hold: the branch's solid **button** and
+**toolbutton** recipes are now genuine flat fills (`relief=FLAT`, no clam border
+regions), so `config['bordercolor']` `KeyError`'d. Fix was test-only — the flat
+recipes are correct and intended; the assertions now verify `relief=='flat'` +
+`'bordercolor' not in config` (button) and no-`bordercolor` + `selected` fills
+with the accent (toolbutton). `menubutton`/`calendar` still use the clam-face
+pattern and their assertions were left intact. No production recipe changed.
+
+## Private color ramps and builder helpers — IMPLEMENTED, VISUAL GATE PASSED
 
 - Private immutable 50–950 ramps use bootstack's Bootstrap-compatible weights
   and a bounded 256-entry cache; no public palette API was added.
@@ -94,8 +108,8 @@ visual feedback that black-on-saturated-accent — e.g. sandstone `info`
 - Interim `on_color` iterations (raw max-contrast, plain white-preferred@3.0)
   were superseded; the design doc's `on_color` section is current. Test
   `test_on_color_is_safe_and_independent_of_legacy_toggle` now asserts the 2.3
-  white floor, not 3.0. Verified by direct computation (pytest not installed in
-  the dev env — run `python -m pytest -q` before merge).
+  white floor, not 3.0. Now verified by an actual `python -m pytest -q` run
+  (2026-07-01): 188 passed / 1 known Tcl `nl.msg` env failure.
 
 ### Fast-follow scoped (next PR, after this branch merges)
 

--- a/tests/widget_styles/test_color_helpers.py
+++ b/tests/widget_styles/test_color_helpers.py
@@ -232,9 +232,10 @@ def test_solid_button_recipe_uses_helper_state_contract(
     background_map = option_map(ttkstyle, 'background')
     foreground_map = option_map(ttkstyle, 'foreground')
     assert config['foreground'].lower() == builder.on_color(background)
-    # This clam recipe has no separately rendered border treatment: its
-    # border/dark/light colors intentionally track the button face.
-    assert config['bordercolor'].lower() == background
+    # The solid button is a plain flat fill: it renders no clam border/dark/
+    # light regions, so those options are absent from its configuration.
+    assert config['relief'].lower() == 'flat'
+    assert 'bordercolor' not in config
     assert background_map[('hover', '!disabled')].lower() == active
     assert background_map[('pressed', '!disabled')].lower() == pressed
     disabled = builder.disabled()
@@ -242,9 +243,9 @@ def test_solid_button_recipe_uses_helper_state_contract(
         'text', disabled
     )
 
-    # Options named "border" are not automatically semantic borders. These
-    # recipes deliberately paint their clam border/dark/light regions with the
-    # same color as the current face.
+    # Options named "border" are not automatically semantic borders. The
+    # menubutton and calendar recipes deliberately paint their clam
+    # border/dark/light regions with the same color as the current face.
     for family, variant in (
         ('menubutton', 'default'),
         ('toolbutton', 'default'),
@@ -258,8 +259,11 @@ def test_solid_button_recipe_uses_helper_state_contract(
         ('hover', '!disabled')
     ] == active
 
+    # The solid toolbutton, like the solid button, is a plain flat fill with no
+    # clam border treatment; its selected state simply fills with the accent.
     toolbutton = f'{colorname}.Toolbutton'
-    assert option_map(toolbutton, 'bordercolor')[
+    assert 'bordercolor' not in style.configure(toolbutton)
+    assert option_map(toolbutton, 'background')[
         ('selected', '!disabled')
     ] == background
 


### PR DESCRIPTION
Focused first slice of Workstream E (2.0 cleanup): add bounded, module-private
RGB color ramps and five `StyleBuilderTTK` derivation helpers, and migrate the
approved ttk recipes onto them. No public palette/`Colors` API is added.

Design (approved): `development/2_0_color_helpers_design.md`.

## What's in it
- Private 50–950 Bootstrap-weight RGB ramps in `style/theme.py` (bounded
  256-entry cache; immutable mapping; no ramp stored on `Style`/`Colors`/root).
- Five coordinator helpers: `active`, `pressed`, `border`, `disabled`,
  `on_color` — porting bootstack's luminance/mode-aware derivation policy.
  `on_color` is white-preferred and saturation-aware (3:1 UI-text floor).
- Approved ttk recipes use the helpers by the color actually rendered. Clam
  face regions keep tracking the face; theme-authored structural borders and
  readonly fills remain authored. Ten remaining direct HSV/alpha sites are
  special-effect sites guarded by an exact AST allowlist.
- `examples/color_states_preview.py` for the human gate.

## Verification
- Suite genuinely run (pytest was absent in the authoring session): **188 passed
  / 1 known Tcl `nl.msg` env failure** (183 excluding localization).
- A follow-up commit fixes two `test_color_helpers` assertions that were written
  against the old clam-face `bordercolor` pattern but never executed; the solid
  button/toolbutton recipes are genuine flat fills, so the assertions now verify
  flatness. Test-only; no production recipe changed.
- Six-theme human visual gate (flatly/minty/morph/darkly/solar/vapor) **passed**.

Canonical bootstyle grammar (Workstream D) follows later with its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)