### PR TITLE
Add `neutral` color + flat hairline-border restyle for the button family

### DIFF
--- a/development/2_0_bootstyle_reference.md
+++ b/development/2_0_bootstyle_reference.md
@@ -15,7 +15,7 @@ default; `set_bootstyle_strict(True)` or `TTKBOOTSTRAP_STRICT=1` raises).
 
 ## Colors
 
-`primary`, `secondary`, `success`, `info`, `warning`, `danger`, `light`, `dark`
+`primary`, `secondary`, `success`, `info`, `warning`, `danger`, `light`, `dark`, `neutral`
 
 ## Widget families and variants
 

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -1,0 +1,128 @@
+# ttkbootstrap 2.0 — breaking & notable changes (running log)
+
+> The consolidated log of 2.0 changes that alter behavior or appearance, each
+> with **what** changed and **why**. Kept in `development/` so it survives the
+> docs transition; it is the source for the Workstream-H *Migrating to 2.0* page.
+> Dedicated guides hold the deep detail for some areas (linked below); this log
+> is the index plus the home for changes without their own guide.
+>
+> Legend: **API** = source-level break · **Visual** = appearance-only (no code
+> change needed) · **New** = additive.
+
+## Index
+
+| Area | Kind | Where |
+|---|---|---|
+| Theme model, `Theme`, default theme, ramp addressing | API | `development/2_0_theme_migration.md` |
+| Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
+| Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
+| Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
+| **`neutral` color** | New | this doc, below |
+| **Button-family visual restyle (flat + hairline border)** | Visual | this doc, below |
+
+---
+
+## `neutral` — a new semantic color  *(New)*
+
+**What.** A new bootstyle color, `neutral` (e.g. `bootstyle="neutral"`,
+`bootstyle="neutral-outline"`), for a low-emphasis, unaccented button. Additive —
+nothing existing changes; the default button is still `primary`.
+
+**Why.** There was no calm, theme-adaptive "just a button." `secondary` is a
+medium-emphasis gray *fill*; `light` is a fixed pale tone with no border, so it
+vanishes on a light surface. People reached for `light` to fake a quiet button,
+which then became a *bright* button in dark themes. `neutral` fills the gap
+correctly: it is **derived from the theme surface** (a mode-aware raise — darker
+than the page in light themes, lighter in dark), always low-emphasis, and it
+follows the theme. Ported from bootstack's neutral (its default button =
+`elevate(surface, 1)` + a derived border) — mechanism borrowed, not API.
+
+**`neutral` vs `light`/`dark`.** They are not redundant. `light`/`dark` are
+**fixed tones** (always pale / always dark, regardless of mode) and are full
+palette colors usable on every widget; `neutral` is **theme-adaptive, always
+quiet**, and is scoped to buttons. Use `light`/`dark` for a deliberate tone (e.g.
+a light button on a colored header); use `neutral` for "no emphasis, follow the
+theme."
+
+**Scope.** Buttons (and the extending button-family widgets — see below).
+`NEUTRAL_FAMILIES` in `constants.py` gates where it is advertised.
+
+**Migration.** None required. Optionally replace `bootstyle="light"` buttons that
+were standing in for a quiet/subtle button with `bootstyle="neutral"` — it will
+stay quiet in dark mode where `light` would turn bright.
+
+Design: `development/2_0_neutral_color_design.md`.
+
+## Button-family visual restyle — flat fill + 1px hairline border  *(Visual)*
+
+**What.** Solid buttons changed from a flat fill with **no border** to a flat
+fill with a subtle **1px hairline border** derived from the fill. Applies to the
+solid `ttk.Button` and (as it lands) the other button-family widgets
+(`Menubutton`, `Toolbutton`, the DateEntry button). No API change — existing
+`bootstyle` values are unchanged; only the rendered appearance differs.
+
+**Why.**
+- **Definition on any surface.** A borderless fill has no edge where it meets a
+  same-ish background (a `light`/`neutral` button on a white page effectively
+  disappeared). A hairline border gives every button a defined shape.
+- **Consistency.** With `neutral` introduced (which *needs* a border to read),
+  bordering only neutral would make it a different species from the accent
+  buttons. One border rule keeps the family uniform.
+- **Still flat.** The border is not a bevel. clam ties "border" to a two-tone 3D
+  bevel; to keep the button flat we set `darkcolor`/`lightcolor` to track the
+  fill at rest so only a single-color 1px edge shows (the resting edge sharpens
+  slightly to the border color on hover/press). The border color is
+  **fill-derived** (same hue), never a gray outline.
+
+**Details that were deliberately chosen (and why):**
+- **`borderwidth=1`, unscaled.** A hairline stays one physical pixel at every DPI;
+  scaling it makes it read as a thick 2px+ edge on hi-DPI displays. (A narrow
+  exception in the scaling guard permits the literal `borderwidth=1`.)
+- **clam limits, acknowledged.** clam cannot draw a flat, bevel-free, *rounded*
+  border — rounded/consistent corners would require image-based (9-slice) border
+  elements (bootstack's approach; the recolor pipeline from #1081 exists but no
+  button template was added for 2.0). 2.0 ships the flat clam border; image-based
+  rounded buttons remain a possible later change.
+
+**Migration.** None required. Apps will simply look slightly more defined. If you
+had custom `TButton` styles that assumed no `bordercolor`, note that the built-in
+solid recipe now sets one.
+
+Design/rationale trail: `development/2_0_neutral_color_design.md` §3a.
+
+## Toolbutton & switch state colors — bootstack on/off model  *(Visual)*
+
+**What.** The unselected/selected ("off"/"on") colors for the solid **Toolbutton**
+and the "off" track of the **switch** (round/square toggle) were re-derived to
+bootstack's model:
+- **Toolbutton OFF** was a fairly heavy gray fill (`colors.border` in light /
+  `colors.selectbg` in dark) with a full-contrast label. It is now a **quiet
+  raised surface** (`neutral_fill` = a mode-aware ~6% elevation of the surface)
+  with a **muted** label (`mute(fg)`). **ON** is unchanged (the accent).
+- **Switch OFF** track was `mute(fg)` (a mid-gray from the text); it is now
+  `border(surface)` — the derived neutral border color, a lighter/quieter off
+  state.
+- **Neutral toolbutton** (new — `bootstyle="neutral-toolbutton"`) has no accent to
+  latch to, so "on" is shown by a **stronger** surface raise (`neutral_fill`
+  level 2, ~12%) versus the level-1 "off" fill.
+- **Toolbuttons are now pure toggles**: only ON (selected) vs OFF (unselected)
+  change the appearance. The previous hover/active "preview the on state" and the
+  pressed state were removed -- a toggle has two states, and previewing the
+  selected look on hover was misleading. (Outline toolbuttons also gained the
+  solid toolbutton's `focusthickness`, so both variants are the same height and a
+  toolbutton no longer nudges its neighbors when it takes keyboard focus.)
+
+**Why.** The old toolbutton off state was visually loud (a solid gray chip),
+competing with the selected accent. bootstack's model reads better: off is a calm,
+barely-there surface with de-emphasized text, so the *selected* segment clearly
+carries the emphasis. The switch off track likewise reads quieter. All derived
+(no new authored colors), mode-aware, via existing helpers (`neutral_fill`/`mute`/
+`border`), ported from bootstack's `toolbutton`/`switch` builders (mechanism, not
+API). `neutral_fill` gained a `level` argument for the level-1/level-2 raise.
+
+**Open (visual gate):** the neutral toolbutton distinguishes on/off by elevation
+only (~6% vs ~12%); confirm on a light↔dark spot-check that the selected state
+reads clearly enough (the level-2 weight is the knob).
+
+**Migration.** None (appearance only). `toolbutton` joins `NEUTRAL_FAMILIES`, so
+`neutral-toolbutton` / `neutral-outline-toolbutton` are now valid bootstyles.

