### PR TITLE
Button-family follow-ups: date-button border + fix bare `toggle` bootstyle

### DIFF
--- a/src/ttkbootstrap/style/builders/button.py
+++ b/src/ttkbootstrap/style/builders/button.py
@@ -307,11 +307,28 @@ def build_date_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     pressed = builder.pressed(background)
     hover = builder.active(background)
 
+    # Same hairline-border treatment as the solid button: dark/light track the
+    # fill (no bevel), bordercolor is the fill's derived border.
+    fill_states = [
+        ("disabled", disabled),
+        ("pressed !disabled", pressed),
+        ("hover !disabled", hover),
+    ]
+    border_states = [
+        ("disabled", disabled),
+        ("pressed !disabled", builder.border(pressed)),
+        ("hover !disabled", builder.border(hover)),
+    ]
+
     builder.configure(
         ttk_style,
         foreground=on_background,
         background=background,
-        relief=tk.FLAT,
+        bordercolor=builder.border(background),
+        darkcolor=background,
+        lightcolor=background,
+        relief=tk.RAISED,
+        borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=0,
         focuscolor=on_background,
         padding=builder.scale_size((2, 2)),
@@ -322,21 +339,9 @@ def build_date_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         ttk_style,
         image=[("disabled", img_disabled)],
         foreground=[("disabled", on_disabled)],
-        background=[
-            ("disabled", disabled),
-            ("pressed !disabled", pressed),
-            ("hover !disabled", hover),
-        ],
-        bordercolor=[("disabled", disabled)],
-        darkcolor=[
-            ("disabled", disabled),
-            ("pressed !disabled", pressed),
-            ("hover !disabled", hover),
-        ],
-        lightcolor=[
-            ("disabled", disabled),
-            ("pressed !disabled", pressed),
-            ("hover !disabled", hover),
-        ],
+        background=fill_states,
+        bordercolor=border_states,
+        darkcolor=fill_states,
+        lightcolor=fill_states,
     )
     builder.register_ttkstyle(ttk_style)

--- a/src/ttkbootstrap/style/builders/toggle.py
+++ b/src/ttkbootstrap/style/builders/toggle.py
@@ -11,15 +11,22 @@ from ttkbootstrap.style.builders.utils import indicator_spacer
 
 @register_builder("default", "toggle")
 def build_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
-    """Create a round toggle style for the ttk.Checkbutton widget.
+    """Create the default toggle style for the ttk.Checkbutton widget.
+
+    The default toggle *is* a round toggle, but it must be built under the base
+    ``Toggle`` style name -- that is what the bare ``bootstyle="toggle"`` resolves
+    to (``round-toggle`` resolves to ``Round.Toggle``). Building it under
+    ``Round.Toggle`` here left ``Toggle`` with no layout ("Layout Toggle not
+    found").
 
     Parameters:
 
         builder (StyleBuilderTTK):
             The style builder.
         colorname (str):
+            The color label used to style the widget.
     """
-    builder.build_style("round", "toggle", colorname, required=True)
+    _build_round_toggle_style(builder, colorname, "Toggle")
 
 
 @register_builder("round", "toggle")
@@ -33,7 +40,11 @@ def build_round_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    ttk_class = "Round.Toggle"
+    _build_round_toggle_style(builder, colorname, "Round.Toggle")
+
+
+def _build_round_toggle_style(builder: StyleBuilderTTK, colorname, ttk_class):
+    """Build a round toggle under `ttk_class` (`Toggle` or `Round.Toggle`)."""
     disabled_fg = builder.disabled("text")
     off_track = builder.border(builder.colors.bg)  # bootstack: off track = border(surface)
 

--- a/tests/widget_styles/test_button_family.py
+++ b/tests/widget_styles/test_button_family.py
@@ -1,0 +1,46 @@
+"""Regression tests for button-family follow-ups (2.0).
+
+- the bare ``toggle`` bootstyle must build (it resolves to a ``Toggle`` style that
+  the default toggle recipe previously never created -> "Layout Toggle not found")
+- DateEntry's button carries the same hairline border as the other buttons
+"""
+import ttkbootstrap as ttk
+
+
+def _lookup(app, style, option):
+    return str(app.tk.call("ttk::style", "lookup", style, f"-{option}")).lower()
+
+
+def test_bare_toggle_bootstyle_builds(root):
+    """`bootstyle="toggle"` resolves to a real, laid-out `Toggle` style."""
+    style = root.style
+    cb = ttk.Checkbutton(root, text="t", bootstyle="toggle")
+    root.update_idletasks()
+    assert cb.cget("style") == "Toggle"
+    assert style.style_exists_in_theme("Toggle")
+
+
+def test_toggle_variants_all_build(root):
+    """The default toggle and the explicit round/square variants all resolve."""
+    for bootstyle, expected in (
+        ("toggle", "Toggle"),
+        ("round-toggle", "Round.Toggle"),
+        ("square-toggle", "Square.Toggle"),
+        ("primary-toggle", "primary.Toggle"),
+    ):
+        cb = ttk.Checkbutton(root, text=bootstyle, bootstyle=bootstyle)
+        root.update_idletasks()
+        assert cb.cget("style") == expected
+        assert root.style.style_exists_in_theme(expected)
+
+
+def test_date_button_has_hairline_border(root):
+    """DateEntry's button gets the same fill-derived border as other buttons."""
+    style = root.style
+    ttk.DateEntry(root)
+    root.update_idletasks()
+    border = _lookup(root, "Date.TButton", "bordercolor")
+    assert border, "date button must have a border"
+    # a distinct edge derived from the fill, not the raw fill
+    assert border != _lookup(root, "Date.TButton", "background")
+    assert _lookup(root, "Date.TButton", "relief") == "raised"


### PR DESCRIPTION
Two small button-family follow-ups deferred from #1096.

## Date button border *(visual)*

DateEntry's calendar button was still flat/borderless. It now carries the same flat **1px hairline border** as the rest of the button family (`relief=raised`, fill-derived `bordercolor`, `dark`/`light` track the fill). `focusthickness` stays `0`, so DateEntry's geometry is unchanged.

## Fix bare `toggle` bootstyle *(bug)*

Pre-existing crash: the canonical bootstyle **`toggle`** resolved to a `Toggle` style name, but the default toggle recipe delegated to the round builder and only ever registered `Round.Toggle` — so `Toggle` had no layout:

```
ttk.Checkbutton(bootstyle="toggle")  ->  TclError: Layout Toggle not found
```

(`round-toggle` / `primary-toggle` worked; only the bare base was broken — which is what turned a malformed string in the example demos into a hard crash.) The default toggle now builds a round toggle **under the `Toggle` name** via a shared `_build_round_toggle_style(ttk_class)` helper, so `toggle` / `primary-toggle` resolve alongside the explicit `round-toggle`.

## Tests

New `tests/widget_styles/test_button_family.py`: the bare `toggle` + variants all build and their `Toggle`/`Round.Toggle`/`Square.Toggle` styles exist; the date button has a fill-derived border.

Suite: **277 passed** + the known `nl.msg` localization env flake.

## Still deferred

**neutral-as-default** — its own design pass/discussion next (bigger scope; construction-time config, not a runtime toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)