### PR TITLE
Follow-ups: datepicker selected-day fix, ghost button, demo refresh

### DIFF
--- a/development/2_0_bootstyle_reference.md
+++ b/development/2_0_bootstyle_reference.md
@@ -43,6 +43,7 @@ default; `set_bootstyle_strict(True)` or `TTKBOOTSTRAP_STRICT=1` raises).
 | `toggle` | `default` | `primary-toggle` |
 | `toolbutton` | `default` | `primary-toolbutton` |
 | `treeview` | `default` | `primary` |
+| `button` | `ghost` | `primary-ghost` |
 | `label` | `inverse` | `primary-inverse` |
 | `button` | `link` | `primary-link` |
 | `button` | `outline` | `primary-outline` |

--- a/development/2_0_bootstyle_reference.md
+++ b/development/2_0_bootstyle_reference.md
@@ -54,4 +54,5 @@ default; `set_bootstyle_strict(True)` or `TTKBOOTSTRAP_STRICT=1` raises).
 | `toggle` | `square` | `primary-square-toggle` |
 | `progressbar` | `striped` | `primary-striped` |
 | `progressbar` | `thin` | `primary-thin` |
+| `scrollbar` | `thin` | `primary-thin` |
 

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -20,6 +20,7 @@
 | **`neutral` color** | New | this doc, below |
 | **`ghost` button variant** | New | this doc, below |
 | **`thin` scrollbar variant** | New | this doc, below |
+| **Scrollbar restyle (visible trough, square default)** | Visual | this doc, below |
 | **Button-family visual restyle (flat + hairline border)** | Visual | this doc, below |
 
 ---
@@ -54,6 +55,31 @@ were standing in for a quiet/subtle button with `bootstyle="neutral"` — it wil
 stay quiet in dark mode where `light` would turn bright.
 
 Design: `development/2_0_neutral_color_design.md`.
+
+## Scrollbar restyle — visible trough, inset thumb, square default  *(Visual)*
+
+**What.** The standard (`default`) and `round` scrollbars were reworked:
+- a **visible trough** (a subtle track shade of the surface) so the thumb reads
+  as sliding in a channel rather than floating on the surface;
+- the thumb is **inset** ~1px from the trough walls (a transparent margin baked
+  into the thumb image), so there is a track of space around it;
+- the thumb has a **minimum length** (a 9-slice end region), so a long list can't
+  shrink it to a microscopic sliver;
+- `default` is now a **flat square** thumb and `round` a **pill** (they used to be
+  nearly identical rounded thumbs);
+- **no arrows** (the previous `arrowsize` was already dead layout config).
+
+The `thin` variant is unchanged. The combobox popdown uses `thin`; the font dialog
+lists use the square `default`.
+
+**Why.** The 2.0 scrollbars had an invisible trough (= surface) and a thumb that
+floated with no track and could collapse to nothing on a long list. Restoring a
+visible trough + inset thumb + min size makes them read as real scrollbars (closer
+to 1.0), and splitting square/round gives a genuine choice. Ports the visible-trough
+idea from 1.0; thumb margin/min-size are implemented via the image + 9-slice border.
+
+**Migration.** None (appearance only). `bootstyle="round"` is still the pill;
+the default is now square.
 
 ## `thin` — a new scrollbar variant  *(New)*
 

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -18,6 +18,7 @@
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
 | **`neutral` color** | New | this doc, below |
+| **`ghost` button variant** | New | this doc, below |
 | **Button-family visual restyle (flat + hairline border)** | Visual | this doc, below |
 
 ---
@@ -52,6 +53,21 @@ were standing in for a quiet/subtle button with `bootstyle="neutral"` — it wil
 stay quiet in dark mode where `light` would turn bright.
 
 Design: `development/2_0_neutral_color_design.md`.
+
+## `ghost` — a new button variant  *(New)*
+
+**What.** A new button modifier, `ghost` (e.g. `bootstyle="ghost"`,
+`bootstyle="primary-ghost"`). A ghost button is **transparent at rest** — no fill,
+no border, just its label — and gains a **subtle wash** on hover/press: a light
+tint of the accent for a colored ghost (`primary-ghost` → a faint blue wash), or a
+neutral surface raise for the default/neutral ghost. Additive.
+
+**Why.** It fills the gap between `link` (text-only, hyperlink feel) and `outline`
+(bordered): more button-like than a link (it has a hover surface), quieter than an
+outline. Common for toolbar/icon buttons and low-emphasis actions. Ported from
+bootstack's ghost button (derivation, not API). Button family only.
+
+**Migration.** None (additive).
 
 ## Button-family visual restyle — flat fill + 1px hairline border  *(Visual)*
 

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -19,6 +19,7 @@
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
 | **`neutral` color** | New | this doc, below |
 | **`ghost` button variant** | New | this doc, below |
+| **`thin` scrollbar variant** | New | this doc, below |
 | **Button-family visual restyle (flat + hairline border)** | Visual | this doc, below |
 
 ---
@@ -53,6 +54,23 @@ were standing in for a quiet/subtle button with `bootstyle="neutral"` — it wil
 stay quiet in dark mode where `light` would turn bright.
 
 Design: `development/2_0_neutral_color_design.md`.
+
+## `thin` — a new scrollbar variant  *(New)*
+
+**What.** A thin scrollbar (`bootstyle="thin"`, `primary-thin`, …): a few-pixel
+flat thumb on a surface-matched track, **no arrows**. Neutral by default (thumb =
+`border(surface)`), or the accent when a color is given; darkens/lightens on
+hover/press. It is now the scrollbar used in the **Combobox popdown** and the
+**font dialog** lists — narrow spaces where the bar is a scroll *indicator* more
+than a drag handle. Additive; the standard (`default`) and `round` scrollbars are
+unchanged.
+
+**Why.** The standard scrollbar (with arrows, an 18×8 rounded thumb) is heavy in a
+cramped dropdown. bootstack's thin bar reads as a clean sliver. Ported from
+bootstack (mechanism, not API) — the thumb is a solid box from the `rect` toolkit,
+so no new PNG asset was added.
+
+**Migration.** None (additive). Opt in with `bootstyle="thin"` on any `Scrollbar`.
 
 ## `ghost` — a new button variant  *(New)*
 

--- a/examples/widget_styles/button.py
+++ b/examples/widget_styles/button.py
@@ -26,7 +26,7 @@ def button_style_frame(bootstyle, style, widget_name):
         bootstyle=bootstyle
     ).pack(padx=5, pady=5, fill=tk.BOTH)
 
