### PR TITLE
D1: canonical bootstyle grammar — closed vocab + loud failure

### DIFF
--- a/development/2_0_bootstyle_grammar_design.md
+++ b/development/2_0_bootstyle_grammar_design.md
@@ -1,0 +1,267 @@
+# Workstream D — Canonical bootstyle grammar: design
+
+> Status: **DESIGN LOCKED** (2026-07-06). Supersedes the prep notes
+> `development/2_0_bootstyle_grammar_notes.md` (ground truth + open forks). This
+> doc records the locked decisions and the PR sequence. Implement **PR by PR**;
+> do not exceed a PR's scope without revisiting this doc (the hard rule).
+
+## 0. Goal (from `2_0_plan.md` §D)
+
+Turn the incidental substring-regex resolver into a **closed, documented
+vocabulary in fixed slot order** with **exactly one canonical spelling per
+style**, that **fails loudly** on unknown tokens instead of silently falling
+through to default. bootstyle stays **semantic** (role + variant); ramp
+precision lives in the Theme/custom-style API (Workstream E, done). Retire the
+component-tuple form.
+
+## 1. The slot grammar (LOCKED)
+
+Canonical bootstyle string:
+
+```
+[color-][modifier-]<base-type>[-orient]
+```
+
+- **Exactly one** of each slot. **Fork 4 resolved: single modifier**, not
+  "modifier(s)". Ground truth: all 36 registry keys are `(single-variant,
+  family)`; **no** builder takes two modifiers (`outline-striped` does not
+  exist). The plan's `[modifier(s)]` plural was aspirational; the registry is
+  the authority.
+- Slots are **order-fixed** in the canonical form (color, then modifier, then
+  base-type, then orient). The `_compat` normalizer (PR D2) accepts the legacy
+  order-free / tuple input and rewrites it to canonical, warning as it does.
+- `base-type` is usually **inferred from the widget** (`winfo_class`), so most
+  users write just `[color-][modifier]` (e.g. `"success"`, `"primary-outline"`).
+  It is only spelled explicitly for the family-selecting bootstyles the user
+  applies to a host widget — `"toggle"`, `"round-toggle"`, `"toolbutton"`,
+  `"striped"` (progressbar), `"thin"` (progressbar), `"inverse"` (label).
+
+## 2. Single vocabulary source of truth (LOCKED — Fork 5)
+
+The vocabulary is currently split across `Keywords` (bootstyle.py) and
+`BootColor`/`BootType` (constants.py), out of sync. Consolidate to **one home:
+`constants.py`** — it is the low layer (`style/` imports it, never the reverse),
+already owns `BootColor`/`BootType`, and is public.
+
+`constants.py` defines four runtime token tuples + the matching `Literal`s
+adjacent to each (a test asserts tuple ≡ Literal membership, since static
+`Literal[*tuple]` is not checker-visible). `Keywords` in `bootstyle.py`
+**imports these tuples** and compiles its regexes from them — no second copy.
+
+### 2.1 The token classification (the Fork-5 reclassification)
+
+| Slot | Tokens | Literal |
+|---|---|---|
+| **color** (8) | primary secondary success info warning danger light dark | `BootColor` (unchanged) |
+| **modifier** — public (7) | outline link inverse round square striped thin | `BootType` (**fixed**) |
+| **modifier** — internal (4) | meter metersubtxt date table | not in a public Literal |
+| **base-type / family** | button checkbutton radiobutton toggle toolbutton combobox entry spinbox scale progressbar floodgauge scrollbar separator sizegrip label labelframe frame notebook panedwindow treeview menubutton calendar optionmenu + tk: menu text canvas tk toplevel listbox | `BootBase` (**new**, the user-nameable subset: toggle toolbutton) |
+| **orient** (2) | horizontal vertical | `Orient` (unchanged) |
+
+Changes vs today:
+- **`BootType` fixed**: was `["outline","link","toggle","inverse","striped",
+  "thin","toolbutton","square"]`. New: `["outline","link","inverse","round",
+  "square","striped","thin"]` — **adds `round`** (the plan's noted bug: buildable
+  but missing), **removes `toggle`/`toolbutton`** (they are base-types/families,
+  proven by registry keys `(default|round|square, toggle)` and
+  `(default|outline, toolbutton)`).
+- **`TOGGLE`/`TOOLBUTTON` constants stay** (still valid bootstyle values); their
+  annotation moves from `Final[BootType]` to a new `Final[BootBase]`.
+- **`focus`/`input` dropped** — dead keywords, no builder (grep-confirmed).
+- **`meter`/`metersubtxt`/`date`/`table`** remain **valid internal** modifiers
+  (registry variants of `label`/`button`/`treeview`) but are **undocumented** —
+  not in any public Literal, not in the reference table. They exist only so
+  Meter/DateEntry/Tableview can build their composite sub-styles.
+
+### 2.2 Validity is the registry, not the cartesian product
+
+A token being in-vocab is necessary but not sufficient: the `(modifier,
+base-type)` pair must be a **registered builder key** (or `(default, family)`
+for the bare-color forms). The validator's authority for "does this resolve to a
+real style" is `builders.registry.builder_keys()` — the same 36 keys, already
+frozen. `outline-scale` is well-formed tokens but not a real style; the resolver
+already returns the base style for it, and the validator warns that the
+`(outline, scale)` pair is unknown.
+
+## 3. The tokenizer + validator (LOCKED)
+
+Replace the four independent `re.search` substring probes with a **real
+tokenizer**: split the input on `-`/whitespace (after `_compat` has normalized
+tuples/lists to a string), then classify **each** token against the closed
+vocab. This removes the substring hazards (`button` inside `toolbutton`,
+`label` inside `labelframe`) that the hand-ordered alternations paper over.
+
+Per token, in slot-priority order: color? modifier (public or internal)?
+base-type? orient? If a token matches **no** slot → it is **unknown**:
+
+- **Default (warn)** — emit a `UserWarning` naming the offending token and, when
+  cheap, the nearest valid token (`difflib.get_close_matches` against the flat
+  vocab). Then resolve best-effort from the tokens that *did* classify (today's
+  silent behavior, minus the silence). **Fork 1 resolved.**
+- **Strict** — raise `ValueError` with the same message. Opt in process-wide via
+  a flag (see §5).
+
+Duplicate-slot input (two colors, two modifiers) is also a loud condition: warn
+(or raise) "more than one <slot> token"; keep the first for best-effort.
+
+### 3.1 Base-type is implied; validation splits into two phases
+
+The base-type is **inferred from the widget** (`winfo_class`) and only taken from
+the string when a base-type token is explicitly present (§1). The two families a
+user ever spells out are the chameleons `toggle`/`toolbutton` (a Checkbutton
+rendered as a switch / a Checkbutton|Radiobutton|Button rendered as a
+toolbutton), where the desired family differs from the host widget's class.
+
+Because the family is usually implied, loud-failure validation is **two phases**:
+- **Unknown-*token*** (`"primaryy"`, `"focus"`) — a token matching no slot.
+  Detectable at **parse time**, widget not required.
+- **Invalid-*pair*** (`outline-scale`) — every token is in-vocab, but the
+  `(modifier, resolved-family)` pair is not a registered builder key. Requires
+  the **resolved family**, so it is checked at **resolve time** (widget class
+  known). `bootstyle="outline"` is valid on a Button (`(outline, button)` ✓) and
+  invalid on a Scale (`(outline, scale)` ✗).
+
+Both phases route through the same warn/strict emitter.
+
+Mirror the existing loud-failure seam: `style/layout.py`'s `statespec`/
+`state_map` already validate the `!neg`/space-AND state grammar against
+`TTK_STATES` and were built as "the Workstream D loud-failure seam." Same
+shape — validate against a closed set, warn-or-raise.
+
+## 4. The `_compat` quarantine (LOCKED — Fork 2)
+
+New module **`src/ttkbootstrap/style/_compat.py`** (first tenant of the
+Workstream-F compat quarantine). Public-ish to the package, not to end users.
+
+```python
+def normalize_bootstyle(value) -> str:
+    """Accept a legacy bootstyle value (tuple/list, alt slot order, old
+    token) and return the canonical dash-joined string. Emits a
+    DeprecationWarning when the input used a retired form."""
+
+def warn_deprecated(old, new, *, removed_in="3.0") -> None:
+    """Standard deprecation-warning emitter for the quarantine."""
+```
+
+- **Tuple/list form** → dash-join then re-order to canonical, **with** a
+  `DeprecationWarning` pointing at the canonical string. **Fork 2 resolved:
+  warn-and-normalize through 2.x, removed in 3.0** — consistent with the tiered
+  convention (new-2.0 standardizations warn through 2.x). The one exception:
+  the resolver's *internal* call sites (after the D2 migration none remain) must
+  not trip the warning; D2 migrates them off tuples first (§7).
+- **Alt token order** (`outline-primary`) → normalized to canonical, no warning
+  in 2.0 (order-freedom was never documented as deprecated; the canonical order
+  is simply what the table publishes). *Optional:* a soft warning could be added
+  later; not in 2.0 scope.
+- `warn_deprecated` centralizes the message format so H docs can link one page.
+
+## 5. Strictness opt-in mechanism (LOCKED)
+
+Process-wide flag in `_compat` (the vocab/validator layer), with a public
+setter re-exported from `ttkbootstrap`:
+
+```python
+ttkbootstrap.set_bootstyle_strict(True)   # raise on unknown/invalid tokens
+ttkbootstrap.set_bootstyle_strict(False)  # default: warn
+```
+
+Also honor env var **`TTKBOOTSTRAP_STRICT=1`** at import (CI convenience, matches
+how test suites want a hard gate without editing app code). Default = warn.
+No per-widget granularity in 2.0 (keep it simple; revisit only on demand).
+
+## 6. Meter / DateEntry / Tableview (LOCKED — Fork 3: no new public API)
+
+Finding: these widgets **already expose clean public kwargs**
+(`Meter(bootstyle=, subtextstyle=)`, `DateEntry(bootstyle=)`,
+`Tableview(bootstyle=)`); the tuple/list form they use is **internal plumbing**
+to build composite sub-styles. **No new public kwargs** — just internalize:
+
+- `widgets/meter.py` — replace the six `bootstyle=(self._x, "meter"|"metersubtxt")`
+  tuples with canonical strings `f"{color}-meter"` / `f"{color}-metersubtxt"`.
+  (Line ~353 already builds the dash-joined string form.)
+- `widgets/dateentry.py:180` — replace `[self._bootstyle, "date"]` with
+  `f"{self._bootstyle}-date"` (line ~142 already does this).
+- `widgets/tooltip.py:39` — `(DANGER, INVERSE)` → `"danger-inverse"`.
+- `dialogs/datepicker.py:223` — `(SECONDARY, INVERSE)` → `"secondary-inverse"`.
+
+`meter`/`metersubtxt`/`date`/`table` stay valid internal modifiers (§2.1). After
+this migration, **zero internal callers use the tuple form**, so the D2
+deprecation warning only fires for genuine external tuple use.
+
+## 7. PR sequence (LOCKED)
+
+> **D1 — IMPLEMENTED (2026-07-06, branch `feat/2.0-pr-d1-bootstyle-grammar`).**
+> Suite **258 passed**, warning-free import, standalone `_compat` import,
+> annotation force-eval clean, theme-switch smoke OK. Two things the design pass
+> under-specified surfaced during implementation and are now handled:
+> - **The resolver has two input dialects, not one.** Besides user bootstyle
+>   strings, `update_ttk_widget_style` also receives *already-built ttk style
+>   names* — from the theme-walk repaint (a widget's dotted `cget("style")`,
+>   including a bare base like `"TFrame"`), from `Style.configure` subclassing a
+>   base (`"symbol.Link.TButton"`), and from user custom style names. These are
+>   parsed leniently (`_classify_style_name`, no unknown-token warnings — custom
+>   prefixes are legal); only a genuine bootstyle string gets the closed-vocab
+>   tokenizer + loud failure. `_looks_like_style_name` discriminates: a built
+>   name has a Title-cased class (contains uppercase, no dash/space) or a dot.
+> - **Invalid-pair best-effort improved.** Previously an unbuildable pair like
+>   `outline`-on-Scale returned the raw fragment `"outline"` as the style name,
+>   which then crashed in `configure`. Now it warns (bootstyle input only) and
+>   falls back to the family's **default** style; genuine third-party widgets
+>   (family not one of ours) still pass through untouched.
+
+### D1 — vocab source + tokenizer/validator + `_compat` + strict flag (no caller changes)
+- Consolidate the token tuples + reconciled Literals into `constants.py`
+  (fix `BootType`, add `BootBase`, drop `focus`/`input`); `Keywords` imports
+  them. Add the tuple≡Literal sync test.
+- Replace the substring probes in `bootstyle.py` with the real tokenizer +
+  closed-vocab validator (warn-on-unknown, warn-on-duplicate-slot).
+- New `style/_compat.py`: `normalize_bootstyle` (tuples/lists/alt-order →
+  canonical) + `warn_deprecated`. **In D1 the tuple form normalizes WITHOUT a
+  deprecation warning** (internal callers still use tuples until D2) — this keeps
+  the suite green and defers the user-facing warning to after the internal
+  migration.
+- `set_bootstyle_strict` + `TTKBOOTSTRAP_STRICT` env var; re-export from
+  `ttkbootstrap`.
+- Route the resolver's string handling through `normalize_bootstyle`.
+- **No behavior change for valid input; suite stays green.** New
+  `tests/test_bootstyle_grammar.py`: token classification, slot order, unknown
+  → warn/raise, duplicate-slot, registry-pair validation, and a **round-trip**:
+  every built-in `(variant, family)` registry key → expected canonical string →
+  resolves back to the same ttk style.
+
+### D2 — migrate internal callers + turn on the tuple deprecation
+- Migrate meter/dateentry/tooltip/datepicker off the tuple form (§6).
+- Flip `normalize_bootstyle` to **emit the `DeprecationWarning`** on tuple/list
+  input now that no internal caller trips it.
+- Verify `import ttkbootstrap` + constructing every widget stays warning-free;
+  add a test that a tuple bootstyle warns and still resolves.
+
+### D3 — generated reference table + combined-string Literal (feeds H docs)
+- A small generator (a `tools/` script or a tested function) enumerates the
+  vocab × registry into: (a) a **canonical grammar table** (markdown, for the
+  Workstream-H docs), and (b) a generated **`BootStyle` Literal** union of the
+  canonical strings that resolve to a real builder, for editor autocomplete.
+  `bootstyle` params type as `BootStyle | str` (Literal aids completion; the
+  runtime validator is the real gate).
+- Test: the generated table/Literal matches the live vocab + registry (fails if
+  a builder is added without updating the vocab).
+
+## 8. Verification seams (carry forward)
+- `import ttkbootstrap` stays **warning-free**; the PEP 649 annotation
+  force-evaluation sweep and the standalone-submodule cycle guard carry over
+  (any new module — `_compat` — joins the cycle guard).
+- Reuse the `statespec`/`state_map` validation pattern as the model.
+- The registry (`builder_keys()`) is the round-trip oracle for D1's test.
+
+## 9. Decisions ledger (forks)
+1. **Strictness** → warn-by-default + opt-in strict (`set_bootstyle_strict` /
+   `TTKBOOTSTRAP_STRICT`). *(user, 2026-07-06)*
+2. **Tuple form** → warn-and-normalize through 2.x, removed 3.0. *(user)*
+3. **Meter/DateEntry** → no new public API; internalize the composite tuples.
+   *(user)*
+4. **Multi-modifier** → single modifier slot (registry proves it). *(design,
+   ground-truth-forced)*
+5. **Reclassify** → toggle/toolbutton = base-types; add `round` to `BootType`;
+   new `BootBase`; drop focus/input; meter/metersubtxt/date/table = internal.
+   *(design, registry-forced)*
+6. **Generated table + Literal** → yes, from vocab × registry (D3). *(design)*

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,7 +3,29 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-07-06 (**Workstream E (theme/anchor) COMPLETE** — all three
+_Last updated: 2026-07-06 (**Workstream D design pass DONE + D1 IMPLEMENTED**.
+Design locked in `development/2_0_bootstyle_grammar_design.md` (6 forks resolved:
+warn-by-default+opt-in strict; tuple form warn-and-normalize through 2.x;
+Meter/DateEntry get no new public API; single modifier slot; toggle/toolbutton
+reclassified as base-types + `round` added to `BootType`; generated table in D3).
+**D1 committed on `feat/2.0-pr-d1-bootstyle-grammar`** (commit `b4970a11`, off
+`2.0` tip): single vocab source in `constants.py`, real tokenizer replacing the
+substring regex, loud failure on unknown tokens (`_compat.py` — new Workstream-F
+quarantine — with `set_bootstyle_strict`/`TTKBOOTSTRAP_STRICT`), no caller
+changes (tuple still normalizes quietly). Suite **258 passed**, warning-free
+import, annotation sweep clean, theme-switch smoke OK. Implementation surfaced
+two under-specified points, now handled + documented in the design doc's "D1 —
+IMPLEMENTED" note: the resolver has **two input dialects** (bootstyle strings vs
+already-built ttk style names from the theme walk / `Style.configure` /custom
+styles — lenient parse, no warns), and invalid pairs now fall back to the
+family default instead of returning an unusable fragment. **NEXT → D2**: migrate
+the 4 internal tuple callers (meter/dateentry/tooltip/datepicker) to canonical
+strings, then flip `normalize_bootstyle` to `warn=True`. Then D3 (generated
+`BootStyle` Literal + reference table for docs H). Env note: the repo `.venv/`
+is broken on this Windows box (launcher fails); `.venv-home/` works — pytest was
+installed into it. _
+
+_Prior 2026-07-06 (**Workstream E (theme/anchor) COMPLETE** — all three
 PRs merged: E1 #1088 (`Colors`→`RampColor` resolved view + `c.primary[300]`),
 E2 #1089 (semantic-anchor `Theme` model + curated 15-family/30-theme catalog +
 `install_legacy_themes()` + 16-key adapter + hue-correct `inputbg`; default

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -66,6 +66,8 @@ from ttkbootstrap.style import (
     Assets, El, layout, register_style, image_element, statespec, state_map, StyleName,
     # Icon-rendered assets: glyph atoms + per-state icon element sugar.
     Icon, icon_element,
+    # Canonical bootstyle grammar strictness (Workstream D).
+    set_bootstyle_strict, is_bootstyle_strict,
 )
 # Opt-in migration path for the pre-2.0 theme names (Workstream E/F).
 from ttkbootstrap.themes.legacy import install_legacy_themes
@@ -232,6 +234,8 @@ __all__ = [
     "StyleName",
     "Icon",
     "icon_element",
+    "set_bootstyle_strict",
+    "is_bootstyle_strict",
 
     # Windows
     "Toplevel",

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -94,9 +94,52 @@ ProgressMode = Literal["determinate", "indeterminate"]
 
 BootColor = Literal["primary", "secondary", "success", "danger", "warning", "info", "light", "dark"]
 
-BootType = Literal["outline", "link", "toggle", "inverse", "striped", "thin", "toolbutton", "square"]
+# The bootstyle type modifiers (variant slot). NOTE for 2.0 (Workstream D): this
+# is the reconciled set -- `round` is included (it is buildable; its historical
+# omission was a bug), and `toggle`/`toolbutton` are *removed* because they are
+# base-types (widget families), not modifiers. Those two moved to `BootBase`.
+BootType = Literal["outline", "link", "inverse", "round", "square", "striped", "thin"]
+
+# Base-types a user may name explicitly in a bootstyle string. Most base-types
+# are inferred from the widget's class and never typed; these two "chameleon"
+# families are the exception (e.g. a Checkbutton rendered as a switch/toolbutton).
+BootBase = Literal["toggle", "toolbutton"]
 
 TreeviewDisplay = Literal["tree", "headings", "tree headings"]
+
+# ---------------------------------------------------------------------------
+# Bootstyle vocabulary -- the single runtime source of truth for the grammar.
+# The bootstyle resolver (style/bootstyle.py) tokenizes against these tuples;
+# it no longer keeps a second copy. The `Literal` aliases above must match the
+# public tuples member-for-member (enforced by tests/test_bootstyle_grammar.py,
+# since a static `Literal[*tuple]` is not visible to type checkers).
+# ---------------------------------------------------------------------------
+BOOTSTYLE_COLORS: Final = (
+    "primary", "secondary", "success", "info", "warning", "danger",
+    "light", "dark",
+)
+# Public, documented type modifiers -- matches BootType.
+BOOTSTYLE_MODIFIERS: Final = (
+    "outline", "link", "inverse", "round", "square", "striped", "thin",
+)
+# Internal-only composite modifiers used by Meter/DateEntry/Tableview to build
+# their sub-styles. Valid grammar tokens, but undocumented and not in any public
+# Literal -- end users never type these.
+BOOTSTYLE_INTERNAL_MODIFIERS: Final = (
+    "meter", "metersubtxt", "date", "table",
+)
+# User-nameable base-types -- matches BootBase.
+BOOTSTYLE_BASES: Final = ("toggle", "toolbutton")
+# Every base-type/family the resolver recognizes, whether inferred from the
+# widget class or named explicitly in the string.
+BOOTSTYLE_FAMILIES: Final = (
+    "button", "checkbutton", "radiobutton", "toggle", "toolbutton",
+    "combobox", "entry", "spinbox", "scale", "progressbar", "floodgauge",
+    "scrollbar", "separator", "sizegrip", "label", "labelframe", "frame",
+    "notebook", "panedwindow", "treeview", "menubutton", "calendar",
+    "optionmenu", "menu", "text", "canvas", "tk", "toplevel", "listbox",
+)
+BOOTSTYLE_ORIENTS: Final = ("horizontal", "vertical")
 
 # ---------------------------
 # Booleans (legacy Tk style)
@@ -274,12 +317,15 @@ DARK: Final[BootColor] = "dark"
 
 OUTLINE: Final[BootType] = "outline"
 LINK: Final[BootType] = "link"
-TOGGLE: Final[BootType] = "toggle"
 INVERSE: Final[BootType] = "inverse"
 STRIPED: Final[BootType] = "striped"
 THIN: Final[BootType] = "thin"
-TOOLBUTTON: Final[BootType] = "toolbutton"
 SQUARE: Final[BootType] = "square"
+# ROUND ("round") is a valid BootType too, but the constant is already defined
+# above for LineCap/LineJoin with the same value -- reuse it; do not redefine.
+# Base-types (families), not modifiers -- see BootBase.
+TOGGLE: Final[BootBase] = "toggle"
+TOOLBUTTON: Final[BootBase] = "toolbutton"
 
 # ---------------------------
 # Treeview
@@ -296,7 +342,11 @@ __all__ = [
     "Anchor", "Sticky", "Fill", "Side", "Relief", "Orient", "Tabs", "Wrap",
     "Align", "BorderMode", "State", "MenuItemType", "SelectMode", "ActiveStyle",
     "PieStyle", "LineCap", "LineJoin", "IndexPos", "ViewArg", "TtkTheme",
-    "MeterMode", "ProgressMode", "BootColor", "BootType", "TreeviewDisplay",
+    "MeterMode", "ProgressMode", "BootColor", "BootType", "BootBase",
+    "TreeviewDisplay",
+    # bootstyle vocabulary (single source of truth)
+    "BOOTSTYLE_COLORS", "BOOTSTYLE_MODIFIERS", "BOOTSTYLE_INTERNAL_MODIFIERS",
+    "BOOTSTYLE_BASES", "BOOTSTYLE_FAMILIES", "BOOTSTYLE_ORIENTS",
     # constants
     "NO", "FALSE", "OFF", "YES", "TRUE", "ON",
     "N", "S", "W", "E", "NW", "SW", "NE", "SE", "NS", "EW", "NSEW", "CENTER",

--- a/src/ttkbootstrap/style/__init__.py
+++ b/src/ttkbootstrap/style/__init__.py
@@ -30,6 +30,10 @@ from ttkbootstrap.style.layout import (
     StyleName,
 )
 from ttkbootstrap.style.icons import Icon, icon_element, IconRenderer
+from ttkbootstrap.style._compat import (
+    set_bootstyle_strict,
+    is_bootstyle_strict,
+)
 
 __all__ = [
     "Colors",
@@ -59,4 +63,7 @@ __all__ = [
     "Icon",
     "icon_element",
     "IconRenderer",
+    # bootstyle grammar strictness (Workstream D)
+    "set_bootstyle_strict",
+    "is_bootstyle_strict",
 ]

--- a/src/ttkbootstrap/style/_compat.py
+++ b/src/ttkbootstrap/style/_compat.py
@@ -1,0 +1,89 @@
+"""Compatibility quarantine for the bootstyle grammar (2.0 Workstream D/F).
+
+Everything that translates a *legacy* bootstyle spelling into the canonical
+form, and everything that decides how loudly the resolver complains about an
+invalid one, lives here -- isolated from the resolver so the deprecation surface
+is in one place and can be retired wholesale in 3.0.
+
+Public-to-the-package, not to end users, except `set_bootstyle_strict` /
+`is_bootstyle_strict`, which `ttkbootstrap` re-exports.
+"""
+import os
+import warnings
+
+# ---------------------------------------------------------------------------
+# Strictness policy (Fork 1: warn by default, opt-in strict).
+# ---------------------------------------------------------------------------
+_TRUE = {"1", "true", "yes", "on"}
+_STRICT = os.environ.get("TTKBOOTSTRAP_STRICT", "").strip().lower() in _TRUE
+
+
+def set_bootstyle_strict(strict: bool = True) -> None:
+    """Choose how the resolver reacts to an invalid bootstyle.
+
+    In the default (non-strict) mode an unknown token or an unbuildable
+    ``(modifier, widget)`` combination emits a ``UserWarning`` and the resolver
+    falls back to a best-effort style. In strict mode the same conditions raise
+    ``ValueError`` instead -- useful in tests/CI to turn typos into hard
+    failures. Also settable at import via the ``TTKBOOTSTRAP_STRICT`` env var.
+    """
+    global _STRICT
+    _STRICT = bool(strict)
+
+
+def is_bootstyle_strict() -> bool:
+    """Return whether strict bootstyle validation is active."""
+    return _STRICT
+
+
+def report_invalid(kind: str, token: str, source: str, suggestions=()) -> None:
+    """Report an invalid bootstyle token/pair: raise (strict) or warn.
+
+    Parameters:
+        kind: what is wrong -- e.g. ``"token"``, ``"color"``, ``"modifier"``.
+        token: the offending token (or ``"(modifier, family)"`` pair text).
+        source: the original bootstyle string, for context.
+        suggestions: optional near-matches to include in the message.
+    """
+    msg = f"invalid bootstyle {kind} {token!r} in {source!r}"
+    if suggestions:
+        hint = " or ".join(repr(s) for s in suggestions)
+        msg += f"; did you mean {hint}?"
+    msg += " (unknown tokens are ignored; see the bootstyle reference)"
+    if _STRICT:
+        raise ValueError(msg)
+    warnings.warn(msg, UserWarning, stacklevel=3)
+
+
+def warn_deprecated(old: str, new: str, *, removed_in: str = "3.0") -> None:
+    """Emit the quarantine's standard deprecation warning."""
+    warnings.warn(
+        f"{old} is deprecated and will be removed in {removed_in}; use {new}.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def normalize_bootstyle(value, *, warn: bool = False) -> str:
+    """Return the canonical dash-joined bootstyle string for a legacy value.
+
+    Accepts the retired tuple/list form (``("primary", "outline")``) as well as
+    a plain string, and returns a single dash-joined string the tokenizer can
+    split. Slot re-ordering is handled downstream by the tokenizer, not here.
+
+    In 2.0 D1 this is called with ``warn=False`` so the internal tuple callers
+    (Meter/DateEntry/...) stay quiet until they are migrated in D2; D2 flips the
+    default caller to ``warn=True`` so genuine external tuple use is flagged.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple)):
+        parts = [str(v).strip() for v in value if v is not None and str(v).strip()]
+        canonical = "-".join(parts)
+        if warn and parts:
+            warn_deprecated(
+                "passing a tuple/list bootstyle",
+                f'the canonical string "{canonical}"',
+            )
+        return canonical
+    return str(value).strip()

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -6,9 +6,18 @@ delivery path; `bootify`/`apply_bootstyle`/`enable_global_api` are the dynamic
 and opt-in-global delivery primitives. Top layer of the `style` package. Split
 out of the monolithic `style.py` in 2.0.
 """
+import difflib
 import re
 from tkinter import TclError, ttk
 
+from ttkbootstrap.constants import (
+    BOOTSTYLE_COLORS,
+    BOOTSTYLE_MODIFIERS,
+    BOOTSTYLE_INTERNAL_MODIFIERS,
+    BOOTSTYLE_FAMILIES,
+    BOOTSTYLE_ORIENTS,
+)
+from ttkbootstrap.style import _compat
 from ttkbootstrap.style.engine import Style
 from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
 from ttkbootstrap.style.builders_tk import StyleBuilderTK
@@ -28,69 +37,173 @@ class Keywords:
 
     This class is internal to the styling system and not intended to be
     instantiated.
+
+    As of 2.0 (Workstream D) the token lists are sourced from the single
+    vocabulary in `ttkbootstrap.constants` -- this class no longer keeps a
+    second copy. The "type" slot spans both public modifiers (`outline`,
+    `round`, ...) and the internal composite modifiers (`meter`, `date`, ...).
+    The compiled patterns are retained for the orientation lookup and any
+    back-compat callers; the primary parse path is the token classifier below.
     """
-    
-    COLORS = [
-        "primary",
-        "secondary",
-        "success",
-        "info",
-        "warning",
-        "danger",
-        "light",
-        "dark",
-    ]
-    ORIENTS = ["horizontal", "vertical"]
-    TYPES = [
-        "outline",
-        "link",
-        "inverse",
-        "round",
-        "square",
-        "striped",
-        "thin",
-        "focus",
-        "input",
-        "date",
-        "metersubtxt",
-        "meter",
-        "table"
-    ]
-    CLASSES = [
-        "button",
-        "progressbar",
-        "checkbutton",
-        "combobox",
-        "entry",
-        "labelframe",
-        "label",
-        "frame",
-        "floodgauge",
-        "sizegrip",
-        "optionmenu",
-        "menubutton",
-        "menu",
-        "notebook",
-        "panedwindow",
-        "radiobutton",
-        "separator",
-        "scrollbar",
-        "spinbox",
-        "scale",
-        "text",
-        "toolbutton",
-        "treeview",
-        "toggle",
-        "tk",
-        "calendar",
-        "listbox",
-        "canvas",
-        "toplevel",
-    ]
-    COLOR_PATTERN = re.compile("|".join(COLORS))
+
+    COLORS = list(BOOTSTYLE_COLORS)
+    ORIENTS = list(BOOTSTYLE_ORIENTS)
+    TYPES = list(BOOTSTYLE_MODIFIERS) + list(BOOTSTYLE_INTERNAL_MODIFIERS)
+    CLASSES = list(BOOTSTYLE_FAMILIES)
+    # Longest-first alternation so a longer token wins over a substring it
+    # contains (e.g. `labelframe` over `label`, `menubutton` over `button`).
+    COLOR_PATTERN = re.compile("|".join(sorted(COLORS, key=len, reverse=True)))
     ORIENT_PATTERN = re.compile("|".join(ORIENTS))
-    CLASS_PATTERN = re.compile("|".join(CLASSES))
-    TYPE_PATTERN = re.compile("|".join(TYPES))
+    CLASS_PATTERN = re.compile("|".join(sorted(CLASSES, key=len, reverse=True)))
+    TYPE_PATTERN = re.compile("|".join(sorted(TYPES, key=len, reverse=True)))
+
+
+# --------------------------------------------------------------------------- #
+# Bootstyle tokenizer (2.0 Workstream D)
+#
+# The pre-2.0 resolver `re.search`-ed the whole string for a color/type/class
+# substring anywhere, which silently dropped unknown tokens and risked
+# substring collisions. The tokenizer below splits the (normalized) string into
+# tokens and classifies each against the closed vocabulary, so an unrecognized
+# token fails loudly (warn by default, raise in strict mode) instead of being
+# ignored.
+# --------------------------------------------------------------------------- #
+_COLORS = frozenset(BOOTSTYLE_COLORS)
+_PUBLIC_MODIFIERS = frozenset(BOOTSTYLE_MODIFIERS)
+_MODIFIERS = _PUBLIC_MODIFIERS | frozenset(BOOTSTYLE_INTERNAL_MODIFIERS)
+_FAMILIES = frozenset(BOOTSTYLE_FAMILIES)
+_ORIENTS = frozenset(BOOTSTYLE_ORIENTS)
+# winfo_class inference matches the class name by substring; try longer family
+# names first so `TLabelframe` resolves to `labelframe`, not `label`.
+_FAMILIES_BY_LEN = tuple(sorted(BOOTSTYLE_FAMILIES, key=len, reverse=True))
+# Suggestion pool for typos -- the tokens a user might reasonably have meant
+# (exclude the internal composite modifiers, which are not user-facing).
+_SUGGESTION_POOL = tuple(
+    sorted(_COLORS | _PUBLIC_MODIFIERS | _FAMILIES | _ORIENTS)
+)
+# Tokens that carry no slot meaning: empty fragments and the "no bootstyle"
+# sentinel the delivery paths pass when only a base style is wanted.
+_SENTINELS = frozenset({"", "default"})
+_TOKEN_SPLIT = re.compile(r"[-\s]+")
+
+
+def _classify_tokens(style_string, *, source=None, warn=False):
+    """Split a bootstyle string and classify each token into a slot.
+
+    Returns ``(color, modifier, base, orient)`` -- the first token seen for each
+    slot (matching the pre-2.0 leftmost-wins behavior). When ``warn`` is true,
+    an unrecognized token and a duplicate-slot token are reported through the
+    `_compat` loud-failure path (warn by default, raise in strict mode).
+    """
+    source = style_string if source is None else source
+    color = modifier = base = orient = ""
+    for token in _TOKEN_SPLIT.split(style_string.strip().lower()):
+        if token in _SENTINELS:
+            continue
+        if token in _COLORS:
+            if warn and color and token != color:
+                _compat.report_invalid("color", token, source)
+            color = color or token
+        elif token in _MODIFIERS:
+            if warn and modifier and token != modifier:
+                _compat.report_invalid("modifier", token, source)
+            modifier = modifier or token
+        elif token in _FAMILIES:
+            if warn and base and token != base:
+                _compat.report_invalid("base-type", token, source)
+            base = base or token
+        elif token in _ORIENTS:
+            orient = orient or token
+        elif warn:
+            suggestions = difflib.get_close_matches(
+                token, _SUGGESTION_POOL, n=1
+            )
+            _compat.report_invalid("token", token, source, suggestions)
+    return color, modifier, base, orient
+
+
+def _looks_like_style_name(style_string):
+    """Return whether the input is an already-built ttk style name.
+
+    The resolver accepts two dialects. A *bootstyle* is lowercase and dash/space
+    separated (``"primary-outline"``). A built *ttk style name* always has a
+    Title-cased class component, so it contains an uppercase letter and no dash
+    or space (``"TFrame"``, ``"primary.Outline.TButton"``, ``"symbol.Link.
+    TButton"``); a dotted string is always a style name. This lets the theme
+    walk re-resolve a widget's dotted ``cget("style")`` (including a bare base
+    like ``"TFrame"``) without misreading it as a mistyped bootstyle.
+    """
+    if "." in style_string:
+        return True
+    return (
+        "-" not in style_string
+        and " " not in style_string
+        and any(ch.isupper() for ch in style_string)
+    )
+
+
+def _classify_style_name(name):
+    """Classify the segments of an already-built dotted ttk style name.
+
+    The resolver receives two input dialects: a dashed/spaced *bootstyle*
+    (``"primary-outline"``) and an already-built *ttk style name*
+    (``"primary.Outline.TButton"``, ``"symbol.Link.TButton"``). The latter
+    arrives from the theme-walk repaint (a widget's current ``cget("style")``),
+    from `Style.configure` subclassing a base style, and from user-supplied
+    custom style names. Segments are split on ``.``; the class segment is
+    title-cased with an optional ``T`` prefix, so ``TButton`` -> ``button`` but
+    ``Treeview``/``Toggle`` map directly. Unknown segments (custom prefixes such
+    as ``symbol``) are ignored *without* warning -- style names legitimately
+    carry them, unlike a user's bootstyle.
+    """
+    color = modifier = base = orient = ""
+    for segment in name.split("."):
+        seg = segment.strip().lower()
+        if not seg or seg in _SENTINELS:
+            continue
+        if seg in _COLORS:
+            color = color or seg
+        elif seg in _MODIFIERS:
+            modifier = modifier or seg
+        elif seg in _ORIENTS:
+            orient = orient or seg
+        elif seg in _FAMILIES:
+            base = base or seg
+        elif seg.startswith("t") and seg[1:] in _FAMILIES:
+            base = base or seg[1:]
+        # else: an unknown custom segment -- ignore it silently
+    return color, modifier, base, orient
+
+
+def _infer_family(widget):
+    """Infer the widget family from its Tcl class (longest match wins)."""
+    if widget is None:
+        return ""
+    try:
+        widget_class = widget.winfo_class().lower()
+    except Exception:
+        return ""
+    for family in _FAMILIES_BY_LEN:
+        if family in widget_class:
+            return family
+    return ""
+
+
+def _build_ttkstyle_name(color, modifier, orient, family):
+    """Assemble the dotted ttk style name from resolved slot tokens.
+
+    Preserves the exact pre-2.0 casing: the color stays lowercase, the modifier
+    and orientation are title-cased, and the family is title-cased with a ``T``
+    prefix unless it already starts with ``t`` (``Treeview``, ``Toplevel``).
+    """
+    color = f"{color}." if color else ""
+    modifier = f"{modifier.title()}." if modifier else ""
+    orient = f"{orient.title()}." if orient else ""
+    if family.startswith("t"):
+        family = family.title()
+    else:
+        family = f"T{family.title()}"
+    return f"{color}{modifier}{orient}{family}"
 
 
 class Bootstyle:
@@ -126,22 +239,12 @@ class Bootstyle:
             str:
                 A widget class keyword.
         """
-        # find widget class from string pattern
-        match = re.search(Keywords.CLASS_PATTERN, string.lower())
-        if match is not None:
-            widget_class = match.group(0)
-            return widget_class
-
-        # find widget class from tkinter/tcl method
-        if widget is None:
-            return ""
-        _class = widget.winfo_class()
-        match = re.search(Keywords.CLASS_PATTERN, _class.lower())
-        if match is not None:
-            widget_class = match.group(0)
-            return widget_class
-        else:
-            return ""
+        # an explicit base-type token in the string wins; otherwise infer the
+        # family from the widget's Tcl class
+        _, _, base, _ = _classify_tokens(string)
+        if base:
+            return base
+        return _infer_family(widget)
 
     @staticmethod
     def ttkstyle_widget_type(string):
@@ -157,12 +260,8 @@ class Bootstyle:
             str:
                 A widget type keyword.
         """
-        match = re.search(Keywords.TYPE_PATTERN, string.lower())
-        if match is None:
-            return ""
-        else:
-            widget_type = match.group(0)
-            return widget_type
+        _, modifier, _, _ = _classify_tokens(string)
+        return modifier
 
     @staticmethod
     def ttkstyle_widget_orient(widget=None, string="", **kwargs):
@@ -228,12 +327,8 @@ class Bootstyle:
             str:
                 A color keyword.
         """
-        _color = re.search(Keywords.COLOR_PATTERN, string.lower())
-        if _color is None:
-            return ""
-        else:
-            widget_color = _color.group(0)
-            return widget_color
+        color, _, _, _ = _classify_tokens(string)
+        return color
 
     @staticmethod
     def ttkstyle_name(widget=None, string="", **kwargs):
@@ -255,30 +350,38 @@ class Bootstyle:
             str:
                 A ttk style name
         """
-        style_string = "".join(string).lower()
-        widget_color = Bootstyle.ttkstyle_widget_color(style_string)
-        widget_type = Bootstyle.ttkstyle_widget_type(style_string)
-        widget_orient = Bootstyle.ttkstyle_widget_orient(
-            widget, style_string, **kwargs
+        style_string = _compat.normalize_bootstyle(string)
+        color, modifier, _, orient, family = Bootstyle._parse_components(
+            widget, style_string, warn=False, **kwargs
         )
-        widget_class = Bootstyle.ttkstyle_widget_class(widget, style_string)
+        return _build_ttkstyle_name(color, modifier, orient, family)
 
-        if widget_color:
-            widget_color = f"{widget_color}."
+    @staticmethod
+    def _parse_components(widget, style_string, *, warn, **kwargs):
+        """Resolve a bootstyle/style string to ``(color, modifier, base,
+        orient, family)``.
 
-        if widget_type:
-            widget_type = f"{widget_type.title()}."
-
-        if widget_orient:
-            widget_orient = f"{widget_orient.title()}."
-
-        if widget_class.startswith("t"):
-            widget_class = widget_class.title()
+        A dotted input is an already-built ttk style name and is parsed
+        leniently (`_classify_style_name`); a dashed/spaced input is a bootstyle
+        and goes through the closed-vocab tokenizer, which fails loudly on
+        unknown tokens when ``warn`` is set. ``family`` is the explicit base
+        token if present, else inferred from the widget.
+        """
+        if _looks_like_style_name(style_string):
+            color, modifier, base, orient = _classify_style_name(style_string)
+            if not orient:
+                orient = Bootstyle.ttkstyle_widget_orient(
+                    widget, "", **kwargs
+                )
         else:
-            widget_class = f"T{widget_class.title()}"
-
-        ttkstyle = f"{widget_color}{widget_type}{widget_orient}{widget_class}"
-        return ttkstyle
+            color, modifier, base, _ = _classify_tokens(
+                style_string, warn=warn
+            )
+            orient = Bootstyle.ttkstyle_widget_orient(
+                widget, style_string, **kwargs
+            )
+        family = base or _infer_family(widget)
+        return color, modifier, base, orient, family
 
     @staticmethod
     def ttkstyle_method_name(widget=None, string=""):
@@ -478,6 +581,11 @@ class Bootstyle:
         if style_string is None:
             style_string = widget.cget("style")
 
+        # normalize legacy forms (tuple/list) to a canonical string. D1 keeps
+        # this quiet (warn=False) because the internal composite-widget callers
+        # still pass tuples; D2 migrates them and turns the warning on.
+        style_string = _compat.normalize_bootstyle(style_string)
+
         # do nothing if the style has not been set
         if not style_string:
             return ""
@@ -485,22 +593,38 @@ class Bootstyle:
         if style_string == '.':
             return '.'
 
+        # parse once (loud-fail on unknown tokens for a bootstyle string; lenient
+        # for an already-built ttk style name); build the ttk style name from
+        # the resolved tokens rather than re-parsing the generated name.
+        is_bootstyle = not _looks_like_style_name(style_string)
+        color, modifier, _, orient, family = Bootstyle._parse_components(
+            widget, style_string, warn=True, **kwargs
+        )
+        variant = modifier or DEFAULT_VARIANT
+        ttkstyle = _build_ttkstyle_name(color, modifier, orient, family)
+
         # build style if not existing (example: theme changed)
-        ttkstyle = Bootstyle.ttkstyle_name(widget, style_string, **kwargs)
         if not style.style_exists_in_theme(ttkstyle):
-            widget_color = Bootstyle.ttkstyle_widget_color(ttkstyle)
-            widget_type = (
-                Bootstyle.ttkstyle_widget_type(ttkstyle)
-                or DEFAULT_VARIANT
-            )
-            widget_family = Bootstyle.ttkstyle_widget_class(widget, ttkstyle)
             builder: StyleBuilderTTK = style._get_builder()
-            if not builder.build_style(
-                widget_type, widget_family, widget_color
-            ):
-                # Style name is from a third-party widget (e.g. tkcalendar) and
-                # doesn't map to any ttkbootstrap builder; pass it through as-is.
-                return style_string
+            if not builder.build_style(variant, family, color):
+                if family in _FAMILIES and variant != DEFAULT_VARIANT:
+                    # An invalid modifier for one of our own widgets
+                    # (e.g. "outline-scale"): fail loudly for a bootstyle string,
+                    # then fall back to the family's default style rather than
+                    # returning the unusable raw fragment.
+                    if is_bootstyle and modifier:
+                        _compat.report_invalid(
+                            "combination", f"{modifier}-{family}", style_string
+                        )
+                    ttkstyle = _build_ttkstyle_name(color, "", orient, family)
+                    if not style.style_exists_in_theme(ttkstyle) and (
+                        not builder.build_style(DEFAULT_VARIANT, family, color)
+                    ):
+                        return style_string
+                else:
+                    # A third-party widget whose class maps to no ttkbootstrap
+                    # builder: pass its style through untouched.
+                    return style_string
 
         # Repaint the combobox popdown. It is a Tcl-level toplevel that the
         # theme walk's winfo_children() DFS cannot reach, so it is refreshed

--- a/tests/test_bootstyle_grammar.py
+++ b/tests/test_bootstyle_grammar.py
@@ -1,0 +1,247 @@
+"""Grammar tests for the canonical bootstyle vocabulary (2.0 Workstream D, D1).
+
+These lock the D1 contract: a single closed vocabulary, a real tokenizer that
+classifies each token into a fixed slot, loud failure (warn by default, raise in
+strict mode) on unknown/duplicate tokens, tuple normalization, and a round-trip
+proving every registered builder key is expressible in the grammar.
+"""
+from typing import get_args
+
+import warnings
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap import constants as C
+from ttkbootstrap.style import _compat
+from ttkbootstrap.style.bootstyle import (
+    _classify_tokens,
+    _infer_family,
+    _build_ttkstyle_name,
+)
+from ttkbootstrap.style.builders import load_builders
+from ttkbootstrap.style.builders.registry import builder_keys, DEFAULT_VARIANT
+
+
+@pytest.fixture(autouse=True)
+def _reset_strict():
+    """Keep strict-mode changes from leaking across tests."""
+    before = _compat.is_bootstyle_strict()
+    yield
+    _compat.set_bootstyle_strict(before)
+
+
+# --------------------------------------------------------------------------- #
+# Single source of truth: Literals mirror the runtime vocab tuples
+# --------------------------------------------------------------------------- #
+def test_literals_match_vocab_tuples():
+    assert set(get_args(C.BootColor)) == set(C.BOOTSTYLE_COLORS)
+    assert set(get_args(C.BootType)) == set(C.BOOTSTYLE_MODIFIERS)
+    assert set(get_args(C.BootBase)) == set(C.BOOTSTYLE_BASES)
+
+
+def test_reclassification_fixed_the_audit():
+    # `round` is now a modifier (was buildable but missing from BootType)...
+    assert "round" in C.BOOTSTYLE_MODIFIERS
+    # ...and toggle/toolbutton are base-types, not modifiers.
+    assert "toggle" not in C.BOOTSTYLE_MODIFIERS
+    assert "toolbutton" not in C.BOOTSTYLE_MODIFIERS
+    assert set(C.BOOTSTYLE_BASES) == {"toggle", "toolbutton"}
+    # the dead keywords are gone from every slot
+    for slot in (
+        C.BOOTSTYLE_COLORS, C.BOOTSTYLE_MODIFIERS,
+        C.BOOTSTYLE_INTERNAL_MODIFIERS, C.BOOTSTYLE_FAMILIES,
+    ):
+        assert "focus" not in slot
+        assert "input" not in slot
+
+
+# --------------------------------------------------------------------------- #
+# Tokenizer / classification
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("primary-outline", ("primary", "outline", "", "")),
+        ("success-round-toggle", ("success", "round", "toggle", "")),
+        ("info-striped", ("info", "striped", "", "")),
+        ("primary", ("primary", "", "", "")),
+        ("outline", ("", "outline", "", "")),
+        ("toolbutton", ("", "", "toolbutton", "")),
+        ("horizontal", ("", "", "", "horizontal")),
+        ("danger-inverse", ("danger", "inverse", "", "")),
+        # order-free input still classifies to the same slots
+        ("outline-primary", ("primary", "outline", "", "")),
+        # whitespace separator is accepted alongside the dash
+        ("primary outline", ("primary", "outline", "", "")),
+        # internal composite modifiers are valid tokens
+        ("primary-meter", ("primary", "meter", "", "")),
+        ("date", ("", "date", "", "")),
+    ],
+)
+def test_classify_slots(text, expected):
+    assert _classify_tokens(text) == expected
+
+
+def test_sentinels_classify_to_nothing():
+    assert _classify_tokens("default") == ("", "", "", "")
+    assert _classify_tokens("") == ("", "", "", "")
+    assert _classify_tokens("-primary-") == ("primary", "", "", "")
+
+
+# --------------------------------------------------------------------------- #
+# Loud failure: warn by default, raise in strict mode
+# --------------------------------------------------------------------------- #
+def test_unknown_token_is_silent_without_warn_flag():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _classify_tokens("primaryy") == ("", "", "", "")
+
+
+def test_unknown_token_warns():
+    with pytest.warns(UserWarning, match="primaryy"):
+        _classify_tokens("primaryy", warn=True)
+
+
+def test_unknown_token_suggests_nearest():
+    with pytest.warns(UserWarning, match="did you mean 'primary'"):
+        _classify_tokens("primaryy", warn=True)
+
+
+def test_unknown_token_strict_raises():
+    _compat.set_bootstyle_strict(True)
+    with pytest.raises(ValueError, match="primaryy"):
+        _classify_tokens("primaryy", warn=True)
+
+
+def test_duplicate_slot_warns():
+    with pytest.warns(UserWarning, match="color"):
+        _classify_tokens("primary-info", warn=True)
+
+
+def test_strict_toggle_and_default():
+    assert _compat.is_bootstyle_strict() is False
+    _compat.set_bootstyle_strict(True)
+    assert _compat.is_bootstyle_strict() is True
+    _compat.set_bootstyle_strict(False)
+    assert _compat.is_bootstyle_strict() is False
+
+
+# --------------------------------------------------------------------------- #
+# Name assembly (exact pre-2.0 casing preserved)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (("primary", "outline", "", "button"), "primary.Outline.TButton"),
+        (("success", "", "", "button"), "success.TButton"),
+        (("", "", "", "treeview"), "Treeview"),
+        (("", "striped", "horizontal", "progressbar"),
+         "Striped.Horizontal.TProgressbar"),
+        (("", "round", "", "toggle"), "Round.Toggle"),
+        (("", "", "", "toplevel"), "Toplevel"),
+    ],
+)
+def test_build_name(args, expected):
+    assert _build_ttkstyle_name(*args) == expected
+
+
+# --------------------------------------------------------------------------- #
+# _compat.normalize_bootstyle
+# --------------------------------------------------------------------------- #
+def test_normalize_tuple_is_quiet_in_d1():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _compat.normalize_bootstyle(("primary", "outline")) == \
+            "primary-outline"
+        assert _compat.normalize_bootstyle(["danger", "inverse"]) == \
+            "danger-inverse"
+        assert _compat.normalize_bootstyle("primary-outline") == \
+            "primary-outline"
+        assert _compat.normalize_bootstyle(None) == ""
+
+
+def test_normalize_tuple_warns_when_asked():
+    # D2 will flip the resolver's default to warn=True; the machinery is here.
+    with pytest.warns(DeprecationWarning, match="tuple/list bootstyle"):
+        assert _compat.normalize_bootstyle(
+            ("primary", "outline"), warn=True
+        ) == "primary-outline"
+
+
+# --------------------------------------------------------------------------- #
+# Registry round-trip: every built-in (variant, family) is expressible
+# --------------------------------------------------------------------------- #
+def test_every_registry_key_roundtrips():
+    load_builders()
+    keys = builder_keys()
+    assert keys, "registry should be populated after load_builders()"
+    for variant, family in keys:
+        # family is a real vocabulary token...
+        assert family in C.BOOTSTYLE_FAMILIES, (variant, family)
+        # ...and the variant is either the default or a known modifier
+        known_modifiers = set(C.BOOTSTYLE_MODIFIERS) | set(
+            C.BOOTSTYLE_INTERNAL_MODIFIERS
+        )
+        assert variant == DEFAULT_VARIANT or variant in known_modifiers, (
+            variant, family,
+        )
+
+        tokens = ["primary"]
+        if variant != DEFAULT_VARIANT:
+            tokens.append(variant)
+        tokens.append(family)
+        color, modifier, base, _ = _classify_tokens("-".join(tokens))
+        assert color == "primary"
+        assert base == family
+        assert (modifier or DEFAULT_VARIANT) == variant
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: canonical strings resolve to real, existing ttk styles
+# --------------------------------------------------------------------------- #
+def test_infer_family_from_widget(root):
+    btn = ttk.Button(root)
+    assert _infer_family(btn) == "button"
+    lf = ttk.Labelframe(root)
+    assert _infer_family(lf) == "labelframe"  # not the "label" substring
+
+
+@pytest.mark.parametrize(
+    "factory, bootstyle, expected_name",
+    [
+        (ttk.Button, "primary-outline", "primary.Outline.TButton"),
+        (ttk.Button, "success", "success.TButton"),
+        (ttk.Checkbutton, "round-toggle", "Round.Toggle"),
+        (ttk.Checkbutton, "toolbutton", "Toolbutton"),
+        (ttk.Progressbar, "info-striped", None),
+        (ttk.Label, "inverse", None),
+        (ttk.Scrollbar, "primary", None),
+    ],
+)
+def test_canonical_bootstyle_resolves_to_real_style(
+    root, factory, bootstyle, expected_name
+):
+    widget = factory(root, bootstyle=bootstyle)
+    applied = widget.cget("style")
+    if expected_name is not None:
+        assert applied == expected_name
+    assert root.style.style_exists_in_theme(applied)
+
+
+def test_invalid_pair_warns_for_our_widget(root):
+    # `thin` is a real modifier, `button` a real family, but (thin, button) is
+    # not a registered builder -> loud failure, not silent fallthrough. (A
+    # Button is used rather than a Scale so this does not pre-populate the
+    # session-global image cache the order-sensitive image-cache test checks.)
+    with pytest.warns(UserWarning, match="thin-button"):
+        ttk.Button(root, bootstyle="thin")
+
+
+def test_valid_widget_construction_is_warning_free(root):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ttk.Button(root, bootstyle="primary")
+        ttk.Checkbutton(root, bootstyle="success-round-toggle")
+        ttk.Progressbar(root, bootstyle="info-striped")
+        ttk.Label(root, bootstyle="inverse")

--- a/tests/test_style_package.py
+++ b/tests/test_style_package.py
@@ -30,6 +30,7 @@ PUBLIC_NAMES = [
 ]
 
 SUBMODULES = [
+    "ttkbootstrap.style._compat",
     "ttkbootstrap.style.theme",
     "ttkbootstrap.style.scaling",
     "ttkbootstrap.style.builders_tk",


### PR DESCRIPTION
Workstream D, PR 1 of 3. Design pass first (the hard rule): decisions locked in
`development/2_0_bootstyle_grammar_design.md`. Replaces the substring-regex
bootstyle resolver with a real tokenizer over a **single closed vocabulary** that
**fails loudly** on unknown tokens instead of silently dropping them. **No caller
changes** — the tuple/list form still normalizes (quietly in D1; the internal
composite callers migrate in D2), so behavior for valid input is unchanged.

## What's in D1
- **Single vocab source of truth in `constants.py`** — runtime tuples
  (`BOOTSTYLE_COLORS/MODIFIERS/INTERNAL_MODIFIERS/BASES/FAMILIES/ORIENTS`) + the
  reconciled `Literal`s. `BootType` fixed: **`round` added** (was buildable but
  missing), **`toggle`/`toolbutton` removed** (they are base-types, not
  modifiers) → new `BootBase` carries `TOGGLE`/`TOOLBUTTON`. Dead `focus`/`input`
  dropped. A test asserts each `Literal` matches its tuple.
- **`style/_compat.py`** (new — Workstream-F quarantine): `normalize_bootstyle`,
  `warn_deprecated`, and the strictness policy — `set_bootstyle_strict` /
  `is_bootstyle_strict` (re-exported from `ttkbootstrap`) + `TTKBOOTSTRAP_STRICT`
  env var. Default warns on invalid input; strict mode raises `ValueError`.
- **Real tokenizer in `bootstyle.py`** — `Keywords` sources its lists from
  `constants`; `_classify_tokens` classifies each dash/space token against the
  closed vocab; `_infer_family` maps a widget's Tcl class (longest match);
  `_build_ttkstyle_name` assembles the name with the exact pre-2.0 casing. The
  resolver parses the raw input **once** and builds from the tokens (no more
  re-parsing the generated dotted name).

## Two things the design pass under-specified (found + handled during impl)
- **The resolver has two input dialects, not one.** Besides user bootstyle
  strings it also receives already-built ttk style names — the theme-walk
  repaint (a widget's dotted `cget("style")`, incl. a bare `"TFrame"`),
  `Style.configure` subclassing (`"symbol.Link.TButton"`), and user custom
  styles. These are parsed leniently (`_classify_style_name` — custom prefixes
  are legal, no unknown-token warnings); only a genuine bootstyle string gets the
  loud-failure path. `_looks_like_style_name` discriminates (a built name has a
  Title-cased class → uppercase + no dash/space, or a dot).
- **Invalid-pair best-effort improved.** Previously an unbuildable pair like
  `outline`-on-Scale returned the raw fragment `"outline"` as the style name and
  then crashed in `configure`; now it warns (bootstyle input only) and falls back
  to the family's **default** style. Genuine third-party widgets still pass
  through untouched.

## Tests / gates
- New `tests/test_bootstyle_grammar.py` (40 tests): token classification, slot
  order, unknown/duplicate → warn + strict-raise, tuple normalization,
  `Literal`/tuple sync, a **registry round-trip** proving every built-in
  `(variant, family)` key is expressible in the grammar, and end-to-end
  resolution to real ttk styles.
- **Suite 258 passed**; warning-free `import ttkbootstrap`; standalone `_compat`
  import (cycle guard); annotation force-eval clean; light↔dark theme-switch
  smoke OK.

Next: **D2** (migrate the 4 internal tuple callers → canonical strings, then flip
the tuple `DeprecationWarning` on), then **D3** (generated `BootStyle` Literal +
reference table for the Workstream-H docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)