### PR TITLE
Make bare buttons default to `neutral` (opt out via default_button="primary")

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -19,6 +19,7 @@
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
 | **`neutral` color** | New | this doc, below |
 | **Button-family visual restyle (flat + hairline border)** | Visual | this doc, below |
+| **Bare buttons default to `neutral`** | Visual/API | this doc, below |
 
 ---
 
@@ -126,3 +127,32 @@ reads clearly enough (the level-2 weight is the knob).
 
 **Migration.** None (appearance only). `toolbutton` joins `NEUTRAL_FAMILIES`, so
 `neutral-toolbutton` / `neutral-outline-toolbutton` are now valid bootstyles.
+
+## Bare buttons default to `neutral`  *(Visual / small API)*
+
+**What.** A bare `ttk.Button()` / `ttk.Menubutton()` (no `bootstyle`) now renders
+**neutral** instead of **primary**. Opt into an accent explicitly
+(`bootstyle="primary"`). A new construction-time setting restores the old default:
+`Window(default_button="primary")` (or `Style(theme, default_button="primary")`).
+
+**Why.** A plain button is not a call-to-action — it should be quiet by default,
+and you opt into emphasis (the Bootstrap/bootstack model). This suits
+ttkbootstrap's utility/scientific audience, who generally want a calm default over
+a blue CTA.
+
+**Scope.** `Button` and `Menubutton` only. **Not** Toolbutton / Toggle /
+Checkbutton / Radiobutton — their default accent is the *selection* signal, and
+they are already neutral *at rest* (OFF = the quiet surface, ON = accent), so
+flipping their ON state would only remove the selection color. The DateEntry
+button (an internal affordance) also stays primary.
+
+**Mechanism.** `default_button` is a **color name** (default `"neutral"`) stored on
+the `Style` and read once when the base `TButton`/`TMenubutton` builds — a
+construction-time choice, **not** a runtime toggle. Explicit styles
+(`primary.TButton`, etc.) are unchanged. Dialogs set `bootstyle` explicitly, so
+their CTA emphasis is unaffected.
+
+**Migration.** Add `bootstyle="primary"` to buttons that should be call-to-action,
+or set `Window(default_button="primary")` to restore the pre-2.0 default globally.
+
+Design: `development/2_0_neutral_default_design.md`.