-    for color in [*style.colors, 'neutral']:
+    for color in style.colors:
         ttk.Button(
             master=frame,
             text=color,

--- a/examples/widget_styles/button.py
+++ b/examples/widget_styles/button.py
@@ -56,6 +56,7 @@ if __name__ == '__main__':
 
     button_style_frame('outline', style, 'Outline Button').pack(side=tk.LEFT)
     button_style_frame('', style, 'Solid Button').pack(side=tk.LEFT)
+    button_style_frame('ghost', style, 'Ghost Button').pack(side=tk.LEFT)
     button_style_frame('link', style, 'Link Button').pack(side=tk.LEFT)
     ttk.Button(text="Change Theme", command=change_style).pack(padx=10, pady=10)
 

--- a/examples/widgets/date_entry_widget.py
+++ b/examples/widgets/date_entry_widget.py
@@ -11,3 +11,4 @@ de = ttk.DateEntry(frame)
 de.pack(fill=X)
 
 root.mainloop()
+

--- a/gallery/calculator.py
+++ b/gallery/calculator.py
@@ -55,9 +55,9 @@ class Calculator(ttk.Frame):
         if text == "=":
             bootstyle = SUCCESS
         elif not isinstance(text, int):
-            bootstyle = SECONDARY
+            bootstyle = None
         else:
-            bootstyle = PRIMARY
+            bootstyle = SECONDARY
         return ttk.Button(
             master=master,
             text=text,

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -98,7 +98,7 @@ BootColor = Literal["primary", "secondary", "success", "danger", "warning", "inf
 # is the reconciled set -- `round` is included (it is buildable; its historical
 # omission was a bug), and `toggle`/`toolbutton` are *removed* because they are
 # base-types (widget families), not modifiers. Those two moved to `BootBase`.
-BootType = Literal["outline", "link", "inverse", "round", "square", "striped", "thin"]
+BootType = Literal["outline", "link", "ghost", "inverse", "round", "square", "striped", "thin"]
 
 # Base-types a user may name explicitly in a bootstyle string. Most base-types
 # are inferred from the widget's class and never typed; these two "chameleon"
@@ -126,7 +126,7 @@ BOOTSTYLE_COLORS: Final = (
 NEUTRAL_FAMILIES: Final = ("button", "menubutton", "toolbutton")
 # Public, documented type modifiers -- matches BootType.
 BOOTSTYLE_MODIFIERS: Final = (
-    "outline", "link", "inverse", "round", "square", "striped", "thin",
+    "outline", "link", "ghost", "inverse", "round", "square", "striped", "thin",
 )
 # Internal-only composite modifiers used by Meter/DateEntry/Tableview to build
 # their sub-styles. Valid grammar tokens, but undocumented and not in any public
@@ -157,6 +157,7 @@ BOOTSTYLE_ORIENTS: Final = ("horizontal", "vertical")
 # ---------------------------------------------------------------------------
 BootStyle = Literal[
     'danger',
+    'danger-ghost',
     'danger-inverse',
     'danger-link',
     'danger-outline',
@@ -169,6 +170,7 @@ BootStyle = Literal[
     'danger-toggle',
     'danger-toolbutton',
     'dark',
+    'dark-ghost',
     'dark-inverse',
     'dark-link',
     'dark-outline',
@@ -180,7 +182,9 @@ BootStyle = Literal[
     'dark-thin',
     'dark-toggle',
     'dark-toolbutton',
+    'ghost',
     'info',
+    'info-ghost',
     'info-inverse',
     'info-link',
     'info-outline',
@@ -194,6 +198,7 @@ BootStyle = Literal[
     'info-toolbutton',
     'inverse',
     'light',
+    'light-ghost',
     'light-inverse',
     'light-link',
     'light-outline',
@@ -207,6 +212,7 @@ BootStyle = Literal[
     'light-toolbutton',
     'link',
     'neutral',
+    'neutral-ghost',
     'neutral-link',
     'neutral-outline',
     'neutral-outline-toolbutton',
@@ -214,6 +220,7 @@ BootStyle = Literal[
     'outline',
     'outline-toolbutton',
     'primary',
+    'primary-ghost',
     'primary-inverse',
     'primary-link',
     'primary-outline',
@@ -228,6 +235,7 @@ BootStyle = Literal[
     'round',
     'round-toggle',
     'secondary',
+    'secondary-ghost',
     'secondary-inverse',
     'secondary-link',
     'secondary-outline',
@@ -242,6 +250,7 @@ BootStyle = Literal[
     'square-toggle',
     'striped',
     'success',
+    'success-ghost',
     'success-inverse',
     'success-link',
     'success-outline',
@@ -257,6 +266,7 @@ BootStyle = Literal[
     'toggle',
     'toolbutton',
     'warning',
+    'warning-ghost',
     'warning-inverse',
     'warning-link',
     'warning-outline',
@@ -447,6 +457,7 @@ NEUTRAL: Final[BootColor] = "neutral"
 
 OUTLINE: Final[BootType] = "outline"
 LINK: Final[BootType] = "link"
+GHOST: Final[BootType] = "ghost"
 INVERSE: Final[BootType] = "inverse"
 STRIPED: Final[BootType] = "striped"
 THIN: Final[BootType] = "thin"
@@ -500,6 +511,6 @@ __all__ = [
     "FULL", "SEMI", "DETERMINATE", "INDETERMINATE",
     "PRIMARY", "SECONDARY", "SUCCESS", "DANGER", "WARNING", "INFO", "LIGHT", "DARK",
     "NEUTRAL",
-    "OUTLINE", "LINK", "TOGGLE", "INVERSE", "STRIPED", "THIN", "TOOLBUTTON", "SQUARE",
+    "OUTLINE", "LINK", "GHOST", "TOGGLE", "INVERSE", "STRIPED", "THIN", "TOOLBUTTON", "SQUARE",
     "TREE", "HEADINGS", "TREEHEADINGS",
 ]

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -191,7 +191,7 @@ class DatePickerDialog:
                         text=day,
                         takefocus=True,
                         bootstyle=day_style,
-                        padding=5,
+                        padding=4,
                         command=selected,
                     )
                     btn.grid(row=row, column=col, sticky=NSEW)
@@ -206,7 +206,7 @@ class DatePickerDialog:
             master=self.frm_title,
             textvariable=self.titlevar,
             anchor=CENTER,
-            font="-weight bold",
+            font="-size 11 -weight bold",
         )
         self.title.pack(side=LEFT, fill=X, expand=YES)
 
@@ -224,7 +224,7 @@ class DatePickerDialog:
                 master=self.frm_header,
                 text=col,
                 anchor=CENTER,
-                padding=5,
+                padding=4,
                 bootstyle="secondary-inverse",
             ).pack(side=LEFT, fill=X, expand=YES)
 

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -140,9 +140,12 @@ class DatePickerDialog:
         self.title.configure(bootstyle=f"{self.bootstyle}-inverse")
         self.prev_period.configure(style=f"Chevron.{self.bootstyle}.TButton")
         self.next_period.configure(style=f"Chevron.{self.bootstyle}.TButton")
-        # caret-fill nav arrows, in the title bar's contrasting foreground color
-        # (matches the filled-triangle arrows used elsewhere in the app)
-        arrow_color = ttk.Style.get_instance().colors.get_foreground(self.bootstyle)
+        # caret-fill nav arrows, in the header's contrasting on-accent color.
+        # (Use on_color, not colors.get_foreground(), which returns black on a
+        # saturated dark-theme accent -- wrong on the accent-colored title bar.)
+        style = ttk.Style.get_instance()
+        accent = style.colors.get(self.bootstyle)
+        arrow_color = style._get_builder().on_color(accent)
         self.prev_period.configure(image=ttk.Icon("caret-left-fill", 14, arrow_color))
         self.next_period.configure(image=ttk.Icon("caret-right-fill", 14, arrow_color))
 

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -173,6 +173,11 @@ class DatePickerDialog:
                             ]
                     ):
                         day_style = "secondary-toolbutton"
+                        # Put this day in the ttk "selected" state so the
+                        # toolbutton renders its ON look. Without this the day
+                        # sits in the (now quiet + muted) OFF state and reads as
+                        # a disabled button.
+                        self.datevar.set(day)
                     else:
                         day_style = f"{self.bootstyle}-calendar"
 

--- a/src/ttkbootstrap/dialogs/fontdialog.py
+++ b/src/ttkbootstrap/dialogs/fontdialog.py
@@ -83,6 +83,10 @@ class FontDialog(Dialog):
         height = utility.scale_size(master, 500)
         self._toplevel.geometry(f"{width}x{height}")
 
+        # A borderless Treeview: the list border is carried by a wrapping frame
+        # instead, so the (thin) scrollbar sits *inside* the border with the list.
+        ttk.Style.get_instance().configure("Flat.Treeview", borderwidth=0)
+
         family_size_frame = ttk.Frame(master, padding=10)
         family_size_frame.pack(fill=X, anchor=N)
         self._initial_focus = self._font_families_selector(family_size_frame)
@@ -126,22 +130,27 @@ class FontDialog(Dialog):
         )
         header.pack(fill=X, pady=(0, 2), anchor=N)
 
+        # bordered box wrapping the list + its thin scrollbar as one unit
+        listbox_frame = ttk.Frame(container, relief=SOLID, borderwidth=1)
+        listbox_frame.pack(fill=BOTH, expand=YES)
+
         listbox = ttk.Treeview(
-            master=container,
+            master=listbox_frame,
             height=5,
             show="",
             columns=[0],
+            style="Flat.Treeview",
         )
         listbox.column(0, width=utility.scale_size(listbox, 250))
 
         listbox_vbar = ttk.Scrollbar(
-            container,
+            listbox_frame,
             command=listbox.yview,
             orient=VERTICAL,
             bootstyle="thin",
         )
-        # pack the scrollbar first so it reserves the right edge inside the
-        # container; then the list fills the remaining space
+        # scrollbar first (reserves the right edge inside the border), then the
+        # list fills the rest
         listbox_vbar.pack(side=RIGHT, fill=Y)
         listbox.pack(side=LEFT, fill=BOTH, expand=YES)
         listbox.configure(yscrollcommand=listbox_vbar.set)
@@ -167,7 +176,12 @@ class FontDialog(Dialog):
         )
         header.pack(fill=X, pady=(0, 2), anchor=N)
 
-        sizes_listbox = ttk.Treeview(container, height=7, columns=[0], show="")
+        # bordered box wrapping the list + its thin scrollbar as one unit
+        sizes_frame = ttk.Frame(container, relief=SOLID, borderwidth=1)
+        sizes_frame.pack(fill=BOTH, expand=YES)
+
+        sizes_listbox = ttk.Treeview(
+            sizes_frame, height=7, columns=[0], show="", style="Flat.Treeview")
         sizes_listbox.column(0, width=utility.scale_size(sizes_listbox, 24))
 
         sizes = [*range(8, 13), *range(13, 30, 2), 36, 48, 72]
@@ -180,13 +194,13 @@ class FontDialog(Dialog):
         sizes_listbox.bind("<<TreeviewSelect>>", lambda e: self._on_select_font_size(e))
 
         sizes_listbox_vbar = ttk.Scrollbar(
-            master=container,
+            master=sizes_frame,
             orient=VERTICAL,
             command=sizes_listbox.yview,
             bootstyle="thin",
         )
         sizes_listbox.configure(yscrollcommand=sizes_listbox_vbar.set)
-        # scrollbar first (right edge), then the list fills the rest
+        # scrollbar first (right edge, inside the border), then the list
         sizes_listbox_vbar.pack(side=RIGHT, fill=Y)
         sizes_listbox.pack(side=LEFT, fill=BOTH, expand=YES)
 

--- a/src/ttkbootstrap/dialogs/fontdialog.py
+++ b/src/ttkbootstrap/dialogs/fontdialog.py
@@ -133,7 +133,6 @@ class FontDialog(Dialog):
             columns=[0],
         )
         listbox.column(0, width=utility.scale_size(listbox, 250))
-        listbox.pack(side=LEFT, fill=BOTH, expand=YES)
 
         listbox_vbar = ttk.Scrollbar(
             container,
@@ -141,7 +140,10 @@ class FontDialog(Dialog):
             orient=VERTICAL,
             bootstyle="thin",
         )
+        # pack the scrollbar first so it reserves the right edge inside the
+        # container; then the list fills the remaining space
         listbox_vbar.pack(side=RIGHT, fill=Y)
+        listbox.pack(side=LEFT, fill=BOTH, expand=YES)
         listbox.configure(yscrollcommand=listbox_vbar.set)
 
         for f in sorted(self._families):
@@ -184,8 +186,9 @@ class FontDialog(Dialog):
             bootstyle="thin",
         )
         sizes_listbox.configure(yscrollcommand=sizes_listbox_vbar.set)
-        sizes_listbox.pack(side=LEFT, fill=Y, expand=YES, anchor=N)
-        sizes_listbox_vbar.pack(side=LEFT, fill=Y, expand=YES)
+        # scrollbar first (right edge), then the list fills the rest
+        sizes_listbox_vbar.pack(side=RIGHT, fill=Y)
+        sizes_listbox.pack(side=LEFT, fill=BOTH, expand=YES)
 
     def _font_options_selectors(self, master: tkinter.Misc, padding: int) -> None:
         container = ttk.Frame(master, padding=padding)

--- a/src/ttkbootstrap/dialogs/fontdialog.py
+++ b/src/ttkbootstrap/dialogs/fontdialog.py
@@ -147,7 +147,7 @@ class FontDialog(Dialog):
             listbox_frame,
             command=listbox.yview,
             orient=VERTICAL,
-            bootstyle="round",
+            bootstyle="",
         )
         # scrollbar first (reserves the right edge inside the border), then the
         # list fills the rest
@@ -197,7 +197,7 @@ class FontDialog(Dialog):
             master=sizes_frame,
             orient=VERTICAL,
             command=sizes_listbox.yview,
-            bootstyle="round",
+            bootstyle="",
         )
         sizes_listbox.configure(yscrollcommand=sizes_listbox_vbar.set)
         # scrollbar first (right edge, inside the border), then the list

--- a/src/ttkbootstrap/dialogs/fontdialog.py
+++ b/src/ttkbootstrap/dialogs/fontdialog.py
@@ -139,7 +139,7 @@ class FontDialog(Dialog):
             container,
             command=listbox.yview,
             orient=VERTICAL,
-            bootstyle="rounded",
+            bootstyle="thin",
         )
         listbox_vbar.pack(side=RIGHT, fill=Y)
         listbox.configure(yscrollcommand=listbox_vbar.set)
@@ -181,7 +181,7 @@ class FontDialog(Dialog):
             master=container,
             orient=VERTICAL,
             command=sizes_listbox.yview,
-            bootstyle="round",
+            bootstyle="thin",
         )
         sizes_listbox.configure(yscrollcommand=sizes_listbox_vbar.set)
         sizes_listbox.pack(side=LEFT, fill=Y, expand=YES, anchor=N)