--- a/development/2_0_neutral_color_design.md
+++ b/development/2_0_neutral_color_design.md
@@ -1,0 +1,180 @@
+# ttkbootstrap 2.0 — a `neutral` bootstyle color — design / scoping
+
+> Design pass per the hard rule (this adds a token to the closed bootstyle
+> vocabulary Workstream D locked, plus recipe + generator changes). Pairs with
+> `development/2_0_bootstyle_grammar_design.md` (the closed-vocab grammar) and
+> `development/2_0_color_helpers_design.md` / `2_0_color_math_followup_design.md`
+> (the derived-color machinery this builds on).
+
+## 1. Motivation
+
+Today a bare `ttk.Button` renders **primary** (blue), and the only lower-emphasis
+options are `secondary` (a medium-emphasis gray *fill*), `light` (a pale fill with
+**no border**, so it vanishes on the `bg` surface), and `link` (hyperlink look).
+There is no calm, low-emphasis "just a button" — *surface fill + a visible neutral
+border + normal text* (the classic OS / Bootstrap-3 `btn-default`). Demos end up
+accenting **every** control because the unaccented option doesn't read as a button.
+
+Add an explicit, opt-in **`neutral`** color meaning *"no accent — render in the
+theme's neutral surface tone."* The default stays primary; `neutral` is always
+typed. (Author decision 2026-07-06: include in 2.0 — the demos benefit.)
+
+## 2. It is a color, and it is *derived*
+
+`neutral` occupies the **color slot** of the grammar (`[color-][modifier-]<base>`)
+— it is an alternative to `primary`/`secondary`/…, mutually exclusive with them,
+so it belongs in `BOOTSTYLE_COLORS`, not `BOOTSTYLE_MODIFIERS` (a modifier like
+`outline` still takes a color; neutral replaces the color) and not a base type
+(it is not widget-family-specific).
+
+It is **derived** from the theme surface via the existing color-math helpers — no
+per-theme authoring. Unlike the accent colors, though, neutral is not "one hex you
+derive fill/text/hover from": its defining property is that **text stays `fg`**
+(not the fill color) and it **carries a border**. A single resolved hex cannot
+encode that policy — e.g. an outline recipe sets `foreground=<the color hex>`, and
+a pale neutral hex would be invisible as text. So neutral is a *policy*, applied in
+the recipe, not a value substituted into the generic derive-from-accent path.
+
+**Neutral render policy — ported from bootstack** (`style/builders/button.py`,
+`build_solid_button_style`, the `accent is None` branch). bootstack's neutral is
+literally its *default* button: `bg = elevate(surface, 1)` (a mode-aware ~6% raise
+of the surface — toward black in light, toward white in dark) with a **derived**
+`border(bg)` (the fill blended ~16% toward its own text color) and `on_color(bg)`
+text. That is more correct than a fixed `colors.light`, which is only right in
+light themes. ttkbootstrap already has every equivalent helper (`shade`/`tint`,
+`border`, `on_color`, `active`/`pressed`, `disabled`, `is_light_theme`), so this
+ports 1:1 with no new helper.
+
+| slot | solid `neutral` | `neutral-outline` |
+|---|---|---|
+| fill (`background`) | `shade(bg, 0.06)` (light) / `tint(bg, 0.06)` (dark) — the elevate | `colors.bg` |
+| text (`foreground`) | `on_color(fill)` (= normal `fg`) | `colors.fg` |
+| border (`bordercolor`) | `border(fill)` — derived from the fill | `border(colors.bg)` |
+| hover / pressed | `active(fill)` / `pressed(fill)` | fill → `active(colors.bg)` |
+| disabled | existing `disabled()` helpers | existing |
+
+This closes the gap the author saw (`light` has no border and vanishes on the
+surface) with a subtly raised, bordered fill that reads as a button in **both**
+modes. The ~6% elevate weight and whether solid neutral shows a fill at all vs a
+pure bordered/flat button are settle-on-the-light↔dark-visual-gate knobs.
+
+> Provenance: mirrors bootstack's `StyleBuilderTtk.elevate`/`border` (memory
+> `borrow-bootstack-mechanisms-not-api` — we take the derivation, not the API).
+
+## 3. Scope — which families get `neutral` (the generator constraint)
+
+`tools/generate_bootstyle_reference.py` crosses `BOOTSTYLE_COLORS` × **every**
+registered `(variant, family)` key (`_strings_for_key`, line 76). So merely adding
+`"neutral"` to `BOOTSTYLE_COLORS` would advertise `neutral-<anything>` for all ~22
+families and let the resolver accept them — but only families with a neutral-aware
+recipe would render correctly; the rest would feed a pale hex into their generic
+accent path (invisible text/borders). We must not advertise combinations that look
+broken.
+
+**2.0 scope = the plain Button (solid + outline)** — the one place accent-vs-neutral
+is unambiguous and exactly where demos over-accent.
+
+Deliberately **out for 2.0**, with rationale (each is a poor or bespoke fit, not an
+oversight):
+- **Toolbutton** — stateful; a "neutral" toolbutton renders its *selected* state
+  neutral too, destroying the selection affordance that is the whole point.
+- **Menubutton** — the *outline* variant fills with the accent on hover; for neutral
+  that would hover to near-`fg` (jarring), so it needs a bespoke neutral hover, not
+  the shared branch. A clean fast-follow once Button lands, not part of the MVP.
+- **entry/combobox/spinbox** — already neutral by default (a themed field border,
+  no accent).
+- **scale/progressbar/scrollbar** — geometry, not emphasis.
+- **label/frame/labelframe** — their *default* already is the neutral surface.
+
+**Generator gate:** add `NEUTRAL_FAMILIES = {"button"}` (next to the vocab tuples in
+`constants.py`) and make `_strings_for_key` emit the `neutral` color only when
+`family in NEUTRAL_FAMILIES`. This keeps neutral a real `BOOTSTYLE_COLORS` member
+(so the tokenizer parses it) while the reference/`Literal` advertise it only where
+it renders. Net new canonical strings: **2** (`neutral`, `neutral-outline`). Adding
+a family later is a one-line change to the set plus that family's recipe branch.
+
+Note the asymmetry this introduces: neutral is the first color that is *not*
+valid for every family. The resolver still tokenizes `neutral-<family>` for an
+unsupported family (it's a real color token); it should then fall back to that
+family's default like any unbuildable pair (the Workstream-D "invalid pairs fall
+back to the family default" behavior already covers this). The gate is about what
+we *document/advertise*, not a second parser rule.
+
+## 3a. Follow-on decision — border *all* solid buttons (author, 2026-07-06)
+
+Introducing a bordered neutral raised the question of whether the *accented* solid
+buttons should stay flat/borderless (as they were) while neutral alone is bordered.
+Decision: **border every solid button with the same `border(fill)` logic** — no
+carve-out for neutral. This matches bootstack (its solid button always draws
+`border(bg_normal)`), keeps the button family visually uniform, and lets neutral
+fold into the single solid recipe as "just the no-accent fill" rather than a
+separate code path.
+
+Mechanics (in `build_button_style`): `relief=RAISED`, `bordercolor=border(fill)`,
+`darkcolor=lightcolor=fill` (so only the border ring shows, no clam bevel), with
+the border mapped across hover/pressed/disabled. The border is **fill-derived**
+(the fill blended toward its own text color), so it is same-hue — a slightly
+lighter edge on dark accents, a slightly darker edge on light accents — never a
+gray outline. `neutral` is now `colorname == NEUTRAL -> fill = _neutral_fill(...)`
+inside the same recipe; the standalone `_build_neutral_button_style` is gone.
+
+Scope: the **solid `ttk.Button`** recipe only. Solid **toolbutton**, **menubutton**,
+and **date** buttons remain flat for now — a consistency follow-up to weigh once
+the bordered Button is eyeballed (they would look inconsistent beside bordered
+plain buttons in a toolbar, so this likely wants to extend, but it is a separate,
+gated visual change). This flips the earlier "solid button is a plain flat fill"
+decision from the color-helper PR; `test_color_helpers.py`'s solid-button contract
+is updated to assert the derived border instead of `relief=flat`/no-border.
+
+**Human visual gate required** (light↔dark, all accents) — a same-hue border on a
+solid fill can read as a bevel if too strong; `border()`'s strength is the knob.
+
+## 4. Change list
+
+- **`constants.py`**: add `"neutral"` to `BOOTSTYLE_COLORS`; add
+  `NEUTRAL: Final[BootColor] = "neutral"`; add `"neutral"` to the `BootColor`
+  `Literal`; add `NEUTRAL_FAMILIES`; export both. Regenerate the `BootStyle`
+  `Literal` block.
+- **`style/builders/button.py`**: `build_button_style` + `build_outline_button_style`
+  branch on `colorname == NEUTRAL` to apply §2's policy (fill/text/border), reusing
+  `active`/`pressed`/`disabled`. Register `neutral.TButton` / `neutral.Outline.TButton`.
+- **`style/builders/toolbutton.py`, `menubutton.py`**: same neutral branch.
+- **`tools/generate_bootstyle_reference.py`**: the `NEUTRAL_FAMILIES` gate in
+  `_strings_for_key`; regenerate `development/2_0_bootstyle_reference.md`.
+- **`test_bootstyle_grammar.py`**: `BootColor` ↔ `BOOTSTYLE_COLORS` sync now
+  includes `neutral`; the reference/`Literal` sync test covers the ~6 new strings.
+- **New built-style test**: a `neutral` button configures `background=colors.light`,
+  `bordercolor=colors.border`, `foreground=colors.fg`; a `neutral-outline` button
+  configures `background=colors.bg` + the neutral border/text.
+- **Demos**: convert a few over-accented demos (e.g. the `python -m ttkbootstrap`
+  showcase, dialog button rows, the calculator/media-player secondary actions) to
+  `neutral` so the calmer default is visible — the payoff the author called out.
+- **Docs (Workstream H)**: `neutral` lands in the *bootstyle grammar* Colors list
+  and the Widgets/Button catalog as the low-emphasis option; no separate workstream.
+
+## 5. Compatibility
+
+Purely additive — a new valid token, no deprecation, no behavior change to existing
+styles. Strict mode is unaffected (`neutral` is now a known token). The default
+button is unchanged (still primary). `colors.get("neutral")` is **not** relied on
+by the recipes (they branch on the name); we do **not** add a `neutral` entry to
+the `Colors` resolved view, to avoid implying it is an authored/derivable single
+hex when it is a render policy.
+
+## 6. Open decisions
+
+- **Name — needs confirmation.** `neutral` (recommended: design-system term of art
+  — Spectrum/Radix; zero tk collisions; precisely "no accent"). Rejected: `normal`
+  (collides with the exported `NORMAL = 'normal'` widget-state constant and the
+  font weight), `default` (overloads ttk's dialog "default button" / `-default`,
+  and implies a default-ness ttkbootstrap doesn't give it). Alternatives if
+  `neutral` is unwanted: `subtle` (Bootstrap 5.3 lineage), `plain`, `quiet`.
+- **Solid neutral fill = `colors.light` vs `colors.bg` + border only** (a truly
+  flat, fill-less bordered button). Lean `colors.light` (reads as a button); settle
+  on the light↔dark visual gate.
+- **Menubutton inclusion** — include (consistent with buttons) vs defer (it's less
+  commonly un-accented). Lean include; cheap once the button branch exists.
+- **Later:** a universal neutral (all families) would want a recipe refactor onto a
+  shared `resolve_accent(colorname) -> (fill, on, border, hover, pressed)` helper so
+  the no-accent policy lives in one place. Out of scope for 2.0; noted as a possible
+  follow-up.

--- a/examples/neutral_preview.py
+++ b/examples/neutral_preview.py
@@ -1,0 +1,63 @@
+"""Visual spot-check for the `neutral` bootstyle color (2.0).
+
+Shows the new low-emphasis `neutral` / `neutral-outline` buttons next to the
+existing options (primary, secondary, light, link) so the calm, bordered neutral
+look can be compared against the accented styles across states, in both light and
+dark themes. Run it and toggle the theme:
+
+    python examples/neutral_preview.py
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+
+STYLES = [
+    ("neutral", "neutral"),
+    ("neutral-outline", "neutral-outline"),
+    ("primary", "primary"),
+    ("secondary", "secondary"),
+    ("light", "light"),
+    ("link", "link"),
+]
+
+LIGHT_THEME = "bootstrap-light"
+DARK_THEME = "bootstrap-dark"
+
+
+class NeutralPreview(ttk.Frame):
+    def __init__(self, master):
+        super().__init__(master, padding=20)
+        self.pack(fill=BOTH, expand=YES)
+
+        header = ttk.Frame(self)
+        header.pack(fill=X, pady=(0, 15))
+        ttk.Label(header, text="neutral vs accented buttons", font="-size 14 -weight bold").pack(side=LEFT)
+        self.theme_btn = ttk.Button(header, text="Toggle light/dark",
+                                     bootstyle="neutral", command=self.toggle_theme)
+        self.theme_btn.pack(side=RIGHT)
+
+        # column headers
+        grid = ttk.Frame(self)
+        grid.pack(fill=X)
+        for col, state in enumerate(("bootstyle", "normal", "disabled")):
+            ttk.Label(grid, text=state, font="-weight bold", width=18,
+                      anchor=W).grid(row=0, column=col, padx=6, pady=6, sticky=W)
+
+        for row, (label, style) in enumerate(STYLES, start=1):
+            ttk.Label(grid, text=label, width=18, anchor=W).grid(
+                row=row, column=0, padx=6, pady=4, sticky=W)
+            ttk.Button(grid, text="Button", bootstyle=style).grid(
+                row=row, column=1, padx=6, pady=4, sticky=W)
+            disabled = ttk.Button(grid, text="Button", bootstyle=style)
+            disabled.configure(state=DISABLED)
+            disabled.grid(row=row, column=2, padx=6, pady=4, sticky=W)
+
+    def toggle_theme(self):
+        style = ttk.Style.get_instance()
+        current = style.theme.name
+        style.theme_use(DARK_THEME if current == LIGHT_THEME else LIGHT_THEME)
+
+
+if __name__ == "__main__":
+    app = ttk.Window("Neutral color preview", themename=LIGHT_THEME)
+    NeutralPreview(app)
+    app.mainloop()

--- a/examples/widget_styles/button.py
+++ b/examples/widget_styles/button.py
@@ -4,8 +4,8 @@ from random import choice
 from ttkbootstrap import utility
 utility.enable_high_dpi_awareness()
 
-DARK = 'superhero'
-LIGHT = 'flatly'
+DARK = 'bootstrap-light'
+LIGHT = 'bootstrap-dark'
 
 
 def button_style_frame(bootstyle, style, widget_name):
@@ -26,7 +26,7 @@ def button_style_frame(bootstyle, style, widget_name):
         bootstyle=bootstyle
     ).pack(padx=5, pady=5, fill=tk.BOTH)
 
-    for color in style.colors:
+    for color in [*style.colors, 'neutral']:
         ttk.Button(
             master=frame,
             text=color,
@@ -52,7 +52,7 @@ def change_style():
 if __name__ == '__main__':
     # create visual widget style tests
     root = tk.Tk()
-    style = ttk.Style(theme='minty')
+    style = ttk.Style()
 
     button_style_frame('outline', style, 'Outline Button').pack(side=tk.LEFT)
     button_style_frame('', style, 'Solid Button').pack(side=tk.LEFT)

--- a/examples/widget_styles/checkbutton.py
+++ b/examples/widget_styles/checkbutton.py
@@ -1,11 +1,6 @@
 import tkinter as tk
 import ttkbootstrap as ttk
 from random import choice
-from ttkbootstrap import utility
-utility.enable_high_dpi_awareness()
-
-DARK = 'superhero'
-LIGHT = 'flatly'
 
 def create_checkbutton_test(bootstyle, style, name):
     frame = ttk.Frame(padding=10)
@@ -16,16 +11,19 @@ def create_checkbutton_test(bootstyle, style, name):
     ttk.Separator(frame).pack(padx=5, pady=5, fill=tk.X)
 
     # default style
-    cb = ttk.Checkbutton(frame, text='default', bootstyle=bootstyle)
+    if 'toolbutton' in bootstyle:
+        cb = ttk.Checkbutton(frame, text='default', bootstyle=f'neutral-{bootstyle}')
+    else:
+        cb = ttk.Checkbutton(frame, text='default', bootstyle=bootstyle)
     cb.pack(padx=5, pady=5, fill=tk.BOTH)
     cb.invoke()
 
     # color styles
     for color in style.theme.colors:
         cb = ttk.Checkbutton(
-            master=frame, 
-            text=color, 
-            bootstyle=color + bootstyle,
+            master=frame,
+            text=color,
+            bootstyle=f"{color}-{bootstyle}" if bootstyle else color,
             width=15
         )
         cb.pack(padx=5, pady=5, fill=tk.BOTH)
@@ -51,7 +49,7 @@ def change_style():
 if __name__ == '__main__':
     # create visual widget style tests
     root = tk.Tk()
-    style = ttk.Style(theme=LIGHT)
+    style = ttk.Style()
 
     test1 = create_checkbutton_test('', style, 'Checkbutton')
     test1.pack(side=tk.LEFT, fill=tk.BOTH)

--- a/examples/widget_styles/menubutton.py
+++ b/examples/widget_styles/menubutton.py
@@ -1,12 +1,6 @@
 import tkinter as tk
 import ttkbootstrap as ttk
 from random import choice
-from ttkbootstrap import utility
-utility.enable_high_dpi_awareness()
-
-DARK = 'superhero'
-LIGHT = 'flatly'
-
 
 def create_menubutton_frame(bootstyle, style, testname):
     frame = ttk.Frame(root, padding=5)
@@ -23,7 +17,7 @@ def create_menubutton_frame(bootstyle, style, testname):
     btn = ttk.Menubutton(
         master=frame,
         text='default',
-        bootstyle=bootstyle
+        bootstyle=f'neutral-{bootstyle}'
     )
     btn.pack(padx=5, pady=5, fill=tk.BOTH)
 

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -92,7 +92,7 @@ MeterMode = Literal["full", "semi"]
 
 ProgressMode = Literal["determinate", "indeterminate"]
 
-BootColor = Literal["primary", "secondary", "success", "danger", "warning", "info", "light", "dark"]
+BootColor = Literal["primary", "secondary", "success", "danger", "warning", "info", "light", "dark", "neutral"]
 
 # The bootstyle type modifiers (variant slot). NOTE for 2.0 (Workstream D): this
 # is the reconciled set -- `round` is included (it is buildable; its historical
@@ -116,8 +116,14 @@ TreeviewDisplay = Literal["tree", "headings", "tree headings"]
 # ---------------------------------------------------------------------------
 BOOTSTYLE_COLORS: Final = (
     "primary", "secondary", "success", "info", "warning", "danger",
-    "light", "dark",
+    "light", "dark", "neutral",
 )
+# Families for which `neutral` (the derived, no-accent color) produces a real
+# style. Unlike the accent colors, `neutral` is not valid everywhere -- it is a
+# render policy (surface fill + derived border + normal text), meaningful only
+# where accent-vs-neutral is a genuine choice. The reference generator advertises
+# `neutral-<family>` only for these (see tools/generate_bootstyle_reference.py).
+NEUTRAL_FAMILIES: Final = ("button", "menubutton", "toolbutton")
 # Public, documented type modifiers -- matches BootType.
 BOOTSTYLE_MODIFIERS: Final = (
     "outline", "link", "inverse", "round", "square", "striped", "thin",
@@ -200,6 +206,11 @@ BootStyle = Literal[
     'light-toggle',
     'light-toolbutton',
     'link',
+    'neutral',
+    'neutral-link',
+    'neutral-outline',
+    'neutral-outline-toolbutton',
+    'neutral-toolbutton',
     'outline',
     'outline-toolbutton',
     'primary',
@@ -432,6 +443,7 @@ WARNING: Final[BootColor] = "warning"
 INFO: Final[BootColor] = "info"
 LIGHT: Final[BootColor] = "light"
 DARK: Final[BootColor] = "dark"
+NEUTRAL: Final[BootColor] = "neutral"
 
 OUTLINE: Final[BootType] = "outline"
 LINK: Final[BootType] = "link"
@@ -464,7 +476,7 @@ __all__ = [
     "TreeviewDisplay",
     # bootstyle vocabulary (single source of truth)
     "BOOTSTYLE_COLORS", "BOOTSTYLE_MODIFIERS", "BOOTSTYLE_INTERNAL_MODIFIERS",
-    "BOOTSTYLE_BASES", "BOOTSTYLE_FAMILIES", "BOOTSTYLE_ORIENTS",
+    "BOOTSTYLE_BASES", "BOOTSTYLE_FAMILIES", "BOOTSTYLE_ORIENTS", "NEUTRAL_FAMILIES",
     # constants
     "NO", "FALSE", "OFF", "YES", "TRUE", "ON",
     "N", "S", "W", "E", "NW", "SW", "NE", "SE", "NS", "EW", "NSEW", "CENTER",
@@ -487,6 +499,7 @@ __all__ = [
     "DEFAULT", "DEFAULT_THEME", "TTK_CLAM", "TTK_ALT", "TTK_DEFAULT",
     "FULL", "SEMI", "DETERMINATE", "INDETERMINATE",
     "PRIMARY", "SECONDARY", "SUCCESS", "DANGER", "WARNING", "INFO", "LIGHT", "DARK",
+    "NEUTRAL",
     "OUTLINE", "LINK", "TOGGLE", "INVERSE", "STRIPED", "THIN", "TOOLBUTTON", "SQUARE",
     "TREE", "HEADINGS", "TREEHEADINGS",
 ]

--- a/src/ttkbootstrap/style/builders/button.py
+++ b/src/ttkbootstrap/style/builders/button.py
@@ -5,6 +5,7 @@ import tkinter as tk
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.builders.registry import register_builder
+from ttkbootstrap.style.builders.utils import neutral_fill
 
 
 @register_builder("default", "button")
@@ -20,27 +21,93 @@ def build_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "TButton"
 
-    if any([colorname == DEFAULT, colorname == ""]):
+    # Every solid button carries a subtle border derived from its own fill
+    # (`border(fill)` -- the fill blended toward its text color), so the shape
+    # stays defined on any surface. `darkcolor`/`lightcolor` track the fill so
+    # only the border ring shows (no clam bevel). `neutral` is just the
+    # no-accent fill (a mode-aware raise of the surface) through this same path.
+    if colorname == NEUTRAL:
+        ttk_style = f"{NEUTRAL}.{ttk_class}"
+        fill = neutral_fill(builder)
+    elif any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class
-        accent = builder.colors.primary
-        on_accent = builder.on_color(accent)
+        fill = builder.colors.primary
     else:
         ttk_style = f"{colorname}.{ttk_class}"
-        accent = builder.colors.get(colorname)
-        on_accent = builder.on_color(accent)
+        fill = builder.colors.get(colorname)
 
-    pressed = builder.pressed(accent)
-    hover = builder.active(accent)
+    on_fill = builder.on_color(fill)
+    hover = builder.active(fill)
+    pressed = builder.pressed(fill)
     disabled = builder.disabled()
     on_disabled = builder.disabled("text", disabled)
 
+    # Border: a subtle same-hue edge derived from the fill. The clam dark/light
+    # regions always track the *fill* (in every state), so no two-tone bevel is
+    # ever drawn -- `bordercolor` is the only distinct edge color, itself the
+    # fill's derived border in each state.
+    fill_states = [
+        ("disabled", disabled),
+        ("pressed !disabled", pressed),
+        ("hover !disabled", hover),
+    ]
+    border_states = [
+        ("disabled", disabled),
+        ("pressed !disabled", builder.border(pressed)),
+        ("hover !disabled", builder.border(hover)),
+    ]
+
     builder.configure(
         ttk_style,
-        foreground=on_accent,
-        background=accent,
-        relief=tk.FLAT,
+        foreground=on_fill,
+        background=fill,
+        bordercolor=builder.border(fill),
+        darkcolor=fill,
+        lightcolor=fill,
+        relief=tk.RAISED,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),
-        focuscolor=on_accent,
+        focuscolor=on_fill,
+        padding=builder.scale_size((10, 5)),
+        anchor=tk.CENTER,
+    )
+    builder.style.map(
+        ttk_style,
+        foreground=[("disabled", on_disabled)],
+        focuscolor=[("disabled", on_disabled)],
+        background=fill_states,
+        bordercolor=border_states,
+        darkcolor=fill_states,
+        lightcolor=fill_states,
+    )
+    # register ttkstyle
+    builder.register_ttkstyle(ttk_style)
+
+
+def _build_neutral_outline_button_style(builder: StyleBuilderTTK, ttk_class):
+    """Outline `neutral` button: flush with the surface, a derived neutral border.
+
+    fill = the surface itself; border = `border(bg)`; text = normal `fg`. Hover
+    fills with a subtle elevate of the surface (`active`), staying unaccented.
+    """
+    ttk_style = f"{NEUTRAL}.{ttk_class}"
+    surface = builder.colors.bg
+    fg = builder.colors.fg
+    hover = builder.active(surface)
+    pressed = builder.pressed(surface)
+    on_disabled = builder.disabled("text")
+
+    builder.configure(
+        ttk_style,
+        foreground=fg,
+        background=surface,
+        bordercolor=builder.border(surface),
+        darkcolor=surface,
+        lightcolor=surface,
+        relief=tk.RAISED,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
+        focusthickness=builder.scale_size(1),
+        focuscolor=fg,
         padding=builder.scale_size((10, 5)),
         anchor=tk.CENTER,
     )
@@ -49,12 +116,23 @@ def build_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         foreground=[("disabled", on_disabled)],
         focuscolor=[("disabled", on_disabled)],
         background=[
-            ("disabled", disabled),
+            ("pressed !disabled", pressed),
+            ("hover !disabled", hover),
+        ],
+        bordercolor=[
+            ("disabled", on_disabled),
+            ("pressed !disabled", builder.border(pressed)),
+            ("hover !disabled", builder.border(hover)),
+        ],
+        darkcolor=[
+            ("pressed !disabled", pressed),
+            ("hover !disabled", hover),
+        ],
+        lightcolor=[
             ("pressed !disabled", pressed),
             ("hover !disabled", hover),
         ],
     )
-    # register ttkstyle
     builder.register_ttkstyle(ttk_style)
 
 
@@ -71,6 +149,9 @@ def build_outline_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Outline.TButton"
 
+    if colorname == NEUTRAL:
+        _build_neutral_outline_button_style(builder, ttk_class)
+        return
 
     if any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class
@@ -94,6 +175,7 @@ def build_outline_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         darkcolor=builder.colors.bg,
         lightcolor=builder.colors.bg,
         relief=tk.RAISED,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),
         focuscolor=accent,
         padding=builder.scale_size((10, 5)),

--- a/src/ttkbootstrap/style/builders/menubutton.py
+++ b/src/ttkbootstrap/style/builders/menubutton.py
@@ -6,7 +6,7 @@ from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, image_element, layout
 from ttkbootstrap.style.builders.registry import register_builder
-from ttkbootstrap.style.builders.utils import simple_arrow_assets
+from ttkbootstrap.style.builders.utils import simple_arrow_assets, neutral_fill
 
 
 @register_builder("default", "menubutton")
@@ -22,28 +22,45 @@ def build_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "TMenubutton"
 
-    if any([colorname == DEFAULT, colorname == ""]):
+    # `neutral` = the no-accent adaptive fill; otherwise the accent (or primary).
+    if colorname == NEUTRAL:
+        ttk_style = f"{NEUTRAL}.{ttk_class}"
+        background = neutral_fill(builder)
+    elif any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class
         background = builder.colors.primary
-        foreground = builder.on_color(background)
     else:
         ttk_style = f"{colorname}.{ttk_class}"
         background = builder.colors.get(colorname)
-        foreground = builder.on_color(background)
+    foreground = builder.on_color(background)
 
     disabled_bg = builder.disabled()
     disabled_fg = builder.disabled("text", disabled_bg)
     pressed = builder.pressed(background)
     hover = builder.active(background)
 
+    # 1px hairline border, matching the ttk.Button treatment: dark/light always
+    # track the fill (no bevel), `bordercolor` is the only distinct edge.
+    fill_states = [
+        ("disabled", disabled_bg),
+        ("pressed !disabled", pressed),
+        ("hover !disabled", hover),
+    ]
+    border_states = [
+        ("disabled", disabled_bg),
+        ("pressed !disabled", builder.border(pressed)),
+        ("hover !disabled", builder.border(hover)),
+    ]
+
     builder.configure(
         ttk_style,
         foreground=foreground,
         background=background,
-        bordercolor=background,
+        bordercolor=builder.border(background),
         darkcolor=background,
         lightcolor=background,
         relief=tk.RAISED,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=0,
         focuscolor=foreground,
         padding=builder.scale_size((10, 5)),
@@ -51,26 +68,10 @@ def build_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     builder.style.map(
         ttk_style,
         foreground=[("disabled", disabled_fg)],
-        background=[
-            ("disabled", disabled_bg),
-            ("pressed !disabled", pressed),
-            ("hover !disabled", hover),
-        ],
-        bordercolor=[
-            ("disabled", disabled_bg),
-            ("pressed !disabled", pressed),
-            ("hover !disabled", hover),
-        ],
-        darkcolor=[
-            ("disabled", disabled_bg),
-            ("pressed !disabled", pressed),
-            ("hover !disabled", hover),
-        ],
-        lightcolor=[
-            ("disabled", disabled_bg),
-            ("pressed !disabled", pressed),
-            ("hover !disabled", hover),
-        ],
+        background=fill_states,
+        bordercolor=border_states,
+        darkcolor=fill_states,
+        lightcolor=fill_states,
     )
     # caret-down-fill indicator (replaces the native clam triangle); the
     # solid menubutton arrow keeps one color (only the background changes on
@@ -106,6 +107,53 @@ def _build_menubutton_arrow(builder: StyleBuilderTTK, ttk_style, normal, disable
                     El("Menubutton.label", side=LEFT, sticky="")])])]))
 
 
+def _build_neutral_outline_menubutton(builder: StyleBuilderTTK, ttk_class, disabled_fg):
+    """Neutral outline menubutton: surface fill, derived border, normal fg.
+
+    The no-accent analog of the outline menubutton -- it does not fill with an
+    accent on hover (that would break the "unaccented" intent); it stays on the
+    surface with a subtle elevate on interaction, matching the neutral outline
+    button.
+    """
+    ttk_style = f"{NEUTRAL}.{ttk_class}"
+    surface = builder.colors.bg
+    fg = builder.colors.fg
+    hover = builder.active(surface)
+    pressed = builder.pressed(surface)
+    fill_states = [
+        ("pressed !disabled", pressed),
+        ("hover !disabled", hover),
+    ]
+    border_states = [
+        ("disabled", disabled_fg),
+        ("pressed !disabled", builder.border(pressed)),
+        ("hover !disabled", builder.border(hover)),
+    ]
+    builder.configure(
+        ttk_style,
+        foreground=fg,
+        background=surface,
+        bordercolor=builder.border(surface),
+        darkcolor=surface,
+        lightcolor=surface,
+        relief=tk.RAISED,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
+        focusthickness=0,
+        focuscolor=fg,
+        padding=builder.scale_size((10, 5)),
+    )
+    builder.style.map(
+        ttk_style,
+        foreground=[("disabled", disabled_fg)],
+        background=fill_states,
+        bordercolor=border_states,
+        darkcolor=fill_states,
+        lightcolor=fill_states,
+    )
+    _build_menubutton_arrow(builder, ttk_style, fg, disabled_fg, fg)
+    builder.register_ttkstyle(ttk_style)
+
+
 @register_builder("outline", "menubutton")
 def build_outline_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """Create an outline button style for the ttk.Menubutton widget
@@ -120,6 +168,10 @@ def build_outline_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     ttk_class = "Outline.TMenubutton"
 
     disabled_fg = builder.disabled("text")
+
+    if colorname == NEUTRAL:
+        _build_neutral_outline_menubutton(builder, ttk_class, disabled_fg)
+        return
 
     if any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class
@@ -142,6 +194,7 @@ def build_outline_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         darkcolor=builder.colors.bg,
         lightcolor=builder.colors.bg,
         relief=tk.RAISED,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=0,
         focuscolor=foreground,
         padding=builder.scale_size((10, 5)),

--- a/src/ttkbootstrap/style/builders/toggle.py
+++ b/src/ttkbootstrap/style/builders/toggle.py
@@ -35,7 +35,7 @@ def build_round_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Round.Toggle"
     disabled_fg = builder.disabled("text")
-    fg_muted = builder.mute(builder.colors.fg)
+    off_track = builder.border(builder.colors.bg)  # bootstack: off track = border(surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class
@@ -69,7 +69,7 @@ def build_round_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     )
     a = builder.assets
     on = a.recolor("switch_round", white=accent, black=builder.colors.bg)
-    off = a.recolor("switch_round", white=fg_muted, black=builder.colors.bg, transform="flip-x")
+    off = a.recolor("switch_round", white=off_track, black=builder.colors.bg, transform="flip-x")
     disabled_on = a.recolor("switch_round", white=disabled_fg, black=builder.colors.bg)
     disabled_off = a.recolor("switch_round", white=disabled_fg, black=builder.colors.bg, transform="flip-x")
     spacer_name = f"{ttk_style}.spacer"
@@ -116,7 +116,7 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Square.Toggle"
     disabled_fg = builder.disabled("text")
-    fg_muted = builder.mute(builder.colors.fg)
+    off_track = builder.border(builder.colors.bg)  # bootstack: off track = border(surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class
@@ -143,7 +143,7 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     )
     a = builder.assets
     on = a.recolor("switch_square", white=accent, black=builder.colors.bg)
