### PR TITLE
Refine input indicators: constant-color arrows, padding, striped trough

### DIFF
--- a/src/ttkbootstrap/style/builders/combobox.py
+++ b/src/ttkbootstrap/style/builders/combobox.py
@@ -6,7 +6,6 @@ from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, image_element, layout
 from ttkbootstrap.style.builders.registry import register_builder
-from ttkbootstrap.style.builders.utils import simple_arrow_assets
 
 
 @register_builder("default", "combobox")
@@ -36,23 +35,16 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         element = f"{ttk_style.replace('TC', 'C')}"
         focus_ring = builder.colors.get(colorname)
 
-    # Create custom arrow assets since the default ones don't work with Tcl/Tk bundled in python 3.13
-    arrow_images = simple_arrow_assets(builder,
-        builder.colors.inputfg,
-        on_disabled,
-        focus_ring,
-    )
-    down_arrow_image = arrow_images[0][1]
-    down_arrow_disabled_image = arrow_images[1][1]
-    down_arrow_focused_image = arrow_images[2][1]
+    # A `chevron-down` glyph (the open V) rather than the solid `caret-down-fill`
+    # triangle used elsewhere -- reads lighter in a combobox. Custom asset since
+    # the native ttk arrow doesn't work with the Tcl/Tk bundled in python 3.13.
+    a = builder.assets
+    chevron_size = [12, 12]
+    # One fixed color in every state (no focus/hover/pressed/disabled recolor) so
+    # the chevron reads as a steady glyph rather than reacting to field state.
+    down_arrow_image = a.icon("chevron-down", chevron_size, builder.colors.inputfg)
     image_element(
-        builder.style, f"{element}.downarrow", default=down_arrow_image,
-        states={"disabled": down_arrow_disabled_image,
-                "pressed !disabled": down_arrow_focused_image,
-                "focus !disabled": down_arrow_focused_image,
-                "hover !disabled": down_arrow_focused_image},
-        # right padding so the caret isn't flush against the border
-        padding=(0, 0, builder.scale_size(6), 0))
+        builder.style, f"{element}.downarrow", default=down_arrow_image)
     #  builder.style.element_create(f"{element}.downarrow", "from", TTK_DEFAULT)  # doesn't work in python 3.13
     builder.style.element_create(f"{element}.padding", "from", TTK_CLAM)
     builder.style.element_create(f"{element}.textarea", "from", TTK_CLAM)
@@ -70,7 +62,9 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         background=builder.colors.inputbg,
         insertcolor=builder.colors.inputfg,
         relief=tk.FLAT,
-        padding=builder.scale_size(5),
+        # (left, top, right, bottom): extra right inset holds the chevron a bit
+        # further off the border than the text is on the left.
+        padding=builder.scale_size((5, 6, 7, 4)),
     )
     builder.style.map(
         ttk_style,
@@ -95,10 +89,13 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             ("readonly", readonly),
         ],
     )
+    # Lay the chevron out like the Menubutton indicator: inside the padded
+    # region, packed right and vertically centered (sticky="") so the widget
+    # padding holds it off the border instead of it being pinned bottom-right.
     layout(builder.style, ttk_style,
            El("combo.Spinbox.field", side=tk.TOP, sticky=tk.EW, children=[
-               El("Combobox.downarrow", side=tk.RIGHT, sticky=tk.S),
                El("Combobox.padding", expand="1", sticky=tk.NSEW, children=[
+                   El("Combobox.downarrow", side=tk.RIGHT, sticky=""),
                    El("Combobox.textarea", sticky=tk.NSEW)])]))
     builder.register_ttkstyle(ttk_style)
     try:

--- a/src/ttkbootstrap/style/builders/menubutton.py
+++ b/src/ttkbootstrap/style/builders/menubutton.py
@@ -66,7 +66,9 @@ def build_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=0,
         focuscolor=foreground,