--- a/src/ttkbootstrap/dialogs/fontdialog.py
+++ b/src/ttkbootstrap/dialogs/fontdialog.py
@@ -147,7 +147,7 @@ class FontDialog(Dialog):
             listbox_frame,
             command=listbox.yview,
             orient=VERTICAL,
-            bootstyle="thin",
+            bootstyle="round",
         )
         # scrollbar first (reserves the right edge inside the border), then the
         # list fills the rest
@@ -197,7 +197,7 @@ class FontDialog(Dialog):
             master=sizes_frame,
             orient=VERTICAL,
             command=sizes_listbox.yview,
-            bootstyle="thin",
+            bootstyle="round",
         )
         sizes_listbox.configure(yscrollcommand=sizes_listbox_vbar.set)
         # scrollbar first (right edge, inside the border), then the list

--- a/src/ttkbootstrap/style/builders/button.py
+++ b/src/ttkbootstrap/style/builders/button.py
@@ -274,6 +274,68 @@ def build_link_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     builder.register_ttkstyle(ttk_style)
 
 
+@register_builder("ghost", "button")
+def build_ghost_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
+    """Create a ghost style for the ttk.Button widget.
+
+    A ghost button is transparent at rest -- no fill, no border, just its
+    (accent-colored) label -- and gains a subtle wash on hover/press: a light
+    tint of the accent for a colored ghost, or a neutral surface raise for the
+    default/neutral ghost. It sits between `link` (text-only) and `outline`
+    (bordered): more button-like than a link, quieter than an outline. Ported
+    from bootstack's ghost button.
+
+    Parameters:
+
+        builder (StyleBuilderTTK):
+            The style builder
+        colorname (str):
+            The color label used to style the widget.
+    """
+    style_class = "Ghost.TButton"
+    surface = builder.colors.bg
+
+    if colorname in (DEFAULT, "", NEUTRAL):
+        # default/neutral ghost: normal text, a neutral surface raise on hover
+        ttk_style = style_class if colorname in (DEFAULT, "") else f"{NEUTRAL}.{style_class}"
+        fg = builder.colors.fg
+        hover = neutral_fill(builder, 1)
+        pressed = neutral_fill(builder, 2)
+    else:
+        # colored ghost: accent text, a subtle wash of the accent on hover
+        ttk_style = f"{colorname}.{style_class}"
+        fg = builder.colors.get(colorname)
+        hover = builder.mute(fg, surface, 0.16)
+        pressed = builder.mute(fg, surface, 0.26)
+
+    on_disabled = builder.disabled("text")
+
+    builder.configure(
+        ttk_style,
+        foreground=fg,
+        background=surface,
+        relief=tk.FLAT,
+        # flat relief draws no border, but keep borderwidth=1 (like link) so the
+        # ghost reserves the same space and matches the solid/outline size.
+        borderwidth=1,
+        focusthickness=builder.scale_size(1),
+        focuscolor=fg,
+        padding=builder.scale_size((10, 5)),
+        anchor=tk.CENTER,
+    )
+    builder.style.map(
+        ttk_style,
+        foreground=[("disabled", on_disabled)],
+        focuscolor=[("disabled", on_disabled)],
+        background=[
+            ("disabled", surface),
+            ("pressed !disabled", pressed),
+            ("hover !disabled", hover),
+        ],
+    )
+    builder.register_ttkstyle(ttk_style)
+
+
 @register_builder("date", "button")
 def build_date_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """Create a date button style for the ttk.Button widget.

--- a/src/ttkbootstrap/style/builders/calendar.py
+++ b/src/ttkbootstrap/style/builders/calendar.py
@@ -45,11 +45,9 @@ def build_calendar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         bordercolor=builder.colors.bg,
         darkcolor=builder.colors.bg,
         lightcolor=builder.colors.bg,
-        relief=tk.RAISED,
-        focusthickness=builder.scale_size(1),
         focuscolor=builder.colors.fg,
         borderwidth=builder.scale_size(1),
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size(4),
         anchor=tk.CENTER,
     )
     layout(builder.style, ttk_style,
@@ -94,7 +92,30 @@ def build_calendar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             ("hover !disabled", on_active),
         ]
     )
-    builder.configure(chevron_style, font="-size 14")
+    # The prev/next chevrons sit on the accent-colored title bar. Style them as
+    # ghost buttons: blend into the header (no border, no fill of their own, no
+    # padding) with a subtle darken/lighten on hover/press.
+    builder.configure(
+        chevron_style,
+        font="-size 12",
+        foreground=builder.on_color(accent),
+        focuscolor='',
+        background=accent,
+        relief=tk.FLAT,
+        padding=builder.scale_size(4),
+        anchor=tk.CENTER,
+    )
+    chevron_states = [
+        ("pressed !disabled", pressed),
+        ("hover !disabled", active),
+    ]
+    builder.style.map(
+        chevron_style,
+        background=chevron_states,
+        bordercolor=chevron_states,
+        darkcolor=chevron_states,
+        lightcolor=chevron_states,
+    )
 
     # register ttk_style
     builder.register_ttkstyle(ttk_style)

--- a/src/ttkbootstrap/style/builders/combobox.py
+++ b/src/ttkbootstrap/style/builders/combobox.py
@@ -102,7 +102,8 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
                    El("Combobox.textarea", sticky=tk.NSEW)])]))
     builder.register_ttkstyle(ttk_style)
     try:
-        builder.build_style("default", "scrollbar", DEFAULT, required=True)
+        # the popdown uses the thin scrollbar (a scroll indicator in a small space)
+        builder.build_style("thin", "scrollbar", DEFAULT, required=True)
     except Exception:
         # style already created
         pass
@@ -141,6 +142,8 @@ def update_combobox_popdown_style(builder: StyleBuilderTTK, widget):
     popdown = widget.tk.eval(f"ttk::combobox::PopdownWindow {widget}")
     widget.tk.call(f"{popdown}.f.l", "configure", *tk_settings)
 
-    # set scrollbar style
-    sb_style = "TCombobox.Vertical.TScrollbar"
+    # set scrollbar style -- the thin bar suits the narrow popdown
+    sb_style = "Thin.Vertical.TScrollbar"
+    if not builder.style.style_exists_in_theme(sb_style):
+        builder.build_style("thin", "scrollbar", DEFAULT, required=True)
     widget.tk.call(f"{popdown}.f.sb", "configure", "-style", sb_style)

--- a/src/ttkbootstrap/style/builders/scrollbar.py
+++ b/src/ttkbootstrap/style/builders/scrollbar.py
@@ -11,6 +11,122 @@ from ttkbootstrap.style.builders.registry import register_builder
 # A few-pixel thumb for the 'thin' variant -- suits narrow lists/dropdowns.
 _THIN_SCROLLBAR_THICKNESS = 4
 
+# The standard scrollbar thumb thickness (square + round variants).
+_SCROLLBAR_THICKNESS = 8
+
+
+def _scrollbar_trough(builder):
+    """A subtle, visible track color for the scrollbar trough.
+
+    2.0 originally left the trough = surface (invisible), so the thumb floated
+    with no track. This gives it a faint recessed channel -- a touch off the
+    surface in either mode -- so the bar reads as a real scrollbar (the 1.0 look).
+    """
+    bg = builder.colors.bg
+    return builder.shade(bg, 0.05) if builder.is_light_theme else builder.tint(bg, 0.05)
+
+
+def _scrollbar_thumb_color(builder, colorname):
+    """The default (neutral) thumb color, or the accent when a color is given."""
+    if colorname in (DEFAULT, ""):
+        return builder.colors.border if builder.is_light_theme else builder.colors.selectbg
+    return builder.colors.get(colorname)
+
+
+# Trough margin (logical px) left on each side of the thumb, so the visible
+# trough shows around it. Baked into the thumb image (a transparent margin) --
+# ttk's trough borderwidth doesn't reliably inset an image thumb.
+_SCROLLBAR_THUMB_INSET = 1
+_SCROLLBAR_MIN_THUMB = 16  # minimum thumb length (logical) so it stays grabbable
+
+
+def _scrollbar_thumb(builder, color, orient, rounded):
+    """A thumb image with a transparent cross-axis margin, so the trough shows
+    around it. Returns (image_name, border) for `image_element`.
+
+    Square thumbs are a solid rect that stretches uniformly (border 0); round
+    thumbs are a capped pill 9-sliced along the length so the caps don't
+    distort when the thumb stretches.
+    """
+    a = builder.assets
+    inset = _SCROLLBAR_THUMB_INSET
+    t = _SCROLLBAR_THICKNESS
+    cross = 0 if orient == "vertical" else 1  # x for vertical, y for horizontal
+
+    def draw(d, w, h):
+        dims = (w, h)
+        margin = round(dims[cross] * inset / t)
+        box = [0, 0, w - 1, h - 1]
+        box[cross] += margin
+        box[cross + 2] -= margin
+        if rounded:
+            radius = round((dims[cross] - 2 * margin) / 2)
+            d.rounded_rectangle(box, radius=radius, fill=color)
+        else:
+            d.rectangle(box, fill=color)
+
+    # A 9-slice border sets the *minimum* thumb length -- its fixed end regions
+    # can't shrink -- so a long list (e.g. the font family picker) can't squash
+    # the thumb to a microscopic sliver. For the round thumb those end regions
+    # also hold the rounded caps.
+    cap = builder.scale_size(_SCROLLBAR_MIN_THUMB // 2)
+    length = _SCROLLBAR_MIN_THUMB + 1
+    if orient == "vertical":
+        size = (t, length)
+        border = (0, cap)
+    else:
+        size = (length, t)
+        border = (cap, 0)
+    return a.image(size, draw, "scrollbar-thumb", color, orient, rounded), border
+
+
+def _build_scrollbar(builder: StyleBuilderTTK, colorname, rounded):
+    """Build the horizontal + vertical scrollbar styles (square or round).
+
+    A subtle visible trough (every region shares the trough color, so the whole
+    widget reads as one track) with an inset thumb, no arrows.
+    """
+    ttk_class = "TScrollbar"
+    prefix = "Round." if rounded else ""
+    trough = _scrollbar_trough(builder)
+    thumb = _scrollbar_thumb_color(builder, colorname)
+    pressed = builder.pressed(thumb)
+    active = builder.active(thumb)
+
+    if colorname in (DEFAULT, ""):
+        base = prefix
+    else:
+        base = f"{colorname}.{prefix}"
+
+    for orient, sticky, trough_el in (
+        ("horizontal", "we", "Horizontal.Scrollbar.trough"),
+        ("vertical", "ns", "Vertical.Scrollbar.trough"),
+    ):
+        axis = "Horizontal" if orient == "horizontal" else "Vertical"
+        ttk_style = f"{base}{axis}.{ttk_class}"
+        builder.configure(
+            ttk_style,
+            troughcolor=trough,
+            bordercolor=trough,
+            background=trough,
+            darkcolor=trough,
+            lightcolor=trough,
+            relief=tk.FLAT,
+            borderwidth=0,
+            arrowsize=0,
+        )
+        normal, border = _scrollbar_thumb(builder, thumb, orient, rounded)
+        pressed_img, _ = _scrollbar_thumb(builder, pressed, orient, rounded)
+        active_img, _ = _scrollbar_thumb(builder, active, orient, rounded)
+        image_element(
+            builder.style, f"{ttk_style}.thumb", default=normal,
+            states={"pressed": pressed_img, "active": active_img},
+            border=border, sticky=sticky)
+        layout(builder.style, ttk_style,
+               El(trough_el, sticky=sticky, children=[
+                   El(f"{ttk_style}.thumb", expand="1", sticky=sticky)]))
+        builder.register_ttkstyle(ttk_style)
+
 
 @register_builder("thin", "scrollbar")
 def build_thin_scrollbar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
@@ -68,7 +184,7 @@ def build_thin_scrollbar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         border=0, sticky="ew")
     layout(builder.style, h_ttk_style,
            El("Horizontal.Scrollbar.trough", sticky="we", children=[
-               El(f"{h_ttk_style}.thumb", expand="1", sticky="ew")]))
+               El(f"{h_ttk_style}.thumb", expand="1", sticky="we")]))
 
     # vertical
     _configure(v_ttk_style)
@@ -86,25 +202,6 @@ def build_thin_scrollbar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     builder.register_ttkstyle(v_ttk_style)
 
 
-def _create_round_scrollbar_assets(builder, thumb_color, pressed, active):
-    """Create image assets to be used when building the round
-    scrollbar style.
-
-    Parameters:
-
-        thumb_color (str):
-            The color value of the thumb in normal state.
-
-        pressed (str):
-            The color value to use when the thumb is pressed.
-
-        active (str):
-            The color value to use when the thumb is active or
-            hovered.
-    """
-    return _create_scrollbar_assets(builder, thumb_color, pressed, active)
-
-
 @register_builder("round", "scrollbar")
 def build_round_scrollbar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """Create a round style for the ttk.Scrollbar widget.
