### PR TITLE
Resolved-view Colors + ramp addressing (2.0 Workstream E, PR E1)

### DIFF
--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,11 +3,16 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-07-06 (the **fast-follow color-math PR is MERGED into `2.0`**
-— PR #1087, merge commit `0218aba3`; visual gate passed, suite 191. Branch
-deleted. Next actionable is canonical bootstyle grammar (Workstream D) or
-theme/anchor (Workstream E), each needing its own design pass first. The prior
-color-helper branch is also merged — PR #1085, merge commit `b7872a98`.)_
+_Last updated: 2026-07-06 (**Workstream E design pass DONE** — approved model in
+`development/2_0_theme_anchor_design.md`: adopt bootstack's semantic-anchor
+`Theme` family, curated catalog + opt-in `install_legacy_themes()`, minimal
+derived surface layer, `Colors` resolved view + ramp addressing. **PR E1 is
+implemented + green** (`Colors`→`RampColor` resolved view, `c.primary[300]`; no
+catalog/visual change; suite **201 passed**) on branch
+`refactor/2.0-pr-e1-colors-ramp`, **PR open against `2.0`**. E2
+= `Theme` model + curated catalog + adapter (carries the human visual gate + 3
+open forks); E3 = migration doc/polish. Prior: color-math PR #1087 merged
+(`0218aba3`, suite 191); color-helper PR #1085 merged (`b7872a98`).)_
 
 _Prior (2026-07-01): focused Workstream E private ramps and builder color
 helpers implemented on `refactor/2.0-color-helpers`; `on_color` retuned to a

--- a/development/2_0_theme_anchor_design.md
+++ b/development/2_0_theme_anchor_design.md
@@ -1,0 +1,287 @@
+# ttkbootstrap 2.0 — Workstream E: semantic-anchor theme model
+
+**Status:** design pass approved; **PR E1 implemented + green** (§8). E2/E3 not
+started.
+**Branch (planned):** cut from `2.0`.
+**Date:** 2026-07-06.
+
+> **PR E1 — DONE** (branch `refactor/2.0-pr-e1-colors-ramp`, PR open against
+> `2.0`). `Colors` is now a resolved view:
+> each field is a `RampColor` (a `str` subclass, drop-in everywhere, additionally
+> `c.primary[300]`-addressable) and `Colors.ramp(label)` returns the full 50-950
+> mapping. `RampColor` re-exported from `ttkbootstrap.style`. No catalog/visual
+> change. New `tests/widget_styles/test_theme_ramp.py` (10 tests). Suite **201
+> passed** (191 + 10); warning-free import + standalone `style.theme` import
+> clean. Only int keys that are ramp stops (50-950 step 50) are intercepted;
+> ordinary str indexing/slicing falls through untouched.
+
+Pairs with `development/2_0_plan.md` (§E, §F) and `development/2_0_handoff.md`.
+This is the design pass required by the hard rule before any Workstream-E coding.
+
+---
+
+## 1. Goal
+
+Replace the flat 16-key per-theme dict with a **semantic-anchor `Theme`
+family**: declare the accent colors once (as `[500]` ramp anchors) plus a
+`light`/`dark` background block, and generate a well-contrasted light **and**
+dark variant from one declaration. The generator fixes today's hand-authored
+contrast/consistency bugs (inconsistent `border`/`inputbg`/`selectbg`, sub-AA
+on-colors) by *deriving* the plumbing instead of authoring it per theme.
+
+The **mechanism is ported from bootstack** (`bootstack/src/bootstack/style/
+theme.py`, `theme_provider.py`) — the same author, and ttkbootstrap already
+carries the matching ramp math from the color-helper PR (`style/theme.py`
+`_color_ramp`, `_mix_colors`, `_tint`/`_shade`, `_darken_color`/`_lighten_color`,
+`_state_color`, `_accent_on_color`, luminance/contrast). We borrow the model, not
+bootstack's public API or its full surface taxonomy.
+
+---
+
+## 2. Approved decisions (locked with user, 2026-07-06)
+
+1. **Adopt bootstack's `Theme` family model.** One anchor set + `light=`/`dark=`
+   blocks → `<name>-light` + `<name>-dark`. Per-mode ramp-step selection gives
+   contrast in both modes with no per-mode shade authoring.
+2. **`Colors` becomes a resolved view** keeping all 16 current attrs
+   (`c.primary`, `c.bg`, `c.get(...)`, …) **and** gaining ramp addressing
+   (`c.primary[300]`). Backward-compatible.
+3. **Curated default catalog** (~15 families → ~30 light/dark themes), not a
+   mechanical port of all ~18 built-ins. Membership in §5.
+4. **`install_legacy_themes()`** — opt-in call that registers the old theme
+   names, each re-expressed through the new generator. **Fidelity: keep each old
+   theme's authored accents + bg/fg exact; regenerate only the plumbing**
+   (`border`/`inputbg`/`selectbg`/`active`/on-colors). Preserves recognizability,
+   fixes the contrast bugs, and stays a thin adapter (Workstream-F discipline).
+5. **Raw 16-key dict stays an accepted input** (`ttkcreator`, `USER_THEMES`,
+   `load_user_themes(json)`) via the same adapter — never a parallel engine.
+6. **Minimal surface layer.** Derive only `bg/inputbg/selectbg/border/active`
+   (+ their on-colors). Do **not** import bootstack's chrome/content/card/
+   overlay/raised taxonomy — ttk does not need it.
+7. **Plumbing is derived, not authored, for the curated set** (this is where the
+   deferred `inputbg` fix lands).
+
+---
+
+## 3. The `Theme` model (ttkbootstrap port)
+
+A `Theme` is a *family* declared in code. Ported from bootstack's dataclass,
+trimmed to ttkbootstrap's needs (no `surfaces` taxonomy, no `display_name`
+machinery beyond a label).
+
+```python
+Theme(
+    name="pulse",
+    primary="#593196", success="#13b955", info="#009cdc",
+    warning="#efa31d", danger="#fc3939",
+    secondary=None,              # optional colored secondary; else from neutral ramp
+    neutral="#adb5bd",           # gray base for secondary/light/dark/border/muted
+    light=dict(background="#ffffff", foreground="#17141f"),
+    dark=dict(background="#17141f",  foreground="#e9ecef"),
+).register()                     # registers pulse-light + pulse-dark
+```
+
+- **Accent roles** (`primary success info warning danger`) + optional
+  `secondary` take a `[500]` anchor and generate a private 50–950 ramp
+  (`_color_ramp`, already cached/bounded).
+- `neutral` generates the gray ramp used for `secondary` (when uncolored),
+  the `light`/`dark` accent keys, `border`, and muted text.
+- `light`/`dark` each carry only `{background, foreground}`. A family may define
+  one or both; `register()` produces a variant per defined block.
+- `.register()` = ttkbootstrap's analog of bootstack's `.install()`. It builds a
+  per-mode **schema** and registers it with `Style` (see §7 back-compat for how
+  this coexists with `Style.register_theme(ThemeDefinition)`).
+- **`Theme.from_existing(base, name=..., **overrides)`** ported for
+  brand-a-builtin ergonomics (change just `primary`, inherit the rest).
+
+`Theme` lives in `style/theme.py` alongside `Colors`/`ThemeDefinition`.
+
+### Per-mode step tables (ported, tunable in the visual gate)
+
+```python
+_SOLID_STOP = {  # which ramp step a solid fill uses per mode
+    "light": {"primary":600,"success":600,"danger":600,"info":500,"warning":500},
+    "dark":  {"primary":400,"success":400,"danger":400,"info":400,"warning":400},
+}
+_SECONDARY_STOP = {"light": 700, "dark": 400}   # neutral step for uncolored secondary
+```
+
+Rationale (bootstack's, verified): on light a darker step reads against white; on
+dark a brighter step reads against the dark bg. `warning`/`info` stay at `[500]`
+on light — they carry dark on-color at any shade, so darkening only mutes them.
+
+---
+
+## 4. Schema → 16-key `Colors` mapping (the core of E)
+
+`register()` generates a per-mode schema; an adapter resolves it into the 16
+`Colors` fields the builders already consume. This is the whole compatibility
+trick: **builders are untouched; only how `Colors` is populated changes.**
+
+Let `mode ∈ {light, dark}`, `bg`/`fg` = the authored block, `R(role)` = the
+role's 50–950 ramp, `N` = the neutral ramp. Surface derivations use the existing
+hue-preserving `_darken_color`/`_lighten_color`.
+
+| `Colors` key | Curated derivation | Notes |
+|---|---|---|
+| `primary` | `R(primary)[_SOLID_STOP[mode].primary]` | per-mode solid |
+| `success` | `R(success)[…]` | ″ |
+| `info` | `R(info)[…]` | ″ |
+| `warning` | `R(warning)[…]` | ″ |
+| `danger` | `R(danger)[…]` | ″ |
+| `secondary` | authored `R(secondary)[…]` if given, else `N[_SECONDARY_STOP[mode]]` | |
+| `light` | `N[100]` | fixed gray accent (both modes) |
+| `dark` | `N[800]` | fixed gray accent (both modes) |
+| `bg` | `bg` (authored) | |
+| `fg` | `fg` (authored) | |
+| `inputfg` | `fg` | |
+| `inputbg` | light: `bg`; dark: `_lighten_color(bg, _INPUT_LIFT)` | **hue-correct — the deferred fix** |
+| `border` | light: `_darken_color(bg, _BORDER_MIX)`; dark: `_lighten_color(bg, _BORDER_MIX_D)` | hue-preserving |
+| `active` | light: `_darken_color(bg, _ACTIVE_MIX)`; dark: `_lighten_color(bg, _ACTIVE_MIX_D)` | subtle hover fill |
+| `selectbg` | `primary` (resolved above) — **decision, see §4.1** | |
+| `selectfg` | `_accent_on_color(selectbg)` | reuses on-color policy |
+
+### 4.1 Tunable constants (initial values; settle in the human visual gate)
+
+```python
+_INPUT_LIFT    = 0.03   # dark inputbg lift off bg
+_BORDER_MIX    = 0.14   # light border darken
+_BORDER_MIX_D  = 0.22   # dark border lighten
+_ACTIVE_MIX    = 0.06   # light active/hover darken
+_ACTIVE_MIX_D  = 0.09   # dark active/hover lighten
+```
+
+These are the E analog of the color-helper PR's `_ON_COLOR_*` knobs — named,
+documented, and confirmed by the six-theme sweep, not guessed-and-shipped.
+
+### 4.2 Open decision — `selectbg`
+
+Today `selectbg` is usually the **secondary gray** (cosmo `#7e8081`). Modern
+Bootstrap selection uses **primary**. Options for the doc to lock before coding:
+- **(a) `selectbg = primary`** — modern, visible change to selection color
+  everywhere (Treeview/listbox/text selection). Lean.
+- **(b) `selectbg = secondary`** — preserves current behavior.
+
+Recommend (a) for the curated set; **`install_legacy_themes()` keeps whatever the
+legacy theme authored** (it only regenerates border/inputbg/active, per
+decision 4), so legacy selection color is preserved regardless.
+
+---
+
+## 5. Curated default catalog (approved)
+
+~15 families → ~30 `-light`/`-dark` themes.
+
+| Source | Families |
+|---|---|
+| **From bootstack (10)** | bootstrap, pydata, nord, solarized, catppuccin, gruvbox, dracula, tokyo-night, one, everforest |
+| **Migrated from ttkbootstrap (5)** | vapor, minty, pulse, united, sandstone |
+
+The migrated five are expressed as `Theme` families: their existing accents +
+bg become the light (or dark) anchors, and the **opposite** mode is generated
+new (e.g. `vapor` is dark today → `vapor-light` is generated; author a light bg
+block for it). Where a migrated theme has no natural opposite-mode background,
+pick a neutral bg/fg pair in the family's spirit (settle in the visual gate).
+
+Everything else (cosmo/flatly/litera/lumen/yeti/journal/simplex/cerulean/morph/
+superhero/solar/cyborg) is covered by a near-equivalent (solar≈solarized,
+cosmo≈bootstrap) or reachable via `install_legacy_themes()`.
+
+---
+
+## 6. `install_legacy_themes()` and the raw-dict adapter
+
+```python
+# style/_compat.py (or themes/legacy.py) — the ONLY place the 16-key shape is understood
+def theme_from_legacy_dict(name, spec) -> ThemeDefinition:
+    """Adapt a legacy {'type','colors':{16 keys}} into a resolved ThemeDefinition,
+    keeping authored accents + bg/fg, regenerating border/inputbg/active/on-colors."""
+
+def install_legacy_themes() -> None:
+    """Register every legacy STANDARD_THEMES name via the adapter (opt-in)."""
+```
+
+- **Fidelity (decision 4):** accents, `bg`, `fg`, `selectbg`, `selectfg`,
+  `light`, `dark` taken from the authored dict verbatim; `border`, `inputbg`,
+  `active` **regenerated** by the §4 surface derivation (this is the "optimized
+  as possible" part — the buggy plumbing is what we throw away). Legacy accents
+  are **not** re-stepped through `_SOLID_STOP` (that would change identity).
+- `USER_THEMES` and `load_user_themes(json)` route through the same adapter, so
+  custom 16-key themes keep working and get the same plumbing cleanup.
+- `install_legacy_themes()` is **not** called at import — opt-in, warns once that
+  these names are legacy (removed/renamed guidance in the migration doc).
+
+---
+
+## 7. Back-compat & integration
+
+- **`Style.register_theme(ThemeDefinition)`** stays the low-level registration
+  primitive. `Theme.register()` builds per-mode `ThemeDefinition`s (whose
+  `Colors` is the resolved view) and calls it — no second registry.
+- **`Style._load_themes`** switches from iterating `STANDARD_THEMES` dicts to
+  registering the curated `Theme` families. `STANDARD_THEMES` is retained (moved
+  behind the legacy adapter) for `install_legacy_themes()`.
+- **`themename="darkly"`** and friends: resolve only after
+  `install_legacy_themes()`. Ship a migration note + a small alias map for the
+  highest-traffic old names → nearest curated variant (e.g. `darkly` →
+  `bootstrap-dark`?) — **alias list is an open item for the visual gate.**
+- **`ttkcreator`** authors 16-key dicts → still valid via the adapter; a
+  follow-up (Workstream H/docs) can teach it the `Theme` form.
+- **Ramp addressing** (`c.primary[300]`): `Colors` gains `__getitem__`-on-attr
+  or a small resolved-ramp holder. `c.primary` stays a `str` (the solid) but
+  also indexable — implement as a `str` subclass carrying its ramp, or resolve
+  `c.primary[300]` via a `Colors.ramp(role)` lookup. **Decision for PR E1:**
+  prefer a `str` subclass (`RampColor(str)`) so `c.primary` is still a plain
+  string everywhere it's used today and `c.primary[300]` works additively.
+
+---
+
+## 8. PR sequencing (proposed; confirm)
+
+- **PR E1 — resolved `Colors` + ramp addressing, no catalog change.** `Colors`
+  becomes a resolved view; add `RampColor`/`c.primary[300]`; keep the existing
+  16-key dicts feeding it. No visual change → suite stays green, low risk.
+- **PR E2 — `Theme` model + curated catalog + adapter.** Port `Theme`/schema/
+  step tables; add the §4 derivation; replace `_load_themes` built-ins with the
+  curated families; add `install_legacy_themes()` + raw-dict adapter. **Human
+  visual gate here** (every theme shifts). Settle §4.1 knobs, §4.2 `selectbg`,
+  §7 alias map, and the migrated-five opposite-mode backgrounds.
+- **PR E3 — cleanup/migration doc + `ttkcreator`/`USER_THEMES` polish** as
+  needed; retire any now-dead code paths.
+
+---
+
+## 9. Risks / open items
+
+- **Every curated theme shifts visually** (intended; approved drift). Gate on the
+  six-theme human sweep like the color PRs. Extend
+  `examples/color_states_preview.py` (or a theme-gallery example) to cycle the
+  full catalog light↔dark.
+- **`selectbg = primary`** (§4.2) — lock before E2 coding.
+- **Legacy alias map** (§7) — which old names get a courtesy alias vs a clean
+  break. Lock in E2.
+- **Migrated-five opposite-mode backgrounds** (§5) — need authored bg/fg for the
+  mode each lacks today.
+- **PEP 649 annotation sweep** — carry the 3.14 force-evaluation gate into the
+  new/edited modules (per PR 4's finding).
+- **`Colors.get_foreground` / `dynamic_foreground`** stay for external compat;
+  the resolved view must keep them working.
+
+---
+
+## 10. Verification plan
+
+- Ramp-addressing unit tests (`c.primary[300]` equals `_color_ramp` stop;
+  `c.primary` still `== str`).
+- Schema→Colors derivation tests: each of the 16 keys for a light and a dark
+  family; `inputbg` hue-preservation (dark `inputbg` shares bg hue, is not
+  desaturated toward white) — the explicit regression check for the deferred
+  fix.
+- `install_legacy_themes()` fidelity tests: authored accents/bg/fg preserved
+  byte-for-byte; `border`/`inputbg`/`active` differ from the legacy dict.
+- All 8 bootstyle color keywords resolve in every curated theme.
+- Structural: warning-free import; standalone-submodule cycle guard; Python 3.10
+  parse; PEP 649 force-evaluation sweep.
+- Full headless suite green (record the new expected count).
+- **Human visual gate** across the full curated catalog, light↔dark, before E2
+  merge.

--- a/src/ttkbootstrap/style/__init__.py
+++ b/src/ttkbootstrap/style/__init__.py
@@ -6,7 +6,7 @@ module). The implementation is split across submodules (`theme`, `builders_tk`,
 implementation detail and carry no back-compat guarantee. Import the names below
 from `ttkbootstrap.style` (or, preferably, from `ttkbootstrap`).
 """
-from ttkbootstrap.style.theme import Colors, ThemeDefinition
+from ttkbootstrap.style.theme import Colors, RampColor, ThemeDefinition
 from ttkbootstrap.style.builders_tk import StyleBuilderTK
 from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
 from ttkbootstrap.style.engine import Style
@@ -33,6 +33,7 @@ from ttkbootstrap.style.icons import Icon, icon_element, IconRenderer
 
 __all__ = [
     "Colors",
+    "RampColor",
     "ThemeDefinition",
     "StyleBuilderTK",
     "StyleBuilderTTK",

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -90,6 +90,47 @@ def _color_ramp(color: str) -> Mapping[int, str]:
     return _cached_color_ramp(_normalize_color(color))
 
 
+# The valid 50-950 ramp stops, in 50-step increments. Every stop is >= 50, and
+# no hex/named color string is that long, so an int index of this magnitude is
+# unambiguously a ramp request and never collides with ordinary str indexing
+# (char indices 0-6, slices) -- which `RampColor` delegates to `str` untouched.
+_RAMP_STOPS = frozenset(range(50, 1000, 50))
+
+
+class RampColor(str):
+    """A hex color string that also addresses its own 50-950 tint/shade ramp.
+
+    Behaves as the plain color string everywhere it is used today
+    (`str.__eq__`, formatting, `color[1:]` slicing, char indexing), so it is a
+    drop-in for the previous `str` color values. Additionally, indexing with a
+    ramp stop returns that step of the color's ramp, treating the color itself
+    as the `[500]` anchor:
+
+        c.primary          # '#2780e3'  (a str)
+        c.primary[500]     # '#2780e3'  (the anchor, normalized)
+        c.primary[300]     # a lighter tint
+        c.primary[700]     # a darker shade
+        c.primary[1:]      # '2780e3'   (ordinary str slicing, unchanged)
+
+    Only int keys that are valid ramp stops (multiples of 50 in 50-950) are
+    intercepted; every other key falls through to `str.__getitem__`.
+    """
+
+    __slots__ = ()
+
+    def __getitem__(self, key):
+        if isinstance(key, int) and key in _RAMP_STOPS:
+            return _color_ramp(self)[key]
+        return super().__getitem__(key)
+
+
+def _as_ramp_color(value):
+    """Wrap a color string as a `RampColor`; pass through non-strings/None."""
+    if isinstance(value, str) and not isinstance(value, RampColor):
+        return RampColor(value)
+    return value
+
+
 def _relative_luminance(color: str) -> float:
     """Return WCAG relative luminance for a Pillow-supported color."""
     channels = [value / 255 for value in ImageColor.getrgb(color)]
@@ -298,22 +339,24 @@ class Colors:
             active (str):
                 An accent color.
         """
-        self.primary = primary
-        self.secondary = secondary
-        self.success = success
-        self.info = info
-        self.warning = warning
-        self.danger = danger
-        self.light = light
-        self.dark = dark
-        self.bg = bg
-        self.fg = fg
-        self.selectbg = selectbg
-        self.selectfg = selectfg
-        self.border = border
-        self.inputfg = inputfg
-        self.inputbg = inputbg
-        self.active = active
+        # Colors are stored as RampColor -- a str subclass that additionally
+        # ramp-addresses (c.primary[300]); a no-op for every existing str use.
+        self.primary = _as_ramp_color(primary)
+        self.secondary = _as_ramp_color(secondary)
+        self.success = _as_ramp_color(success)
+        self.info = _as_ramp_color(info)
+        self.warning = _as_ramp_color(warning)
+        self.danger = _as_ramp_color(danger)
+        self.light = _as_ramp_color(light)
+        self.dark = _as_ramp_color(dark)
+        self.bg = _as_ramp_color(bg)
+        self.fg = _as_ramp_color(fg)
+        self.selectbg = _as_ramp_color(selectbg)
+        self.selectfg = _as_ramp_color(selectfg)
+        self.border = _as_ramp_color(border)
+        self.inputfg = _as_ramp_color(inputfg)
+        self.inputbg = _as_ramp_color(inputbg)
+        self.active = _as_ramp_color(active)
 
     @staticmethod
     def make_transparent(alpha, foreground, background='#ffffff'):
@@ -457,6 +500,25 @@ class Colors:
         """
         return self.__dict__.get(color_label)
 
+    def ramp(self, color_label: str) -> Mapping[int, str]:
+        """Return the full immutable 50-950 tint/shade ramp for a color role.
+
+        The role's current value is treated as the `[500]` anchor. Equivalent
+        to reading each stop off the addressable color (`self.get(label)[stop]`)
+        but returns the whole mapping at once.
+
+        Parameters:
+
+            color_label (str):
+                A color label corresponding to a class property.
+
+        Returns:
+
+            Mapping[int, str]:
+                An immutable mapping of ramp stop (50-950) to hex color.
+        """
+        return _color_ramp(self.get(color_label))
+
     def set(self, color_label: str, color_value: str):
         """Set a color property value. This does not update any existing
         widgets. Can also be used to create on-demand color properties
@@ -470,7 +532,7 @@ class Colors:
             color_value (str):
                 A hexadecimal color value
         """
-        self.__dict__[color_label] = color_value
+        self.__dict__[color_label] = _as_ramp_color(color_value)
 
     def __iter__(self):
         return iter(

--- a/tests/widget_styles/test_theme_ramp.py
+++ b/tests/widget_styles/test_theme_ramp.py
@@ -1,0 +1,128 @@
+"""Tests for the resolved-view `Colors` and `RampColor` ramp addressing (E, PR E1).
+
+`Colors` stores each color as a `RampColor` -- a `str` subclass that behaves
+exactly like the plain hex string everywhere it is used today, and additionally
+addresses its own 50-950 tint/shade ramp (`c.primary[300]`). These tests pin
+both the drop-in-`str` behavior and the new ramp addressing, with no catalog or
+visual change.
+"""
+import pytest
+
+from ttkbootstrap.style.theme import (
+    Colors,
+    RampColor,
+    _color_ramp,
+    _normalize_color,
+)
+
+
+RAMP_STOPS = tuple(range(50, 1000, 50))
+
+# The 16 constructor colors, in signature order.
+SAMPLE = (
+    "#2780e3",  # primary
+    "#7E8081",  # secondary
+    "#3fb618",  # success
+    "#9954bb",  # info
+    "#ff7518",  # warning
+    "#ff0039",  # danger
+    "#F8F9FA",  # light
+    "#373A3C",  # dark
+    "#ffffff",  # bg
+    "#373a3c",  # fg
+    "#7e8081",  # selectbg
+    "#ffffff",  # selectfg
+    "#ced4da",  # border
+    "#373a3c",  # inputfg
+    "#fdfdfe",  # inputbg
+    "#efefef",  # active
+)
+
+
+def make_colors():
+    return Colors(*SAMPLE)
+
+
+def test_rampcolor_is_a_drop_in_str():
+    c = RampColor("#2780e3")
+    assert isinstance(c, str)
+    assert c == "#2780e3"
+    assert c.upper() == "#2780E3"
+    # ordinary str indexing/slicing is untouched (char indices, slices)
+    assert c[0] == "#"
+    assert c[1:] == "2780e3"
+    assert list(c[:3]) == ["#", "2", "7"]
+
+
+def test_rampcolor_addresses_its_ramp():
+    c = RampColor("#0d6efd")
+    ramp = _color_ramp("#0d6efd")
+    assert c[500] == ramp[500] == "#0d6efd"
+    assert c[300] == ramp[300]
+    assert c[700] == ramp[700]
+    # every valid stop resolves to the same value the ramp holds
+    assert all(c[stop] == ramp[stop] for stop in RAMP_STOPS)
+
+
+def test_rampcolor_anchor_is_500_normalized():
+    # a short/named color still anchors correctly and normalizes on lookup
+    assert RampColor("#abc")[500] == _normalize_color("#abc")
+    assert RampColor("white")[500] == "#ffffff"
+
+
+def test_non_ramp_int_index_falls_through_to_str():
+    c = RampColor("#2780e3")
+    # 6 is a normal char index, not a ramp stop
+    assert c[6] == "3"
+    # an out-of-range non-stop int raises like a plain str would
+    with pytest.raises(IndexError):
+        _ = c[42]
+
+
+def test_colors_wraps_every_field_as_rampcolor():
+    c = make_colors()
+    for label in Colors.label_iter():
+        value = c.get(label)
+        assert isinstance(value, RampColor), label
+        # equality with the authored string is preserved byte-for-byte
+    assert c.primary == "#2780e3"
+    assert c.inputbg == "#fdfdfe"
+
+
+def test_colors_attr_and_get_are_ramp_addressable():
+    c = make_colors()
+    assert c.primary[500] == _normalize_color("#2780e3")
+    assert c.primary[300] == _color_ramp("#2780e3")[300]
+    assert c.get("info")[700] == _color_ramp("#9954bb")[700]
+
+
+def test_colors_ramp_returns_full_mapping():
+    c = make_colors()
+    ramp = c.ramp("primary")
+    assert tuple(ramp) == RAMP_STOPS
+    assert ramp == _color_ramp("#2780e3")
+    # the mapping is immutable
+    with pytest.raises(TypeError):
+        ramp[500] = "#000000"
+
+
+def test_colors_set_wraps_and_addresses():
+    c = make_colors()
+    c.set("custom", "#0d6efd")
+    assert isinstance(c.get("custom"), RampColor)
+    assert c.get("custom")[300] == _color_ramp("#0d6efd")[300]
+
+
+def test_colors_still_usable_as_plain_strings():
+    # the values must remain interchangeable with str in every legacy use
+    c = make_colors()
+    assert f"bg is {c.bg}" == "bg is #ffffff"
+    assert c.fg.lstrip("#") == "373a3c"
+    assert {c.primary, c.secondary} == {"#2780e3", "#7E8081"}
+
+
+def test_live_theme_colors_are_ramp_addressable(root):
+    # integration: the active theme's Colors resolves ramp stops end-to-end
+    colors = root.style.colors
+    assert colors.primary[300] == _color_ramp(colors.primary)[300]
+    assert colors.primary == str(colors.primary)


### PR DESCRIPTION
First slice of Workstream E (semantic-anchor theme model). The lowest-risk,
**no-visual-change** step: `Colors` becomes a resolved view over its values.

## What changed
- Each `Colors` field is now a `RampColor` — a `str` subclass that is a drop-in
  for the previous plain hex strings everywhere they are used today (equality,
  formatting, `color[1:]` slicing, char indexing) and **additionally** addresses
  its own 50–950 tint/shade ramp: `c.primary[300]`, treating the value as the
  `[500]` anchor.
- Only int keys that are valid ramp stops (50–950 in steps of 50) are
  intercepted; every other key falls through to `str.__getitem__`. Since no
  color string is that long, there is **no collision** with ordinary
  indexing/slicing.
- `Colors.ramp(label)` returns the full immutable 50–950 mapping.
- `RampColor` re-exported from `ttkbootstrap.style`.

No catalog or theme-format change — the existing 16-key dicts still feed
`Colors`. The `Theme` family model, curated catalog, `install_legacy_themes()`,
and derived plumbing (incl. the deferred hue-correct `inputbg` fix) land in
**PR E2**.

## Design
`development/2_0_theme_anchor_design.md` (approved model; §8 sequencing). This PR
is PR E1 from that doc.

## Verification
- **Suite: 201 passed** (191 baseline + 10 new in
  `tests/widget_styles/test_theme_ramp.py`).
- Warning-free `import ttkbootstrap`; standalone `ttkbootstrap.style.theme`
  import clean.
- Tests pin both the drop-in-`str` behavior (equality, slicing, fall-through
  indexing) and the new ramp addressing (attr, `get()`, `ramp()`, `set()`), plus
  a live-theme integration check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)