-    off = a.recolor("switch_square", white=fg_muted, black=builder.colors.bg, transform="flip-x")
+    off = a.recolor("switch_square", white=off_track, black=builder.colors.bg, transform="flip-x")
     disabled_on = a.recolor("switch_square", white=disabled_fg, black=builder.colors.bg)
     disabled_off = a.recolor("switch_square", white=disabled_fg, black=builder.colors.bg, transform="flip-x")
     spacer_name = f"{ttk_style}.spacer"

--- a/src/ttkbootstrap/style/builders/toolbutton.py
+++ b/src/ttkbootstrap/style/builders/toolbutton.py
@@ -5,6 +5,7 @@ import tkinter as tk
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.builders.registry import register_builder
+from ttkbootstrap.style.builders.utils import neutral_fill
 
 
 @register_builder("default", "toolbutton")
@@ -21,29 +22,50 @@ def build_toolbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Toolbutton"
 
-    if any([colorname == DEFAULT, colorname == ""]):
+    # bootstack on/off model: OFF is a quiet raised surface with muted text; ON
+    # is the accent -- or, for `neutral` (no accent to switch to), a stronger
+    # surface raise so "on" still reads as distinct from "off".
+    unselected = neutral_fill(builder, 1)
+
+    if colorname == NEUTRAL:
+        ttk_style = f"{NEUTRAL}.{ttk_class}"
+        selected = neutral_fill(builder, 2)
+    elif any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class
         selected = builder.colors.primary
     else:
         ttk_style = f"{colorname}.{ttk_class}"
         selected = builder.colors.get(colorname)
 