@@ -116,99 +213,7 @@ def build_round_scrollbar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    ttk_class = "TScrollbar"
-
-    if any([colorname == DEFAULT, colorname == ""]):
-        h_ttk_style = f"Round.Horizontal.{ttk_class}"
-        v_ttk_style = f"Round.Vertical.{ttk_class}"
-
-        if builder.is_light_theme:
-            background = builder.colors.border
-        else:
-            background = builder.colors.selectbg
-
-    else:
-        h_ttk_style = f"{colorname}.Round.Horizontal.{ttk_class}"
-        v_ttk_style = f"{colorname}.Round.Vertical.{ttk_class}"
-        background = builder.colors.get(colorname)
-
-    pressed = builder.pressed(background)
-    active = builder.active(background)
-
-    scroll_images = _create_round_scrollbar_assets(builder, background, pressed, active)
-
-    # horizontal scrollbar
-    builder.configure(
-        h_ttk_style,
-        troughcolor=builder.colors.bg,
-        darkcolor=builder.colors.bg,
-        bordercolor=builder.colors.bg,
-        lightcolor=builder.colors.bg,
-        background=builder.colors.bg,
-        relief=tk.FLAT,
-        borderwidth=0,
-    )
-    image_element(
-        builder.style, f"{h_ttk_style}.thumb", default=scroll_images[0].image,
-        states={"pressed": scroll_images[1].image,
-                "active": scroll_images[2].image},
-        border=scroll_images[0].meta.border,
-        padding=scroll_images[0].meta.padding)
-    layout(builder.style, h_ttk_style,
-           El("Horizontal.Scrollbar.trough", sticky="we", children=[
-               El(f"{h_ttk_style}.thumb", expand="1", sticky="we")]))
-
-    # vertical scrollbar
-    builder.configure(
-        v_ttk_style,
-        troughcolor=builder.colors.bg,
-        darkcolor=builder.colors.bg,
-        bordercolor=builder.colors.bg,
-        lightcolor=builder.colors.bg,
-        background=builder.colors.bg,
-        relief=tk.FLAT,
-    )
-    image_element(
-        builder.style, f"{v_ttk_style}.thumb", default=scroll_images[3].image,
-        states={"pressed": scroll_images[4].image,
-                "active": scroll_images[5].image},
-        border=scroll_images[3].meta.border,
-        padding=scroll_images[3].meta.padding)
-    layout(builder.style, v_ttk_style,
-           El("Vertical.Scrollbar.trough", sticky="ns", children=[
-               El(f"{v_ttk_style}.thumb", expand="1", sticky="ns")]))
-
-    # register ttk styles
-    builder.register_ttkstyle(h_ttk_style)
-    builder.register_ttkstyle(v_ttk_style)
-
-
-def _create_scrollbar_assets(builder: StyleBuilderTTK, thumb_color, pressed, active):
-    """Create the image assets used to build the standard scrollbar
-    style.
-
-    Parameters:
-        builder (StyleBuilderTTK):
-            The style builder.
-
-        thumb_color (str):
-            The primary color value used to color the thumb.
-
-        pressed (str):
-            The color value to use when the thumb is pressed.
-
-        active (str):
-            The color value to use when the thumb is active or
-            hovered.
-    """
-    a = builder.assets
-    h_normal = a.recolor("scrollbar_thumb", white=thumb_color, black=thumb_color)
-    h_pressed = a.recolor("scrollbar_thumb", white=pressed, black=pressed)
-    h_active = a.recolor("scrollbar_thumb", white=active, black=active)
-    v_normal = a.recolor("scrollbar_thumb", white=thumb_color, black=thumb_color, transform="rotate-90")
-    v_pressed = a.recolor("scrollbar_thumb", white=pressed, black=pressed, transform="rotate-90")
-    v_active = a.recolor("scrollbar_thumb", white=active, black=active, transform="rotate-90")
-    return h_normal, h_pressed, h_active, v_normal, v_pressed, v_active
+    _build_scrollbar(builder, colorname, rounded=True)
 
 
 @register_builder("default", "scrollbar")
