### PR TITLE
D2: migrate internal tuple callers + turn on the tuple deprecation

### DIFF
--- a/development/2_0_bootstyle_grammar_design.md
+++ b/development/2_0_bootstyle_grammar_design.md
@@ -229,6 +229,16 @@ deprecation warning only fires for genuine external tuple use.
   every built-in `(variant, family)` registry key → expected canonical string →
   resolves back to the same ttk style.
 
+> **D2 — IMPLEMENTED (2026-07-06, branch `feat/2.0-pr-d2-bootstyle-migrate`).**
+> Suite **260 passed**; import + all-warnings-as-errors widget smoke clean. The
+> tuple-caller sweep found **more first-party sites than the prep doc listed** —
+> besides meter/dateentry/tooltip/datepicker, the `python -m ttkbootstrap` demo
+> (8 sites) and ttkcreator (5 sites) also used tuples and would have tripped
+> their own new warning; all were migrated to canonical strings. `tooltip`'s
+> public `bootstyle` param (which accepted a tuple) was narrowed to `Optional[str]`
+> and its docstrings updated; the runtime pass-through still tolerates a tuple via
+> compat (now warning). No new grammar tokens were needed.
+
 ### D2 — migrate internal callers + turn on the tuple deprecation
 - Migrate meter/dateentry/tooltip/datepicker off the tuple form (§6).
 - Flip `normalize_bootstyle` to **emit the `DeprecationWarning`** on tuple/list

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -18,12 +18,18 @@ two under-specified points, now handled + documented in the design doc's "D1 —
 IMPLEMENTED" note: the resolver has **two input dialects** (bootstyle strings vs
 already-built ttk style names from the theme walk / `Style.configure` /custom
 styles — lenient parse, no warns), and invalid pairs now fall back to the
-family default instead of returning an unusable fragment. **NEXT → D2**: migrate
-the 4 internal tuple callers (meter/dateentry/tooltip/datepicker) to canonical
-strings, then flip `normalize_bootstyle` to `warn=True`. Then D3 (generated
-`BootStyle` Literal + reference table for docs H). Env note: the repo `.venv/`
-is broken on this Windows box (launcher fails); `.venv-home/` works — pytest was
-installed into it. _
+family default instead of returning an unusable fragment. **D2 IMPLEMENTED** (branch `feat/2.0-pr-d2-bootstyle-migrate`, PR #1092 open
+against `2.0`): migrated every first-party tuple caller to canonical strings
+(meter/dateentry/tooltip/datepicker **plus** the `python -m ttkbootstrap` and
+ttkcreator demos — more sites than the prep doc listed) and flipped
+`normalize_bootstyle(..., warn=True)`, so an external tuple bootstyle now warns
+(removed in 3.0) while still resolving. `tooltip.bootstyle` narrowed to
+`Optional[str]`. Suite **260 passed**; import + all-warnings-as-errors widget
+smoke clean. **NEXT → D3**: generate the canonical reference table + a `BootStyle`
+string `Literal` from the vocab × registry (feeds the Workstream-H docs); add a
+test that the generated artifacts stay in sync with the live vocab + registry.
+Env note: the repo `.venv/` is broken on this Windows box (launcher fails);
+`.venv-home/` works — pytest was installed into it. _
 
 _Prior 2026-07-06 (**Workstream E (theme/anchor) COMPLETE** — all three
 PRs merged: E1 #1088 (`Colors`→`RampColor` resolved view + `c.primary[300]`),

--- a/src/ttkbootstrap/__main__.py
+++ b/src/ttkbootstrap/__main__.py
@@ -165,7 +165,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
         master=lframe_inner,
         orient=HORIZONTAL,
         value=75,
-        bootstyle=(SUCCESS, STRIPED),
+        bootstyle="success-striped",
     ).pack(fill=X, pady=5, expand=YES)
 
     m = ttk.Meter(
@@ -186,7 +186,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     sb.pack(fill=X, pady=5, expand=YES)
 
     sb = ttk.Scrollbar(
-        master=lframe_inner, orient=HORIZONTAL, bootstyle=(DANGER, ROUND)
+        master=lframe_inner, orient=HORIZONTAL, bootstyle="danger-round"
     )
     sb.set(0.1, 0.9)
     sb.pack(fill=X, pady=5, expand=YES)
@@ -213,7 +213,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     cb = ttk.Checkbutton(
         master=btn_group,
         text="solid toolbutton",
-        bootstyle=(SUCCESS, TOOLBUTTON),
+        bootstyle="success-toolbutton",
     )
     cb.invoke()
     cb.pack(fill=X, pady=5)
@@ -221,7 +221,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     ob = ttk.Button(
         master=btn_group,
         text="outline button",
-        bootstyle=(INFO, OUTLINE),
+        bootstyle="info-outline",
         command=lambda: Messagebox.ok("You pushed an outline button"),
     )
     ob.pack(fill=X, pady=5)
@@ -229,7 +229,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     mb = ttk.Menubutton(
         master=btn_group,
         text="outline menubutton",
-        bootstyle=(WARNING, OUTLINE),
+        bootstyle="warning-outline",
         menu=menu,
     )
     mb.pack(fill=X, pady=5)
@@ -237,7 +237,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     cb = ttk.Checkbutton(
         master=btn_group,
         text="outline toolbutton",
-        bootstyle=(SUCCESS, OUTLINE, TOOLBUTTON),
+        bootstyle="success-outline-toolbutton",
     )
     cb.pack(fill=X, pady=5)
 
@@ -247,13 +247,13 @@ Namespaces are one honking great idea -- let's do more of those!"""
     cb1 = ttk.Checkbutton(
         master=btn_group,
         text="rounded toggle",
-        bootstyle=(SUCCESS, ROUND, TOGGLE),
+        bootstyle="success-round-toggle",
     )
     cb1.invoke()
     cb1.pack(fill=X, pady=5)
 
     cb2 = ttk.Checkbutton(
-        master=btn_group, text="squared toggle", bootstyle=(SQUARE, TOGGLE)
+        master=btn_group, text="squared toggle", bootstyle="square-toggle"
     )
     cb2.pack(fill=X, pady=5)
     cb2.invoke()

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -220,7 +220,7 @@ class DatePickerDialog:
                 text=col,
                 anchor=CENTER,
                 padding=5,
-                bootstyle=(SECONDARY, INVERSE),
+                bootstyle="secondary-inverse",
             ).pack(side=LEFT, fill=X, expand=YES)
 
     def _set_title(self) -> None:

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -581,10 +581,10 @@ class Bootstyle:
         if style_string is None:
             style_string = widget.cget("style")
 