-    if builder.is_light_theme:
-        unselected = builder.colors.border
-    else:
-        unselected = builder.colors.selectbg
-
     disabled = builder.disabled()
 
     on_selected = builder.on_color(selected)
-    on_unselected = builder.on_color(unselected)
+    on_unselected = builder.mute(builder.colors.fg, unselected)  # muted off text
     on_disabled = builder.disabled("text", disabled)
+
+    # 1px hairline border, matching the ttk.Button treatment: dark/light always
+    # track the fill (no bevel); `bordercolor` is the only distinct edge and is
+    # derived from whatever fill the segment is currently showing.
+    # A toolbutton is a toggle: only ON (selected) and OFF (unselected) change
+    # the appearance -- no hover/active or pressed preview.
+    fill_states = [
+        ("disabled", disabled),
+        ("selected !disabled", selected),
+    ]
+    border_states = [
+        ("disabled", disabled),
+        ("selected !disabled", builder.border(selected)),
+    ]
 
     builder.configure(
         ttk_style,
         foreground=on_unselected,
         background=unselected,
-        relief=tk.FLAT,
+        bordercolor=builder.border(unselected),
+        darkcolor=unselected,
+        lightcolor=unselected,
+        relief=tk.RAISED,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),
         focuscolor=on_unselected,
         padding=builder.scale_size((10, 5)),