@@ -222,74 +227,4 @@ def build_scrollbar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    ttk_class = "TScrollbar"
-
-    if any([colorname == DEFAULT, colorname == ""]):
-        h_ttk_style = f"Horizontal.{ttk_class}"
-        v_ttk_style = f"Vertical.{ttk_class}"
-
-        if builder.is_light_theme:
-            background = builder.colors.border
-        else:
-            background = builder.colors.selectbg
-
-    else:
-        h_ttk_style = f"{colorname}.Horizontal.{ttk_class}"
-        v_ttk_style = f"{colorname}.Vertical.{ttk_class}"
-        background = builder.colors.get(colorname)
-
-    pressed = builder.pressed(background)
-    active = builder.active(background)
-
-    scroll_images = _create_scrollbar_assets(builder,
-        background, pressed, active
-    )
-    # horizontal scrollbar
-    builder.configure(
-        h_ttk_style,
-        troughcolor=builder.colors.bg,
-        darkcolor=builder.colors.bg,
-        bordercolor=builder.colors.bg,
-        lightcolor=builder.colors.bg,
-        arrowcolor=background,
-        arrowsize=builder.scale_size(11),
-        background=builder.colors.bg,
-        relief=tk.FLAT,
-        borderwidth=0,
-    )
-    image_element(
-        builder.style, f"{h_ttk_style}.thumb", default=scroll_images[0].image,
-        states={"pressed": scroll_images[1].image,
-                "active": scroll_images[2].image},
-        border=scroll_images[0].meta.border,
-        padding=scroll_images[0].meta.padding)
-    layout(builder.style, h_ttk_style,
-           El("Horizontal.Scrollbar.trough", sticky="we", children=[
-               El(f"{h_ttk_style}.thumb", expand="1", sticky="we")]))
-
-    # vertical scrollbar
-    builder.configure(
-        v_ttk_style,
-        troughcolor=builder.colors.bg,
-        darkcolor=builder.colors.bg,
-        bordercolor=builder.colors.bg,
-        lightcolor=builder.colors.bg,
-        arrowcolor=background,
-        arrowsize=builder.scale_size(11),
-        background=builder.colors.bg,
-        relief=tk.FLAT,
-        borderwidth=0,
-    )
-    image_element(
-        builder.style, f"{v_ttk_style}.thumb", default=scroll_images[3].image,
-        states={"pressed": scroll_images[4].image,
-                "active": scroll_images[5].image},
-        border=scroll_images[3].meta.border,
-        padding=scroll_images[3].meta.padding)
-    layout(builder.style, v_ttk_style,
-           El("Vertical.Scrollbar.trough", sticky="ns", children=[
-               El(f"{v_ttk_style}.thumb", expand="1", sticky="ns")]))
-
-    # register ttk_styles
-    builder.register_ttkstyle(h_ttk_style)
-    builder.register_ttkstyle(v_ttk_style)
+    _build_scrollbar(builder, colorname, rounded=False)

