### PR TITLE
Normalize dialog API (shipped-widget API pass, PR A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,21 @@ opt-out (#1098), a `ghost` button variant + `thin` scrollbar + full scrollbar
 restyle + datepicker/font-dialog fixes (#1099), and the input-indicator refinements
 (#1100 — menubutton/combobox/spinbox arrow glyphs, padding, constant-color arrows,
 striped-progressbar flat trough). Expected suite on `2.0` ~283 (excl. the known
-`nl.msg` localization env flake). **Current → docs sub-PR #1** (nav/IA skeleton +
-un-break the 7 broken API `:::` stubs + `inherited_members: false`); sub-PR
-sequence in `development/2_0_docs_design.md` §11.
+`nl.msg` localization env flake). **The deferred shipped-widget API-normalization
+pass (`Window`/dialogs/`Tableview`) was then STARTED ahead of the docs** (the
+author reversed docs-first so the docs get written against normalized signatures):
+design pass done + confirmed in `development/2_0_shipped_widget_api_design.md`
+(Hybrid posture · port bootstack window mechanisms · unify dialog returns +
+`get_date`→None-on-cancel · Tableview fix+re-export now, defer the verb rename).
+**PR A (dialogs)** is implemented on branch `feat/2.0-shipped-api-dialogs`:
+Messagebox uniform keyword-only signatures, Querybox `get_*` return via `.result`,
+`get_date`→None-on-cancel + `position=`, `DatePickerDialog` `autoshow`/`show()`/
+`result`, `MessageDialog.command` plain-callable (tuple deprecated via `_compat`),
+`ColorChoice` deduped, dialogs re-exported at top level; `tests/test_dialogs_api.py`
+(+19). **Current → open/merge PR A vs `2.0`, then PR B (Window/Toplevel) + PR C
+(Tableview) per the design §8.** The docs Workstream H (starting with docs sub-PR
+#1 — nav/IA skeleton + un-break the 7 broken API `:::` stubs, per
+`development/2_0_docs_design.md` §11) now trails the API pass.
 
 ## Repository layout
 

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -23,6 +23,7 @@
 | **Scrollbar restyle (visible trough, square default)** | Visual | this doc, below |
 | **Button-family visual restyle (flat + hairline border)** | Visual | this doc, below |
 | **Bare buttons default to `neutral`** | Visual/API | this doc, below |
+| **Dialog API normalization (Messagebox/Querybox)** | API | `development/2_0_shipped_widget_api_design.md` (PR A) |
 
 ---
 
@@ -216,3 +217,53 @@ their CTA emphasis is unaffected.
 or set `Window(default_button="primary")` to restore the pre-2.0 default globally.
 
 Design: `development/2_0_neutral_default_design.md`.
+
+## Dialog API normalization — Messagebox/Querybox signatures & returns  *(API)*
+
+Shipped-widget API pass, **PR A** (design: `development/2_0_shipped_widget_api_design.md`).
+
+**What.**
+- **`Messagebox` signatures are uniform and `parent`/`alert` are keyword-only.**
+  Every method is now `method(message, title, *, parent=None, alert=False,
+  position=None, buttons=None, icon=None, localize=True)`. Previously some methods
+  ordered the positional args `parent, alert` and others `alert, parent`, so a
+  positional third argument was ambiguous. The formerly hidden `**kwargs` options
+  (`position`, `buttons`, `icon`, `localize`) are now discoverable named params.
+- **`Querybox.get_date` returns `None` when cancelled** (closed without picking a
+  day). Previously it *always* returned a `date`, silently falling back to
+  `startdate`/today, so cancellation was indistinguishable from a selection.
+  `get_date` also gained a `position=` argument.
+- **All `Querybox.get_*` methods return via the `Dialog.result` property**, not
+  the private `._result`, so the modal grab is released consistently. `get_string`
+  / `get_item` still return `""` on submit-of-empty vs `None` on cancel (now
+  documented, not accidental).
+- **`MessageDialog.command` accepts a plain zero-argument callable.** The legacy
+  `(callable, label)` tuple form (the label was never used) is deprecated and
+  normalized with a `DeprecationWarning` (removed in 3.0).
+- **`Messagebox`/`Querybox` and the dialog classes are re-exported at top level**
+  (`ttk.Messagebox`, `ttk.Querybox`, `ttk.MessageDialog`, …), matching how widgets
+  are exposed. `ttkbootstrap.dialogs.*` import paths remain valid.
+- Internal: `DatePickerDialog` gained an `autoshow=False` path + a `show()` method
+  + a `result` property so `get_date` can position the popup and detect
+  cancellation without blocking in the constructor (the default `autoshow=True`
+  keeps the old blocking-in-`__init__` behavior for direct users). The duplicate
+  `ColorChoice` namedtuple in `colorchooser.py` now imports the one in
+  `colordropper.py` (single type).
+
+**Why.** These were the shipped-widget inconsistencies flagged by the 2.0 API
+survey: an ambiguous positional order, an un-signalable cancel, four different
+result-access conventions, and a vestigial tuple param. Normalizing them now (API
+pass before the Workstream-H docs) means the docs get written against final
+signatures.
+
+**Migration.**
+- Pass `parent=`/`alert=` by keyword to `Messagebox.*` (positional no longer
+  accepted). Almost all existing code already does.
+- If you called `Querybox.get_date(...)` and used the result unconditionally,
+  guard for `None` (a cancel). E.g. `d = Querybox.get_date(); if d: ...`.
+- Replace any `MessageDialog(command=(fn, "label"))` with
+  `MessageDialog(command=fn)`.
+
+**Not breaking.** `message` (Messagebox) vs `prompt` (Querybox) is kept — it is a
+real told-vs-asked distinction. `parent` stays the owner-argument name across the
+dialog surface (the embeddable `ColorChooser` frame keeps `master`).

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,7 +3,25 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-07-07 (**icon-drop PREREQ + a visual-polish batch are all
+_Last updated: 2026-07-07 (**shipped-widget API pass STARTED — design pass done
++ PR A (dialogs) implemented on a branch**). The deferred shipped-widget API
+normalization (`Window`/dialogs/`Tableview`) was picked up ahead of the docs
+(author reversed the docs-first call so docs get written against normalized
+signatures). Design pass **confirmed**:
+`development/2_0_shipped_widget_api_design.md` (Hybrid posture · port bootstack
+window mechanisms · unify dialog returns + `get_date`→None-on-cancel · Tableview
+fix+re-export now, defer verb rename). **PR A (dialogs)** is committed on
+`feat/2.0-shipped-api-dialogs` (from `2.0`), not yet pushed/merged: Messagebox
+uniform keyword-only signatures; Querybox `get_*` return via `.result`;
+`get_date` returns None on cancel + gained `position=`; DatePickerDialog
+`autoshow=False`/`show()`/`result`; `MessageDialog.command` plain-callable (tuple
+deprecated via `_compat`); `ColorChoice` deduped; dialogs re-exported at top
+level. `tests/test_dialogs_api.py` (+19); suite 297 passed excl. the known
+`nl.msg` flake; modal cancel + happy paths verified end-to-end. **NEXT → push/
+open PR A vs `2.0`, then PR B (Window/Toplevel) + PR C (Tableview) per the design
+§8.** (Prior recommended step, docs sub-PR #1, still trails the API pass.)_
+
+_Prior 2026-07-07 (**icon-drop PREREQ + a visual-polish batch are all
 MERGED into `2.0`; NEXT → docs sub-PR #1**). Merged since the prior entry:
 **#1094** (icon-drop prereq — `ttkbootstrap.icons` removed, brand logo preserved
 as `window.py` `_DEFAULT_ICON_DATA`, the 4 Messagebox icons render from the

--- a/development/2_0_shipped_widget_api_design.md
+++ b/development/2_0_shipped_widget_api_design.md
@@ -1,0 +1,345 @@
+# ttkbootstrap 2.0 — Shipped-Widget API Normalization (design pass)
+
+> Design pass for the deferred **shipped-widget API normalization** workstream:
+> `Window`/`Toplevel`, the `dialogs/` package, and `Tableview`. Follows the 2.0
+> hard rule (design pass before implementation). Pair with `2_0_plan.md`,
+> `2_0_handoff.md`, and the docs design `2_0_docs_design.md` §11a.
+>
+> **Status: CONFIRMED (author sign-off 2026-07-07).** The four gating forks (§4)
+> were drafted from a full ground-truth survey while the author was away and then
+> **approved as-is** ("I'm good with your defaults"). Implementation proceeds
+> PR-by-PR per §8, starting with **PR A (dialogs)**.
+
+## 1. Why this, why now
+
+`Window`, the dialogs, and `Tableview` are the shipped widgets that never got a
+2.0 API cleanup. The docs design (`2_0_docs_design.md` §11a) explicitly deferred
+this and *accepted docs-first*. The author reversed that on 2026-07-07: do the
+**API pass first** so the Workstream-H docs get written against normalized
+signatures instead of provisional ones, avoiding the §11a rework tax (autogen
+API Reference regenerates for free; the fragile hand-written catalog/How-To
+examples get written once, correctly).
+
+This is **its own workstream**, not Workstream H. It carries warn-and-normalize
+compat through `style/_compat.py` per the tiered deprecation policy (new 2.0
+standardizations warn-and-normalize through 2.x, removed in 3.0).
+
+**Reference project:** per author steer (2026-07-07, memory
+`prefer-bootstack-reference`), borrow **mechanisms** (not API) from bootstack at
+`D:/Development/bootstack`, especially its cross-platform / Tcl-Tk quirk handling.
+Relevant bootstack files are cited inline below.
+
+## 2. Scope & non-goals
+
+**In scope (3 surfaces):**
+- `src/ttkbootstrap/window.py` — `Window`, `Toplevel`.
+- `src/ttkbootstrap/dialogs/` — `base.py`, `message.py`, `query.py`,
+  `colorchooser.py`, `colordropper.py`, `datepicker.py`, `fontdialog.py`, and the
+  `Messagebox`/`Querybox` facades.
+- `src/ttkbootstrap/widgets/tableview.py` — `Tableview` + `TableColumn`/`TableRow`.
+
+**Non-goals:**
+- No theming/style-engine changes (that work is complete — Workstreams A/E/D).
+- No new widgets or features. Consolidation only.
+- The Tableview method-verb *rename* is **deferred** to a later slice (see §4.4);
+  this pass fixes bugs, dead code, discoverability, and re-exports.
+
+## 3. Ground-truth inventory (summary)
+
+Full per-surface inventories were produced by survey agents (2026-07-07). The
+load-bearing findings:
+
+### 3a. `Window` / `Toplevel`
+- `size`/`position` are split tuple params (bootstack `App`/`Toplevel` use the
+  same shape — validated); but `position` hardcodes `f"+{x}+{y}"` → cannot
+  express edge-relative (`-x`/`-y`) offsets, and size+position are two separate
+  `geometry()` calls.
+- **`iconphoto` diverges** between the classes: `Window` treats `''`→brand icon,
+  `None`→skip, path→load-with-fallback (typed `Optional[str]`); `Toplevel` types
+  it plain `str=''`, `''`→skip, has no `None` path (so `iconphoto=None` →
+  `PhotoImage(file=None)` crash) and no embedded default.
+- `iconify` is smuggled through `**kwargs` on `Toplevel` (popped at
+  `window.py:517-520`) instead of being a real param.
+- `style` is a stored `self._style` on `Window` but a fresh `Style()` call on
+  `Toplevel` — inconsistent implementation of the same property.
+- No keyword-only marker on ~14-param constructors (everything positional-or-kw).
+- Attribute params mirror raw Tk names (`overrideredirect`, `windowtype`,
+  `toolwindow`, `topmost`, `hdpi`) rather than snake_case; `hdpi` **and**
+  `scaling` both drive `enable_high_dpi_awareness`.
+- `Window` has `themename`/`default_button`/`hdpi`/`scaling`; `Toplevel` has none
+  (inherits app theme) — acceptable divergence, keep.
+- Already-correct: the x11 `<Visibility>` alpha deferral is present in both (it
+  mirrors bootstack's `on_visibility_alpha`); `place_window_center` +
+  `position_center` alias exist in both.
+
+### 3b. Dialogs
+- Package is split (there is **no** `dialogs.py`). Base `Dialog(BaseWidget)` owns
+  a lazily-built `Toplevel`. `MessageDialog`/`QueryDialog`/`FontDialog`/
+  `ColorChooserDialog` subclass it; **`DatePickerDialog` and `ColorDropperDialog`
+  do not** (plain classes; `DatePickerDialog` blocks inside `__init__` via
+  `grab_set()`/`wait_window()`, so it has no `show()`).
+- `parent` is **consistent** across the dialog surface (only the embeddable
+  `ColorChooser` `ttk.Frame` uses `master`, which is defensible — it's a child
+  widget, not a popup). **Note:** bootstack is *less* consistent here (its base
+  `Dialog`=`parent`, all facades=`master`) — do **not** copy bootstack's drift;
+  ttkbootstrap's `parent`-everywhere is the better target.
+- Content arg splits `message` (MessageDialog/Messagebox) vs `prompt`
+  (QueryDialog/Querybox). Arguably a real semantic distinction (told vs asked) —
+  keep both, but document.
+- **`Messagebox` positional order flips**: `show_*`/`ok` order `parent, alert`;
+  `okcancel`/`yesno`/`yesnocancel`/`retrycancel` order `alert, parent`. A
+  positional 3rd arg means `parent` in five methods and `alert` in four.
+- `position`, `buttons`, `icon`, `localize` are **undiscoverable `**kwargs`** on
+  the facades (not named params).
+- **Return conventions diverge four ways**: `.result` property (Messagebox,
+  `get_color`, `get_font`) vs private `._result` (`get_string`/`get_item`/
+  `get_integer`/`get_float`, bypassing the property's `grab_release()`) vs bespoke
+  `date_selected` (`get_date`) vs a traced `Variable` (`ColorDropperDialog`).
+- **`get_date` can never signal cancellation** — `date_selected` defaults to
+  `startdate or today()` and is never reset, so it always returns a `date`.
+- `get_date` and `ColorDropperDialog.show()` are the only entry points with **no
+  `position` support**.
+- `MessageDialog.command` is typed `Optional[Tuple[Callable, str]]` but invoked as
+  a zero-arg `command()` — tuple form vestigial.
+- Two identical `ColorChoice` namedtuples (`colorchooser.py:75`,
+  `colordropper.py:55`).
+- **Dialogs are not re-exported at top level** (only via `ttkbootstrap.dialogs`).
+
+### 3c. `Tableview`
+- **Not re-exported** — no `ttk.Tableview` (every other widget is top-level);
+  only `from ttkbootstrap.widgets.tableview import Tableview`.
+- Verb sprawl: `get_`/`insert_`/`delete_`/`purge_`/`unload_`/`build_`;
+  `move_selected_row_up` vs `move_row_down` (drops `selected` + the `_rows_`
+  pattern); columns use `hide`/`unhide` while row/column objects use `show`/`hide`.
+- `configure(cnf=...)` on `Tableview` vs `configure(opt=...)` on
+  `TableColumn`/`TableRow`.
+- **Dead/vestigial**: `reset_row_sort` body is literally `...`;
+  `_build_table_rows`/`_build_table_columns` are superseded and unused;
+  commented-out `_select_pagesize` (2525-2528); `get_columns` documented as a
+  duplicate of the `tablecolumns` property; `maxwidth` in the `coldata` docstring
+  has no implementation.
+- **Latent bugs**: `delete_column` line 961 `self.cidmap(int(cid))` (calls a dict
+  → `TypeError`); `TableHeaderRightClickMenu.__init__` line 2791
+  `self.master = self.master` (self-assignment; never sets from arg); `insert_row`
+  uses `print('[TableView] …')` for a diagnostic instead of raising/logging.
+- `coldata`/`rowdata` are terse vs the stored `tablecolumns`/`tablerows`.
+
+## 4. Proposed decisions (the four gating forks)
+
+> **All four are PROPOSED defaults, pending author confirmation.** Rationale
+> included so the author can accept or redirect quickly.
+
+### 4.1 Posture = **Hybrid**
+Aggressively normalize the small, high-value surfaces (`Window`/`Toplevel` +
+dialogs) with warn-and-normalize aliases via `_compat`; on `Tableview`, fix
+bugs / dead code / discoverability + add the re-export, but **keep established
+method names** (the verb rename is a separate later slice). Rationale: Window and
+dialogs are heavily used and their inconsistencies are cheap to fix behind
+aliases; Tableview's method surface is huge (≈70 public methods) and a rename
+there is mostly doc/example churn for modest gain — better as its own scoped slice
+once the docs exist to update in lockstep.
+
+### 4.2 Window = **port bootstack mechanisms**
+Centralize the `winsys`-branched attribute handling and adopt a shared positioning
+utility, rather than leaving per-attribute branching inline. Rationale: this is
+exactly the cross-platform/Tcl-Tk-quirk surface the author flagged for bootstack
+reuse, and bootstack has already solved the edge cases (aqua override-redirect
+no-op, multi-monitor centering, on-screen clamping, the unified `windowtype`
+switch). See §5a for the concrete shape.
+
+### 4.3 Dialog returns = **unify + fix `get_date`**
+Route every entry point through the `.result` property; make `get_date` return
+`None` on cancel (BREAKING — currently always returns a date) so cancellation is
+detectable like every other `get_*`. Rationale: the always-returns-a-date behavior
+is a silent footgun (callers can't tell "user picked today" from "user cancelled").
+This is the one genuinely breaking change in the pass; it gets a prominent
+migration note. The `None`-vs-`""` distinction for `get_string`/`get_item` is kept
+but documented.
+
+### 4.4 Tableview = **fix + re-export, keep names; defer the verb rename**
+This pass: add `ttk.Tableview` (+ `TableColumn`/`TableRow`) re-export, fix the
+latent bugs, delete dead code (the `reset_row_sort` stub, the two unused private
+builders, the commented method), replace `print()` diagnostics with a raised
+error, and surface the hidden/undocumented params. The method-verb rename
+(`move_row_down`→`move_selected_row_down`, `hide/unhide`→`hide/show`,
+`coldata`/`rowdata` aliases, etc.) is deferred to its own slice with deprecated
+aliases, tracked in §8.
+
+## 5. Proposed normalized API
+
+### 5a. `Window` / `Toplevel`
+
+**Introduce a private `_BaseWindow` mixin** (mirrors bootstack's `BaseWindow`,
+`bootstack/src/bootstack/_runtime/base_window.py`) holding the shared wm/geometry/
+attribute/icon logic, so `Window` and `Toplevel` stop duplicating (and drifting
+on) it. Keep the public `Window`/`Toplevel` split (bootstack keeps App/Toplevel
+split too; ttkbootstrap's `Window`==root, `Toplevel`==secondary is the right
+model — do **not** merge them).
+
+Concrete changes:
+1. **Unify `iconphoto` semantics** across both classes via one `_setup_icon`
+   helper: `None`→skip, `''`→default (brand icon on `Window`, inherit on
+   `Toplevel`), path→load-with-fallback. Fix the `Toplevel` `None` crash. (bootstack
+   ref: `base_window.py:264-322`, incl. `.ico`→`wm_iconbitmap` on win32.)
+2. **Promote `iconify` to a real keyword-only param** on `Toplevel`; stop popping
+   it from `**kwargs`.
+3. **Make the `style` property identical** in both (return the singleton
+   consistently).
+4. **Add a `*` keyword-only marker** after the first 1–2 positional params
+   (`title`, and for `Window` `themename`) — the ~14-param positional surface is a
+   fragility trap. This is technically breaking for anyone passing later args
+   positionally; warn-and-normalize is not possible for positional args, so this
+   is a documented breaking change (low real-world incidence — nobody passes
+   `alpha` as the 14th positional).
+5. **Snake_case the raw-Tk-mirroring params** with deprecated aliases via
+   `_compat`: `overrideredirect`→`override_redirect`, `windowtype`→`window_type`,
+   `toolwindow`→`tool_window`, `hdpi`→`high_dpi`. (bootstack public layer uses
+   `override_redirect`; note bootstack's own runtime/public `minsize` vs
+   `min_size` drift — we pick **one**: keep `minsize`/`maxsize` since they mirror
+   the Tk method names the tuple wraps, and consistency-with-Tk wins here.)
+6. **Fix the `+{x}+{y}` limitation**: accept negative offsets in `position`
+   (emit `f"{x:+d}{y:+d}"`) so edge-relative placement works; optionally accept a
+   single combined `geometry="WxH+X+Y"` passthrough. Apply size+position as one
+   combined geometry string when both are given.
+7. **Adopt a shared positioning utility** — a private
+   `internal/positioning.py` (ported subset of bootstack's `WindowPositioning`,
+   `bootstack/src/bootstack/_runtime/window_utilities.py`): `center_on_screen`,
+   `center_on_parent`, `ensure_on_screen` (clamp into the monitor). Re-point
+   `place_window_center` at it (it currently ignores titlebar height and is not
+   multi-monitor aware). Establish the **priority `position > center_on_parent >
+   center_on_screen`** (bootstack `base_window.py:169-179`). Multi-monitor via
+   optional `screeninfo` with a graceful single-screen fallback (no new hard dep).
+8. **Aqua `overrideredirect` no-op guard** (bootstack `base_window.py:619-639`) —
+   `overrideredirect(True)` silently no-ops on macOS where it hangs/misbehaves.
+9. **Consider the `windowtype` unified switch** (bootstack `toplevel.py:117-206`):
+   `'splash'`/`'tooltip'`/`'dock'`/`'utility'` → the right native primitive per
+   platform. *Optional for this pass* — flag as a stretch item; the minimum is
+   the x11 `-type` passthrough that already exists.
+10. **AppUserModelID taskbar fix** (bootstack `app.py:534-540`) — on win32 set
+    the explicit AppUserModelID so the taskbar shows the app icon, not
+    `python.exe`. Low-risk, high-polish; include.
+
+### 5b. Dialogs
+
+1. **Keep `parent` everywhere** (already consistent); leave `ColorChooser`'s
+   `master` as-is (embeddable widget). Do not adopt bootstack's `master` facade
+   convention.
+2. **Fix `Messagebox` positional-order inconsistency**: make `(message, title,
+   parent, alert, ...)` the uniform order; the four flipped methods
+   (`okcancel`/`yesno`/`yesnocancel`/`retrycancel`) change. Since `parent`/`alert`
+   are almost always passed by keyword, real breakage is low; document it. Add a
+   `*` keyword-only marker after `message, title`.
+3. **Promote `position`, `buttons`, `icon`, `localize` to named params** on the
+   facades (discoverability); keep `**kwargs` passthrough for forward-compat.
+4. **Unify the result convention on the `.result` property** for all
+   `Dialog`-based entry points; route `get_string`/`get_item`/`get_integer`/
+   `get_float` through `.result` (so `grab_release()` runs consistently).
+5. **`get_date` returns `None` on cancel** (§4.3). Detect real selection vs
+   window-close; return `None` when closed without a pick. Prominent migration note.
+6. **Add `position` support to `get_date`** (it has none today) via the standard
+   `show(position=...)` path. `DatePickerDialog` gains a `show()` and stops
+   blocking inside `__init__` (align it to the `Dialog` lifecycle — makes it a
+   proper `Dialog` subclass or at least gives it the same `show`/`result` seam).
+   `ColorDropperDialog` stays fullscreen (no position — genuinely N/A).
+7. **De-vestigialize `MessageDialog.command`**: accept a plain `Callable`; keep
+   the tuple form working through `_compat` with a deprecation warning.
+8. **Dedupe `ColorChoice`** — one definition, imported by both modules.
+9. **Re-export the public dialog surface at top level** (`ttkbootstrap.Messagebox`,
+   `ttkbootstrap.Querybox`, and the dialog classes) to match the widgets — resolves
+   the "widgets exported, dialogs not" asymmetry. (Keep `ttkbootstrap.dialogs.*`
+   valid.)
+
+### 5c. `Tableview` (this pass — fixes only, per §4.4)
+
+1. **Re-export** `Tableview`, `TableColumn`, `TableRow` from
+   `widgets/__init__.py` and top-level `ttkbootstrap` (→ `ttk.Tableview`).
+2. **Fix latent bugs**: `delete_column`'s `self.cidmap(int(cid))` →
+   `self.cidmap[str(cid)]` (subscript, correct key type);
+   `TableHeaderRightClickMenu` `self.master = self.master` → set from the arg.
+3. **Delete dead code**: the `reset_row_sort` `...` stub (or implement it — decide
+   during impl; leaning delete since `reset_column_sort` covers the real need),
+   the unused `_build_table_rows`/`_build_table_columns`, the commented
+   `_select_pagesize`.
+4. **Replace `print()` diagnostics** (`insert_row` empty-values path) with a
+   raised `ValueError` (or a no-op with a real warning) — library code must not
+   print to stdout.
+5. **Fix the `coldata` docstring** (drop the unimplemented `maxwidth`, or
+   implement it — leaning doc-fix).
+6. **Deprecated verb-rename aliases are OUT of this pass** — tracked in §8 as the
+   follow-up slice.
+
+## 6. Compat & deprecation strategy
+
+All new-in-2.0 renames go through `style/_compat.py` (the existing quarantine),
+warn-and-normalize through 2.x, removed in 3.0:
+- Old kwarg names (`overrideredirect`, `windowtype`, `toolwindow`, `hdpi`, the
+  `command` tuple form) accepted with a `DeprecationWarning` that names the new
+  form. Implement as a small `_normalize_kwargs(old→new)` helper reused by
+  `Window.__init__`, `Toplevel.__init__`, and `MessageDialog`.
+- **Positional-order and keyword-only changes cannot be shimmed** (positional args
+  carry no name) → these are documented breaking changes, kept to the few listed
+  above, all low-incidence.
+- `get_date` cancellation is a documented breaking behavior change (no shim
+  possible for a return value).
+- **`import ttkbootstrap` stays warning-free** — warnings fire only when a
+  deprecated form is actually used.
+
+All breaking/behavioral changes are recorded in
+`development/2_0_breaking_changes.md` (the existing running log) and feed the
+Workstream-H "Migrating to 2.0" page.
+
+## 7. bootstack references (mechanisms borrowed)
+
+| Concern | bootstack source | Adopt as |
+|---|---|---|
+| Shared window logic mixin | `_runtime/base_window.py` | private `_BaseWindow` in `window.py` |
+| Positioning / clamping | `_runtime/window_utilities.py` (`WindowPositioning`) | private `internal/positioning.py` (subset) |
+| Center priority (pos>parent>screen) | `base_window.py:169-179` | `_setup_window` ordering |
+| x11 `<Visibility>` alpha deferral | `base_window.py:31-44,240-262` | already present — keep |
+| aqua override-redirect no-op | `base_window.py:619-639` | guard in both classes |
+| Unified `windowtype` switch | `toplevel.py:117-206` | *stretch* item (§5a.9) |
+| win32 AppUserModelID taskbar | `app.py:534-540` | `Window.__init__` (win32) |
+| Icon platform branching (.ico) | `base_window.py:264-322` | `_setup_icon` helper |
+
+We borrow mechanisms only. We do **not** adopt bootstack's `master`-facade dialog
+convention (ttkbootstrap's `parent` is more consistent) nor its `min_size`/`max_size`
+public rename (we keep Tk-mirroring `minsize`/`maxsize`).
+
+## 8. Proposed PR sequence
+
+Three independently-reviewable PRs against `2.0`, each with its own visual/headless
+gate. Recommended order (smallest-blast-radius first):
+
+- **PR A — Dialogs normalization.** §5b. Result unification, `get_date` cancel fix
+  + position, `Messagebox` order, named facade params, `ColorChoice` dedupe,
+  top-level re-exports, `command` de-vestigialize. New/updated tests in a headless
+  `tests/test_dialogs_api.py` (result conventions, cancel→None, kwarg normalization).
+  Human spot-check: each dialog opens/positions/returns correctly light+dark.
+- **PR B — Window/Toplevel normalization.** §5a. `_BaseWindow` mixin, `_setup_icon`,
+  positioning utility + priority, snake_case aliases, keyword-only, edge-relative
+  position, aqua guard, AppUserModelID. Cross-platform is the risk — gate on a
+  manual check on win32 + (if available) x11/aqua. Tests: kwarg normalization,
+  geometry string construction, centering math (headless-computable).
+- **PR C — Tableview fixes + re-export.** §5c. Bug fixes, dead-code removal,
+  `print()`→error, re-export. Tests: re-export presence, the two bug regressions,
+  no-stdout-on-empty-insert.
+
+**Deferred follow-up slice (own design mini-pass):** Tableview method-verb rename
+with deprecated aliases (`move_row_down`, `hide/unhide`, `coldata`/`rowdata`,
+`configure(cnf=)` vs `(opt=)`, export-method naming). Do it once the Workstream-H
+Tableview docs exist so names + docs move together.
+
+## 9. Open questions (for author)
+
+1. **Confirm the four §4 forks** (posture, window scope, `get_date` breaking fix,
+   Tableview depth). These gate PR structure.
+2. **`windowtype` unified switch** (§5a.9) — include now or leave as x11-only
+   passthrough? (Leaning: leave for the follow-up to keep PR B focused.)
+3. **`reset_row_sort`** — delete the stub or implement it? (Leaning: delete;
+   `reset_column_sort` + `reset_table` cover the need.)
+4. **`min_size`/`max_size`** — confirm we keep Tk-mirroring `minsize`/`maxsize`
+   (not bootstack's public `min_size`). (Leaning: keep `minsize`/`maxsize`.)
+5. **`new dep `screeninfo`** for multi-monitor centering — acceptable as an
+   *optional* import (graceful fallback), or avoid entirely and single-screen
+   only? (Leaning: optional import, no hard dep — matches "Pillow is the only
+   runtime dep".)

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -201,6 +201,23 @@ from ttkbootstrap import widgets as _widgets
 from ttkbootstrap.widgets import DateEntry, Floodgauge, FloodgaugeLegacy, LabeledScale, M, Meter
 from ttkbootstrap.window import Toplevel, Window
 
+# Dialogs re-exported at top level so the common front doors are reachable as
+# ttk.Messagebox / ttk.Querybox, matching how widgets are exposed (2.0). The
+# ttkbootstrap.dialogs.* import paths remain valid. Placed after the widget and
+# window classes above, since the dialogs build on them at runtime.
+from ttkbootstrap.dialogs import (
+    ColorChooser,
+    ColorChooserDialog,
+    ColorDropperDialog,
+    DatePickerDialog,
+    Dialog,
+    FontDialog,
+    MessageDialog,
+    Messagebox,
+    QueryDialog,
+    Querybox,
+)
+
 __all__ = [
     # Tk exports
     "Tk", "Menu", "Text", "Canvas", "TkFrame", "LabelFrame", "Variable", "StringVar", "IntVar", "BooleanVar",
@@ -247,5 +264,17 @@ __all__ = [
     "FloodgaugeLegacy",
     "LabeledScale",
     "Meter",
-    "M"
+    "M",
+
+    # Dialogs
+    "Messagebox",
+    "Querybox",
+    "Dialog",
+    "MessageDialog",
+    "QueryDialog",
+    "DatePickerDialog",
+    "FontDialog",
+    "ColorChooser",
+    "ColorChooserDialog",
+    "ColorDropperDialog",
 ]

--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -148,6 +148,20 @@ class Dialog(BaseWidget):
 
     @property
     def result(self) -> Any:
-        """Returns the result of the dialog."""
-        self._toplevel.grab_release()
+        """Returns the result of the dialog.
+
+        Safe to read whether the toplevel is already destroyed (e.g.
+        ``QueryDialog`` destroys it synchronously on submit) or only queued for
+        destruction (``MessageDialog`` uses ``after_idle``); the grab is released
+        only if the window still exists. This is the single result accessor for
+        every ``Dialog`` subclass -- facades must read ``.result``, not the
+        private ``._result`` (2.0 result-convention unification).
+        """
+        toplevel = self._toplevel
+        if toplevel is not None:
+            try:
+                if toplevel.winfo_exists():
+                    toplevel.grab_release()
+            except tkinter.TclError:
+                pass
         return self._result

--- a/src/ttkbootstrap/dialogs/colorchooser.py
+++ b/src/ttkbootstrap/dialogs/colorchooser.py
@@ -63,7 +63,7 @@ from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
 from ttkbootstrap.widgets.tooltip import ToolTip
 from ttkbootstrap.validation import add_range_validation, add_validation, validator
-from .colordropper import ColorDropperDialog
+from .colordropper import ColorChoice, ColorDropperDialog
 
 STD_SHADES: List[float] = [0.9, 0.8, 0.7, 0.4, 0.3]
 STD_COLORS: List[str] = [
@@ -71,8 +71,9 @@ STD_COLORS: List[str] = [
     '#0070C0', '#7030A0', '#FFFFFF', '#000000'
 ]
 
+# ColorChoice is defined once in colordropper.py and imported above, so
+# get_color and the dropper return the same type (2.0 dedupe).
 ColorValues = namedtuple('ColorValues', 'h s l r g b hex')
-ColorChoice = namedtuple('ColorChoice', 'rgb hsl hex')
 
 PEN = '✛'
 

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -46,6 +46,7 @@ class DatePickerDialog:
             firstweekday: int = 6,
             startdate: Optional[date] = None,
             bootstyle: str = PRIMARY,
+            autoshow: bool = True,
     ) -> None:
         """Create a date picker dialog with a calendar popup.
 
@@ -74,6 +75,14 @@ class DatePickerDialog:
             bootstyle (str):
                 The color theme for the calendar (primary, secondary, success,
                 info, warning, danger, light, dark) (default=PRIMARY).
+
+            autoshow (bool):
+                If True (default, back-compatible), the dialog grabs focus and
+                blocks during construction, so ``date_selected`` is readable as
+                soon as the constructor returns. If False, construction does not
+                block; call :meth:`show` explicitly and read :attr:`result`
+                afterward (the path :meth:`Querybox.get_date` uses so it can
+                position the popup and detect cancellation).
 
         Interaction:
             - Left-click month arrows: Move calendar by one month
@@ -104,13 +113,43 @@ class DatePickerDialog:
         self.date_selected = self.startdate
         self.date = startdate or self.date_selected
         self.calendar = calendar.Calendar(firstweekday=firstweekday)
+        # Track whether the user actually picked a day, so cancellation
+        # (closing the window without a selection) is distinguishable from a
+        # real selection -- `date_selected` alone cannot tell them apart because
+        # it defaults to `startdate`/today. Read via the `result` property.
+        self._selection_made = False
 
         self.titlevar = ttk.StringVar()
         self.datevar = ttk.IntVar()
 
         self._setup_calendar()
+        if autoshow:
+            self.show()
+
+    def show(self, position: Optional[Tuple[int, int]] = None, wait_for_result: bool = True) -> None:
+        """Grab focus and (optionally) block until the dialog closes.
+
+        Parameters:
+
+            position (tuple[int, int]):
+                Optional ``(x, y)`` screen coordinates for the popup. If omitted,
+                the default placement (bottom-right of the parent, else centered)
+                set up during construction is kept.
+
+            wait_for_result (bool):
+                If True (default), block until the dialog is closed; read the
+                selection from :attr:`result` afterward.
+        """
+        if position is not None:
+            self._set_window_position(position)
         self.root.grab_set()
-        self.root.wait_window()
+        if wait_for_result:
+            self.root.wait_window()
+
+    @property
+    def result(self) -> Optional[date]:
+        """The selected ``date``, or ``None`` if the dialog was cancelled."""
+        return self.date_selected if self._selection_made else None
 
     def _setup_calendar(self) -> None:
         """Setup the calendar widget"""
@@ -259,6 +298,7 @@ class DatePickerDialog:
     def _on_date_selected(self, row: int, col: int) -> None:
         """Callback for selecting a date."""
         self.date_selected = self.monthdates[row][col]
+        self._selection_made = True
         self.root.destroy()
 
     def _selection_callback(func):
@@ -297,9 +337,16 @@ class DatePickerDialog:
     def on_reset_date(self, *_: Any) -> None:
         self.date = self.startdate
 
-    def _set_window_position(self) -> None:
-        """Move window to bottom-right of parent, else center on master."""
-        if self.parent:
+    def _set_window_position(self, position: Optional[Tuple[int, int]] = None) -> None:
+        """Position the popup.
+
+        An explicit ``(x, y)`` wins; otherwise anchor to the bottom-right of the
+        parent, else center on the master.
+        """
+        if position is not None:
+            x, y = position
+            self.root.geometry(f"+{x}+{y}")
+        elif self.parent:
             xpos = self.parent.winfo_rootx() + self.parent.winfo_width()
             ypos = self.parent.winfo_rooty() + self.parent.winfo_height()
             self.root.geometry(f"+{xpos}+{ypos}")

--- a/src/ttkbootstrap/dialogs/message.py
+++ b/src/ttkbootstrap/dialogs/message.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, List, Optional, Tuple
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
+from ttkbootstrap.style._compat import warn_deprecated
 from .base import Dialog
 
 
@@ -45,7 +46,7 @@ class MessageDialog(Dialog):
             message: str,
             title: str = " ",
             buttons: Optional[List[str]] = None,
-            command: Optional[Tuple[Callable[..., Any], str]] = None,
+            command: Optional[Callable[[], Any]] = None,
             width: int = 50,
             parent: Optional[tkinter.Misc] = None,
             alert: bool = False,
@@ -72,7 +73,10 @@ class MessageDialog(Dialog):
                 displayed in reverse order (rightmost first).
 
             command (Callable):
-                Optional callback function to execute when a button is pressed.
+                Optional zero-argument callback to run when a button is
+                pressed. The legacy ``(callable, label)`` tuple form is
+                deprecated (the label was never used) and will be removed in
+                3.0; pass the callable directly.
 
             width (int):
                 Maximum width in characters for text wrapping (default=50).
@@ -104,7 +108,15 @@ class MessageDialog(Dialog):
         """
         super().__init__(parent, title, alert)
         self._message = message
-        self._command: Optional[Tuple[Callable[..., Any], str]] = command
+        # Accept a plain zero-arg callable. The legacy (callable, label) tuple
+        # is normalized to the callable with a deprecation warning (2.0).
+        if isinstance(command, tuple):
+            warn_deprecated(
+                "passing a (callable, label) tuple as MessageDialog command",
+                "a plain zero-argument callable",
+            )
+            command = command[0] if command else None
+        self._command: Optional[Callable[[], Any]] = command
         self._width = width
         self._alert = alert
         self._default = default
@@ -231,30 +243,40 @@ class MessageDialog(Dialog):
 
 
 class Messagebox:
-    """This class contains various static methods that show popups with
-    a message to the end user with various arrangments of buttons
-    and alert options."""
+    """Static methods that pop up a message with various button arrangements
+    and alert options, and return the label of the button the user pressed
+    (or ``None`` if the dialog was dismissed via Escape / the window close).
+
+    2.0 signature normalization: every method takes ``(message, title, *,
+    parent, alert, position, buttons, icon, localize)``. ``parent``/``alert``
+    are now **keyword-only** and in a uniform order (previously some methods
+    ordered them ``parent, alert`` and others ``alert, parent`` positionally,
+    so a positional third argument was ambiguous). The formerly hidden
+    ``**kwargs`` options -- ``position``, ``buttons``, ``icon``, ``localize`` --
+    are now discoverable named parameters.
+    """
 
     @staticmethod
     def show_info(
             message: str,
             title: str = " ",
+            *,
             parent: Optional[tkinter.Misc] = None,
             alert: bool = False,
+            position: Optional[Tuple[int, int]] = None,
+            buttons: Optional[List[str]] = None,
+            icon: Optional[str] = None,
+            localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
         """Display a modal dialog box with an OK button and an INFO icon."""
-        position = kwargs.pop("position", None)
-        buttons = kwargs.pop("buttons", ["OK:primary"])
-        icon = kwargs.pop("icon", None) or _alert_icon("info")
-        localize = kwargs.pop("localize", True)
         dialog = MessageDialog(
             message=message,
             title=title,
-            alert=alert,
             parent=parent,
-            buttons=buttons,
-            icon=icon,
+            alert=alert,
+            buttons=buttons or ["OK:primary"],
+            icon=icon or _alert_icon("info"),
             localize=localize,
             **kwargs,
         )
@@ -265,22 +287,23 @@ class Messagebox:
     def show_warning(
             message: str,
             title: str = " ",
+            *,
             parent: Optional[tkinter.Misc] = None,
             alert: bool = True,
+            position: Optional[Tuple[int, int]] = None,
+            buttons: Optional[List[str]] = None,
+            icon: Optional[str] = None,
+            localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
         """Display a modal dialog box with an OK button and a warning icon."""
-        position = kwargs.pop("position", None)
-        buttons = kwargs.pop("buttons", ["OK:primary"])
-        icon = kwargs.pop("icon", None) or _alert_icon("warning")
-        localize = kwargs.pop("localize", True)
         dialog = MessageDialog(
             message=message,
             title=title,
             parent=parent,
-            buttons=buttons,
-            icon=icon,
             alert=alert,
+            buttons=buttons or ["OK:primary"],
+            icon=icon or _alert_icon("warning"),
             localize=localize,
             **kwargs,
         )
@@ -291,22 +314,23 @@ class Messagebox:
     def show_error(
             message: str,
             title: str = " ",
+            *,
             parent: Optional[tkinter.Misc] = None,
             alert: bool = True,
+            position: Optional[Tuple[int, int]] = None,
+            buttons: Optional[List[str]] = None,
+            icon: Optional[str] = None,
+            localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
         """Display a modal dialog box with an OK button and an error icon."""
-        position = kwargs.pop("position", None)
-        buttons = kwargs.pop("buttons", ["OK:primary"])
-        icon = kwargs.pop("icon", None) or _alert_icon("error")
-        localize = kwargs.pop("localize", True)
         dialog = MessageDialog(
             message=message,
             title=title,
             parent=parent,
-            buttons=buttons,
-            icon=icon,
             alert=alert,
+            buttons=buttons or ["OK:primary"],
+            icon=icon or _alert_icon("error"),
             localize=localize,
             **kwargs,
         )
@@ -317,22 +341,23 @@ class Messagebox:
     def show_question(
             message: str,
             title: str = " ",
+            *,
             parent: Optional[tkinter.Misc] = None,
             alert: bool = False,
+            position: Optional[Tuple[int, int]] = None,
+            buttons: Optional[List[str]] = None,
+            icon: Optional[str] = None,
+            localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
         """Display a modal dialog box with an OK button and a question icon."""
-        position = kwargs.pop("position", None)
-        buttons = kwargs.pop("buttons", ["OK:primary"])
-        icon = kwargs.pop("icon", None) or _alert_icon("question")
-        localize = kwargs.pop("localize", True)
         dialog = MessageDialog(
             message=message,
             title=title,
             parent=parent,
-            buttons=buttons,
-            icon=icon,
             alert=alert,
+            buttons=buttons or ["OK:primary"],
+            icon=icon or _alert_icon("question"),
             localize=localize,
             **kwargs,
         )
@@ -343,19 +368,23 @@ class Messagebox:
     def ok(
             message: str,
             title: str = " ",
+            *,
             parent: Optional[tkinter.Misc] = None,
             alert: bool = False,
+            position: Optional[Tuple[int, int]] = None,
+            buttons: Optional[List[str]] = None,
+            icon: Optional[str] = None,
+            localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
-        position = kwargs.pop("position", None)
-        buttons = kwargs.pop("buttons", ["OK:primary"])
-        localize = kwargs.pop("localize", True)
+        """Display a modal dialog box with a single OK button."""
         dialog = MessageDialog(
-            title=title,
             message=message,
+            title=title,
             parent=parent,
             alert=alert,
-            buttons=buttons,
+            buttons=buttons or ["OK:primary"],
+            icon=icon,
             localize=localize,
             **kwargs,
         )
@@ -366,17 +395,23 @@ class Messagebox:
     def okcancel(
             message: str,
             title: str = " ",
-            alert: bool = False,
+            *,
             parent: Optional[tkinter.Misc] = None,
+            alert: bool = False,
+            position: Optional[Tuple[int, int]] = None,
+            buttons: Optional[List[str]] = None,
+            icon: Optional[str] = None,
+            localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
-        position = kwargs.pop("position", None)
-        localize = kwargs.pop("localize", True)
+        """Display a modal dialog box with OK and Cancel buttons."""
         dialog = MessageDialog(
-            title=title,
             message=message,
+            title=title,
             parent=parent,
             alert=alert,
+            buttons=buttons,
+            icon=icon,
             localize=localize,
             **kwargs,
         )
@@ -387,19 +422,23 @@ class Messagebox:
     def yesno(
             message: str,
             title: str = " ",
-            alert: bool = False,
+            *,
             parent: Optional[tkinter.Misc] = None,
+            alert: bool = False,
+            position: Optional[Tuple[int, int]] = None,
+            buttons: Optional[List[str]] = None,
+            icon: Optional[str] = None,
+            localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
-        position = kwargs.pop("position", None)
-        buttons = kwargs.pop("buttons", ["No", "Yes"])
-        localize = kwargs.pop("localize", True)
+        """Display a modal dialog box with Yes and No buttons."""
         dialog = MessageDialog(
-            title=title,
             message=message,
+            title=title,
             parent=parent,
-            buttons=buttons,
             alert=alert,
+            buttons=buttons or ["No", "Yes"],
+            icon=icon,
             localize=localize,
             **kwargs,
         )
@@ -410,19 +449,23 @@ class Messagebox:
     def yesnocancel(
             message: str,
             title: str = " ",
-            alert: bool = False,
+            *,
             parent: Optional[tkinter.Misc] = None,
+            alert: bool = False,
+            position: Optional[Tuple[int, int]] = None,
+            buttons: Optional[List[str]] = None,
+            icon: Optional[str] = None,
+            localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
-        position = kwargs.pop("position", None)
-        buttons = kwargs.pop("buttons", ["Cancel", "No", "Yes"])
-        localize = kwargs.pop("localize", True)
+        """Display a modal dialog box with Yes, No, and Cancel buttons."""
         dialog = MessageDialog(
-            title=title,
             message=message,
+            title=title,
             parent=parent,
             alert=alert,
-            buttons=buttons,
+            buttons=buttons or ["Cancel", "No", "Yes"],
+            icon=icon,
             localize=localize,
             **kwargs,
         )
@@ -433,19 +476,23 @@ class Messagebox:
     def retrycancel(
             message: str,
             title: str = " ",
-            alert: bool = False,
+            *,
             parent: Optional[tkinter.Misc] = None,
+            alert: bool = False,
+            position: Optional[Tuple[int, int]] = None,
+            buttons: Optional[List[str]] = None,
+            icon: Optional[str] = None,
+            localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
-        position = kwargs.pop("position", None)
-        buttons = kwargs.pop("buttons", ["Cancel", "Retry"])
-        localize = kwargs.pop("localize", True)
+        """Display a modal dialog box with Retry and Cancel buttons."""
         dialog = MessageDialog(
-            title=title,
             message=message,
+            title=title,
             parent=parent,
             alert=alert,
-            buttons=buttons,
+            buttons=buttons or ["Cancel", "Retry"],
+            icon=icon,
             localize=localize,
             **kwargs,
         )

--- a/src/ttkbootstrap/dialogs/query.py
+++ b/src/ttkbootstrap/dialogs/query.py
@@ -3,7 +3,7 @@
 import textwrap
 import tkinter
 from datetime import date
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
@@ -213,13 +213,17 @@ class Querybox:
             parent: Optional[tkinter.Misc] = None,
             title: str = "Color Chooser",
             initialcolor: Optional[str] = None,
+            *,
+            position: Optional[Tuple[int, int]] = None,
             **kwargs: Any,
     ) -> Any:
-        """Show a color picker and return the selected color when OK is pressed."""
+        """Show a color picker and return the selected color when OK is pressed.
+
+        Returns a ``ColorChoice`` namedtuple, or ``None`` if cancelled.
+        """
         from ttkbootstrap.dialogs.colorchooser import ColorChooserDialog
 
         dialog = ColorChooserDialog(parent, title, initialcolor)
-        position = kwargs.pop("position", None)
         dialog.show(position)
         return dialog.result
 
@@ -230,15 +234,26 @@ class Querybox:
             firstweekday: int = 6,
             startdate: Optional[date] = None,
             bootstyle: str = "primary",
-    ) -> date:
+            *,
+            position: Optional[Tuple[int, int]] = None,
+    ) -> Optional[date]:
+        """Show a calendar and return the selected ``date``.
+
+        2.0 change: returns ``None`` when the picker is cancelled (closed
+        without choosing a day). Previously it always returned a ``date`` --
+        falling back to ``startdate``/today -- so cancellation was
+        indistinguishable from a real selection.
+        """
         chooser = DatePickerDialog(
             parent=parent,
             title=title,
             firstweekday=firstweekday,
             startdate=startdate,
             bootstyle=bootstyle,
+            autoshow=False,
         )
-        return chooser.date_selected
+        chooser.show(position)
+        return chooser.result
 
     @staticmethod
     def get_string(
@@ -246,13 +261,19 @@ class Querybox:
             title: str = " ",
             initialvalue: Optional[str] = None,
             parent: Optional[tkinter.Misc] = None,
+            *,
+            position: Optional[Tuple[int, int]] = None,
             **kwargs: Any,
     ) -> Optional[str]:
+        """Prompt for a string. Returns the text, or ``None`` if cancelled.
+
+        Note: submitting an empty field returns ``""`` (distinct from the
+        ``None`` returned on cancel).
+        """
         initialvalue = initialvalue or ""
-        position = kwargs.pop("position", None)
         dialog = QueryDialog(prompt, title, initialvalue, parent=parent, **kwargs)
         dialog.show(position)
-        return dialog._result
+        return dialog.result
 
     @staticmethod
     def get_item(
@@ -261,13 +282,15 @@ class Querybox:
             initialvalue: Optional[str] = None,
             items: Optional[List[str]] = None,
             parent: Optional[tkinter.Misc] = None,
+            *,
+            position: Optional[Tuple[int, int]] = None,
             **kwargs: Any,
     ) -> Optional[str]:
+        """Prompt for one item from a list. Returns it, or ``None`` if cancelled."""
         initialvalue = initialvalue or ""
-        position = kwargs.pop("position", None)
         dialog = QueryDialog(prompt, title, initialvalue, items=items, parent=parent, **kwargs)
         dialog.show(position)
-        return dialog._result
+        return dialog.result
 
     @staticmethod
     def get_integer(
@@ -277,10 +300,12 @@ class Querybox:
             minvalue: Optional[int] = None,
             maxvalue: Optional[int] = None,
             parent: Optional[tkinter.Misc] = None,
+            *,
+            position: Optional[Tuple[int, int]] = None,
             **kwargs: Any,
     ) -> Optional[int]:
+        """Prompt for an integer. Returns it, or ``None`` if cancelled."""
         initialvalue = initialvalue or ""
-        position = kwargs.pop("position", None)
         datatype = kwargs.pop("datatype", int)
         dialog = QueryDialog(
             prompt,
@@ -293,7 +318,7 @@ class Querybox:
             **kwargs,
         )
         dialog.show(position)
-        return dialog._result
+        return dialog.result
 
     @staticmethod
     def get_float(
@@ -303,10 +328,12 @@ class Querybox:
             minvalue: Optional[float] = None,
             maxvalue: Optional[float] = None,
             parent: Optional[tkinter.Misc] = None,
+            *,
+            position: Optional[Tuple[int, int]] = None,
             **kwargs: Any,
     ) -> Optional[float]:
+        """Prompt for a float. Returns it, or ``None`` if cancelled."""
         initialvalue = initialvalue or ""
-        position = kwargs.pop("position", None)
         datatype = kwargs.pop("datatype", float)
         dialog = QueryDialog(
             prompt,
@@ -319,11 +346,16 @@ class Querybox:
             **kwargs,
         )
         dialog.show(position)
-        return dialog._result
+        return dialog.result
 
     @staticmethod
-    def get_font(parent: Optional[tkinter.Misc] = None, **kwargs: Any):
-        position = kwargs.pop("position", None)
+    def get_font(
+            parent: Optional[tkinter.Misc] = None,
+            *,
+            position: Optional[Tuple[int, int]] = None,
+            **kwargs: Any,
+    ):
+        """Show a font picker. Returns a ``Font``, or ``None`` if cancelled."""
         dialog = FontDialog(parent=parent, **kwargs)
         dialog.show(position)
         return dialog.result

--- a/src/ttkbootstrap/widgets/dateentry.py
+++ b/src/ttkbootstrap/widgets/dateentry.py
@@ -382,5 +382,8 @@ class DateEntry(Frame):
             firstweekday=self._firstweekday,
             bootstyle=self._bootstyle,
         )
-        self.set_date(new_date)
-        self.event_generate("<<DateEntrySelected>>")
+        # get_date returns None when the picker is cancelled (2.0); leave the
+        # field unchanged rather than resetting it.
+        if new_date is not None:
+            self.set_date(new_date)
+            self.event_generate("<<DateEntrySelected>>")

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -1,0 +1,136 @@
+"""Headless tests for the 2.0 shipped-widget dialog API normalization (PR A).
+
+These exercise the *contract* changes -- signatures, result conventions,
+deprecations, and re-exports -- WITHOUT opening a modal dialog. The dialog
+facades block on ``grab_set``/``wait_window`` when shown, so nothing here calls
+``.show()``; the modal appearance is left to the manual visual gate.
+"""
+import inspect
+import warnings
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.dialogs import Messagebox, Querybox
+from ttkbootstrap.dialogs.base import Dialog
+from ttkbootstrap.dialogs.message import MessageDialog
+from ttkbootstrap.dialogs.datepicker import DatePickerDialog
+
+
+_MESSAGEBOX_METHODS = [
+    "show_info", "show_warning", "show_error", "show_question",
+    "ok", "okcancel", "yesno", "yesnocancel", "retrycancel",
+]
+
+
+# --- re-exports ------------------------------------------------------------
+
+def test_dialog_surface_reexported_at_top_level():
+    for name in (
+        "Messagebox", "Querybox", "Dialog", "MessageDialog", "QueryDialog",
+        "DatePickerDialog", "FontDialog", "ColorChooser", "ColorChooserDialog",
+        "ColorDropperDialog",
+    ):
+        assert hasattr(ttk, name), f"ttk.{name} should be re-exported"
+        assert name in ttk.__all__
+
+
+# --- Messagebox uniform, keyword-only signatures ---------------------------
+
+@pytest.mark.parametrize("method", _MESSAGEBOX_METHODS)
+def test_messagebox_parent_and_alert_are_keyword_only(method):
+    sig = inspect.signature(getattr(Messagebox, method))
+    params = sig.parameters
+    # message + title stay positional-or-keyword; the rest are keyword-only.
+    assert params["message"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert params["title"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    for name in ("parent", "alert", "position", "buttons", "icon", "localize"):
+        assert name in params, f"{method} missing named param {name!r}"
+        assert params[name].kind is inspect.Parameter.KEYWORD_ONLY, (
+            f"{method}.{name} should be keyword-only"
+        )
+
+
+def test_messagebox_rejects_positional_parent(root):
+    # parent is keyword-only now, so a positional 3rd arg raises before any
+    # dialog is built -- no window is shown.
+    with pytest.raises(TypeError):
+        Messagebox.ok("message", "title", root)
+
+
+# --- result convention -----------------------------------------------------
+
+def test_base_result_is_safe_without_a_toplevel(root):
+    # A dialog that was constructed but never shown has no toplevel; reading
+    # .result must not raise (it used to call grab_release unconditionally).
+    dialog = MessageDialog(message="hi", parent=root)
+    assert dialog._toplevel is None
+    assert dialog.result is None
+
+
+def test_querybox_get_string_returns_via_result_property():
+    # Every get_* now returns dialog.result, not the private ._result.
+    src = inspect.getsource(Querybox.get_string)
+    assert "dialog.result" in src
+    assert "dialog._result" not in src
+
+
+# --- MessageDialog.command de-vestigialization -----------------------------
+
+def test_command_plain_callable_stored_without_warning(root):
+    called = []
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        dialog = MessageDialog(message="x", parent=root, command=lambda: called.append(1))
+    assert callable(dialog._command)
+
+
+def test_command_tuple_form_is_deprecated_and_unwrapped(root):
+    fn = lambda: None
+    with pytest.warns(DeprecationWarning):
+        dialog = MessageDialog(message="x", parent=root, command=(fn, "label"))
+    # the callable is unwrapped from the legacy (callable, label) tuple
+    assert dialog._command is fn
+
+
+# --- ColorChoice dedupe ----------------------------------------------------
+
+def test_colorchoice_is_a_single_type():
+    from ttkbootstrap.dialogs.colorchooser import ColorChoice as CC1
+    from ttkbootstrap.dialogs.colordropper import ColorChoice as CC2
+    assert CC1 is CC2
+
+
+# --- get_date cancellation -------------------------------------------------
+
+def test_get_date_signature_returns_optional_and_position_kwonly():
+    sig = inspect.signature(Querybox.get_date)
+    assert sig.parameters["position"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_datepicker_result_is_none_until_a_day_is_selected(root):
+    # autoshow=False builds the calendar without grabbing/blocking.
+    chooser = DatePickerDialog(parent=root, autoshow=False)
+    try:
+        # No selection yet -> cancellation semantics -> None, even though
+        # date_selected defaults to today.
+        assert chooser.date_selected is not None
+        assert chooser._selection_made is False
+        assert chooser.result is None
+
+        # Simulate a real pick (the flag is what _on_date_selected sets).
+        picked = chooser.date_selected
+        chooser._selection_made = True
+        assert chooser.result == picked
+    finally:
+        try:
+            chooser.root.destroy()
+        except Exception:
+            pass
+
+
+def test_datepicker_has_show_and_autoshow():
+    sig = inspect.signature(DatePickerDialog.__init__)
+    assert "autoshow" in sig.parameters
+    assert hasattr(DatePickerDialog, "show")
+    assert isinstance(inspect.getattr_static(DatePickerDialog, "result"), property)


### PR DESCRIPTION
First PR of the **2.0 shipped-widget API normalization** workstream (design: `development/2_0_shipped_widget_api_design.md`). Dialogs only — the smallest-blast-radius surface. Targets `2.0`.

## Why now
The docs design (`2_0_docs_design.md` §11a) deferred this and accepted docs-first. Doing the **API pass first** means the Workstream-H docs get written against final signatures instead of provisional ones.

## What changed
- **`Messagebox` uniform, keyword-only signatures** — every method is now `(message, title, *, parent=None, alert=False, position=None, buttons=None, icon=None, localize=True)`. Previously some methods ordered `parent, alert` and others `alert, parent` positionally, so a positional 3rd arg was ambiguous. The formerly hidden `**kwargs` options are now discoverable named params.
- **`Querybox.get_date` returns `None` on cancel** (was: always a `date`, silently falling back to `startdate`/today — cancellation was undetectable). Also gained `position=`. `DateEntry` guards the new `None` (cancel no longer overwrites the field).
- **All `Querybox.get_*` return via the `Dialog.result` property**, not the private `._result`, so the modal grab is released consistently.
- **`MessageDialog.command` accepts a plain zero-arg callable**; the legacy `(callable, label)` tuple is deprecated + normalized via `style/_compat`.
- **Dedupe the duplicate `ColorChoice` namedtuple** (single type).
- **Re-export `Messagebox`/`Querybox` + dialog classes at top level** (`ttk.Messagebox`, …); `ttkbootstrap.dialogs.*` paths unchanged.
- Internal: `DatePickerDialog` gained `autoshow=False` + `show()` + a `result` property (default `autoshow=True` keeps the old blocking-in-`__init__` behavior for direct users); `base.Dialog.result` is now safe whether the toplevel is destroyed or queued for destruction.

## Breaking changes (documented in `development/2_0_breaking_changes.md`)
- Pass `parent=`/`alert=` by keyword to `Messagebox.*` (positional no longer accepted). Almost all existing code already does.
- Guard `Querybox.get_date(...)` for `None` if you used the result unconditionally.
- Replace `MessageDialog(command=(fn, "label"))` with `MessageDialog(command=fn)`.

## Tests / verification
- New `tests/test_dialogs_api.py` (+19 headless tests).
- Full suite **297 passed** excluding the known order-dependent `nl.msg` localization env flake.
- Drove the **real modal dialogs**: cancel paths (`get_date`, `yesno`, `get_string`) all return `None`; happy paths return `'Yes'` / `'Ada'`.

Next in the workstream: **PR B (Window/Toplevel)** — the cross-platform bootstack mechanism port — then **PR C (Tableview)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
