### PR TITLE
Retire ad-hoc HSV/alpha color math onto mix-based builder helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,13 +86,14 @@ don't exceed a PR's scope without revisiting it.
 
 Recolorable raster widget assets (#1081), the modular `StyleBuilderTTK`
 registry (#1082), and scaling/asset-geometry normalization (#1083) are now also
-merged into `2.0`; the expected suite is 177 tests. **Current:** the focused
-private color ramps and `StyleBuilderTTK` helpers are implemented on
-`refactor/2.0-color-helpers` per
-`development/2_0_color_helpers_design.md`; the branch suite is 189 tests. Run
-`python examples/color_states_preview.py` and complete its six-theme visual
-gate before merge. Canonical bootstyle grammar (D) follows later with its own
-design pass.
+merged into `2.0`; the expected suite is 177 tests. The focused private color
+ramps and `StyleBuilderTTK` helpers (#1085, merge commit `b7872a98`, per
+`development/2_0_color_helpers_design.md`) are now also **merged** into `2.0`;
+the expected suite is 189 tests. **Current:** the fast-follow color-math PR
+(`elevate` + `input_bg`, retiring the remaining ad-hoc HSV/alpha sites) is next
+and needs its own design pass first — stub at
+`development/2_0_color_math_followup_design.md`. Canonical bootstyle grammar (D)
+and theme/anchor (E) follow later, each with its own design pass.
 
 ## Repository layout
 

--- a/development/2_0_color_math_followup_design.md
+++ b/development/2_0_color_math_followup_design.md
@@ -1,7 +1,9 @@
 # 2.0 — Fast-follow color-math PR (`shade` / `tint` / `mute`)
 
 **Status:** IMPLEMENTED on `refactor/2.0-color-math` (from `2.0`); automated
-gates pass; human visual gate pending.
+gates pass; **human visual gate PASSED** (user, 2026-07-06 — colors approved,
+no tuning changes; `_TROUGH_SHADE=0.2` / `_STRIPE_TINT=0.2` / floodgauge `0.7`
+are the settled values).
 **Prereq reading:** `development/2_0_color_helpers_design.md` and the handoff's
 "Fast-follow scoped" block.
 

--- a/development/2_0_color_math_followup_design.md
+++ b/development/2_0_color_math_followup_design.md
@@ -1,86 +1,150 @@
-# 2.0 — Fast-follow color-math PR (`elevate` + `input_bg`)
+# 2.0 — Fast-follow color-math PR (`shade` / `tint` / `mute`)
 
-> **STATUS: DESIGN STUB — NOT YET APPROVED.** Per the hard rule (see
-> `CLAUDE.md` / handoff), this PR does **not** start as ad-hoc coding. Hold the
-> design discussion, settle the open decision below, get user sign-off, then
-> implement. This file captures the scope carried over from the color-helper
-> design's fast-follow section so the next session starts from the right place.
+**Status:** IMPLEMENTED on `refactor/2.0-color-math` (from `2.0`); automated
+gates pass; human visual gate pending.
+**Prereq reading:** `development/2_0_color_helpers_design.md` and the handoff's
+"Fast-follow scoped" block.
 
-## Context
+## Decision summary
 
-The color-helper PR (#1085, merged into `2.0`) added the private 50–950 ramps
-and the five `StyleBuilderTTK` helpers (`active`, `pressed`, `border`,
-`disabled`, `on_color`). It deliberately **left 10 ad-hoc HSV/alpha color-math
-sites in place**, guarded by an exact AST allowlist, because they are
-specialized surface/mute effects rather than state-color derivation. This
-fast-follow retires those sites onto two mode-aware utilities built on the
-private `_mix` / `_relative_luminance` primitives.
+Retire the **10 ad-hoc HSV/alpha color-math sites** the color-helper PR (#1085)
+deliberately left allowlisted in the ttk recipes, moving them onto three thin
+mix-based `StyleBuilderTTK` helpers built on the private `_mix_colors`
+primitive. Second and final focused color-math slice before the semantic-anchor
+`Theme` API (Workstream E). No public palette surface; theme dictionaries
+untouched.
 
-Prereq reading: `development/2_0_color_helpers_design.md` (esp. its fast-follow
-section) and the handoff's "Fast-follow scoped" block.
+Two forks were opened with the user and both were re-decided against the stub
+after reading ground truth (2026-07-05 → 07-06):
 
-## Proposed surface
+1. **Trough/track/stripe sites (6):** the stub proposed a mode-aware `elevate`.
+   Ground truth killed that framing — the trough sites are **already
+   mode-branched** and the HSV call only runs in the **dark** `else` branch
+   (light themes use `colors.light`/`bg`, which are not HSV and out of scope).
+   A mode-aware `elevate` would *lighten* dark-theme troughs, which is visually
+   wrong (an empty track should recede darker in a dark theme). So we **retire
+   the HSV onto plain mix-based `shade`/`tint`, preserving each site's current
+   appearance** — still well inside the drift envelope the user approved, but
+   *less* drift, no direction flip. (For gray `selectbg` — the common dark case
+   — `shade` is byte-identical to the old value.)
+2. **`input_bg`: DEFERRED to Workstream E** (user, 2026-07-06). In light themes
+   `bg == inputbg` already, so `input_bg()=bg` is a no-op; the field affordance
+   is `bordercolor=colors.border`, not the fill. In dark themes the authored
+   `inputbg` deltas *carry theme hue* (vapor `#190831`→`#30115e` toward purple),
+   which a uniform tint-toward-white would desaturate — a regression. A
+   hue-preserving derivation needs the semantic model, so it belongs in E.
 
-### `elevate(surface, level)` — mode-aware surface raise
-Built on `_mix` / `_relative_luminance`. Replaces the 5 inconsistent
-trough/track `update_hsv` sites and folds the 4 `make_transparent(0.4, …)`
-unchecked-indicator muting sites onto `_mix` (must stay visually identical):
+This is visual normalization, not a behavior-exact refactor. The 2.0 plan
+permits trough/track drift; the muting fold is visually identical (≤1/255).
 
-- `label.py` — trough darken 20%
-- `progressbar.py` (×2) — trough darken 20%
-- `scale.py` — track darken 20%
-- `floodgauge.py` — lightens 80% (the odd one out — confirm direction under
-  `elevate`'s mode-aware model)
-- 4× `make_transparent(0.4, …)` unchecked-indicator mute sites → `_mix`
-- One stripe site (`progressbar.py:40`) may want a `tint` rather than `elevate`
-  — decide during the design pass.
+## Ground truth — the 10 sites (all in `style/builders/`)
 
-### `input_bg(surface=None)` — mode-aware field background policy
-Built on `elevate`. Encodes "fill vs outline are substitutes, use one per mode":
+`builders_tk.py` (legacy tk) is out of scope and outside the AST guard.
 
-- **light:** `= bg` (border carries the affordance)
-- **dark:** `= elevate(bg)` (fill carries it; border ≈ bg)
+| # | Site | Old math (dark branch / effect) | Migration |
+|---|---|---|---|
+| 1 | `label.py` `build_meter_label_style` | `update_hsv(selectbg, vd=-0.2)` | `builder.shade(selectbg)` |
+| 2 | `progressbar.py` `build_striped_progressbar_style` | `update_hsv(selectbg, vd=-0.2)` | `builder.shade(selectbg)` |
+| 3 | `progressbar.py` `_create_recolored_progressbar_style` | `update_hsv(selectbg, vd=-0.2)` | `builder.shade(selectbg)` |
+| 4 | `scale.py` `_create_scale_assets` | `update_hsv(selectbg, vd=-0.2)` | `builder.shade(selectbg)` |
+| 5 | `floodgauge.py` `build_floodgauge_style` | `update_hsv(background, sd=-0.3, vd=0.8)` | `builder.tint(background, 0.7)` |
+| 6 | `progressbar.py` `_create_striped_progressbar_assets` | `update_hsv(bar_color, sd=-0.2, vd=value_delta)` | `builder.tint(bar_color)` |
+| 7 | `checkbutton.py` `build_checkbutton_style` | `make_transparent(0.4, fg, bg)` | `builder.mute(fg)` |
+| 8 | `radiobutton.py` `build_radiobutton_style` | `make_transparent(0.40, fg, bg)` | `builder.mute(fg)` |
+| 9 | `toggle.py` `build_round_toggle_style` | `make_transparent(0.40, fg, bg)` | `builder.mute(colors.fg)` |
+| 10 | `toggle.py` `build_square_toggle_style` | `make_transparent(0.40, fg, bg)` | `builder.mute(colors.fg)` |
 
-## OPEN DECISION (settle first)
+Sites 1–4 are byte-identical copy-paste; only the dark branch is HSV. Site 5 is
+a pale wash (kept via a strong `tint`). Site 6 is a lighter highlight over the
+bar; its brightness-adaptive `value_delta` block is **deleted** — mixing toward
+white is self-limiting (a near-white bar barely shifts; a dark bar lifts
+clearly), which is what the adaptive delta hand-rolled. Sites 7–10 are alpha
+blends → `_mix_colors` (visually identical: `make_transparent` truncated,
+`_mix_colors` rounds).
 
-Does `input_bg` **derive** `inputbg` (dropping the hand-authored, inconsistent
-per-theme dark deltas), or **coexist** with them?
+## New primitives (`style/theme.py`)
 
-- The **derive** path needs the deferred built-in theme-dict conversion
-  (Workstream E) — so deriving here may pull E's scope forward or block on it.
-- The **coexist** path keeps the authored deltas and only routes *new* uses
-  through `input_bg`.
+```python
+def _tint(color, weight):   return _mix_colors('#ffffff', color, weight)  # toward white
+def _shade(color, weight):  return _mix_colors('#000000', color, weight)  # toward black
+```
 
-Recommendation to bring to the design discussion: **coexist** for this PR (keep
-it self-contained, no E dependency), and fold the derive path into E when the
-theme-dict conversion lands. Confirm with user.
+`_mix_colors(a, b, w) = round(w·a + (1-w)·b)` per channel; `weight` is the
+fraction of `a`. So `_tint`/`_shade` mix `weight` of white/black into `color`.
 
-## Constraints / guardrails (carry from color-helper PR)
+## New builder helpers (`StyleBuilderTTK`, `builders_ttk.py`)
 
-- `StyleBuilderTK` (legacy tk) stays out of scope.
-- Keep the AST allowlist mechanism; shrink it as sites migrate. New direct
-  `Colors.update_hsv` / `Colors.make_transparent` in ttk recipes must still fail
-  the guard unless allowlisted with a reason.
-- Behavior-preserving: the mute sites must be **visually identical**; the
-  trough/track sites are allowed normalized drift (2.0 plan permits it) but
-  should be reviewed light↔dark.
-- Carry the **PEP 649 annotation force-evaluation sweep** (3.14 gotcha) over any
-  new/moved module.
+Three methods, mirroring the existing five (`active`/`pressed`/`border`/
+`disabled`/`on_color`). Keeping all color policy on the coordinator lets the AST
+guard enforce **zero** raw `Colors.update_hsv`/`make_transparent` in recipes.
 
-## Gates
+```python
+_TROUGH_SHADE = 0.2   # recessed dark-theme track/trough
+_STRIPE_TINT  = 0.2   # progress-stripe highlight
+_MUTE_AMOUNT  = 0.4   # unchecked-indicator muting
 
-- Focused unit tests for `elevate` / `input_bg` (mode-aware direction, exact
-  deltas, mute-equivalence to the old `make_transparent(0.4)` output).
-- Full headless suite green (expected baseline on `2.0`: **189 passed** / 1 known
-  Tcl `nl.msg` env failure).
-- **Human visual gate** light↔dark across the affected widgets
-  (troughs/tracks/stripes, unchecked indicators, input fields) — the headless
-  suite asserts color-at-pixel, not appearance. Extend or reuse
-  `examples/color_states_preview.py`.
+def shade(self, color, weight=_TROUGH_SHADE):  # darken toward black
+    return _shade(color, weight)
 
-## Next steps for the implementing session
+def tint(self, color, weight=_STRIPE_TINT):    # lighten toward white
+    return _tint(color, weight)
 
-1. Hold the design discussion; settle the open decision; get sign-off.
-2. Flesh this doc into the full design (signatures, mix ratios, mode detection).
-3. Cut a branch from `2.0`; implement PR-by-PR per the doc.
-4. Run automated + human gates; open the PR against `2.0`; update the handoff.
+def mute(self, color, surface=None, amount=_MUTE_AMOUNT):
+    return _mix_colors(color, surface or self.colors.bg, amount)
+```
+
+No `elevate` and no `input_bg` in this PR (see Decision summary). The floodgauge
+wash passes an explicit `0.7` weight at its single site (gate-tunable).
+
+## AST guard
+
+`test_direct_color_math_is_limited_to_special_effects`: `expected = Counter()`
+(empty). The guard now enforces **zero** direct `Colors.update_hsv` /
+`Colors.make_transparent` in every `style/builders/*.py` recipe — strictly
+stronger than the old 10-entry allowlist. A future genuine special effect must
+be re-added to `expected` with a reason.
+
+## Tests (all passing)
+
+Added to `tests/widget_styles/test_color_helpers.py`:
+
+- `test_tint_and_shade_move_toward_white_and_black` — `_tint`/`_shade` equal the
+  matching `_mix_colors` call; tint lightens / shade darkens; 0-weight no-op,
+  full-weight reaches target.
+- `test_shade_tint_mute_builder_helpers` (darkly) — `shade`/`tint` delegate to
+  the primitives and move luminance the right way; `mute` equals
+  `_mix_colors(fg, bg, 0.4)` and is within 1/255 per channel of the old
+  `Colors.make_transparent(0.4, fg, bg)`.
+- AST guard `expected` emptied.
+
+Gates run: focused **14 passed**; full headless **191 passed** (189 baseline + 2
+new; this Windows box has the `nl.msg` locale file, so no env failure);
+warning-free `import ttkbootstrap`; PEP 649 annotation sweep over 26 changed/
+dependent modules (152 targets) clean; standalone `style.theme` import; all
+edited modules compile; the seven migrated recipe files shed their now-unused
+`from ...theme import Colors` import.
+
+End-to-end smoke: scale, standard/striped progressbar, floodgauge, check/radio/
+round-toggle all build in darkly and flatly; `shade(#555)→#444444` (identical to
+the old HSV for gray selectbg).
+
+## Human visual gate (blocks merge)
+
+Extend `examples/color_states_preview.py` to include: scale, standard/striped/
+thin/recolored progressbars, and the ttk floodgauge. Review at 100% in
+`flatly`, `minty`, `morph`, `darkly`, `solar`, `vapor`, then switch light↔dark.
+
+Accept only if: dark-theme tracks/troughs read as recessed and distinct from
+their fill; the floodgauge pale-wash trough still reads correctly; the striped
+highlight is visible on light and dark bars; muted unchecked indicators are
+unchanged. Tune `_TROUGH_SHADE`, `_STRIPE_TINT`, and the floodgauge `0.7` here
+and record settled values in this doc + the handoff.
+
+## Out of scope (carry to Workstream E)
+
+- `input_bg` / field-background policy and the authored-vs-derived `inputbg`
+  reconciliation; the theme-dict conversion.
+- A mode-aware `elevate` / surface-elevation model (the sites that would use it
+  are already mode-branched; the general model belongs to the semantic theme).
+- Legacy `builders_tk.py` (tk) color math.
+- Any public palette / semantic-anchor `Theme` surface.

--- a/development/2_0_color_math_followup_design.md
+++ b/development/2_0_color_math_followup_design.md
@@ -1,0 +1,86 @@
+# 2.0 — Fast-follow color-math PR (`elevate` + `input_bg`)
+
+> **STATUS: DESIGN STUB — NOT YET APPROVED.** Per the hard rule (see
+> `CLAUDE.md` / handoff), this PR does **not** start as ad-hoc coding. Hold the
+> design discussion, settle the open decision below, get user sign-off, then
+> implement. This file captures the scope carried over from the color-helper
+> design's fast-follow section so the next session starts from the right place.
+
+## Context
+
+The color-helper PR (#1085, merged into `2.0`) added the private 50–950 ramps
+and the five `StyleBuilderTTK` helpers (`active`, `pressed`, `border`,
+`disabled`, `on_color`). It deliberately **left 10 ad-hoc HSV/alpha color-math
+sites in place**, guarded by an exact AST allowlist, because they are
+specialized surface/mute effects rather than state-color derivation. This
+fast-follow retires those sites onto two mode-aware utilities built on the
+private `_mix` / `_relative_luminance` primitives.
+
+Prereq reading: `development/2_0_color_helpers_design.md` (esp. its fast-follow
+section) and the handoff's "Fast-follow scoped" block.
+
+## Proposed surface
+
+### `elevate(surface, level)` — mode-aware surface raise
+Built on `_mix` / `_relative_luminance`. Replaces the 5 inconsistent
+trough/track `update_hsv` sites and folds the 4 `make_transparent(0.4, …)`
+unchecked-indicator muting sites onto `_mix` (must stay visually identical):
+
+- `label.py` — trough darken 20%
+- `progressbar.py` (×2) — trough darken 20%
+- `scale.py` — track darken 20%
+- `floodgauge.py` — lightens 80% (the odd one out — confirm direction under
+  `elevate`'s mode-aware model)
+- 4× `make_transparent(0.4, …)` unchecked-indicator mute sites → `_mix`
+- One stripe site (`progressbar.py:40`) may want a `tint` rather than `elevate`
+  — decide during the design pass.
+
+### `input_bg(surface=None)` — mode-aware field background policy
+Built on `elevate`. Encodes "fill vs outline are substitutes, use one per mode":
+
+- **light:** `= bg` (border carries the affordance)
+- **dark:** `= elevate(bg)` (fill carries it; border ≈ bg)
+
+## OPEN DECISION (settle first)
+
+Does `input_bg` **derive** `inputbg` (dropping the hand-authored, inconsistent
+per-theme dark deltas), or **coexist** with them?
+
+- The **derive** path needs the deferred built-in theme-dict conversion
+  (Workstream E) — so deriving here may pull E's scope forward or block on it.
+- The **coexist** path keeps the authored deltas and only routes *new* uses
+  through `input_bg`.
+
+Recommendation to bring to the design discussion: **coexist** for this PR (keep
+it self-contained, no E dependency), and fold the derive path into E when the
+theme-dict conversion lands. Confirm with user.
+
+## Constraints / guardrails (carry from color-helper PR)
+
+- `StyleBuilderTK` (legacy tk) stays out of scope.
+- Keep the AST allowlist mechanism; shrink it as sites migrate. New direct
+  `Colors.update_hsv` / `Colors.make_transparent` in ttk recipes must still fail
+  the guard unless allowlisted with a reason.
+- Behavior-preserving: the mute sites must be **visually identical**; the
+  trough/track sites are allowed normalized drift (2.0 plan permits it) but
+  should be reviewed light↔dark.
+- Carry the **PEP 649 annotation force-evaluation sweep** (3.14 gotcha) over any
+  new/moved module.
+
+## Gates
+
+- Focused unit tests for `elevate` / `input_bg` (mode-aware direction, exact
+  deltas, mute-equivalence to the old `make_transparent(0.4)` output).
+- Full headless suite green (expected baseline on `2.0`: **189 passed** / 1 known
+  Tcl `nl.msg` env failure).
+- **Human visual gate** light↔dark across the affected widgets
+  (troughs/tracks/stripes, unchecked indicators, input fields) — the headless
+  suite asserts color-at-pixel, not appearance. Extend or reuse
+  `examples/color_states_preview.py`.
+
+## Next steps for the implementing session
+
+1. Hold the design discussion; settle the open decision; get sign-off.
+2. Flesh this doc into the full design (signatures, mix ratios, mode detection).
+3. Cut a branch from `2.0`; implement PR-by-PR per the doc.
+4. Run automated + human gates; open the PR against `2.0`; update the handoff.

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -88,13 +88,11 @@ warning-free import; PEP 649 sweep (26 modules / 152 targets) clean; standalone
 `style.theme` import; seven migrated recipes shed their unused `Colors` import.
 End-to-end smoke: all affected widgets build in darkly + flatly.
 
-**NEXT — human visual gate (blocks merge):** run
-`python examples/color_states_preview.py` (a new "Progress, stripe, and
-floodgauge" section was added) across `flatly`/`minty`/`morph`/`darkly`/`solar`/
-`vapor`, switching light↔dark. Confirm dark troughs recede, floodgauge wash +
-stripe read right, muted indicators unchanged. Tune `_TROUGH_SHADE`/
-`_STRIPE_TINT`/floodgauge `0.7` if needed, record settled values, THEN commit +
-open one PR against `2.0`.
+**Human visual gate PASSED** (user, 2026-07-06): the six-theme
+`examples/color_states_preview.py` sweep (new "Progress, stripe, and floodgauge"
+section) was approved with no tuning changes — `_TROUGH_SHADE=0.2`,
+`_STRIPE_TINT=0.2`, and the floodgauge `0.7` are settled. PR opened against
+`2.0` after approval.
 
 **pytest gap closed + two stale tests fixed (2026-07-01).** The prior session's
 env had no pytest, so `test_color_helpers` was written but never run. Installing

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,20 +3,26 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-07-01 (focused Workstream E private ramps and builder
-color helpers implemented on `refactor/2.0-color-helpers`; `on_color` retuned to
-a white-preferred, saturation-aware policy after visual feedback. pytest
-installed and the suite ACTUALLY RUN this session — 188 passed / 1 known Tcl
-`nl.msg` env failure; two stale `test_color_helpers` assertions corrected (see
-below). Six-theme human visual gate PASSED. Branch is merge-ready — open the PR
-against `2.0`.)_
+_Last updated: 2026-07-05 (the color-helper branch is **MERGED into `2.0`** —
+PR #1085, merge commit `b7872a98`, 2026-07-01 21:04; PR #1084 was an earlier
+merge of the same branch. Prior session's "open the PR" actionable is done. Next
+actionable is the **fast-follow color-math PR** (`elevate` + `input_bg`), which
+needs its own design pass first — a stub is at
+`development/2_0_color_math_followup_design.md`.)_
+
+_Prior (2026-07-01): focused Workstream E private ramps and builder color
+helpers implemented on `refactor/2.0-color-helpers`; `on_color` retuned to a
+white-preferred, saturation-aware policy after visual feedback. pytest installed
+and the suite ACTUALLY RUN — 188 passed / 1 known Tcl `nl.msg` env failure; two
+stale `test_color_helpers` assertions corrected. Six-theme human visual gate
+PASSED._
 
 ## Where we are
 
 Integration branch: **`2.0`** (cut all 2.0 PRs against it, not `master`).
-Expected suite on `2.0`: **177 passed**, headless, order-independent. Expected
-after the color-helper branch: **189 passed**. The latest Python 3.12 run is
-**188 passed / 1 environment failure** because this Tcl install cannot read
+Expected suite on `2.0`: **189 passed** (the color-helper PR #1085 is now merged;
+merge commit `b7872a98`), headless, order-independent. The latest Python 3.12 run
+is **188 passed / 1 environment failure** because this Tcl install cannot read
 `tk8.6/msgs/nl.msg`; excluding localization gives **183 passed**.
 
 The engine keystone (Workstream A) is **complete and merged**: PR 1 (repaint,
@@ -41,12 +47,21 @@ registry, and 22 widget-family modules. Merge commit: `fa1cede8`.
 **PR #1083 is MERGED.** Scaling and asset-geometry normalization landed on
 `2.0` as merge commit `c1f9ed73`; its automated and four-scale human gates pass.
 
-**Current actionable → open the color-helper PR against `2.0`.** Branch:
-`refactor/2.0-color-helpers`, cut from `2.0` at `c1f9ed73`. Approved design:
-`development/2_0_color_helpers_design.md`. The six-theme human visual gate
-(`python examples/color_states_preview.py`) PASSED (user, 2026-07-01). Automated
-gates pass (188/1). Canonical bootstyle grammar (D) remains later and needs its
-own design pass.
+**The color-helper PR is MERGED (#1085 → `2.0`, merge commit `b7872a98`,
+2026-07-01).** Branch was `refactor/2.0-color-helpers` (cut from `2.0` at
+`c1f9ed73`); approved design `development/2_0_color_helpers_design.md`; six-theme
+human visual gate (`python examples/color_states_preview.py`) PASSED (user,
+2026-07-01); automated gates passed (188/1). The local branch is fully contained
+in `2.0` and safe to delete.
+
+**Current actionable → the fast-follow color-math PR (`elevate` + `input_bg`).**
+Per the hard rule it needs its own design pass FIRST — a starting stub is at
+`development/2_0_color_math_followup_design.md` (scope carried from the
+color-helper design's fast-follow section, below). Open the design, settle the
+one open decision (derive `inputbg` vs coexist — note it may depend on the
+deferred Workstream E theme-dict conversion), get sign-off, THEN implement on a
+new branch cut from `2.0`. Canonical bootstyle grammar (D) and theme/anchor (E)
+remain later, each with its own design pass.
 
 **pytest gap closed + two stale tests fixed (2026-07-01).** The prior session's
 env had no pytest, so `test_color_helpers` was written but never run. Installing

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -91,8 +91,8 @@ End-to-end smoke: all affected widgets build in darkly + flatly.
 **Human visual gate PASSED** (user, 2026-07-06): the six-theme
 `examples/color_states_preview.py` sweep (new "Progress, stripe, and floodgauge"
 section) was approved with no tuning changes — `_TROUGH_SHADE=0.2`,
-`_STRIPE_TINT=0.2`, and the floodgauge `0.7` are settled. PR opened against
-`2.0` after approval.
+`_STRIPE_TINT=0.2`, and the floodgauge `0.7` are settled. **PR #1087 opened
+against `2.0`** (awaiting merge).
 
 **pytest gap closed + two stale tests fixed (2026-07-01).** The prior session's
 env had no pytest, so `test_color_helpers` was written but never run. Installing

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -5,9 +5,10 @@
 
 _Last updated: 2026-07-06 (the **fast-follow color-math PR is IMPLEMENTED** on
 `refactor/2.0-color-math` from `2.0`; automated gates pass, **human visual gate
-pending** — see "Fast-follow color-math — IMPLEMENTED" below. Not yet committed/
-pushed as of writing; branch is local. The prior color-helper branch is
-**MERGED into `2.0`** — PR #1085, merge commit `b7872a98`.)_
+pending** — see "Fast-follow color-math — IMPLEMENTED" below. Committed locally
+as `6d95a22b`, **not pushed**; PR not opened, pending the visual gate. The prior
+color-helper branch is **MERGED into `2.0`** — PR #1085, merge commit
+`b7872a98`.)_
 
 _Prior (2026-07-01): focused Workstream E private ramps and builder color
 helpers implemented on `refactor/2.0-color-helpers`; `on_color` retuned to a

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,12 +3,11 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-07-05 (the color-helper branch is **MERGED into `2.0`** —
-PR #1085, merge commit `b7872a98`, 2026-07-01 21:04; PR #1084 was an earlier
-merge of the same branch. Prior session's "open the PR" actionable is done. Next
-actionable is the **fast-follow color-math PR** (`elevate` + `input_bg`), which
-needs its own design pass first — a stub is at
-`development/2_0_color_math_followup_design.md`.)_
+_Last updated: 2026-07-06 (the **fast-follow color-math PR is IMPLEMENTED** on
+`refactor/2.0-color-math` from `2.0`; automated gates pass, **human visual gate
+pending** — see "Fast-follow color-math — IMPLEMENTED" below. Not yet committed/
+pushed as of writing; branch is local. The prior color-helper branch is
+**MERGED into `2.0`** — PR #1085, merge commit `b7872a98`.)_
 
 _Prior (2026-07-01): focused Workstream E private ramps and builder color
 helpers implemented on `refactor/2.0-color-helpers`; `on_color` retuned to a
@@ -54,14 +53,47 @@ human visual gate (`python examples/color_states_preview.py`) PASSED (user,
 2026-07-01); automated gates passed (188/1). The local branch is fully contained
 in `2.0` and safe to delete.
 
-**Current actionable → the fast-follow color-math PR (`elevate` + `input_bg`).**
-Per the hard rule it needs its own design pass FIRST — a starting stub is at
-`development/2_0_color_math_followup_design.md` (scope carried from the
-color-helper design's fast-follow section, below). Open the design, settle the
-one open decision (derive `inputbg` vs coexist — note it may depend on the
-deferred Workstream E theme-dict conversion), get sign-off, THEN implement on a
-new branch cut from `2.0`. Canonical bootstyle grammar (D) and theme/anchor (E)
+**Current actionable → run the human visual gate for the color-math PR**, then
+commit/open the PR. The design pass is done and the code is implemented (see the
+dedicated section below). Canonical bootstyle grammar (D) and theme/anchor (E)
 remain later, each with its own design pass.
+
+## Fast-follow color-math — IMPLEMENTED, VISUAL GATE PENDING
+
+Branch `refactor/2.0-color-math` (from `2.0` at `26dd182f`). Approved+as-built
+design: `development/2_0_color_math_followup_design.md`. Retires the **10 ad-hoc
+HSV/alpha sites** the color-helper PR left allowlisted, onto three thin mix-based
+`StyleBuilderTTK` helpers: `shade`/`tint` (build on new `_shade`/`_tint` in
+`theme.py`) and `mute`. The AST guard now enforces **zero** direct
+`Colors.update_hsv`/`make_transparent` in `style/builders/*.py`.
+
+**Two forks were opened with the user and BOTH re-decided against the original
+stub after reading ground truth:**
+- **No `elevate`.** The stub assumed troughs "always darken regardless of mode";
+  ground truth showed they are **already mode-branched** and the HSV runs only in
+  the dark `else` branch (light uses `colors.light`/`bg`). A mode-aware `elevate`
+  would *lighten* dark troughs — wrong. So troughs migrate to plain `shade`
+  (preserve appearance; for gray `selectbg`, `shade` is byte-identical to the old
+  HSV). Floodgauge wash + progress stripe → `tint`.
+- **`input_bg` DEFERRED to Workstream E** (user, 2026-07-06). Light: `bg ==
+  inputbg` already, so it's a no-op there (the field affordance is
+  `bordercolor=colors.border`). Dark: authored `inputbg` deltas carry theme hue
+  (vapor `#190831`→`#30115e`) that a uniform tint-toward-white would desaturate —
+  a regression. A hue-correct derivation needs the semantic model → E.
+
+**Automated gates PASS:** focused **14 passed**; full headless **191 passed**
+(189 baseline + 2 new; this Windows box has `nl.msg`, no env failure);
+warning-free import; PEP 649 sweep (26 modules / 152 targets) clean; standalone
+`style.theme` import; seven migrated recipes shed their unused `Colors` import.
+End-to-end smoke: all affected widgets build in darkly + flatly.
+
+**NEXT — human visual gate (blocks merge):** run
+`python examples/color_states_preview.py` (a new "Progress, stripe, and
+floodgauge" section was added) across `flatly`/`minty`/`morph`/`darkly`/`solar`/
+`vapor`, switching light↔dark. Confirm dark troughs recede, floodgauge wash +
+stripe read right, muted indicators unchanged. Tune `_TROUGH_SHADE`/
+`_STRIPE_TINT`/floodgauge `0.7` if needed, record settled values, THEN commit +
+open one PR against `2.0`.
 
 **pytest gap closed + two stale tests fixed (2026-07-01).** The prior session's
 env had no pytest, so `test_color_helpers` was written but never run. Installing

--- a/examples/color_states_preview.py
+++ b/examples/color_states_preview.py
@@ -42,6 +42,7 @@ class ColorStatesPreview:
         self._build_fields(content)
         self._build_indicators(content)
         self._build_motion(content)
+        self._build_progress(content)
         self._build_tree(content)
 
     def _build_header(self, parent):
@@ -191,6 +192,29 @@ class ColorStatesPreview:
             disabled_date.grid(row=row, column=4, padx=8, pady=4)
         section.columnconfigure(1, weight=1)
         section.columnconfigure(2, weight=1)
+
+    def _build_progress(self, parent):
+        # Exercises the mix-based trough/track/stripe/wash color math:
+        # progressbar/floodgauge troughs (shade of selectbg in dark themes),
+        # the striped highlight (tint), and the floodgauge pale wash (tint).
+        section = ttk.Labelframe(
+            parent, text="Progress, stripe, and floodgauge", padding=12
+        )
+        section.pack(fill="x", pady=6)
+        for row, color in enumerate(COLORS):
+            ttk.Label(section, text=color, width=9).grid(row=row, column=0)
+            ttk.Progressbar(
+                section, value=55, bootstyle=color
+            ).grid(row=row, column=1, sticky="ew", padx=8, pady=4)
+            ttk.Progressbar(
+                section, value=55, bootstyle=f"{color}-striped"
+            ).grid(row=row, column=2, sticky="ew", padx=8, pady=4)
+            ttk.Floodgauge(
+                section, value=55, bootstyle=color, mask="{}%"
+            ).grid(row=row, column=3, sticky="ew", padx=8, pady=4)
+        section.columnconfigure(1, weight=1)
+        section.columnconfigure(2, weight=1)
+        section.columnconfigure(3, weight=1)
 
     def _build_tree(self, parent):
         section = ttk.Labelframe(parent, text="Treeview", padding=12)

--- a/src/ttkbootstrap/style/builders/checkbutton.py
+++ b/src/ttkbootstrap/style/builders/checkbutton.py
@@ -3,7 +3,6 @@
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, StyleName, image_element, layout, state_map
-from ttkbootstrap.style.theme import Colors
 from ttkbootstrap.style.builders.registry import register_builder
 from ttkbootstrap.style.builders.utils import indicator_spacer
 
@@ -23,7 +22,7 @@ def build_checkbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     fg = builder.colors.fg
 
     disabled = builder.disabled("text")
-    fg_muted = Colors.make_transparent(0.4, fg, builder.colors.bg)
+    fg_muted = builder.mute(fg)
 
     accent = builder.colors.get(colorname or 'primary')
     on_accent = builder.on_color(accent)

--- a/src/ttkbootstrap/style/builders/floodgauge.py
+++ b/src/ttkbootstrap/style/builders/floodgauge.py
@@ -5,7 +5,6 @@ import tkinter as tk
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, layout
-from ttkbootstrap.style.theme import Colors
 from ttkbootstrap.style.builders.registry import register_builder
 
 
@@ -39,7 +38,9 @@ def build_floodgauge_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         foreground = builder.colors.fg
         trough_color = builder.colors.bg
     else:
-        trough_color = Colors.update_hsv(background, sd=-0.3, vd=0.8)
+        # Pale wash of the bar color for the empty trough (was a strong HSV
+        # value lift); mixing ~70% white preserves that near-white look.
+        trough_color = builder.tint(background, 0.7)
         foreground = builder.colors.selectfg
 
     # horizontal floodgauge

--- a/src/ttkbootstrap/style/builders/label.py
+++ b/src/ttkbootstrap/style/builders/label.py
@@ -2,7 +2,6 @@
 
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
-from ttkbootstrap.style.theme import Colors
 from ttkbootstrap.style.builders.registry import register_builder
 
 
@@ -65,7 +64,7 @@ def build_meter_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         else:
             trough_color = builder.colors.light
     else:
-        trough_color = Colors.update_hsv(builder.colors.selectbg, vd=-0.2)
+        trough_color = builder.shade(builder.colors.selectbg)
 
     if any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class

--- a/src/ttkbootstrap/style/builders/progressbar.py
+++ b/src/ttkbootstrap/style/builders/progressbar.py
@@ -5,7 +5,6 @@ import tkinter as tk
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, image_element, layout
-from ttkbootstrap.style.theme import Colors
 from ttkbootstrap.style.builders.registry import register_builder
 
 
@@ -28,16 +27,10 @@ def _create_striped_progressbar_assets(builder, colorname=DEFAULT):
     else:
         bar_color = builder.colors.get(colorname)
 
-    # calculate value of the light color
-    brightness = Colors.rgb_to_hsv(*Colors.hex_to_rgb(bar_color))[2]
-    if brightness < 0.4:
-        value_delta = 0.3
-    elif brightness > 0.8:
-        value_delta = 0
-    else:
-        value_delta = 0.1
-
-    bar_color_light = Colors.update_hsv(bar_color, sd=-0.2, vd=value_delta)
+    # A lighter diagonal highlight over the bar. Mixing toward white is
+    # self-limiting (a near-white bar barely shifts; a dark bar lifts clearly),
+    # which is what the old brightness-adaptive HSV delta hand-rolled.
+    bar_color_light = builder.tint(bar_color)
     a = builder.assets
 
     # Diagonal stripe pattern over a bar_color_light field; the original
@@ -90,7 +83,7 @@ def build_striped_progressbar_style(builder: StyleBuilderTTK, colorname=DEFAULT)
             trough_color = builder.colors.light
             border_color = trough_color
     else:
-        trough_color = Colors.update_hsv(builder.colors.selectbg, vd=-0.2)
+        trough_color = builder.shade(builder.colors.selectbg)
         border_color = trough_color
 
     # ( horizontal, vertical )
@@ -170,7 +163,7 @@ def _create_recolored_progressbar_style(
         trough_color = (
             builder.colors.bg if colorname == LIGHT else builder.colors.light)
     else:
-        trough_color = Colors.update_hsv(builder.colors.selectbg, vd=-0.2)
+        trough_color = builder.shade(builder.colors.selectbg)
 
     if colorname in (DEFAULT, ""):
         bar_color = builder.colors.primary

--- a/src/ttkbootstrap/style/builders/radiobutton.py
+++ b/src/ttkbootstrap/style/builders/radiobutton.py
@@ -3,7 +3,6 @@
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, StyleName, image_element, layout, state_map
-from ttkbootstrap.style.theme import Colors
 from ttkbootstrap.style.builders.registry import register_builder
 from ttkbootstrap.style.builders.utils import indicator_spacer
 
@@ -22,7 +21,7 @@ def build_radiobutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     sn = StyleName("TRadiobutton", colorname)
     fg = builder.colors.fg
     disabled = builder.disabled("text")
-    fg_muted = Colors.make_transparent(0.40, fg, builder.colors.bg)
+    fg_muted = builder.mute(fg)
 
     # Resolve the "on" accent; LIGHT/DARK on their own background need a
     # contrasting indicator so the knockout interior stays readable

--- a/src/ttkbootstrap/style/builders/scale.py
+++ b/src/ttkbootstrap/style/builders/scale.py
@@ -3,7 +3,6 @@
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, StyleName, image_element, layout
-from ttkbootstrap.style.theme import Colors
 from ttkbootstrap.style.builders.registry import register_builder
 
 
@@ -28,7 +27,7 @@ def _create_scale_assets(builder, colorname=DEFAULT):
     if builder.is_light_theme:
         track_color = builder.colors.bg if colorname == LIGHT else builder.colors.light
     else:
-        track_color = Colors.update_hsv(builder.colors.selectbg, vd=-0.2)
+        track_color = builder.shade(builder.colors.selectbg)
 
     if any([colorname == DEFAULT, colorname == ""]):
         normal_color = builder.colors.primary

--- a/src/ttkbootstrap/style/builders/toggle.py
+++ b/src/ttkbootstrap/style/builders/toggle.py
@@ -5,7 +5,6 @@ import tkinter as tk
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, image_element, layout
-from ttkbootstrap.style.theme import Colors
 from ttkbootstrap.style.builders.registry import register_builder
 from ttkbootstrap.style.builders.utils import indicator_spacer
 
@@ -36,7 +35,7 @@ def build_round_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Round.Toggle"
     disabled_fg = builder.disabled("text")
-    fg_muted = Colors.make_transparent(0.40, builder.colors.fg, builder.colors.bg)
+    fg_muted = builder.mute(builder.colors.fg)
 
     if any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class
@@ -117,7 +116,7 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Square.Toggle"
     disabled_fg = builder.disabled("text")
-    fg_muted = Colors.make_transparent(0.40, builder.colors.fg, builder.colors.bg)
+    fg_muted = builder.mute(builder.colors.fg)
 
     if any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -15,8 +15,17 @@ from ttkbootstrap.style.theme import (
     ThemeDefinition,
     _accent_on_color,
     _mix_colors,
+    _shade,
     _state_color,
+    _tint,
 )
+
+# Mix-based surface tuning, retiring the ad-hoc HSV/alpha color math. Weights
+# are fractions mixed toward black (shade), white (tint), or a surface (mute),
+# chosen to preserve each recipe's current appearance; gate-tunable.
+_TROUGH_SHADE = 0.2    # recessed dark-theme track/trough behind a filled bar
+_STRIPE_TINT = 0.2     # lighter diagonal highlight over a progress bar
+_MUTE_AMOUNT = 0.4     # unchecked-indicator muting
 
 
 class StyleBuilderTTK:
@@ -100,6 +109,34 @@ class StyleBuilderTTK:
                 f'Invalid role: {role}. Expected text or background.'
             )
         return _mix_colors(neutral, surface, weight)
+
+    def shade(self, color: str, weight: float = _TROUGH_SHADE) -> str:
+        """Return `color` darkened by mixing `weight` of black into it.
+
+        The recessed dark-theme track/trough recipes use the default weight;
+        this replaces their `Colors.update_hsv(..., vd=-0.2)` darken.
+        """
+        return _shade(color, weight)
+
+    def tint(self, color: str, weight: float = _STRIPE_TINT) -> str:
+        """Return `color` lightened by mixing `weight` of white into it.
+
+        Used for forward highlights that must read lighter than the fill they
+        sit on (progress stripe, pale floodgauge trough) in either mode.
+        """
+        return _tint(color, weight)
+
+    def mute(
+        self, color: str, surface: str | None = None,
+        amount: float = _MUTE_AMOUNT,
+    ) -> str:
+        """Return `color` alpha-blended onto a surface to mute an indicator.
+
+        Replaces `Colors.make_transparent(amount, color, surface)`; visually
+        identical (that helper truncated, `_mix_colors` rounds — at most 1/255
+        per channel).
+        """
+        return _mix_colors(color, surface or self.colors.bg, amount)
 
     def on_color(self, color: str) -> str:
         """Return a readable foreground for a filled surface.

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -58,6 +58,16 @@ def _mix_colors(color1: str, color2: str, weight: float) -> str:
     return f'#{channels[0]:02x}{channels[1]:02x}{channels[2]:02x}'
 
 
+def _tint(color: str, weight: float) -> str:
+    """Mix `weight` of white into `color` (a lighter highlight)."""
+    return _mix_colors('#ffffff', color, weight)
+
+
+def _shade(color: str, weight: float) -> str:
+    """Mix `weight` of black into `color` (a darker shade)."""
+    return _mix_colors('#000000', color, weight)
+
+
 @lru_cache(maxsize=256)
 def _cached_color_ramp(anchor: str) -> Mapping[int, str]:
     """Build one immutable Bootstrap-compatible 50–950 color ramp."""

--- a/tests/widget_styles/test_color_helpers.py
+++ b/tests/widget_styles/test_color_helpers.py
@@ -7,13 +7,16 @@ from pathlib import Path
 import pytest
 
 from ttkbootstrap.style.theme import (
+    Colors,
     _ON_COLOR_WHITE_FLOOR,
     _cached_color_ramp,
     _color_ramp,
     _contrast_ratio,
     _mix_colors,
     _relative_luminance,
+    _shade,
     _state_color,
+    _tint,
 )
 
 
@@ -97,6 +100,52 @@ def test_mix_and_contrast_primitives():
     assert _contrast_ratio('#000000', '#ffffff') == pytest.approx(21.0)
 
 
+def test_tint_and_shade_move_toward_white_and_black():
+    color = '#2780e3'
+    tinted = _tint(color, 0.2)
+    shaded = _shade(color, 0.2)
+
+    assert tinted == _mix_colors('#ffffff', color, 0.2)
+    assert shaded == _mix_colors('#000000', color, 0.2)
+    # tint lightens, shade darkens, regardless of the color
+    assert _relative_luminance(tinted) > _relative_luminance(color)
+    assert _relative_luminance(shaded) < _relative_luminance(color)
+    # zero weight is a no-op; full weight reaches the target
+    assert _tint(color, 0.0) == color
+    assert _shade(color, 1.0) == '#000000'
+
+
+def _channels(hex_color):
+    return Colors.hex_to_rgb(hex_color)
+
+
+def test_shade_tint_mute_builder_helpers(root):
+    style = root.style
+    style.theme_use('darkly')
+    builder = style._get_builder()
+
+    # shade() darkens a fill toward black (the recessed-trough recipes)
+    fill = builder.colors.selectbg
+    assert builder.shade(fill) == _shade(fill, 0.2)
+    assert _relative_luminance(builder.shade(fill)) < _relative_luminance(fill)
+
+    # tint() lightens a fill toward white (progress stripe / floodgauge wash)
+    bar = builder.colors.primary
+    assert builder.tint(bar) == _tint(bar, 0.2)
+    assert builder.tint(bar, 0.7) == _tint(bar, 0.7)
+    assert _relative_luminance(builder.tint(bar)) > _relative_luminance(bar)
+
+    # mute() reproduces the old make_transparent(0.4) alpha blend within 1/255
+    fg, bg = builder.colors.fg, builder.colors.bg
+    muted = builder.mute(fg)
+    legacy = Colors.make_transparent(0.4, fg, bg)
+    assert muted == _mix_colors(fg, bg, 0.4)
+    assert all(
+        abs(m - l) <= 1
+        for m, l in zip(_channels(muted), _channels(legacy))
+    )
+
+
 def test_light_theme_builder_helpers(root):
     style = root.style
     style.theme_use('flatly')
@@ -167,20 +216,12 @@ def test_on_color_is_safe_and_independent_of_legacy_toggle(root):
 
 
 def test_direct_color_math_is_limited_to_special_effects():
-    expected = Counter(
-        {
-            ('checkbutton.py', 'build_checkbutton_style', 'make_transparent'): 1,
-            ('floodgauge.py', 'build_floodgauge_style', 'update_hsv'): 1,
-            ('label.py', 'build_meter_label_style', 'update_hsv'): 1,
-            ('progressbar.py', '_create_striped_progressbar_assets', 'update_hsv'): 1,
-            ('progressbar.py', 'build_striped_progressbar_style', 'update_hsv'): 1,
-            ('progressbar.py', '_create_recolored_progressbar_style', 'update_hsv'): 1,
-            ('radiobutton.py', 'build_radiobutton_style', 'make_transparent'): 1,
-            ('scale.py', '_create_scale_assets', 'update_hsv'): 1,
-            ('toggle.py', 'build_round_toggle_style', 'make_transparent'): 1,
-            ('toggle.py', 'build_square_toggle_style', 'make_transparent'): 1,
-        }
-    )
+    # After the color-math fast-follow, ttk recipes carry ZERO direct
+    # Colors.update_hsv / Colors.make_transparent calls: state and surface
+    # derivation goes through the builder helpers (active/pressed/border/
+    # disabled/on_color/shade/tint/mute). A genuinely new special effect that
+    # needs raw HSV/alpha must be re-added here with a reason.
+    expected = Counter()
     actual = Counter()
     for path in BUILDERS_DIR.glob('*.py'):
         tree = ast.parse(path.read_text(encoding='utf-8'))


### PR DESCRIPTION
Fast-follow to the color-helper PR (#1085). Retires the **10 ad-hoc
`Colors.update_hsv` / `Colors.make_transparent` sites** that PR left allowlisted
in the ttk recipes, moving them onto three thin mix-based `StyleBuilderTTK`
helpers so all state/surface color derivation lives on the builder coordinator.

Design (approved, as-built): `development/2_0_color_math_followup_design.md`.

## Changes
- `theme.py`: `_tint` / `_shade` (mix toward white / black on `_mix_colors`).
- `builders_ttk.py`: `shade()` (recessed dark-theme troughs), `tint()`
  (progress stripe + floodgauge pale wash), `mute()` (unchecked-indicator
  muting; identical to `make_transparent` within 1/255).
- Migrated all 10 sites (label / scale / progressbar ×3 / floodgauge trough +
  stripe; check / radio / toggle ×2 muting). Deleted the stripe's
  brightness-adaptive `value_delta` block (mixing toward white is
  self-limiting). Dropped 7 now-unused `Colors` imports.
- AST guard now enforces **zero** direct `update_hsv`/`make_transparent` in
  `style/builders/*.py` (was a 10-entry allowlist).
- Added a "Progress, stripe, and floodgauge" section to
  `examples/color_states_preview.py` for the visual gate.

## Design decisions (both re-decided against the original stub after reading ground truth)
- **No mode-aware `elevate`.** The trough sites are already mode-branched and
  the HSV only runs in the dark branch (light uses `colors.light`/`bg`), so a
  mode-aware raise would wrongly *lighten* dark troughs. Plain `shade`/`tint`
  preserves appearance — `shade` is byte-identical to the old HSV for gray
  `selectbg`.
- **`input_bg` deferred to Workstream E.** Light `bg == inputbg` makes it a
  no-op; dark authored deltas carry theme hue that a tint-toward-white would
  desaturate. A hue-correct derivation needs the semantic model.

## Verification
- Focused **14 passed**; full headless **191 passed** (189 baseline + 2 new).
- Warning-free import; PEP 649 annotation sweep (26 modules / 152 targets) clean;
  standalone `style.theme` import; all affected widgets build in darkly + flatly.
- **Human visual gate PASSED** (six themes, light↔dark) — colors approved, no
  tuning changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)