--- a/src/ttkbootstrap/style/builders/scrollbar.py
+++ b/src/ttkbootstrap/style/builders/scrollbar.py
@@ -8,6 +8,84 @@ from ttkbootstrap.style.layout import El, image_element, layout
 from ttkbootstrap.style.builders.registry import register_builder
 
 
+# A few-pixel thumb for the 'thin' variant -- suits narrow lists/dropdowns.
+_THIN_SCROLLBAR_THICKNESS = 4
+
+
+@register_builder("thin", "scrollbar")
+def build_thin_scrollbar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
+    """Create a thin scrollbar style for the ttk.Scrollbar widget.
+
+    A few-pixel flat thumb on a surface-matched track, no arrows -- for narrow
+    lists and dropdowns where the bar is more a scroll *indicator* than a drag
+    handle (combobox popdown, font picker, ...). The thumb is neutral (the
+    surface border color) by default, or the accent when a color is given, and
+    darkens/lightens on hover/press. Ported from bootstack (mechanism, not API):
+    a solid box thumb via the `rect` toolkit rather than a rounded PNG.
+
+    Parameters:
+
+        builder (StyleBuilderTTK):
+            The style builder
+        colorname (str):
+            The color label used to style the widget.
+    """
+    ttk_class = "TScrollbar"
+    surface = builder.colors.bg
+
+    if any([colorname == DEFAULT, colorname == ""]):
+        h_ttk_style = f"Thin.Horizontal.{ttk_class}"
+        v_ttk_style = f"Thin.Vertical.{ttk_class}"
+        thumb = builder.border(surface)  # neutral by default
+    else:
+        h_ttk_style = f"{colorname}.Thin.Horizontal.{ttk_class}"
+        v_ttk_style = f"{colorname}.Thin.Vertical.{ttk_class}"
+        thumb = builder.colors.get(colorname)
+
+    active = builder.active(thumb)
+    pressed = builder.pressed(thumb)
+    a = builder.assets
+    t = _THIN_SCROLLBAR_THICKNESS
+
+    def _configure(ttk_style):
+        builder.configure(
+            ttk_style,
+            troughcolor=surface,
+            bordercolor=surface,
+            background=surface,
+            relief=tk.FLAT,
+            borderwidth=0,
+            arrowsize=0,
+        )
+
+    # horizontal: a `t`-px-thick sliver that stretches along the track (EW)
+    _configure(h_ttk_style)
+    image_element(
+        builder.style, f"{h_ttk_style}.thumb",
+        default=a.rect(thumb, (8, t)),
+        states={"pressed": a.rect(pressed, (8, t)),
+                "active": a.rect(active, (8, t))},
+        border=0, sticky="ew")
+    layout(builder.style, h_ttk_style,
+           El("Horizontal.Scrollbar.trough", sticky="we", children=[
+               El(f"{h_ttk_style}.thumb", expand="1", sticky="ew")]))
+
+    # vertical
+    _configure(v_ttk_style)
+    image_element(
+        builder.style, f"{v_ttk_style}.thumb",
+        default=a.rect(thumb, (t, 8)),
+        states={"pressed": a.rect(pressed, (t, 8)),
+                "active": a.rect(active, (t, 8))},
+        border=0, sticky="ns")
+    layout(builder.style, v_ttk_style,
+           El("Vertical.Scrollbar.trough", sticky="ns", children=[
+               El(f"{v_ttk_style}.thumb", expand="1", sticky="ns")]))
+
+    builder.register_ttkstyle(h_ttk_style)
+    builder.register_ttkstyle(v_ttk_style)
+
+
 def _create_round_scrollbar_assets(builder, thumb_color, pressed, active):
     """Create image assets to be used when building the round
     scrollbar style.

--- a/tests/widget_styles/test_builder_registry.py
+++ b/tests/widget_styles/test_builder_registry.py
@@ -20,6 +20,7 @@ from ttkbootstrap.style.builders.registry import (
 EXPECTED_KEYS = {
     ("date", "button"),
     ("default", "button"),
+    ("ghost", "button"),
     ("default", "calendar"),
     ("default", "checkbutton"),
     ("default", "combobox"),

--- a/tests/widget_styles/test_builder_registry.py
+++ b/tests/widget_styles/test_builder_registry.py
@@ -50,6 +50,7 @@ EXPECTED_KEYS = {
     ("outline", "menubutton"),
     ("outline", "toolbutton"),
     ("round", "scrollbar"),
+    ("thin", "scrollbar"),
     ("round", "toggle"),
     ("square", "toggle"),
     ("striped", "progressbar"),

--- a/tests/widget_styles/test_button_family.py
+++ b/tests/widget_styles/test_button_family.py
@@ -34,6 +34,32 @@ def test_toggle_variants_all_build(root):
         assert root.style.style_exists_in_theme(expected)
 
 
+def test_ghost_button_is_transparent_with_accent_text(root):
+    """A colored ghost button is borderless, surface-filled, accent-texted, and
+    washes subtly on hover."""
+    style = root.style
+    ttk.Button(root, bootstyle="primary-ghost")
+    root.update_idletasks()
+    st = "primary.Ghost.TButton"
+    # flat relief => no visible border (borderwidth is kept at 1 only to match the
+    # solid/outline size; nothing is drawn)
+    assert _lookup(root, st, "relief") == "flat"
+    assert _lookup(root, st, "foreground") == str(style.colors.primary).lower()
+    assert _lookup(root, st, "background") == str(style.colors.bg).lower()
+    # hover wash is a subtle tint of the accent, distinct from both fg and surface
+    hover = {tuple(i[:-1]): str(i[-1]).lower() for i in style.map(st, "background")}
+    wash = hover[("hover", "!disabled")]
+    assert wash not in (str(style.colors.bg).lower(), str(style.colors.primary).lower())
+
+
+def test_ghost_is_a_canonical_bootstyle():
+    import typing
+    from ttkbootstrap.constants import BootStyle
+    canonical = set(typing.get_args(BootStyle))
+    assert "ghost" in canonical
+    assert "primary-ghost" in canonical
+
+
 def test_date_button_has_hairline_border(root):
     """DateEntry's button gets the same fill-derived border as other buttons."""
     style = root.style