@@ -53,23 +75,75 @@ def build_toolbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         ttk_style,
         foreground=[
             ("disabled", on_disabled),
-            ("active", on_selected),
             ("selected", on_selected),
         ],
         focuscolor=[
             ("disabled", on_disabled),
-            ("active", on_selected),
             ("selected", on_selected),
         ],
-        background=[
-            ("disabled", disabled),
-            ("pressed !disabled", selected),
-            ("selected !disabled", selected),
-            ("active !disabled", selected),
-        ]
+        background=fill_states,
+        bordercolor=border_states,
+        darkcolor=fill_states,
+        lightcolor=fill_states,
     )
 
     # register ttk style
+    builder.register_ttkstyle(ttk_style)
+
+
+def _build_neutral_outline_toolbutton(builder: StyleBuilderTTK, ttk_class):
+    """Neutral outline toolbutton: OFF is the flat surface, ON a raised surface.
+
+    The no-accent analog of the outline toolbutton -- with no accent to latch to,
+    "on" is shown by a subtle surface raise (`neutral_fill`) rather than a color.
+    """
+    ttk_style = f"{NEUTRAL}.{ttk_class}"
+    unselected = builder.colors.bg
+    selected = neutral_fill(builder, 1)
+    on_unselected = builder.mute(builder.colors.fg, unselected)
+    on_selected = builder.on_color(selected)
+    disabled = builder.disabled()
+    on_disabled = builder.disabled("text", disabled)
+
+    # A toolbutton is a toggle: only ON (selected) and OFF (unselected) change
+    # the appearance -- no hover/active or pressed preview.
+    fill_states = [
+        ("disabled", disabled),
+        ("selected !disabled", selected),
+    ]
+    border_states = [
+        ("disabled", disabled),
+        ("selected !disabled", builder.border(selected)),
+    ]
+    builder.configure(
+        ttk_style,
+        foreground=on_unselected,
+        background=unselected,
+        bordercolor=builder.border(unselected),
+        darkcolor=unselected,
+        lightcolor=unselected,
+        relief=tk.RAISED,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
+        focusthickness=builder.scale_size(1),  # match solid toolbutton height
+        focuscolor=on_unselected,
+        padding=builder.scale_size((10, 5)),
+        anchor=tk.CENTER,
+    )
+    builder.style.map(
+        ttk_style,
+        foreground=[
+            ("disabled", on_disabled),
+            ("selected", on_selected),
+        ],
+        focuscolor=[  # focus ring tracks the text color
+            ("disabled", on_disabled),
+            ("selected", on_selected),
+        ],
+        background=fill_states,
+        bordercolor=border_states,
+        darkcolor=fill_states,
+        lightcolor=fill_states,
+    )
     builder.register_ttkstyle(ttk_style)
 
 