-        # normalize legacy forms (tuple/list) to a canonical string. D1 keeps
-        # this quiet (warn=False) because the internal composite-widget callers
-        # still pass tuples; D2 migrates them and turns the warning on.
-        style_string = _compat.normalize_bootstyle(style_string)
+        # normalize legacy forms (tuple/list) to a canonical string. As of D2 all
+        # first-party callers pass canonical strings, so a tuple/list here is
+        # genuine external use and earns a DeprecationWarning (removed in 3.0).
+        style_string = _compat.normalize_bootstyle(style_string, warn=True)
 
         # do nothing if the style has not been set
         if not style_string:

--- a/src/ttkbootstrap/widgets/dateentry.py
+++ b/src/ttkbootstrap/widgets/dateentry.py
@@ -177,7 +177,7 @@ class DateEntry(Frame):
         if "bootstyle" in kwargs:
             self._bootstyle = kwargs.pop("bootstyle")
             self.entry.configure(bootstyle=self._bootstyle)
-            self.button.configure(bootstyle=[self._bootstyle, "date"])
+            self.button.configure(bootstyle=f"{self._bootstyle}-date")
         if "width" in kwargs:
             width = kwargs.pop("width")
             self.entry.configure(width=width)

--- a/src/ttkbootstrap/widgets/meter.py
+++ b/src/ttkbootstrap/widgets/meter.py
@@ -307,28 +307,28 @@ class Meter(Frame):
             master=self.textframe,
             text=self._textleft,
             font=self._subtextfont,
-            bootstyle=(self._subtextstyle, "metersubtxt"),
+            bootstyle=f"{self._subtextstyle}-metersubtxt",
             anchor=S,
             padding=(0, 5),
         )
         self.textcenter = Label(
             master=self.textframe,
             textvariable=self.amountuseddisplayvar,
-            bootstyle=(self._bootstyle, "meter"),
+            bootstyle=f"{self._bootstyle}-meter",
             font=self._textfont,
         )
         self.textright = Label(
             master=self.textframe,
             text=self._textright,
             font=self._subtextfont,
-            bootstyle=(self._subtextstyle, "metersubtxt"),
+            bootstyle=f"{self._subtextstyle}-metersubtxt",
             anchor=S,
             padding=(0, 5),
         )
         self.subtext = Label(
             master=self.meterframe,
             text=self._subtext,
-            bootstyle=(self._subtextstyle, "metersubtxt"),
+            bootstyle=f"{self._subtextstyle}-metersubtxt",
             font=self._subtextfont,
             textvariable=self.labelvar,
         )