--- a/tests/widget_styles/test_recolor_assets.py
+++ b/tests/widget_styles/test_recolor_assets.py
@@ -124,14 +124,13 @@ def test_scrollbar_layout_stretches_only_along_orientation(root, bootstyle):
     assert v_thumb_options["sticky"] == "ns"
     assert h_layout[0][0] == "Horizontal.Scrollbar.trough"
     assert v_layout[0][0] == "Vertical.Scrollbar.trough"
-    assert root.style.lookup(
-        horizontal.cget("style"), "background") == root.style.colors.bg
-    assert root.style.lookup(
-        vertical.cget("style"), "background") == root.style.colors.bg
-    assert root.style.lookup(
-        horizontal.cget("style"), "troughcolor") == root.style.colors.bg
-    assert root.style.lookup(
-        vertical.cget("style"), "troughcolor") == root.style.colors.bg
+    # the trough is now a subtle *visible* track (2.0 restyle), and every region
+    # is that trough color so the whole widget reads as one track
+    from ttkbootstrap.style.builders.scrollbar import _scrollbar_trough
+    trough = _scrollbar_trough(root.style._get_builder())
+    for sb in (horizontal, vertical):
+        assert root.style.lookup(sb.cget("style"), "troughcolor") == trough
+        assert root.style.lookup(sb.cget("style"), "background") == trough
 
 
 def test_element_assets_are_packaged_next_to_style_module():