@@ -87,6 +161,9 @@ def build_outline_toolbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Outline.Toolbutton"
 
+    if colorname == NEUTRAL:
+        _build_neutral_outline_toolbutton(builder, ttk_class)
+        return
 
     if any([colorname == DEFAULT, colorname == ""]):
         ttk_style = ttk_class
@@ -95,13 +172,9 @@ def build_outline_toolbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         ttk_style = f"{colorname}.{ttk_class}"
 
     accent = builder.colors.get(colorname)
-    selected = active = pressed = accent
-    unselected = builder.colors.bg
-
-    on_selected = on_active = on_pressed = builder.on_color(selected)
-    on_unselected = builder.on_color(unselected)
+    selected = accent
+    on_selected = builder.on_color(selected)
     on_disabled = builder.disabled("text")
-
 
     builder.configure(
         ttk_style,
@@ -111,41 +184,38 @@ def build_outline_toolbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         darkcolor=builder.colors.bg,
         lightcolor=builder.colors.bg,
         relief=tk.RAISED,
-        focusthickness=0,
-        focuscolor=on_unselected,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
+        focusthickness=builder.scale_size(1),  # match solid toolbutton height
+        focuscolor=accent,  # focus ring matches the text color (accent at rest)
         padding=builder.scale_size((10, 5)),
         anchor=tk.CENTER,
     )