@@ -350,8 +350,9 @@ class Meter(Frame):
         Sets the meter foreground, background, and trough colors based on
         the current theme and bootstyle.
         """
-        bootstyle = (self._bootstyle, "meter", "label")
-        ttkstyle = Bootstyle.ttkstyle_name(string="-".join(bootstyle))
+        ttkstyle = Bootstyle.ttkstyle_name(
+            string=f"{self._bootstyle}-meter-label"
+        )
         textcolor = self._lookup_style_option(ttkstyle, "foreground")
         background = self._lookup_style_option(ttkstyle, "background")
         troughcolor = self._lookup_style_option(ttkstyle, "space")
@@ -739,7 +740,7 @@ class Meter(Frame):
             self.textright.configure(font=self._subtextfont)
         if "subtextstyle" in kwargs:
             self._subtextstyle = kwargs.pop("subtextstyle")
-            self.subtext.configure(bootstyle=(self._subtextstyle, "meter"))
+            self.subtext.configure(bootstyle=f"{self._subtextstyle}-meter")
         if "metersize" in kwargs:
             self._metersize = utility.scale_size(self, kwargs.pop("metersize"))
             self.meterframe.configure(
@@ -747,7 +748,7 @@ class Meter(Frame):
             )
         if "bootstyle" in kwargs:
             self._bootstyle = kwargs.pop("bootstyle")
-            self.textcenter.configure(bootstyle=(self._bootstyle, "meter"))
+            self.textcenter.configure(bootstyle=f"{self._bootstyle}-meter")
         if "metertype" in kwargs:
             self._metertype = kwargs.pop("metertype")
         if "meterthickness" in kwargs:

--- a/src/ttkbootstrap/widgets/tooltip.py
+++ b/src/ttkbootstrap/widgets/tooltip.py
@@ -36,7 +36,7 @@ Example:
     ToolTip(
         b2,
         text="This is dangerous",
-        bootstyle=(DANGER, INVERSE),
+        bootstyle="danger-inverse",
         position="top right"
     )
 
@@ -44,7 +44,7 @@ Example:
     ```
 """
 from tkinter import Event, Misc
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal, Optional
 
 import ttkbootstrap as ttk
 from ttkbootstrap import utility
@@ -76,7 +76,7 @@ class ToolTip:
         ToolTip(b1, text="This is the default style")
 
         # styled tooltip
