### PR TITLE
ttkcreator Theme rework + user-theme persistence + migration guide (2.0 Workstream E, PR E3)

### DIFF
--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -5,8 +5,14 @@
 
 _Last updated: 2026-07-06 (**Workstream E in progress.** PR E1 (`Colors`→
 `RampColor` resolved view + `c.primary[300]`) is **MERGED** (PR #1088). **PR E2
-is IMPLEMENTED + green on branch `refactor/2.0-pr-e2-theme-model`, human visual
-gate PASSED** (user, 2026-07-06; ready to PR) — semantic-anchor `Theme` model +
+is MERGED** (PR #1089; visual gate passed). **PR E3 (ttkcreator rework +
+`USER_THEME_SPECS` + migration guide) is IMPLEMENTED + green on branch
+`refactor/2.0-pr-e3-ttkcreator`**, pending a manual `python -m ttkcreator`
+eyeball. Migration guide at **`development/2_0_theme_migration.md`** — FOLD INTO
+the Workstream-H docs rewrite (kept in `development/` so it survives the docs
+transition). That completes Workstream E; next headliner is Workstream D
+(canonical bootstyle grammar, needs its own design pass). E2 was the
+semantic-anchor `Theme` model +
 schema→16-key derivation,
 curated 15-family catalog (30 light/dark themes, `themes/builtin.py`), legacy
 16-key adapter + opt-in `install_legacy_themes()` (`themes/legacy.py`), default

--- a/development/2_0_theme_anchor_design.md
+++ b/development/2_0_theme_anchor_design.md
@@ -1,7 +1,25 @@
 # ttkbootstrap 2.0 — Workstream E: semantic-anchor theme model
 
-**Status:** design pass approved; **PR E1 merged**; **PR E2 implemented + green;
-human visual gate PASSED** (user, 2026-07-06). E3 not started.
+**Status:** design pass approved; **PR E1 merged**; **PR E2 merged** (visual gate
+PASSED). **PR E3 implemented + green** — ttkcreator reworked to a `Theme`
+editor, `USER_THEME_SPECS` store, migration guide. Awaits a manual GUI eyeball
+(`python -m ttkcreator`, no headless view).
+
+> **PR E3 — ttkcreator + user-theme persistence + migration guide.**
+> - `ttkcreator/__main__.py` rebuilt as a **semantic-anchor editor**: edit the
+>   accent anchors + `neutral` and the light/dark background/foreground blocks,
+>   pick a base family, preview either generated mode live. **Export theme
+>   definition** now emits a `ttk.Theme(...).register()` snippet (was a 16-key
+>   `ThemeDefinition`); **Save** persists a `Theme` spec.
+> - New `themes/user.py` store **`USER_THEME_SPECS`** (name → `Theme(**spec)`
+>   kwargs); the engine builds+registers each at load. Legacy `USER_THEMES`
+>   (16-key) still adapted. Fixed the stale `litera` base default.
+> - Migration guide: **`development/2_0_theme_migration.md`** (durable; folded
+>   into the H docs rewrite, not `docs/`, so it survives the transition).
+> - Verified headless (creator constructs, seeds from a family, generates live,
+>   the exported snippet executes + registers, the persisted spec round-trips)
+>   + `tests/widget_styles/test_theme_anchor.py::test_user_theme_spec_builds_and_registers`.
+>   Non-localization suite 210 → **211 passed**; warning-free import.
 
 > **Visual gate — PASSED** after an interactive light↔dark sweep. Fixes made
 > during the gate, all traceable to `selectbg` no longer being a mid-gray:

--- a/development/2_0_theme_anchor_design.md
+++ b/development/2_0_theme_anchor_design.md
@@ -34,9 +34,11 @@ editor, `USER_THEME_SPECS` store, migration guide. Awaits a manual GUI eyeball
 > (6) a `selectfg` audit — tk Button/Menubutton + ttk Floodgauge label
 > foregrounds now `on_color(their own accent bg)`; and
 > (7) unselected notebook tab labels muted (0.6) toward their bg.
-> The three deferred aesthetic items (toolbutton unselected fill, scrollbar
-> thumb, dark readonly-field brightness — all light-neutral `selectbg` fills)
-> were reviewed and accepted as-is.
+> Three aesthetic items were deferred (all light-neutral `selectbg` fills):
+> toolbutton unselected fill and scrollbar thumb were accepted as-is; the
+> **dark readonly-field brightness was fixed in E3** — readonly fields
+> (combobox/entry/spinbox) now use `inputbg` in both modes (they read like
+> normal fields; no greyed box), per user feedback while eyeballing ttkcreator.
 **Branch:** E2 on `refactor/2.0-pr-e2-theme-model` (from `2.0`).
 **Date:** 2026-07-06.
 

--- a/development/2_0_theme_migration.md
+++ b/development/2_0_theme_migration.md
@@ -1,0 +1,147 @@
+# ttkbootstrap 2.0 — Theme migration guide
+
+> **For the docs rewrite (Workstream H):** this is the authoritative,
+> user-facing source for the theming migration content. It lives in
+> `development/` on purpose so it is **not lost** when `docs/` is restructured
+> for 2.0 — fold it into the new "Theming" / "Migrating to 2.0" pages rather than
+> rewriting it from memory. Keep it updated as Workstream D (bootstyle) lands.
+
+2.0 replaces the flat 16-key theme dictionaries with a **semantic-anchor theme
+model**. You declare a theme's accent colors once; the full palette — and a
+matching **light and dark** variant — is generated. This guide covers what
+changed and how to migrate.
+
+## TL;DR
+
+| 1.x | 2.0 |
+|---|---|
+| ~18 single-mode themes (`cosmo`, `darkly`, …) | 15 curated **families** → 30 `-light`/`-dark` themes |
+| Default `litera` | Default **`bootstrap-light`** |
+| `Window(themename="darkly")` just works | Curated names only; legacy names need `install_legacy_themes()` |
+| Author a 16-key `colors` dict | Author a `Theme(...)` (accent anchors + light/dark blocks) |
+| `style.colors.primary` (a string) | Still a string — **plus** `style.colors.primary[300]` ramp steps |
+
+## Theme names changed
+
+The built-in catalog is now 15 curated families, each generating two variants:
+
+```
+bootstrap  pydata  nord  solarized  catppuccin  gruvbox  dracula
+tokyo-night  one  everforest  vapor  minty  pulse  united  sandstone
+```
+
+→ `bootstrap-light`, `bootstrap-dark`, `pydata-light`, … (30 total).
+
+```python
+import ttkbootstrap as ttk
+app = ttk.Window(themename="bootstrap-dark")   # was e.g. "darkly"
+```
+
+### Getting the old themes back
+
+The pre-2.0 names (`cosmo`, `flatly`, `litera`, `darkly`, `superhero`, `solar`,
+`cyborg`, `united`, `journal`, …) are available on demand:
+
+```python
+import ttkbootstrap as ttk
+ttk.install_legacy_themes()          # registers the pre-2.0 names
+app = ttk.Window(themename="darkly")
+```
+
+Legacy themes keep their authored accent and background/foreground colors; only
+their inconsistent plumbing (borders, input backgrounds) is regenerated, so they
+look the same but cleaner. Using a legacy name **without** calling
+`install_legacy_themes()` raises a clear error telling you what to do. These
+names are a migration convenience and are planned for removal in 3.0.
+
+## Authoring your own theme
+
+### The `Theme` API (recommended)
+
+Declare the accent anchors plus a `light` and/or `dark` background block:
+
+```python
+import ttkbootstrap as ttk
+
+ttk.Theme(
+    name="acme",
+    primary="#2780e3", success="#3fb618", info="#9954bb",
+    warning="#ff7518", danger="#ff0039",
+    secondary=None,               # optional colored accent; else from the neutral ramp
+    neutral="#7e8081",            # gray base (borders, secondary, muted)
+    light=dict(background="#ffffff", foreground="#373a3c"),
+    dark=dict(background="#222222",  foreground="#f8f9fa"),
+).register()                      # registers acme-light + acme-dark
+
+app = ttk.Window(themename="acme-light")
+```
+
+- Declare **one or both** of `light`/`dark`; each defined block yields a variant.
+- `Theme.from_existing(base, name="acme", primary="#ff5722")` rebrands a family
+  by overriding just the tokens you want.
+- Call `.register()` after a `Window`/`Style` exists (or persist the spec — below).
+
+### ttkcreator
+
+`python -m ttkcreator` is now a `Theme` editor: pick a base family, tune the
+accent anchors + neutral and the light/dark background/foreground, preview both
+modes live, then **Export theme definition** to get a ready-to-use
+`Theme(...).register()` Python file, or **Save** to persist it.
+
+### Persisting a custom theme (`USER_THEME_SPECS`)
+
+Saved themes are stored in `ttkbootstrap/themes/user.py` as anchor specs and
+loaded at startup:
+
+```python
+from ttkbootstrap.themes.user import USER_THEME_SPECS
+
+USER_THEME_SPECS["acme"] = {
+    "primary": "#2780e3", "success": "#3fb618", "info": "#9954bb",
+    "warning": "#ff7518", "danger": "#ff0039",
+    "secondary": None, "neutral": "#7e8081",
+    "light": {"background": "#ffffff", "foreground": "#373a3c"},
+    "dark":  {"background": "#222222",  "foreground": "#f8f9fa"},
+}
+# -> themename "acme-light" / "acme-dark"
+```
+
+### Legacy 16-key dicts still work
+
+Existing `USER_THEMES` entries and `load_user_themes(json)` files in the old
+16-key shape are still loaded (adapted like the built-in legacy themes:
+authored accents/bg/fg kept, plumbing regenerated). No change required, but
+prefer `USER_THEME_SPECS` / the `Theme` API going forward.
+
+## Colors: same attributes, plus ramp addressing
+
+`style.colors` is unchanged for existing code — every attribute (`primary`,
+`bg`, `fg`, `selectbg`, `border`, `inputbg`, …) is still a hex string. New in
+2.0, each color also addresses its own 50–950 tint/shade ramp:
+
+```python
+c = style.colors
+c.primary            # '#0a58ca'  (still a str)
+c.primary[300]       # a lighter tint of primary
+c.primary[700]       # a darker shade
+c.ramp("primary")    # the full {50: ..., ..., 950: ...} mapping
+```
+
+## Behavior changes to be aware of
+
+- **Selection color (`selectbg`) is now a neutral gray**, not tied to a specific
+  authored value. If you relied on a particular selection color, set it via your
+  own `Theme`/spec or override the style.
+- **Input backgrounds in dark themes** are derived from the theme background
+  (hue-preserving), so a themed dark field keeps its tint instead of washing to
+  gray.
+- **Built-in palettes shifted** — 2.0 regenerates each theme's derived colors
+  from its anchors for consistent contrast (per-mode accent stepping, readable
+  on-colors). Pin exact 1.x colors with your own `Theme`/spec if you need them.
+
+## For library integrators
+
+- `ThemeDefinition` and `Style.register_theme(definition)` are unchanged; a
+  16-key `Colors` still constructs. The `Theme` model builds `ThemeDefinition`s
+  under the hood, so both paths coexist.
+- `DEFAULT_THEME` is now `"bootstrap-light"`.

--- a/src/ttkbootstrap/style/builders/combobox.py
+++ b/src/ttkbootstrap/style/builders/combobox.py
@@ -24,7 +24,8 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 
     on_disabled = builder.disabled("text", builder.colors.inputbg)
     border = builder.colors.border
-    readonly = builder.colors.light if builder.is_light_theme else builder.colors.selectbg
+    # readonly fields read like normal fields (no greyed box).
+    readonly = builder.colors.inputbg
 
     if any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class

--- a/src/ttkbootstrap/style/builders/entry.py
+++ b/src/ttkbootstrap/style/builders/entry.py
@@ -20,7 +20,9 @@ def build_entry_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 
     on_disabled = builder.disabled("text", builder.colors.inputbg)
     border = builder.colors.border
-    readonly = builder.colors.light if builder.is_light_theme else builder.colors.selectbg
+    # readonly fields read like normal fields (no greyed box); the field bg is
+    # the same input surface in both modes.
+    readonly = builder.colors.inputbg
 
     if any([colorname == DEFAULT, not colorname]):
         # default style

--- a/src/ttkbootstrap/style/builders/spinbox.py
+++ b/src/ttkbootstrap/style/builders/spinbox.py
@@ -23,7 +23,8 @@ def build_spinbox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     ttk_class = "TSpinbox"
 
     border_color = builder.colors.border
-    readonly = builder.colors.light if builder.is_light_theme else builder.colors.selectbg
+    # readonly fields read like normal fields (no greyed box).
+    readonly = builder.colors.inputbg
     disabled_fg = builder.disabled("text", builder.colors.inputbg)
 
     if any([colorname == DEFAULT, colorname == ""]):

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -22,6 +22,11 @@ try:
 except (ImportError, ModuleNotFoundError):
     USER_THEMES = {}
 
+try:
+    from ttkbootstrap.themes.user import USER_THEME_SPECS
+except (ImportError, ModuleNotFoundError):
+    USER_THEME_SPECS = {}
+
 
 class Style(ttk.Style):
     """A singleton class for creating and managing the application
@@ -369,11 +374,18 @@ class Style(ttk.Style):
         `ttkbootstrap.install_legacy_themes()`.
         """
         from ttkbootstrap.themes.builtin import CURATED_THEMES
+        from ttkbootstrap.style.theme import Theme
 
         for theme in CURATED_THEMES:
             for definition in theme.to_definitions():
                 self.register_theme(definition)
 
+        # 2.0 user themes: semantic-anchor Theme specs generate light/dark pairs.
+        for name, spec in USER_THEME_SPECS.items():
+            for definition in Theme(name=name, **spec).to_definitions():
+                self.register_theme(definition)
+
+        # Legacy 16-key user/external dicts, cleaned through the compat adapter.
         extra = {}
         if USER_THEMES:
             extra.update(USER_THEMES)

--- a/src/ttkbootstrap/themes/user.py
+++ b/src/ttkbootstrap/themes/user.py
@@ -1,45 +1,42 @@
 """User-defined custom theme storage for ttkbootstrap.
 
-This module provides a dictionary for storing user-created custom themes.
-Users can define their own color schemes and save them for use in their
-ttkbootstrap applications.
+Two stores, both loaded at startup by the Style engine:
 
-The USER_THEMES dictionary follows the same format as STANDARD_THEMES,
-with each theme containing type and colors information.
+- ``USER_THEME_SPECS`` — the **2.0** store: each entry is a semantic-anchor
+  ``Theme`` spec (accent anchors + ``neutral`` + ``light``/``dark``
+  ``{background, foreground}`` blocks). ttkcreator writes here; the engine builds
+  a ``Theme`` from each spec and registers its generated ``<name>-light`` /
+  ``<name>-dark`` variants. This is the recommended way to persist a custom theme.
 
-Example:
-    Creating and using a custom theme:
+- ``USER_THEMES`` — the legacy 16-key dict store (pre-2.0). Still loaded (through
+  the compat adapter, which keeps the authored accents/bg/fg and regenerates the
+  plumbing), so existing custom themes keep working.
+
+Example (2.0 spec):
     ```python
-    from ttkbootstrap.themes.user import USER_THEMES
+    from ttkbootstrap.themes.user import USER_THEME_SPECS
 
-    # Define custom theme
-    USER_THEMES['mytheme'] = {
-        "type": "light",
-        "colors": {
-            "primary": "#FF6B6B",
-            "secondary": "#4ECDC4",
-            "success": "#95E1D3",
-            "info": "#38A3A5",
-            "warning": "#F9CA24",
-            "danger": "#EE5A6F",
-            "light": "#F7F9FA",
-            "dark": "#2C3E50",
-            "bg": "#FFFFFF",
-            "fg": "#2C3E50",
-            "selectbg": "#4ECDC4",
-            "selectfg": "#FFFFFF",
-            "border": "#DEE2E6",
-            "inputfg": "#2C3E50",
-            "inputbg": "#FFFFFF",
-            "active": "#F0F0F0",
-        },
+    USER_THEME_SPECS["mytheme"] = {
+        "primary": "#2780e3", "success": "#3fb618", "info": "#9954bb",
+        "warning": "#ff7518", "danger": "#ff0039",
+        "secondary": None, "neutral": "#7e8081",
+        "light": {"background": "#ffffff", "foreground": "#373a3c"},
+        "dark": {"background": "#222222", "foreground": "#f8f9fa"},
     }
+    ```
 
-    # Use in application
+    Then ``ttk.Window(themename="mytheme-light")`` (or ``-dark``).
+
+Prefer authoring in your own code with the public ``Theme`` API directly:
+    ```python
     import ttkbootstrap as ttk
-    root = ttk.Window(themename="mytheme")
-    root.mainloop()
+    ttk.Theme(name="mytheme", primary="#2780e3", ...,
+              light=dict(background="#ffffff", foreground="#373a3c")).register()
     ```
 """
 
-USER_THEMES={}
+#: 2.0 semantic-anchor theme specs: name -> Theme(**spec) keyword dict.
+USER_THEME_SPECS = {}
+
+#: Legacy 16-key theme dicts (pre-2.0), adapted on load.
+USER_THEMES = {}

--- a/src/ttkcreator/__main__.py
+++ b/src/ttkcreator/__main__.py
@@ -99,9 +99,9 @@ class ThemeCreator(ttk.Window):
         f3 = ttk.Frame(cf, padding=(5, 2))
         ttk.Label(f3, text="preview mode", width=14).pack(side=LEFT)
         self.preview_mode = ttk.Combobox(
-            f3, values=["light", "dark"], state="readonly", width=10)
+            f3, values=["light", "dark"], state="readonly")
         self.preview_mode.set("light")
-        self.preview_mode.pack(side=LEFT)
+        self.preview_mode.pack(side=LEFT, fill=X, expand=YES)
         self.preview_mode.bind("<<ComboboxSelected>>", self.create_temp_theme)
         f3.pack(fill=X, expand=YES, pady=(0, 10))
 
@@ -190,6 +190,11 @@ class ThemeCreator(ttk.Window):
         self.rows["dark_bg"].set_value(dark.get("background", ""))
         self.rows["dark_fg"].set_value(dark.get("foreground", ""))
         self.create_temp_theme()
+        # A family without a colored `secondary` derives it from the neutral
+        # ramp; show that resolved color so the field is populated (and
+        # editable) rather than blank. Clear it to go back to neutral-derived.
+        if not family.secondary:
+            self.rows["secondary"].set_value(self.style.colors.secondary)
 
     # ----- save / export -----------------------------------------------------
 

--- a/src/ttkcreator/__main__.py
+++ b/src/ttkcreator/__main__.py
@@ -329,8 +329,15 @@ class ColorRow(ttk.Frame):
         self.color_value = ""
 
         ttk.Label(self, text=label, width=14).pack(side=LEFT)
-        self.patch = Frame(master=self, width=15)
-        self.patch.pack(side=LEFT, fill=BOTH, padx=2)
+        # A fixed color sample. It must NOT follow the theme (it shows the color
+        # being edited), so opt it out of the theme walk -- otherwise every
+        # temp-theme switch repaints this tk.Frame to the theme background.
+        self.patch = Frame(
+            master=self, width=24, highlightthickness=1,
+            highlightbackground="#888888",
+        )
+        self.patch._tb_no_autostyle = True
+        self.patch.pack(side=LEFT, fill=Y, padx=4, pady=2)
         self.entry = ttk.Entry(self, width=12)
         self.entry.pack(side=LEFT, fill=X, expand=YES)
         self.entry.bind("<FocusOut>", self.enter_color)

--- a/src/ttkcreator/__main__.py
+++ b/src/ttkcreator/__main__.py
@@ -7,15 +7,47 @@ import ttkbootstrap as ttk
 from tkinter import Frame
 from tkinter.colorchooser import askcolor
 from tkinter.filedialog import askopenfilename, asksaveasfilename
-from ttkbootstrap.themes import standard, user
-from ttkbootstrap.style import ThemeDefinition
+from ttkbootstrap.themes import user
+from ttkbootstrap.themes.builtin import CURATED_THEMES
+from ttkbootstrap.style import Theme
+from ttkbootstrap.style.theme import _DEFAULT_NEUTRAL
 from ttkbootstrap.constants import *
 from ttkbootstrap.dialogs import Messagebox
 
 
+# The editable Theme inputs, grouped for the UI. Each entry is
+# (field-key, display label). The field keys map onto `Theme` (or its
+# light/dark blocks) in `_spec()`.
+_ACCENT_FIELDS = [
+    ("primary", "primary"),
+    ("secondary", "secondary"),
+    ("success", "success"),
+    ("info", "info"),
+    ("warning", "warning"),
+    ("danger", "danger"),
+    ("neutral", "neutral"),
+]
+_LIGHT_FIELDS = [
+    ("light_bg", "background"),
+    ("light_fg", "foreground"),
+]
+_DARK_FIELDS = [
+    ("dark_bg", "background"),
+    ("dark_fg", "foreground"),
+]
+
+
 class ThemeCreator(ttk.Window):
+    """Author a semantic-anchor `Theme`: edit the accent anchors + neutral and
+    the light/dark background/foreground blocks; the full palette (and both mode
+    variants) is generated. Preview live, then export a `Theme(...).register()`
+    snippet or save it to your user theme store.
+    """
+
     def __init__(self):
         super().__init__("TTK Creator")
+        self._families = {t.name: t for t in CURATED_THEMES}
+        self.rows = {}
         self.configure_frame = ttk.Frame(self, padding=(10, 10, 5, 10))
         self.configure_frame.pack(side=LEFT, fill=BOTH, expand=YES)
         self.demo_frame = ttk.Frame(self, padding=(5, 10, 10, 10))
@@ -27,100 +59,206 @@ class ThemeCreator(ttk.Window):
     def setup_theme_creator(self):
         # application menu
         self.menu = ttk.Menu()
-
+        commands = [
+            ("Save", self.save_theme),
+            ("Reset", self.change_base_theme),
+            ("Import", self.import_user_themes),
+            ("Export all themes", self.export_user_themes),
+            ("Export theme definition", self.export_theme_as_python_file),
+        ]
         if sys.platform == 'darwin':
-            # mac os menu
             self.file_submenu = ttk.Menu(self.menu)
-            self.file_submenu.add_command(label="Save", command=self.save_theme)
-            self.file_submenu.add_command(label="Reset", command=self.change_base_theme)
-            self.file_submenu.add_command(label="Import", command=self.import_user_themes)
-            self.file_submenu.add_command(label="Export all themes", command=self.export_user_themes)
-            self.file_submenu.add_command(label="Export theme definition", command=self.export_theme_as_python_file)
+            for label, command in commands:
+                self.file_submenu.add_command(label=label, command=command)
             self.menu.add_cascade(menu=self.file_submenu, label="File")
         else:
-            # all other platforms
-            self.menu.add_command(label="Save", command=self.save_theme)
-            self.menu.add_command(label="Reset", command=self.change_base_theme)
-            self.menu.add_command(label="Import", command=self.import_user_themes)
-            self.menu.add_command(label="Export all themes", command=self.export_user_themes)
-            self.menu.add_command(label="Export theme definition", command=self.export_theme_as_python_file)
-
+            for label, command in commands:
+                self.menu.add_command(label=label, command=command)
         self.configure(menu=self.menu)
 
-        # theme configuration settings
+        cf = self.configure_frame
+
         ## user theme name
-        f1 = ttk.Frame(self.configure_frame, padding=(5, 2))
-        ttk.Label(f1, text="name", width=12).pack(side=LEFT)
+        f1 = ttk.Frame(cf, padding=(5, 2))
+        ttk.Label(f1, text="name", width=14).pack(side=LEFT)
         self.theme_name = ttk.Entry(f1)
         self.theme_name.insert(END, "new theme")
         self.theme_name.pack(side=LEFT, fill=X, expand=YES)
         f1.pack(fill=X, expand=YES)
 
-        ## base theme
-        f2 = ttk.Frame(self.configure_frame, padding=(5, 2))
-        ttk.Label(f2, text="base theme", width=12).pack(side=LEFT)
-        self.base_theme = ttk.Combobox(f2, values=self.style.theme_names())
-        self.base_theme.insert(END, "litera")
+        ## base family + preview mode
+        f2 = ttk.Frame(cf, padding=(5, 2))
+        ttk.Label(f2, text="base family", width=14).pack(side=LEFT)
+        self.base_theme = ttk.Combobox(
+            f2, values=list(self._families), state="readonly")
+        self.base_theme.set("bootstrap")
         self.base_theme.pack(side=LEFT, fill=X, expand=YES)
-        f2.pack(fill=X, expand=YES, pady=(0, 15))
         self.base_theme.bind("<<ComboboxSelected>>", self.change_base_theme)
+        f2.pack(fill=X, expand=YES)
 
-        ## color options
-        self.color_rows = []
-        for color in self.style.colors.label_iter():
-            row = ColorRow(self.configure_frame, color, self.style)
-            self.color_rows.append(row)
-            row.pack(fill=BOTH, expand=YES)
+        f3 = ttk.Frame(cf, padding=(5, 2))
+        ttk.Label(f3, text="preview mode", width=14).pack(side=LEFT)
+        self.preview_mode = ttk.Combobox(
+            f3, values=["light", "dark"], state="readonly", width=10)
+        self.preview_mode.set("light")
+        self.preview_mode.pack(side=LEFT)
+        self.preview_mode.bind("<<ComboboxSelected>>", self.create_temp_theme)
+        f3.pack(fill=X, expand=YES, pady=(0, 10))
+
+        ## anchor + block color rows, grouped under headers
+        self._add_section("Accents & neutral", _ACCENT_FIELDS)
+        self._add_section("Light background/foreground", _LIGHT_FIELDS)
+        self._add_section("Dark background/foreground", _DARK_FIELDS)
+
+        # seed the rows from the base family
+        self._load_family(self.base_theme.get())
+
+    def _add_section(self, title, fields):
+        ttk.Label(
+            self.configure_frame, text=title, font="-weight bold",
+            padding=(5, 8, 0, 2),
+        ).pack(fill=X)
+        for key, label in fields:
+            row = ColorRow(self.configure_frame, key, label)
+            row.pack(fill=X, expand=YES)
             row.bind("<<ColorSelected>>", self.create_temp_theme)
+            self.rows[key] = row
+
+    # ----- theme spec / generation ------------------------------------------
+
+    def _mode(self):
+        return self.preview_mode.get() or "light"
+
+    def _spec(self):
+        """Build the `Theme(**spec)` keyword dict from the current rows."""
+        def v(key):
+            return (self.rows[key].color_value or "").strip() or None
+
+        light = {"background": v("light_bg"), "foreground": v("light_fg")}
+        dark = {"background": v("dark_bg"), "foreground": v("dark_fg")}
+        return {
+            "primary": v("primary"),
+            "success": v("success"),
+            "info": v("info"),
+            "warning": v("warning"),
+            "danger": v("danger"),
+            "secondary": v("secondary"),
+            "neutral": v("neutral") or _DEFAULT_NEUTRAL,
+            "light": light if light["background"] and light["foreground"] else None,
+            "dark": dark if dark["background"] and dark["foreground"] else None,
+        }
 
     def create_temp_theme(self, *_):
-        """Creates a temp theme using the current configure settings and
-        changes the theme in tkinter to that new theme.
-        """
-        themename = "temp_" + str(uuid4()).replace("-", "")[:10]
-        colors = {}
-        for row in self.color_rows:
-            colors[row.label["text"]] = row.color_value
-        definition = ThemeDefinition(themename, colors, self.style.theme.type)
-        self.style.register_theme(definition)
-        self.style.theme_use(themename)
-        self.update_color_patches()
+        """Generate a throwaway Theme from the current settings and preview the
+        selected mode. A fresh name each time forces a rebuild (an already-built
+        Tcl theme would otherwise show stale colors)."""
+        spec = self._spec()
+        themename = "temp" + uuid4().hex[:10]
+        try:
+            definitions = Theme(name=themename, **spec).to_definitions()
+        except ValueError:
+            return  # incomplete/invalid spec (e.g. a blank accent) -- skip
+        if not definitions:
+            return
+        for definition in definitions:
+            self.style.register_theme(definition)
+        names = {d.name for d in definitions}
+        target = f"{themename}-{self._mode()}"
+        if target not in names:
+            target = definitions[0].name  # only one block defined
+        self.style.theme_use(target)
 
     def change_base_theme(self, *_):
-        """Sets the initial colors used in the color configuration"""
-        themename = self.base_theme.get()
-        self.style.theme_use(themename)
-        self.update_color_patches()
+        """Load the selected base family's anchors/blocks into the rows."""
+        self._load_family(self.base_theme.get())
 
-    def update_color_patches(self):
-        """Updates the color patches next to the color code entry."""
-        for row in self.color_rows:
-            row.color_value = self.style.colors.get(row.label["text"])
-            row.update_patch_color()
+    def _load_family(self, name):
+        family = self._families.get(name)
+        if family is None:
+            return
+        self.rows["primary"].set_value(family.primary)
+        self.rows["success"].set_value(family.success)
+        self.rows["info"].set_value(family.info)
+        self.rows["warning"].set_value(family.warning)
+        self.rows["danger"].set_value(family.danger)
+        self.rows["secondary"].set_value(family.secondary or "")
+        self.rows["neutral"].set_value(family.neutral)
+        light = family.light or {}
+        dark = family.dark or {}
+        self.rows["light_bg"].set_value(light.get("background", ""))
+        self.rows["light_fg"].set_value(light.get("foreground", ""))
+        self.rows["dark_bg"].set_value(dark.get("background", ""))
+        self.rows["dark_fg"].set_value(dark.get("foreground", ""))
+        self.create_temp_theme()
+
+    # ----- save / export -----------------------------------------------------
+
+    def _theme_key(self):
+        return self.theme_name.get().lower().replace(" ", "")
+
+    def save_theme(self):
+        """Persist the current Theme spec to the user theme store (user.py) and
+        register it live as `<name>-light` / `<name>-dark`."""
+        name = self._theme_key()
+        if not name:
+            Messagebox.ok("Please enter a theme name.", "Save theme", parent=self)
+            return
+        if name in user.USER_THEME_SPECS:
+            result = Messagebox.okcancel(
+                title="Save Theme", alert=True,
+                message=f"Overwrite existing theme {name}?",
+            )
+            if result == "Cancel":
+                return
+
+        spec = self._spec()
+        user.USER_THEME_SPECS[name] = spec
+        self._write_user_file()
+
+        for definition in Theme(name=name, **spec).to_definitions():
+            self.style.register_theme(definition)
+        target = f"{name}-{self._mode()}"
+        if target in self.style.theme_names():
+            self.style.theme_use(target)
+        Messagebox.ok(f"The theme {name} has been saved.", "Save theme", parent=self)
+
+    def _write_user_file(self):
+        """Rewrite themes/user.py with the current spec + legacy dict stores."""
+        header = (
+            '"""User-defined custom theme storage for ttkbootstrap.\n\n'
+            'USER_THEME_SPECS holds 2.0 semantic-anchor Theme specs (managed by\n'
+            'ttkcreator); USER_THEMES holds legacy 16-key dicts. Both are loaded\n'
+            'at startup. You may also hand-edit this file.\n"""\n\n'
+        )
+        content = (
+            header
+            + "USER_THEME_SPECS = "
+            + json.dumps(user.USER_THEME_SPECS, indent=4)
+            + "\n\nUSER_THEMES = "
+            + json.dumps(user.USER_THEMES, indent=4)
+            + "\n"
+        )
+        with open(user.__file__, "w", encoding="utf-8") as f:
+            f.write(content)
 
     def export_user_themes(self):
-        """Export user themes saved in the user.py file"""
+        """Export the user theme store file (user.py)."""
         inpath = Path(user.__file__)
         outpath = asksaveasfilename(
-            initialdir="/",
-            initialfile="user.py",
+            initialdir="/", initialfile="user.py",
             filetypes=[("python", "*.py")],
         )
         if outpath:
             shutil.copyfile(inpath, outpath)
             Messagebox.ok(
-                parent=self,
-                title="Export",
+                parent=self, title="Export",
                 message="User themes have been exported.",
             )
 
     def import_user_themes(self):
-        """Import user themes into the user.py file. Any existing data
-        in the user.py file will be overwritten."""
-        outpath = Path(user.__file__)
+        """Import a user theme store file over the current user.py."""
         inpath = askopenfilename(
-            initialdir="/",
-            initialfile="user.py",
+            initialdir="/", initialfile="user.py",
             filetypes=[("python", "*.py")],
         )
         confirm = Messagebox.okcancel(
@@ -128,150 +266,104 @@ class ThemeCreator(ttk.Window):
             message="This import will overwrite the existing user themes. Ok to import?",
         )
         if confirm == "OK" and inpath:
-            shutil.copyfile(inpath, outpath)
+            shutil.copyfile(inpath, Path(user.__file__))
             Messagebox.ok(
-                parent=self,
-                title="Export",
-                message="User themes have been imported.",
+                parent=self, title="Import",
+                message="User themes have been imported. Restart to load them.",
             )
 
-    def save_theme(self):
-        """Save the current settings as a new theme. Warn using if
-        saving will overwrite existing theme."""
-        name = self.theme_name.get().lower().replace(" ", "")
-
-        if name in user.USER_THEMES:
-            result = Messagebox.okcancel(
-                title="Save Theme",
-                alert=True,
-                message=f"Overwrite existing theme {name}?",
-            )
-            if result == "Cancel":
-                return
-
-        colors = {}
-        for row in self.color_rows:
-            colors[row.label["text"]] = row.color_value
-
-        theme = {name: {"type": self.style.theme.type, "colors": colors}}
-        user.USER_THEMES.update(theme)
-        standard.STANDARD_THEMES[name] = theme[name]
-
-        # save user themes to file
-        formatted = json.dumps(user.USER_THEMES, indent=4)
-        out = 'USER_THEMES = ' + formatted
-        filepath = user.__file__
-        with open(filepath, 'w', encoding='utf-8') as f:
-            f.write(out)
-
-        definition = ThemeDefinition(name, colors, self.style.theme.type)
-        self.style.register_theme(definition)
-        self.style.theme_use(name)
-        new_themes = []
-        for themename in self.style.theme_names():
-            if not themename.startswith("temp"):
-                new_themes.append(themename)
-        self.base_theme.configure(values=new_themes)
-        Messagebox.ok(f"The theme {name} has been created", "Save theme")
-
-    from tkinter.filedialog import asksaveasfilename
+    def theme_to_source(self, name):
+        """Render the current spec as a `Theme(...).register()` Python snippet."""
+        spec = self._spec()
+        lines = ["import ttkbootstrap as ttk", "", "ttk.Theme(", f'    name="{name}",']
+        for role in ("primary", "success", "info", "warning", "danger"):
+            if spec[role]:
+                lines.append(f'    {role}="{spec[role]}",')
+        if spec.get("secondary"):
+            lines.append(f'    secondary="{spec["secondary"]}",')
+        lines.append(f'    neutral="{spec["neutral"]}",')
+        for mode in ("light", "dark"):
+            block = spec.get(mode)
+            if block:
+                lines.append(
+                    f'    {mode}=dict(background="{block["background"]}", '
+                    f'foreground="{block["foreground"]}"),'
+                )
+        lines.append(").register()")
+        return "\n".join(lines)
 
     def export_theme_as_python_file(self):
-        """Export the current theme definition as a Python file."""
-        name = self.theme_name.get().lower().replace(" ", "")
-        theme_type = self.style.theme.type
-        colors = {row.label["text"]: row.color_value for row in self.color_rows}
-
-        lines = [
-            "from ttkbootstrap.style import ThemeDefinition",
-            "",
-            f"theme = ThemeDefinition(",
-            f'    name="{name}",',
-            f'    themetype="{theme_type}",',
-            f"    colors={{"
-        ]
-        for key, value in colors.items():
-            lines.append(f'        "{key}": "{value}",')
-        lines.append("    },")
-        lines.append(")")
-
-        theme_code = "\n".join(lines)
-
+        """Export the current theme as a `Theme(...)` Python file."""
+        name = self._theme_key()
+        code = self.theme_to_source(name)
         filepath = asksaveasfilename(
             defaultextension=".py",
             initialfile=f"{name}_theme.py",
             filetypes=[("Python files", "*.py")],
             title="Save Theme As Python File",
         )
+        if not filepath:
+            return
+        try:
+            with open(filepath, "w", encoding="utf-8") as f:
+                f.write(code + "\n")
+            Messagebox.ok(
+                parent=self, title="Export Successful",
+                message=f"Theme exported to {filepath}",
+            )
+        except Exception as e:
+            Messagebox.ok(
+                parent=self, title="Export Failed",
+                message=f"Failed to save file: {e}", alert=True,
+            )
 
-        if filepath:
-            try:
-                with open(filepath, "w", encoding="utf-8") as f:
-                    f.write(theme_code)
-                Messagebox.ok(
-                    parent=self,
-                    title="Export Successful",
-                    message=f"Theme exported to {filepath}",
-                )
-            except Exception as e:
-                Messagebox.ok(
-                    parent=self,
-                    title="Export Failed",
-                    message=f"Failed to save file: {e}",
-                    alert=True,
-                )
 
 class ColorRow(ttk.Frame):
-    def __init__(self, master, color, style):
-        super().__init__(master, padding=(5, 2))
-        self.colorname = color
-        self.style = style
+    """One editable color: a swatch, a hex entry, and a color picker. `key` maps
+    onto a Theme field in `ThemeCreator._spec()`. An empty value is allowed
+    (e.g. an omitted `secondary`)."""
 
-        self.label = ttk.Label(self, text=color, width=12)
-        self.label.pack(side=LEFT)
-        self.patch = Frame(
-            master=self, background=self.style.colors.get(color), width=15
-        )
+    def __init__(self, master, key, label):
+        super().__init__(master, padding=(5, 2))
+        self.key = key
+        self.color_value = ""
+
+        ttk.Label(self, text=label, width=14).pack(side=LEFT)
+        self.patch = Frame(master=self, width=15)
         self.patch.pack(side=LEFT, fill=BOTH, padx=2)
         self.entry = ttk.Entry(self, width=12)
         self.entry.pack(side=LEFT, fill=X, expand=YES)
         self.entry.bind("<FocusOut>", self.enter_color)
-        self.color_picker = ttk.Button(
-            master=self,
-            text="...",
-            bootstyle=SECONDARY,
-            command=self.pick_color,
-        )
-        self.color_picker.pack(side=LEFT, padx=2)
+        self.entry.bind("<Return>", self.enter_color)
+        ttk.Button(
+            self, text="...", bootstyle=SECONDARY, command=self.pick_color,
+        ).pack(side=LEFT, padx=2)
 
-        # set initial color value and patch color
-        self.color_value = self.style.colors.get(color)
+    def set_value(self, value):
+        """Set the color without firing <<ColorSelected>> (bulk load)."""
+        self.color_value = value or ""
         self.update_patch_color()
 
     def pick_color(self):
-        """Callback for when a color is selected from the color chooser"""
-        color = askcolor(color=self.color_value)
+        color = askcolor(color=self.color_value or None)
         if color[1]:
-            self.color_value = color[1]
+            self.color_value = color[1].lower()
             self.update_patch_color()
-        self.event_generate("<<ColorSelected>>")
+            self.event_generate("<<ColorSelected>>")
 
     def enter_color(self, *_):
-        """Callback for when a color is typed into the entry"""
-        try:
-            self.color_value = self.entry.get().lower()
-            self.update_patch_color()
-        except:
-            self.color_value = self.style.colors.get(self.label["text"])
-            self.update_patch_color()
+        self.color_value = self.entry.get().strip().lower()
+        self.update_patch_color()
         self.event_generate("<<ColorSelected>>")
 
     def update_patch_color(self):
-        """Update the color patch frame with the color value stored in
-        the entry widget."""
         self.entry.delete(0, END)
         self.entry.insert(END, self.color_value)
-        self.patch.configure(background=self.color_value)
+        if self.color_value:
+            try:
+                self.patch.configure(background=self.color_value)
+            except Exception:
+                pass
 
 
 class DemoWidgets(ttk.Frame):

--- a/tests/widget_styles/test_color_helpers.py
+++ b/tests/widget_styles/test_color_helpers.py
@@ -327,11 +327,8 @@ def test_solid_button_recipe_uses_helper_state_contract(
     # border in dark themes too. The readonly fill stays a neutral (light: the
     # `light` accent; dark: `selectbg`).
     border = builder.colors.border.lower()
-    readonly = (
-        builder.colors.light
-        if builder.is_light_theme
-        else builder.colors.selectbg
-    ).lower()
+    # readonly fields read like normal fields now (fieldbackground == inputbg).
+    readonly = builder.colors.inputbg.lower()
     for family, style_name in (
         ('entry', 'TEntry'),
         ('combobox', 'TCombobox'),

--- a/tests/widget_styles/test_theme_anchor.py
+++ b/tests/widget_styles/test_theme_anchor.py
@@ -170,6 +170,36 @@ def test_legacy_adapter_preserves_identity_regenerates_plumbing():
     assert d.type == "dark"
 
 
+def test_user_theme_spec_builds_and_registers(root):
+    # A USER_THEME_SPECS-style anchor spec (what ttkcreator persists) builds a
+    # Theme and registers usable light/dark variants -- the engine's user-theme
+    # load path.
+    style = root.style
+    spec = {
+        "primary": "#2780e3", "success": "#3fb618", "info": "#9954bb",
+        "warning": "#ff7518", "danger": "#ff0039",
+        "secondary": None, "neutral": "#7e8081",
+        "light": {"background": "#ffffff", "foreground": "#373a3c"},
+        "dark": {"background": "#222222", "foreground": "#f8f9fa"},
+    }
+    before = set(style._theme_names)
+    try:
+        for definition in Theme(name="spectest", **spec).to_definitions():
+            style.register_theme(definition)
+        assert {"spectest-light", "spectest-dark"} <= style._theme_names
+        style.theme_use("spectest-dark")
+        assert style.theme.name == "spectest-dark"
+        assert style.colors.bg == "#222222"
+    finally:
+        for name in list(style._theme_names):
+            if name not in before:
+                style._theme_names.discard(name)
+                style._theme_definitions.pop(name, None)
+                style._theme_styles.pop(name, None)
+                style._theme_objects.pop(name, None)
+        style.theme_use("bootstrap-light")
+
+
 def test_from_existing_overrides_and_rejects_unknown_tokens():
     derived = Theme.from_existing(BOOTSTRAP, name="acme", primary="#ff5722")
     assert derived.name == "acme"


### PR DESCRIPTION
Closes out Workstream E (semantic-anchor theme model): make the tooling and
custom-theme paths first-class in the new architecture, and land the migration
guide.

## ttkcreator — now a `Theme` editor
`python -m ttkcreator` is rebuilt as a semantic-anchor editor: edit the accent
anchors + `neutral` and the light/dark background/foreground blocks, pick a base
family, and preview either generated mode live.
- **Export theme definition** emits a `ttk.Theme(...).register()` snippet (was a
  legacy 16-key `ThemeDefinition`).
- **Save** persists a `Theme` spec.
- Fixed the stale `litera` base default.

## User-theme persistence
New `themes/user.py` store **`USER_THEME_SPECS`** (name → `Theme(**spec)`
kwargs); the engine builds and registers each generated `-light`/`-dark` variant
at load. Legacy `USER_THEMES` (16-key) is still adapted, so existing custom
themes keep working.

## Migration guide
`development/2_0_theme_migration.md` — kept in `development/` (not `docs/`) so it
survives the 2.0 docs rewrite; Workstream H folds it into the new docs.

## Fixes from a manual ttkcreator eyeball
- Color swatches keep their color (opted out of the theme walk; a raw `tk.Frame`
  was being repainted to the theme bg every temp-theme switch).
- **Readonly fields (combobox/entry/spinbox) now use `inputbg` in both modes** —
  they read like normal fields instead of a greyed box. Also resolves the
  deferred "dark readonly field too bright" item from the E2 audit.
- Preview-mode dropdown fills X like the other selectors.
- The secondary field populates on load (shows the resolved neutral-derived
  color for families without a colored secondary).

## Verification
- Non-localization suite **211 passed** (+1: `test_user_theme_spec_builds_and_registers`).
- Warning-free import; standalone module imports.
- Headless ttkcreator smoke: seeds from a family, generates live, the exported
  snippet executes + registers both variants, the persisted spec round-trips.
- Manual `python -m ttkcreator` eyeball passed (user).

Workstream E complete after this. Next headliner: Workstream D (canonical
bootstyle grammar), which gets its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)