--- a/development/2_0_neutral_default_design.md
+++ b/development/2_0_neutral_default_design.md
@@ -1,0 +1,103 @@
+# ttkbootstrap 2.0 — neutral-by-default buttons — design / scoping
+
+> Design pass per the hard rule (a breaking default change). Builds on
+> `development/2_0_neutral_color_design.md` (the `neutral` color itself, merged in
+> #1096). Decision locked with the author 2026-07-06: **neutral by default**,
+> breaking, with a **construction-time opt-out** to restore the primary default.
+
+## 1. Decision
+
+A bare `ttk.Button()` (no `bootstyle`) currently renders **primary** (blue). Make
+it render **neutral** — the quiet, theme-adaptive fill. You opt *into* an accent:
+`ttk.Button(bootstyle="primary")`. This matches Bootstrap/bootstack semantics (a
+plain button is not a call-to-action) and suits ttkbootstrap's utility/scientific
+audience, who generally want a calm default rather than a blue CTA.
+
+This is a **documented breaking change** (Visual): every existing app's bare
+buttons change from blue to neutral gray. Justified for an aggressive 2.0, paired
+with a one-line opt-out.
+
+## 2. Scope — which widgets flip
+
+Flip only the widgets where the default accent is *emphasis*, not *selection*:
+
+- **`ttk.Button`** (base `TButton`) — flips to neutral. The core case.
+- **`ttk.Menubutton`** (base `TMenubutton`) — flips too, for "default buttons are
+  neutral" coherence (a dropdown trigger is a button). *(Open Q — see §6.)*
+
+Explicitly **NOT** flipped (their default accent is the *selection indicator*, and
+a neutral selection reads poorly):
+- **Toolbutton**, **Toggle/switch**, **Checkbutton/Radiobutton** — the accent is
+  the "on"/selected color; keep `primary`.
+- **Date button** (DateEntry) — an internal affordance inside a compound widget,
+  not a bare button the user creates; keep `primary`.
+- **Link button** — already flat/text; unaffected.
+
+## 3. Mechanism — construction-time, not a runtime toggle
+
+The default is resolved when the base `TButton`/`TMenubutton` style is built (in
+`StyleBuilderTTK.create_default_style` → `build_button_style(DEFAULT)`), which runs
+once at theme load inside `Style.__init__`. So the setting must be known before
+then and is read at build time — no mutable global that later changes what
+`bootstyle=""` means (the hidden state 2.0 has been removing).
+
+- **`Style` gains `default_button` (a color name, default `"neutral"`).** Set at
+  the very top of `Style.__init__`, before `create_theme()`/`create_default_style()`
+  run, so the base styles pick it up. Persists on the instance, so a later
+  `theme_use()` (which rebuilds base styles) keeps the choice.
+- **`Window(default_button="primary")`** threads the value into its `Style(...)`
+  construction. `Style(themename, default_button="primary")` for `tk.Tk()` users.
+- **`build_button_style` / `build_menubutton_style` DEFAULT branch** resolves the
+  fill from `style.default_button` instead of hardcoding `colors.primary`:
+  `neutral_fill(builder)` when it is `"neutral"`, else `colors.get(default_button)`.
+  (Generalizes cleanly — `default_button` is just a color name; `"neutral"` is the
+  new default value.)
+- **Explicit styles are unaffected**: `primary.TButton`, `secondary.TButton`, etc.
+  build exactly as today; only the *base* (no-color) style changes.
+
+Opt-out to restore the 2.x look:
+```python
+app = ttk.Window(default_button="primary")   # bare buttons render primary again
+```
+
+## 4. Compatibility & migration
+
+- **Dialogs are safe.** `MessageDialog.create_buttonbox` sets `bootstyle="primary"`
+  on the default/CTA button and `"secondary"` on the rest — all explicit — so
+  dialog emphasis is unchanged by the flip.
+- **Native/third-party ttk buttons** (e.g. inside Tk's file dialog) fall back to
+  the base `TButton`, so they become neutral too — consistent, not a regression.
+- **Migration entry** (→ `2_0_breaking_changes.md` + Migrating-to-2.0): "Bare
+  `ttk.Button()`/`ttk.Menubutton()` now render **neutral** instead of primary. Add
+  `bootstyle="primary"` for a call-to-action, or pass
+  `Window(default_button="primary")` to restore the old default globally."
+
+## 5. Test impact
+
+- `tests/widget_styles/test_default_button_style.py` (#1062) asserts the base
+  `TButton` background `== colors.primary`; update it to assert the neutral fill by
+  default, and add a case that `Style(default_button="primary")` restores primary.
+- Add: bare button is neutral by default; `default_button="primary"` opt-out;
+  explicit `primary.TButton` unchanged; the base style follows a theme switch.
+- Sweep for internal bare-button assumptions (grep the suite for `TButton`
+  background == primary).
+
+## 6. Resolved (author, 2026-07-06)
+
+- **Menubutton inclusion — YES.** Flip both `TButton` and `TMenubutton`.
+- **Toolbutton — NO** (and Toggle/Checkbutton/Radiobutton). Their default accent
+  is the *selection* signal, and they are **already neutral at rest** after the
+  bootstack on/off work (OFF = `neutral_fill`, ON = accent). Flipping the ON state
+  to neutral would only *remove* the selection color, not make them calmer. So
+  they keep primary-on-select; the neutral toolbutton stays an explicit opt-in.
+- **Param name — `default_button`** (a color name, default `"neutral"`; more
+  flexible than a bool, reads as "the color a default button uses").
+- **`Style` singleton timing** — if an app constructs `Style()` *after* `Window`
+  already created the singleton, the later `default_button` is ignored (existing
+  singleton behavior). Document: set it on the `Window`/first `Style`.
+
+## 7. PR plan (one PR)
+
+Single small PR: the `Style.default_button` plumbing + `Window` param + the two
+DEFAULT-branch reads + tests + migration note. Gate on a light↔dark eyeball of a
+few bare buttons and one `default_button="primary"` app.

--- a/src/ttkbootstrap/style/builders/button.py
+++ b/src/ttkbootstrap/style/builders/button.py
@@ -5,7 +5,7 @@ import tkinter as tk
 from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.builders.registry import register_builder
-from ttkbootstrap.style.builders.utils import neutral_fill
+from ttkbootstrap.style.builders.utils import neutral_fill, default_button_fill
 
 
 @register_builder("default", "button")
@@ -30,8 +30,10 @@ def build_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         ttk_style = f"{NEUTRAL}.{ttk_class}"
         fill = neutral_fill(builder)
     elif any([colorname == DEFAULT, colorname == ""]):
+        # The base (no-color) button follows the Style's default_button setting
+        # (neutral by default; "primary" restores the pre-2.0 accented default).
         ttk_style = ttk_class
-        fill = builder.colors.primary
+        fill = default_button_fill(builder)
     else:
         ttk_style = f"{colorname}.{ttk_class}"
         fill = builder.colors.get(colorname)

--- a/src/ttkbootstrap/style/builders/menubutton.py
+++ b/src/ttkbootstrap/style/builders/menubutton.py
@@ -6,7 +6,9 @@ from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, image_element, layout
 from ttkbootstrap.style.builders.registry import register_builder
-from ttkbootstrap.style.builders.utils import simple_arrow_assets, neutral_fill
+from ttkbootstrap.style.builders.utils import (
+    simple_arrow_assets, neutral_fill, default_button_fill,
+)
 
 
 @register_builder("default", "menubutton")
@@ -27,8 +29,9 @@ def build_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         ttk_style = f"{NEUTRAL}.{ttk_class}"
         background = neutral_fill(builder)
     elif any([colorname == DEFAULT, colorname == ""]):
+        # base (no-color) menubutton follows the Style's default_button setting
         ttk_style = ttk_class
-        background = builder.colors.primary
+        background = default_button_fill(builder)
     else:
         ttk_style = f"{colorname}.{ttk_class}"
         background = builder.colors.get(colorname)

--- a/src/ttkbootstrap/style/builders/utils.py
+++ b/src/ttkbootstrap/style/builders/utils.py
@@ -1,5 +1,22 @@
 """Shared private helpers used by multiple ttk recipe families."""
 
+from ttkbootstrap.constants import NEUTRAL
+
+
+def default_button_fill(builder):
+    """The fill for a bare (no-color) button/menubutton.
+
+    Honors the Style's `default_button` setting (default `"neutral"`): the quiet
+    neutral raise, or the resolved accent for any other color (e.g. `"primary"`
+    to restore the pre-2.0 accented default). This is what makes a plain
+    `ttk.Button()` render neutral by default.
+    """
+    color = getattr(builder.style, "default_button", NEUTRAL)
+    if color == NEUTRAL:
+        return neutral_fill(builder)
+    return builder.colors.get(color)
+
+
 def neutral_fill(builder, level=1):
     """A mode-aware elevation of the theme surface (bootstack's `elevate`).
 

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -57,23 +57,32 @@ class Style(ttk.Style):
 
     instance = None
 
-    def __new__(cls, theme=None):
+    def __new__(cls, theme=None, default_button="neutral"):
         if Style.instance is None:
             return object.__new__(cls)
         else:
             return Style.instance
 
-    def __init__(self, theme=DEFAULT_THEME):
+    def __init__(self, theme=DEFAULT_THEME, default_button="neutral"):
         """
         Parameters:
 
             theme (str):
                 The name of the theme to use when styling the widget.
+
+            default_button (str):
+                The color a bare `Button`/`Menubutton` (no `bootstyle`) uses.
+                Defaults to `"neutral"`; pass `"primary"` for the pre-2.0
+                accented default. Read once when the base styles build, so set it
+                on the first `Style`/`Window`; ignored on the existing singleton.
         """
         if Style.instance is not None:
             if theme != DEFAULT_THEME:
                 Style.instance.theme_use(theme)
             return
+        # Set before theme_use() below, which builds the base TButton/TMenubutton
+        # styles that read this to resolve their default (no-color) fill.
+        self.default_button = default_button
         self._theme_objects = {}
         self._theme_definitions = {}
         self._style_registry = set()  # all styles used

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -215,6 +215,7 @@ class Window(tkinter.Tk):
             self,
             title: str = "ttkbootstrap",
             themename: str = "bootstrap-light",
+            default_button: str = "neutral",
             iconphoto: Optional[str] = '',
             size: Optional[Tuple[int, int]] = None,
             position: Optional[Tuple[int, int]] = None,
@@ -237,6 +238,11 @@ class Window(tkinter.Tk):
             themename (str):
                 The name of the ttkbootstrap theme to apply to the
                 application.
+
+            default_button (str):
+                The color a bare `Button`/`Menubutton` (no `bootstyle`) uses.
+                Defaults to `"neutral"` (a quiet, unaccented button); pass
+                `"primary"` to restore the pre-2.0 accented default.
 
             iconphoto (str):
                 A path to the image used for the titlebar icon.
@@ -371,7 +377,7 @@ class Window(tkinter.Tk):
 
         apply_class_bindings(self)
         apply_all_bindings(self)
-        self._style = Style(themename)
+        self._style = Style(themename, default_button=default_button)
 
     @property
     def style(self) -> Style:

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -137,7 +137,7 @@ def test_window_and_style_initialize_scaling_before_style_builds():
     )
     assert init_source.index("super().__init__(**kwargs)") < init_source.index(
         "utility.enable_high_dpi_awareness(self, scaling)"
-    ) < init_source.index("self._style = Style(themename)")
+    ) < init_source.index("self._style = Style(themename")
 
     engine_source = (package / "style" / "engine.py").read_text(encoding="utf-8")
     style_init = engine_source[engine_source.index("class Style"):]

--- a/tests/widget_styles/test_default_button_style.py
+++ b/tests/widget_styles/test_default_button_style.py
@@ -15,6 +15,7 @@ runtime theme changes.
 Runnable headlessly with pytest.
 """
 import ttkbootstrap as ttk
+from ttkbootstrap.style.builders.utils import default_button_fill
 
 
 def _tbutton_background(app):
@@ -33,11 +34,48 @@ def test_base_tbutton_themed_without_default_button(root):
 
     assert style.style_exists_in_theme("TButton"), \
         "base TButton should be built at theme load"
-    assert _tbutton_background(root) == str(style.colors.primary).lower(), \
-        "base TButton should use the theme's primary color"
 
-    # The base style must keep tracking the active theme.
+    # The base TButton uses the default_button fill (neutral by default), built
+    # at load, and it must keep tracking the active theme.
+    def expected_default():
+        return str(default_button_fill(style._get_builder())).lower()
+
+    assert _tbutton_background(root) == expected_default(), \
+        "base TButton should use the default_button (neutral) fill"
+
     for theme in ("bootstrap-dark", "minty-light", "pydata-light"):
         style.theme_use(theme)
-        assert _tbutton_background(root) == str(style.colors.primary).lower(), \
+        assert _tbutton_background(root) == expected_default(), \
             f"base TButton did not follow change to {theme}"
+
+
+def test_bare_button_is_neutral_by_default(root):
+    """A bare `ttk.Button()` (no bootstyle) renders neutral, not primary."""
+    style = root.style
+    style.theme_use("bootstrap-light")
+    assert style.default_button == "neutral"
+    ttk.Button(root, bootstyle="neutral")  # build neutral.TButton to compare
+    root.update_idletasks()
+    neutral_bg = str(
+        style.tk.call("ttk::style", "lookup", "neutral.TButton", "-background")
+    ).lower()
+    # the base (no-color) button matches the explicit neutral button...
+    assert _tbutton_background(root) == neutral_bg
+    # ...and is not the accent
+    assert _tbutton_background(root) != str(style.colors.primary).lower()
+
+
+def test_default_button_setting_opts_out_to_primary(root):
+    """`default_button` drives the base fill: 'primary' restores the accent."""
+    style = root.style
+    builder = style._get_builder()
+    before = style.default_button
+    try:
+        style.default_button = "primary"
+        assert str(default_button_fill(builder)).lower() == \
+            str(style.colors.primary).lower()
+        style.default_button = "neutral"
+        assert str(default_button_fill(builder)).lower() != \
+            str(style.colors.primary).lower()
+    finally:
+        style.default_button = before


### PR DESCRIPTION
A bare `ttk.Button()` / `ttk.Menubutton()` (no `bootstyle`) now renders **neutral** instead of **primary**. A plain button is not a call-to-action, so it's quiet by default and you opt into emphasis (`bootstyle="primary"`). Locked with the author; design: `development/2_0_neutral_default_design.md`.

**Documented breaking change** (paired with a one-line opt-out).

## Mechanism — construction-time, not a runtime toggle

- New **`default_button`** color (default `"neutral"`) on `Style` and `Window`, read **once** when the base `TButton`/`TMenubutton` builds (via a shared `default_button_fill(builder)` helper). No mutable global that later changes what `bootstyle=""` means.
- Restore the pre-2.0 accented default:
  ```python
  ttk.Window(default_button="primary")     # or Style(theme, default_button="primary")
  ```

## Scope

- **Flipped:** `Button` + `Menubutton` (momentary actions).
- **Not flipped:** Toolbutton / Toggle / Checkbutton / Radiobutton — their default accent is the *selection* signal, and they're already neutral **at rest** (OFF = quiet surface, ON = accent); flipping the ON state would only remove the selection color. The DateEntry button (internal affordance) stays primary too.
- **Explicit styles unchanged** — `primary.TButton`, `secondary.TButton`, etc. build exactly as before; only the base (no-color) style changes.
- **Dialogs safe** — they set `bootstyle` explicitly on their CTA/secondary buttons, so dialog emphasis is unaffected.

## Tests

- Updated the #1062 base-`TButton` test to assert the neutral default fill (still built at load + follows theme changes).
- Added: bare button is neutral by default; `default_button` opt-out resolves to primary.

Suite: **279 passed** + the known `nl.msg` env flake; warning-free import.

⚠️ **Human-gated**: this is the most visible change in the effort — eyeball a few bare buttons + one `default_button="primary"` app, light↔dark, before release. Recorded in `development/2_0_breaking_changes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)