-        padding=builder.scale_size((10, 5)),
+        # (left, top, right, bottom): 10px label inset on the left, a tighter
+        # 6px on the right so the caret sits closer to the edge than the label.
+        padding=builder.scale_size((10, 5, 6, 5)),
     )
     builder.style.map(
         ttk_style,
@@ -101,12 +103,16 @@ def _build_menubutton_arrow(builder: StyleBuilderTTK, ttk_style, normal, disable
         states={"disabled": down_disabled,
                 "pressed !disabled": down_active,
                 "hover !disabled": down_active},
-        sticky="", padding=(0, 0, builder.scale_size(10), 0))
+        sticky="")
+    # Keep the indicator *inside* `Menubutton.padding` so the configured widget
+    # padding (see `padding=` in configure) holds the caret off the right edge.
+    # clam's image element ignores an outer `-padding` on the element itself, so
+    # placing it outside padding left the caret flush against the border.
     layout(builder.style, ttk_style,
            El("Menubutton.border", sticky=NSEW, children=[
             El("Menubutton.focus", sticky=NSEW, children=[
-                El(f"{ttk_style}.indicator", side=tk.RIGHT, sticky=""),
-                El("Menubutton.padding", sticky=tk.EW, children=[
+                El("Menubutton.padding", sticky=NSEW, children=[
+                    El(f"{ttk_style}.indicator", side=tk.RIGHT, sticky=""),
                     El("Menubutton.label", side=LEFT, sticky="")])])]))
 
 
@@ -143,7 +149,7 @@ def _build_neutral_outline_menubutton(builder: StyleBuilderTTK, ttk_class, disab
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=0,
         focuscolor=fg,
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 5, 6, 5)),
     )
     builder.style.map(
         ttk_style,
@@ -200,7 +206,7 @@ def build_outline_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=0,
         focuscolor=foreground,
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 5, 6, 5)),
     )
     builder.style.map(
         ttk_style,

--- a/src/ttkbootstrap/style/builders/progressbar.py
+++ b/src/ttkbootstrap/style/builders/progressbar.py
@@ -85,6 +85,11 @@ def build_striped_progressbar_style(builder: StyleBuilderTTK, colorname=DEFAULT)
 
     # horizontal progressbar
     h_element = h_ttk_style.replace(".TP", ".P")
+    # A flat clam trough. Without our own trough element, the layout's
+    # `{h_element}.trough` name falls back (via ttk's dotted-name resolution) to
+    # the solid progressbar's *rounded* image trough; create a flat clam trough
+    # so the square striped bar sits in a square channel.
+    builder.style.element_create(f"{h_element}.trough", "from", TTK_CLAM)
     builder.style.element_create(
         f"{h_element}.pbar",
         "image",
@@ -105,6 +110,7 @@ def build_striped_progressbar_style(builder: StyleBuilderTTK, colorname=DEFAULT)
 
     # vertical progressbar
     v_element = v_ttk_style.replace(".TP", ".P")
+    builder.style.element_create(f"{v_element}.trough", "from", TTK_CLAM)
     builder.style.element_create(
         f"{v_element}.pbar",
         "image",

--- a/src/ttkbootstrap/style/builders/spinbox.py
+++ b/src/ttkbootstrap/style/builders/spinbox.py
@@ -6,7 +6,6 @@ from ttkbootstrap.constants import *
 from ttkbootstrap.style import StyleBuilderTTK
 from ttkbootstrap.style.layout import El, image_element, layout
 from ttkbootstrap.style.builders.registry import register_builder
-from ttkbootstrap.style.builders.utils import simple_arrow_assets
 
 
 @register_builder("default", "spinbox")
@@ -37,36 +36,30 @@ def build_spinbox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     if all([colorname, colorname != DEFAULT]):
         border_color = focus_color
 
-    if colorname == "light":
-        arrow_focus = builder.colors.fg
-    else:
-        arrow_focus = focus_color
-
     element = ttk_style.replace(".TS", ".S")
-    arrow_images = simple_arrow_assets(builder, builder.colors.inputfg, disabled_fg, arrow_focus, y_offset=2)
-    up_arrow_image = arrow_images[0][0]
-    up_arrow_disabled_image = arrow_images[1][0]
-    up_arrow_focus_image = arrow_images[2][0]
-    down_arrow_image = arrow_images[0][1]
-    down_arrow_disabled_image = arrow_images[1][1]
-    down_arrow_focus_image = arrow_images[2][1]
+    # The carets keep one fixed color in every state (no focus/hover/pressed/
+    # disabled recolor) so they read as steady glyphs rather than reacting to
+    # field state.
+    a = builder.assets
+    arrow_size = [12, 10]
+    up_arrow_image = a.icon("caret-up-fill", arrow_size, builder.colors.inputfg)
+    down_arrow_image = a.icon("caret-down-fill", arrow_size, builder.colors.inputfg)
 
-    # right padding so the carets aren't flush against the border
-    arrow_pad = (0, 0, builder.scale_size(6), 0)
+    image_element(builder.style, f"{element}.uparrow", default=up_arrow_image)
+    image_element(builder.style, f"{element}.downarrow", default=down_arrow_image)
+
+    # A transparent spacer pinned to the right edge so the carets aren't flush
+    # against the border. clam ignores an outer `-padding` on a packed image
+    # element (the arrows sit outside the field's padded region), so the gap has
+    # to be a real element rather than element padding.
+    gap = builder.scale_size(3) or 1
     image_element(
-        builder.style, f"{element}.uparrow", default=up_arrow_image,
-        states={"disabled": up_arrow_disabled_image,
-                "pressed !disabled": up_arrow_focus_image,
-                "hover !disabled": up_arrow_focus_image},
-        padding=arrow_pad)
-    image_element(
-        builder.style, f"{element}.downarrow", default=down_arrow_image,
-        states={"disabled": down_arrow_disabled_image,
-                "pressed !disabled": down_arrow_focus_image,
-                "hover !disabled": down_arrow_focus_image},
-        padding=arrow_pad)
+        builder.style, f"{element}.arrowgap",
+        default=builder.assets.image((gap, 1), lambda *_: None, "spinbox-arrowgap"),
+        sticky=tk.NS)
     layout(builder.style, ttk_style,
            El(f"{element}.field", side=tk.TOP, sticky=tk.EW, children=[
+               El(f"{element}.arrowgap", side=tk.RIGHT, sticky=tk.NS),
                El("null", side=tk.RIGHT, sticky="", children=[
                    El(f"{element}.uparrow", side=tk.TOP, sticky=tk.E),
                    El(f"{element}.downarrow", side=tk.BOTTOM, sticky=tk.E)]),


### PR DESCRIPTION
A small visual-polish pass on the ttk input/indicator glyphs, settled via a live light↔dark spot-check. No API changes; appearance only.

## Changes

**Menubutton** — the caret was packed to the right *outside* `Menubutton.padding`, relying on an outer `-padding` on the image element that clam ignores, so it sat flush against the border. Moved it *inside* the padded region and switched to asymmetric `(10, 5, 6, 5)` padding — the honored widget padding now holds the caret ~6px off the right edge while the label keeps its 10px left inset.

**Combobox** — swapped the solid `caret-down-fill` for a lighter `chevron-down` glyph, laid out like the menubutton indicator (inside the padded region, vertically centered rather than pinned bottom-right). Renders one fixed color in every state (no focus/hover/pressed recolor).

**Spinbox** — the up/down carets now render at one fixed color in every state instead of recoloring to the accent on focus/hover/press (and greying on disabled). The right-edge gap is now a real transparent spacer element rather than the ignored image-element padding.

**Striped progressbar** — gave it its own flat clam trough element. Without one, the layout's trough name fell back (via ttk's dotted-name resolution) to the *solid* progressbar's rounded image trough, so the square striped bar rendered in a rounded channel. Now it sits in a square channel.

## Notes
- The spinbox/combobox arrows are now fully constant color **including disabled** — matches "same color regardless of state." Easy to restore disabled-grey as the one exception if wanted.
- Branched off `2.0` (independent of the still-open #1099).

## Testing
Full headless suite: **280 passed**. All widget-style builders construct in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)