-        ToolTip(b2, text="This is dangerous", bootstyle=(DANGER, INVERSE))
+        ToolTip(b2, text="This is dangerous", bootstyle="danger-inverse")
 
         app.mainloop()
         ```
@@ -88,7 +88,7 @@ class ToolTip:
             text: str = "widget info",
             padding: int = 10,
             justify: Literal["left", "center", "right"] = "left",
-            bootstyle: Optional[Union[str, tuple[str, ...]]] = None,
+            bootstyle: Optional[str] = None,
             wraplength: Optional[int] = None,
             delay: int = 250,  # milliseconds
             image: Any = None,

--- a/src/ttkcreator/__main__.py
+++ b/src/ttkcreator/__main__.py
@@ -439,20 +439,20 @@ class DemoWidgets(ttk.Frame):
         cb = ttk.Checkbutton(
             master=btn_group,
             text="solid toolbutton",
-            bootstyle=(SUCCESS, TOOLBUTTON),
+            bootstyle="success-toolbutton",
         )
         cb.invoke()
         cb.pack(fill=X, pady=5)
 
         ob = ttk.Button(
-            master=btn_group, text="outline button", bootstyle=(INFO, OUTLINE)
+            master=btn_group, text="outline button", bootstyle="info-outline"
         )
         ob.pack(fill=X, pady=5)
 
         mb = ttk.Menubutton(
             master=btn_group,
             text="outline menubutton",
-            bootstyle=(WARNING, OUTLINE),
+            bootstyle="warning-outline",
             menu=menu,
         )
         mb.pack(fill=X, pady=5)
@@ -470,13 +470,13 @@ class DemoWidgets(ttk.Frame):
         cb1 = ttk.Checkbutton(
             master=btn_group,
             text="rounded toggle",
-            bootstyle=(SUCCESS, ROUND, TOGGLE),
+            bootstyle="success-round-toggle",
         )
         cb1.invoke()
         cb1.pack(fill=X, pady=5)
 
         cb2 = ttk.Checkbutton(
-            master=btn_group, text="squared toggle", bootstyle=(SQUARE, TOGGLE)
+            master=btn_group, text="squared toggle", bootstyle="square-toggle"
         )
         cb2.pack(fill=X, pady=5)
         cb2.invoke()

--- a/tests/test_bootstyle_grammar.py
+++ b/tests/test_bootstyle_grammar.py
@@ -149,7 +149,9 @@ def test_build_name(args, expected):
 # --------------------------------------------------------------------------- #
 # _compat.normalize_bootstyle
 # --------------------------------------------------------------------------- #
-def test_normalize_tuple_is_quiet_in_d1():
+def test_normalize_is_quiet_unless_warn_requested():
+    # warn is opt-in per call; the resolver passes warn=True (D2), but a bare
+    # normalize_bootstyle() call stays quiet.
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         assert _compat.normalize_bootstyle(("primary", "outline")) == \
@@ -245,3 +247,22 @@ def test_valid_widget_construction_is_warning_free(root):
         ttk.Checkbutton(root, bootstyle="success-round-toggle")
         ttk.Progressbar(root, bootstyle="info-striped")
         ttk.Label(root, bootstyle="inverse")
+
+
+def test_composite_widgets_construct_without_tuple_warning(root):
+    # Meter/DateEntry used the internal tuple form for their composite
+    # sub-styles; D2 migrated them to canonical strings, so building them must
+    # not trip the tuple DeprecationWarning.
+    from ttkbootstrap.widgets import Meter, DateEntry
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        Meter(root, bootstyle="info", subtextstyle="secondary").pack()
+        DateEntry(root, bootstyle="primary").pack()
+        root.update_idletasks()
+
+
+def test_external_tuple_bootstyle_warns_and_resolves(root):
+    # A genuine external tuple bootstyle still resolves, but now warns.
+    with pytest.warns(DeprecationWarning, match="tuple/list bootstyle"):
+        b = ttk.Button(root, bootstyle=("primary", "outline"))
+    assert b.cget("style") == "primary.Outline.TButton"

--- a/tests/test_mixin_api.py
+++ b/tests/test_mixin_api.py
@@ -75,8 +75,10 @@ def test_item_access_routes_bootstyle(root):
 
 
 def test_tuple_bootstyle_back_compat(root):
-    """The legacy tuple form still resolves (canonicalization is Workstream D)."""
-    b = ttk.Button(root, bootstyle=("success", "outline"))
+    """The legacy tuple form still resolves, but now warns (Workstream D, D2:
+    warn-and-normalize through 2.x, removed in 3.0)."""
+    with pytest.warns(DeprecationWarning, match="tuple/list bootstyle"):
+        b = ttk.Button(root, bootstyle=("success", "outline"))
     assert b.cget("style") == "success.Outline.TButton"
 
 


### PR DESCRIPTION
Workstream D, PR 2 of 3 (after #1091). All first-party bootstyle callers now use
the canonical string, so the resolver can turn the tuple/list deprecation on: an
external tuple bootstyle earns a `DeprecationWarning` (removed in 3.0) while still
resolving via the `_compat` quarantine.

## Migrations (tuple/list -> canonical string)
- **meter.py** — the six internal `(color, "meter"|"metersubtxt")` composite
  tuples become f-strings (`f"{color}-meter"`); the `"-".join(...)` name build is
  inlined.
- **dateentry.py** — `[self._bootstyle, "date"]` -> `f"{self._bootstyle}-date"`.
- **datepicker.py** — `(SECONDARY, INVERSE)` -> `"secondary-inverse"`.
- **tooltip.py** — docstring examples -> `"danger-inverse"`; the **public**
  `bootstyle` param narrowed from `Union[str, tuple[str, ...]]` to `Optional[str]`
  (a tuple still works at runtime via compat, now warning); unused `Union` import
  dropped.
- **Demos** — the sweep found more first-party tuple sites than the prep doc
  listed: `python -m ttkbootstrap` (8) and `ttkcreator` (5). Migrated so
  first-party code does not trip its own new warning.

## Resolver
`update_ttk_widget_style` now calls `normalize_bootstyle(..., warn=True)`.

## Tests / gates
- `test_tuple_bootstyle_back_compat` now asserts the `DeprecationWarning` fires
  (and the style still resolves).
- New: Meter/DateEntry construct **without** the tuple warning (proves the
  internal migration is complete); an external tuple warns **and** resolves.
- **Suite 260 passed**; warning-free `import ttkbootstrap`; an
  all-warnings-as-errors construction+reconfigure smoke across the migrated
  widgets is clean.

Next: **D3** — generate the canonical reference table + a `BootStyle` string
`Literal` from the vocab × registry (feeds the Workstream-H docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)