+    # A toolbutton is a toggle: only ON (selected) vs OFF (unselected) -- no
+    # hover/active or pressed preview. The focus ring tracks the text color.
     builder.style.map(
         ttk_style,
         foreground=[
             ("disabled", on_disabled),
-            ("pressed !disabled", on_pressed),
             ("selected !disabled", on_selected),
-            ("active !disabled", on_active),
+        ],
+        focuscolor=[
+            ("disabled", on_disabled),
+            ("selected !disabled", on_selected),
         ],
         background=[
-            ("pressed !disabled", pressed),
-            ("selected !disabled", pressed),
-            ("active !disabled", active),
+            ("selected !disabled", selected),
         ],
         bordercolor=[
             ("disabled", on_disabled),
-            ("pressed !disabled", pressed),
-            ("selected !disabled", pressed),
-            ("active !disabled", active),
+            ("selected !disabled", selected),
         ],
         darkcolor=[
             ("disabled", builder.colors.bg),
-            ("pressed !disabled", pressed),
-            ("selected !disabled", pressed),
-            ("active !disabled", active),
+            ("selected !disabled", selected),
         ],
         lightcolor=[
             ("disabled", builder.colors.bg),
-            ("pressed !disabled", pressed),
-            ("selected !disabled", pressed),
-            ("active !disabled", active),
+            ("selected !disabled", selected),
         ],
     )
     # register ttkstyle

--- a/src/ttkbootstrap/style/builders/utils.py
+++ b/src/ttkbootstrap/style/builders/utils.py
@@ -1,5 +1,22 @@
 """Shared private helpers used by multiple ttk recipe families."""
 
+def neutral_fill(builder, level=1):
+    """A mode-aware elevation of the theme surface (bootstack's `elevate`).
+
+    Darkens the surface a touch in a light theme, lightens it in a dark theme, so
+    an unaccented control reads as a subtly raised surface in either mode (a fixed
+    `colors.light` would only be right in light themes). `level` 1 (~6%) is the
+    quiet neutral fill; `level` 2 (~12%) is a stronger raise used to distinguish
+    an "on"/selected neutral state from the "off" fill without an accent color.
+    Shared by the button-family neutral recipes.
+    """
+    weight = level * 0.06
+    surface = builder.colors.bg
+    if builder.is_light_theme:
+        return builder.shade(surface, weight)
+    return builder.tint(surface, weight)
+
+
 def indicator_spacer(builder):
     """Return the shared transparent image used between indicator and label."""
     size = (6, 1)

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -405,6 +405,21 @@ def _is_logical_toolkit_call(call):
     )
 
 
+def _is_hairline_border(arg, value):
+    """A 1px border is a physical hairline, not a scaled logical dimension.
+
+    Solid buttons draw a `borderwidth=1` flat border that should stay a single
+    physical pixel at every DPI (scaling it makes it read as a thick 2px+ edge on
+    hi-DPI). This narrowly permits the literal `borderwidth=1`; any other width or
+    option still must go through the scaling service.
+    """
+    return (
+        arg == "borderwidth"
+        and isinstance(value, ast.Constant)
+        and value.value == 1
+    )
+
+
 def test_builder_numeric_geometry_is_scaled_or_already_physical():
     violations = []
     for path in _builder_paths():
@@ -423,6 +438,7 @@ def test_builder_numeric_geometry_is_scaled_or_already_physical():
                         keyword.arg in GEOMETRY_OPTIONS
                         and _contains_nonzero_literal(value)
                         and not _contains_scaling_call(value)