--- a/tests/widget_styles/test_scrollbar.py
+++ b/tests/widget_styles/test_scrollbar.py
@@ -1,0 +1,33 @@
+"""Tests for the thin scrollbar variant (2.0).
+
+A thin scrollbar is a few-pixel flat thumb on a surface-matched track with no
+arrows -- for narrow lists/dropdowns (combobox popdown, font dialog). Neutral by
+default, or the accent when a color is given. See
+`development/2_0_breaking_changes.md`.
+"""
+import ttkbootstrap as ttk
+
+
+def _lookup(app, style, option):
+    return str(app.tk.call("ttk::style", "lookup", style, f"-{option}")).lower()
+
+
+def test_thin_scrollbar_builds_arrowless_on_the_surface(root):
+    """`bootstyle="thin"` builds a vertical + horizontal arrowless scrollbar
+    whose track matches the surface."""
+    style = root.style
+    ttk.Scrollbar(root, orient="vertical", bootstyle="thin")
+    ttk.Scrollbar(root, orient="horizontal", bootstyle="thin")
+    root.update_idletasks()
+    for st in ("Thin.Vertical.TScrollbar", "Thin.Horizontal.TScrollbar"):
+        assert style.style_exists_in_theme(st)
+        assert _lookup(root, st, "arrowsize") in ("0", "")
+        assert _lookup(root, st, "troughcolor") == str(style.colors.bg).lower()
+
+
+def test_thin_scrollbar_accepts_a_color(root):
+    """A colored thin scrollbar builds its own style."""
+    style = root.style
+    ttk.Scrollbar(root, orient="vertical", bootstyle="primary-thin")
+    root.update_idletasks()
+    assert style.style_exists_in_theme("primary.Thin.Vertical.TScrollbar")


### PR DESCRIPTION
Three button/dialog follow-ups.

## Fix datepicker selected-day disabled look *(regression fix)*

The selected day is a `Radiobutton` styled `secondary-toolbutton`, but `datevar` was an `IntVar()` **never `.set()`**, so no day was ever in the ttk `selected` state. The old toolbutton OFF look (a solid gray fill) masked this; after the 2.0 toolbutton on/off restyle (#1096: OFF = quiet surface + muted text) the selected day read as a **disabled button**. Fix: set `datevar` to the selected day so its toolbutton renders the ON (accent) look.

## `ghost` button variant *(new)*

A ghost button is **transparent at rest** (no fill, no border, just its label) and gains a **subtle wash** on hover/press — a light tint of the accent for a colored ghost (`primary-ghost`), a neutral surface raise for the default/neutral ghost. Fills the gap between `link` (text-only) and `outline` (bordered). Ported from bootstack. Button family only.

- New `ghost` modifier in the vocab; regenerated `BootStyle` Literal + reference (adds `ghost`, `{color}-ghost`, `neutral-ghost`).
- `build_ghost_button_style`; ghost frame added to the button demo.
- `borderwidth=1` (flat relief, so nothing is drawn) so ghost matches the solid/outline/link size.

## Demo refresh *(assumes #1098)*

Drop the now-redundant explicit `neutral` column from the button demo; give the calculator operators the neutral default. Pairs with the neutral-default change (#1098) — if this lands first, those demo buttons render primary until #1098 merges.

## Tests / gates

New button-family tests (ghost is transparent/accent-texted/washes + canonical; registry frozen-set updated); the datepicker fix verified (selected day enters the `selected` state). Suite **280 passed** + the known `nl.msg` env flake; warning-free import. Recorded in `2_0_breaking_changes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)