+                        and not _is_hairline_border(keyword.arg, value)
                     ):
                         violations.append(f"{path.name}:{call.lineno}:{keyword.arg}")
     assert not violations, "unscaled literal builder geometry: " + ", ".join(

--- a/tests/widget_styles/test_color_helpers.py
+++ b/tests/widget_styles/test_color_helpers.py
@@ -276,10 +276,12 @@ def test_solid_button_recipe_uses_helper_state_contract(
     background_map = option_map(ttkstyle, 'background')
     foreground_map = option_map(ttkstyle, 'foreground')
     assert config['foreground'].lower() == builder.on_color(background)
-    # The solid button is a plain flat fill: it renders no clam border/dark/
-    # light regions, so those options are absent from its configuration.
-    assert config['relief'].lower() == 'flat'
-    assert 'bordercolor' not in config
+    # Every solid button has a subtle 1px border derived from its own fill.
+    # At rest the clam dark/light regions track the fill, so the resting edge is
+    # just the distinct `bordercolor`; the face stays the fill.
+    assert config['bordercolor'].lower() == builder.border(background)
+    assert config['darkcolor'].lower() == background
+    assert config['lightcolor'].lower() == background
     assert background_map[('hover', '!disabled')].lower() == active
     assert background_map[('pressed', '!disabled')].lower() == pressed
     disabled = builder.disabled()
@@ -287,9 +289,9 @@ def test_solid_button_recipe_uses_helper_state_contract(
         'text', disabled
     )
 
-    # Options named "border" are not automatically semantic borders. The
-    # menubutton and calendar recipes deliberately paint their clam
-    # border/dark/light regions with the same color as the current face.
+    # The button-family solid recipes (button/menubutton/toolbutton) now share
+    # the hairline-border treatment: a `bordercolor` derived from the fill, with
+    # the clam dark/light regions tracking the fill (no two-tone bevel).
     for family, variant in (
         ('menubutton', 'default'),
         ('toolbutton', 'default'),
@@ -298,18 +300,17 @@ def test_solid_button_recipe_uses_helper_state_contract(
         builder.build_style(variant, family, colorname, required=True)
 
     menubutton = f'{colorname}.TMenubutton'
-    assert style.configure(menubutton)['bordercolor'].lower() == background
-    assert option_map(menubutton, 'bordercolor')[
-        ('hover', '!disabled')
-    ] == active
+    assert style.configure(menubutton)['bordercolor'].lower() == builder.border(background)
+    # dark/light follow the fill; bordercolor is the fill's derived border
+    assert option_map(menubutton, 'darkcolor')[('hover', '!disabled')] == active
+    assert option_map(menubutton, 'bordercolor')[('hover', '!disabled')] == builder.border(active)
 
-    # The solid toolbutton, like the solid button, is a plain flat fill with no
-    # clam border treatment; its selected state simply fills with the accent.
+    # The solid toolbutton now carries the same border; its selected state fills
+    # with the accent and dark/light track that fill.
     toolbutton = f'{colorname}.Toolbutton'
-    assert 'bordercolor' not in style.configure(toolbutton)
-    assert option_map(toolbutton, 'background')[
-        ('selected', '!disabled')
-    ] == background
+    assert 'bordercolor' in style.configure(toolbutton)
+    assert option_map(toolbutton, 'background')[('selected', '!disabled')] == background
+    assert option_map(toolbutton, 'darkcolor')[('selected', '!disabled')] == background
 
     calendar = f'{colorname}.TCalendar'
     calendar_bg = option_map(calendar, 'background')

--- a/tests/widget_styles/test_neutral.py
+++ b/tests/widget_styles/test_neutral.py
@@ -1,0 +1,85 @@
+"""Tests for the `neutral` bootstyle color (2.0).
+
+`neutral` is a derived, no-accent button color: a mode-aware raise of the surface
+(bootstack's `elevate`) with a derived border and normal text. It is scoped to the
+Button family (`NEUTRAL_FAMILIES`); the reference generator advertises it only
+there. See `development/2_0_neutral_color_design.md`.
+"""
+import typing
+import warnings
+
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import BootStyle, NEUTRAL_FAMILIES
+
+
+def _lookup(app, style, option):
+    return str(app.tk.call("ttk::style", "lookup", style, f"-{option}")).lower()
+
+
+def _brightness(hex_color):
+    h = hex_color.lstrip("#")
+    r, g, b = int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+    return 0.299 * r + 0.587 * g + 0.114 * b
+
+
+def test_neutral_solid_button_is_a_bordered_raised_surface(root):
+    """`neutral` builds a filled, bordered button distinct from bg and any accent."""
+    style = root.style
+    ttk.Button(root, bootstyle="neutral")
+    bg = _lookup(root, "neutral.TButton", "background")
+    assert bg, "neutral button must configure a background"
+    # it is a *raised surface*, not the raw page bg and not the primary accent
+    assert bg != str(style.colors.bg).lower()
+    assert bg != str(style.colors.primary).lower()
+    # a distinct 1px border derived from the fill; at rest the clam dark/light
+    # regions track the fill (the face), so bordercolor is the only edge color
+    band = _lookup(root, "neutral.TButton", "bordercolor")
+    assert band and band != bg, "neutral must have a distinct border"
+    assert _lookup(root, "neutral.TButton", "darkcolor") == bg
+    assert _lookup(root, "neutral.TButton", "lightcolor") == bg
+
+
+def test_neutral_outline_button_sits_on_the_surface(root):
+    """`neutral-outline` is flush with the surface: bg == theme bg, text == fg."""
+    style = root.style
+    ttk.Button(root, bootstyle="neutral-outline")
+    assert _lookup(root, "neutral.Outline.TButton", "background") == str(style.colors.bg).lower()
+    assert _lookup(root, "neutral.Outline.TButton", "foreground") == str(style.colors.fg).lower()
+    assert _lookup(root, "neutral.Outline.TButton", "bordercolor")
+
+
+def test_neutral_fill_elevates_in_the_right_direction(root):
+    """The solid neutral fill darkens the surface in light themes, lightens in dark."""
+    style = root.style
+
+    style.theme_use("bootstrap-light")
+    ttk.Button(root, bootstyle="neutral")
+    light_fill = _brightness(_lookup(root, "neutral.TButton", "background"))
+    assert light_fill < _brightness(str(style.colors.bg)), "light neutral should be darker than bg"
+
+    style.theme_use("bootstrap-dark")
+    dark_fill = _brightness(_lookup(root, "neutral.TButton", "background"))
+    assert dark_fill > _brightness(str(style.colors.bg)), "dark neutral should be lighter than bg"
+
+
+def test_neutral_resolves_without_warning(root):
+    """`neutral` is a known token -- the loud tokenizer must not warn on it."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ttk.Button(root, bootstyle="neutral")
+        ttk.Button(root, bootstyle="neutral-outline")
+
+
+def test_neutral_scope_matches_neutral_families():
+    """neutral is advertised only for the neutral families (button-family)."""
+    assert NEUTRAL_FAMILIES == ("button", "menubutton", "toolbutton")
+    canonical = set(typing.get_args(BootStyle))
+    assert "neutral" in canonical
+    assert "neutral-outline" in canonical
+    # toolbutton spells its chameleon base, so neutral-toolbutton is advertised
+    assert "neutral-toolbutton" in canonical
+    assert "neutral-outline-toolbutton" in canonical
+    # but the base is not spelled for menubutton (you type "neutral" on a
+    # Menubutton), and neutral is not a family for toggles
+    for absent in ("neutral-menubutton", "neutral-round-toggle"):
+        assert absent not in canonical

--- a/tools/generate_bootstyle_reference.py
+++ b/tools/generate_bootstyle_reference.py
@@ -35,6 +35,8 @@ from ttkbootstrap.constants import (  # noqa: E402
     BOOTSTYLE_COLORS,
     BOOTSTYLE_BASES,
     BOOTSTYLE_INTERNAL_MODIFIERS,
+    NEUTRAL,
+    NEUTRAL_FAMILIES,
 )
 from ttkbootstrap.style.builders import load_builders  # noqa: E402
 from ttkbootstrap.style.builders.registry import (  # noqa: E402
@@ -74,6 +76,11 @@ def _strings_for_key(variant, family):
     modifier = None if variant == DEFAULT_VARIANT else variant
     base = family if family in BOOTSTYLE_BASES else None
     for color in (None, *BOOTSTYLE_COLORS):
+        # `neutral` is a derived, no-accent color that only renders for a curated
+        # set of families (NEUTRAL_FAMILIES) -- don't advertise it elsewhere even
+        # though the tokenizer would parse it.
+        if color == NEUTRAL and family not in NEUTRAL_FAMILIES:
+            continue
         parts = [p for p in (color, modifier, base) if p]
         if parts:
             yield "-".join(parts)


### PR DESCRIPTION
Introduces a **`neutral`** bootstyle color and restyles the whole button family to a flat, defined look. Derivations ported from bootstack (mechanism, not API). Design: `development/2_0_neutral_color_design.md`; rationale/what-changed log: `development/2_0_breaking_changes.md`.

## `neutral` — a new color *(additive)*

A derived, **no-accent, theme-adaptive** fill (a mode-aware raise of the surface — darker than the page in light themes, lighter in dark), always low-emphasis. Fills the gap where people misused `light` as a "quiet button" (which then went *bright* in dark mode).

- `bootstyle="neutral"`, `bootstyle="neutral-outline"`, `neutral-toolbutton`, `neutral-outline-toolbutton`, and `neutral` on a Menubutton.
- Scoped via `NEUTRAL_FAMILIES` (button / menubutton / toolbutton); `BootStyle` Literal + reference regenerated, sync-tested.
- **Not** redundant with `light`/`dark`: those are *fixed tones* (always pale / always dark, usable on any widget); `neutral` is *quiet + follows the theme*. The default button is still `primary`.

## Button-family flat hairline border *(visual)*

- Every **solid** button now draws a subtle **1px hairline border** derived from its own fill (`border(fill)`), **flat, no bevel** — `darkcolor`/`lightcolor` track the fill in every state so only `bordercolor` is a distinct edge. This gives every button a defined shape on any surface (fixes `light`/`neutral` dissolving into a white page).
- `borderwidth=1` is **intentionally unscaled** (a hairline should stay 1px at any DPI; scaling made it a thick 2px+ edge). A narrow scaling-guard exception permits it.
- Extended to **menubutton** (solid + outline) and **toolbutton** (solid + outline). Shared `neutral_fill(level)` helper.

## Toolbutton & switch state colors (bootstack model) *(visual)*

- **Toolbutton OFF** = a quiet raised surface (`neutral_fill`) + **muted** text; **ON** = the accent (or a stronger surface raise for `neutral`). Was a heavy gray chip competing with the selected accent.
- **Toolbuttons are now pure toggles** — only ON/OFF change the appearance (removed the misleading hover/active "preview the on state" and the pressed state).
- Outline toolbuttons gained the solid toolbutton's `focusthickness` (**matched height**, no layout shift on focus) and a **focus ring that tracks the text color**.
- **Switch OFF** track now uses `border(surface)` (quieter) instead of `mute(fg)`.

## Examples & tests

- Fixed `examples/widget_styles/checkbutton.py`'s `color + bootstyle` concatenation bug (missing dash → `primaryround-toggle`) that the Workstream-D tokenizer now rejects. Refreshed the button/menubutton demos onto current theme names + `neutral`. New `examples/neutral_preview.py`.
- New `tests/widget_styles/test_neutral.py`; updated the solid-button / menubutton / toolbutton style contracts in `test_color_helpers.py`.

## Gates

- Suite **268 passed** + the known `nl.msg` localization env flake; warning-free `-W error::DeprecationWarning` import.
- ⚠️ **Human-gated**: this is a broad visual restyle — reviewed live across light↔dark during development and approved. Screenshots/eyeball recommended before release.

## Deferred (separate branch)

date-button border; the pre-existing bare-`"toggle"` canonical-string crash; neutral-as-default; neutral-toolbutton selected-elevation tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)