### PR TITLE
Normalize Window/Toplevel API (shipped-widget API pass, PR B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,18 @@ Messagebox uniform keyword-only signatures, Querybox `get_*` return via `.result
 `get_date`→None-on-cancel + `position=`, `DatePickerDialog` `autoshow`/`show()`/
 `result`, `MessageDialog.command` plain-callable (tuple deprecated via `_compat`),
 `ColorChoice` deduped, dialogs re-exported at top level; `tests/test_dialogs_api.py`
-(+19); expected suite on `2.0` ~302 (297 excl. localization). **Current → PR B
-(Window/Toplevel — the cross-platform bootstack `_BaseWindow`/`WindowPositioning`
-port, design §5a), then PR C (Tableview, §5c), per the design §8.** The docs
+(+19); expected suite on `2.0` ~302 (297 excl. localization). **PR B (Window/
+Toplevel) is IMPLEMENTED on branch `feat/2.0-shipped-api-window`** (design §5a; not
+yet merged — awaiting a cross-platform visual gate): private `_BaseWindow` mixin
+shared by `Window`/`Toplevel`, unified `_setup_icon` (fixes the
+`Toplevel(iconphoto=None)` crash), new private `internal/positioning.py` (subset of
+bootstack's `WindowPositioning`; optional `screeninfo`, graceful single-screen
+fallback) re-pointing `place_window_center`, snake_case kwarg aliases via
+`_compat.normalize_window_kwargs` (`hdpi`/`overrideredirect`/`windowtype`/
+`toolwindow`, warn-and-normalize), keyword-only constructors, `iconify` promoted,
+edge-relative/combined geometry, aqua `overrideredirect` no-op guard, win32
+AppUserModelID; `tests/test_window_api.py` (+15), suite 317 excl. the `nl.msg`
+flake. **NEXT → PR C (Tableview fixes + re-export, §5c) once PR B lands.** The docs
 Workstream H (starting with docs sub-PR #1 — nav/IA skeleton + un-break the 7
 broken API `:::` stubs, per `development/2_0_docs_design.md` §11) now trails the
 API pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,8 @@ Messagebox uniform keyword-only signatures, Querybox `get_*` return via `.result
 `result`, `MessageDialog.command` plain-callable (tuple deprecated via `_compat`),
 `ColorChoice` deduped, dialogs re-exported at top level; `tests/test_dialogs_api.py`
 (+19); expected suite on `2.0` ~302 (297 excl. localization). **PR B (Window/
-Toplevel) is IMPLEMENTED on branch `feat/2.0-shipped-api-window`** (design §5a; not
-yet merged — awaiting a cross-platform visual gate): private `_BaseWindow` mixin
+Toplevel) is OPEN — PR #1103, branch `feat/2.0-shipped-api-window`** (design §5a;
+awaiting a cross-platform visual gate before merge): private `_BaseWindow` mixin
 shared by `Window`/`Toplevel`, unified `_setup_icon` (fixes the
 `Toplevel(iconphoto=None)` crash), new private `internal/positioning.py` (subset of
 bootstack's `WindowPositioning`; optional `screeninfo`, graceful single-screen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,15 +138,17 @@ author reversed docs-first so the docs get written against normalized signatures
 design pass done + confirmed in `development/2_0_shipped_widget_api_design.md`
 (Hybrid posture · port bootstack window mechanisms · unify dialog returns +
 `get_date`→None-on-cancel · Tableview fix+re-export now, defer the verb rename).
-**PR A (dialogs)** is implemented on branch `feat/2.0-shipped-api-dialogs`:
+**PR A (dialogs) is MERGED (#1102):**
 Messagebox uniform keyword-only signatures, Querybox `get_*` return via `.result`,
 `get_date`→None-on-cancel + `position=`, `DatePickerDialog` `autoshow`/`show()`/
 `result`, `MessageDialog.command` plain-callable (tuple deprecated via `_compat`),
 `ColorChoice` deduped, dialogs re-exported at top level; `tests/test_dialogs_api.py`
-(+19). **Current → open/merge PR A vs `2.0`, then PR B (Window/Toplevel) + PR C
-(Tableview) per the design §8.** The docs Workstream H (starting with docs sub-PR
-#1 — nav/IA skeleton + un-break the 7 broken API `:::` stubs, per
-`development/2_0_docs_design.md` §11) now trails the API pass.
+(+19); expected suite on `2.0` ~302 (297 excl. localization). **Current → PR B
+(Window/Toplevel — the cross-platform bootstack `_BaseWindow`/`WindowPositioning`
+port, design §5a), then PR C (Tableview, §5c), per the design §8.** The docs
+Workstream H (starting with docs sub-PR #1 — nav/IA skeleton + un-break the 7
+broken API `:::` stubs, per `development/2_0_docs_design.md` §11) now trails the
+API pass.
 
 ## Repository layout
 

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -267,3 +267,56 @@ signatures.
 **Not breaking.** `message` (Messagebox) vs `prompt` (Querybox) is kept — it is a
 real told-vs-asked distinction. `parent` stays the owner-argument name across the
 dialog surface (the embeddable `ColorChooser` frame keeps `master`).
+
+## Window/Toplevel API normalization — snake_case, keyword-only, positioning  *(API)*
+
+**What.** `Window` and `Toplevel` now share a private `_BaseWindow` mixin and a
+normalized constructor surface (shipped-widget API pass, PR B).
+
+- **Raw-Tk-mirroring kwargs are snake_cased** with warn-and-normalize aliases
+  (removed in 3.0): `hdpi`→`high_dpi`, `overrideredirect`→`override_redirect`,
+  `windowtype`→`window_type`, `toolwindow`→`tool_window`. The old spellings still
+  work through 2.x but emit a `DeprecationWarning`.
+- **Constructors are keyword-only after the leading positional(s)**: `Window(title,
+  themename, *, ...)` and `Toplevel(title, *, ...)`. Everything past those (e.g.
+  `size`, `iconphoto`, `alpha`, `default_button`) must be passed by keyword. This
+  cannot be shimmed (positional args carry no name) — documented breaking change,
+  low real-world incidence.
+- **`Toplevel.iconify` is a real keyword-only parameter** (default `False`), no
+  longer smuggled through `**kwargs`.
+- **`iconphoto` semantics are unified** across both classes via one `_setup_icon`
+  helper: `None` skips (leave untouched), `''` uses the default (brand icon on
+  `Window`, inherit on `Toplevel`), a path loads with fallback. This fixes the old
+  `Toplevel(iconphoto=None)` crash (it fell into `PhotoImage(file=None)`), and a
+  bad icon path now emits a `UserWarning` instead of `print()`ing to stdout. A
+  `.ico` path is applied via `wm_iconbitmap` on Windows.
+- **`position` accepts negative (edge-relative) offsets** — it now emits
+  `f"{x:+d}{y:+d}"`, so `position=(-10, -10)` places the window relative to the
+  bottom-right edge; `size`+`position` apply as one combined `geometry()` call.
+- **`place_window_center`/`position_center` use the new positioning utility**
+  (`internal/positioning.py`, a subset of bootstack's `WindowPositioning`):
+  monitor-aware centering (via optional `screeninfo`, graceful single-screen
+  fallback) + on-screen clamping. Previously it ignored the titlebar and was not
+  multi-monitor aware.
+- Internal/polish: the `style` property returns the singleton consistently on both
+  classes; `overrideredirect(True)` is a silent no-op on macOS (aqua) where it
+  destabilizes Tk; on win32 an explicit AppUserModelID is set so the taskbar shows
+  the app icon, not `python.exe`.
+
+**Why.** `Window`/`Toplevel` were the last shipped surfaces with un-normalized
+signatures: raw Tk attribute names, a ~14-param all-positional constructor, a
+smuggled `iconify`, two diverging `iconphoto` implementations (one crashing on
+`None`), a `+{x}+{y}` position that couldn't express edge offsets, and a
+titlebar-ignorant single-screen centering. bootstack had already solved the
+cross-platform quirks; we borrow the mechanisms (not the API).
+
+**Migration.**
+- Rename kwargs: `hdpi=`→`high_dpi=`, `overrideredirect=`→`override_redirect=`,
+  `windowtype=`→`window_type=`, `toolwindow=`→`tool_window=`.
+- Pass window options by keyword (they already usually are): `Window("Title",
+  size=(800,600))`, not `Window("Title", "theme", "primary", ...)` positionally.
+
+**Not breaking.** `minsize`/`maxsize` are kept (they mirror the Tk method names the
+tuple wraps — consistency-with-Tk wins over bootstack's `min_size`/`max_size`).
+`screeninfo` is an *optional* import; without it centering falls back to Tk's
+single-screen metrics (no new hard dependency — Pillow stays the only one).

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -4,7 +4,7 @@
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
 _Last updated: 2026-07-07 (**shipped-widget API pass — PR B (Window/Toplevel)
-IMPLEMENTED on branch `feat/2.0-shipped-api-window`, awaiting a cross-platform
+OPEN as PR #1103 (branch `feat/2.0-shipped-api-window`), awaiting a cross-platform
 visual gate + merge**). Per design §5a: new private `_BaseWindow` mixin
 (`Window(_BaseWindow, tk.Tk)` / `Toplevel(_BaseWindow, tk.Toplevel)`) owning the
 shared icon/geometry/alpha/positioning/`style` logic both classes were

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,23 +3,24 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-07-07 (**shipped-widget API pass STARTED — design pass done
-+ PR A (dialogs) implemented on a branch**). The deferred shipped-widget API
+_Last updated: 2026-07-07 (**shipped-widget API pass: design done + PR A
+(dialogs) MERGED into `2.0` (#1102)**). The deferred shipped-widget API
 normalization (`Window`/dialogs/`Tableview`) was picked up ahead of the docs
 (author reversed the docs-first call so docs get written against normalized
 signatures). Design pass **confirmed**:
 `development/2_0_shipped_widget_api_design.md` (Hybrid posture · port bootstack
 window mechanisms · unify dialog returns + `get_date`→None-on-cancel · Tableview
-fix+re-export now, defer verb rename). **PR A (dialogs)** is committed on
-`feat/2.0-shipped-api-dialogs` (from `2.0`), not yet pushed/merged: Messagebox
+fix+re-export now, defer verb rename). **PR A (dialogs) MERGED (#1102):** Messagebox
 uniform keyword-only signatures; Querybox `get_*` return via `.result`;
 `get_date` returns None on cancel + gained `position=`; DatePickerDialog
 `autoshow=False`/`show()`/`result`; `MessageDialog.command` plain-callable (tuple
 deprecated via `_compat`); `ColorChoice` deduped; dialogs re-exported at top
-level. `tests/test_dialogs_api.py` (+19); suite 297 passed excl. the known
-`nl.msg` flake; modal cancel + happy paths verified end-to-end. **NEXT → push/
-open PR A vs `2.0`, then PR B (Window/Toplevel) + PR C (Tableview) per the design
-§8.** (Prior recommended step, docs sub-PR #1, still trails the API pass.)_
+level. `tests/test_dialogs_api.py` (+19); suite on `2.0` **297 passed** excl. the
+known `nl.msg` flake; modal cancel + happy paths were verified end-to-end. A human
+visual spot-check of `examples/widgets/dialogs.py` (light↔dark) is still worth an
+eyeball before docs screenshots. **NEXT → PR B (Window/Toplevel — the
+cross-platform bootstack `_BaseWindow`/`WindowPositioning` port, design §5a), then
+PR C (Tableview, §5c), per §8.** (Docs sub-PR #1 still trails the API pass.)_
 
 _Prior 2026-07-07 (**icon-drop PREREQ + a visual-polish batch are all
 MERGED into `2.0`; NEXT → docs sub-PR #1**). Merged since the prior entry:

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,7 +3,37 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-07-07 (**shipped-widget API pass: design done + PR A
+_Last updated: 2026-07-07 (**shipped-widget API pass — PR B (Window/Toplevel)
+IMPLEMENTED on branch `feat/2.0-shipped-api-window`, awaiting a cross-platform
+visual gate + merge**). Per design §5a: new private `_BaseWindow` mixin
+(`Window(_BaseWindow, tk.Tk)` / `Toplevel(_BaseWindow, tk.Toplevel)`) owning the
+shared icon/geometry/alpha/positioning/`style` logic both classes were
+duplicating and drifting on; `_setup_icon` unifies `iconphoto` (`None`=skip,
+`''`=default/inherit, path=load-with-fallback — fixes the `Toplevel(iconphoto=None)`
+crash, bad path now `UserWarning` not `print`, `.ico`→`wm_iconbitmap` on win32);
+new private `internal/positioning.py` (subset of bootstack's `WindowPositioning`:
+`center_on_screen`/`center_on_parent`/`ensure_on_screen`, optional `screeninfo`
+with graceful single-screen fallback — no new hard dep) re-points
+`place_window_center`; snake_case kwarg aliases via
+`_compat.normalize_window_kwargs` (`hdpi`→`high_dpi`,
+`overrideredirect`→`override_redirect`, `windowtype`→`window_type`,
+`toolwindow`→`tool_window`, warn-and-normalize, removed 3.0); **keyword-only**
+constructors after the leading positional(s) (`Window(title, themename, *, …)`,
+`Toplevel(title, *, …)` — documented breaking, unshimmable); `iconify` promoted to
+a real `Toplevel` kwarg; edge-relative + combined geometry (`f"{x:+d}{y:+d}"`);
+aqua `overrideredirect` no-op guard; win32 AppUserModelID. First-party
+`dialogs/base.py` migrated `windowtype`→`window_type`. New
+`tests/test_window_api.py` (+15); suite **317 passed** excl. the known `nl.msg`
+flake; warning-free import + end-to-end smoke verified. Breaking-change log +
+design §8 updated. **Residual risk = cross-platform** (a manual win32 + if-available
+x11/aqua check is still owed before merge). **Deferred fast-follow (NOT in PR B):**
+the richer bootstack positioning surface (`place_center_on`/`place_at`/
+`place_anchor`/`place_dropdown`/`place_cursor`), the `windowtype` unified switch
+(§5a.9), and routing the dialogs' `internal/utility.center_on_parent` through the
+new `positioning` module. **NEXT → PR C (Tableview fixes + re-export, §5c)** once PR
+B lands. Prior entry (PR A) follows._
+
+_Prior 2026-07-07 (**shipped-widget API pass: design done + PR A
 (dialogs) MERGED into `2.0` (#1102)**). The deferred shipped-widget API
 normalization (`Window`/dialogs/`Tableview`) was picked up ahead of the docs
 (author reversed the docs-first call so docs get written against normalized

--- a/development/2_0_shipped_widget_api_design.md
+++ b/development/2_0_shipped_widget_api_design.md
@@ -315,11 +315,30 @@ gate. Recommended order (smallest-blast-radius first):
   top-level re-exports, `command` de-vestigialize. New/updated tests in a headless
   `tests/test_dialogs_api.py` (result conventions, cancel→None, kwarg normalization).
   Human spot-check: each dialog opens/positions/returns correctly light+dark.
-- **PR B — Window/Toplevel normalization.** §5a. `_BaseWindow` mixin, `_setup_icon`,
-  positioning utility + priority, snake_case aliases, keyword-only, edge-relative
-  position, aqua guard, AppUserModelID. Cross-platform is the risk — gate on a
-  manual check on win32 + (if available) x11/aqua. Tests: kwarg normalization,
-  geometry string construction, centering math (headless-computable).
+- **PR B — Window/Toplevel normalization. IMPLEMENTED (branch
+  `feat/2.0-shipped-api-window`).** §5a. `_BaseWindow` mixin (`Window(_BaseWindow,
+  tk.Tk)` / `Toplevel(_BaseWindow, tk.Toplevel)`) holding the shared
+  icon/geometry/alpha/positioning/`style` logic; `_setup_icon` (unified `None`/`''`/
+  path semantics, fixes the `Toplevel(iconphoto=None)` crash, `.ico`→`wm_iconbitmap`
+  on win32, bad-path → `UserWarning` not `print`); new private
+  `internal/positioning.py` (subset of bootstack's `WindowPositioning`:
+  `center_on_screen`/`center_on_parent`/`ensure_on_screen`, optional `screeninfo`,
+  graceful single-screen fallback) re-pointing `place_window_center`; snake_case
+  aliases via `_compat.normalize_window_kwargs` (`hdpi`/`overrideredirect`/
+  `windowtype`/`toolwindow`); keyword-only constructors after the leading
+  positional(s); `iconify` promoted to a real `Toplevel` kwarg; edge-relative +
+  combined `geometry` (`f"{x:+d}{y:+d}"`); aqua `overrideredirect` no-op guard;
+  win32 AppUserModelID. First-party caller `dialogs/base.py` migrated
+  `windowtype`→`window_type`. New `tests/test_window_api.py` (+15). Suite **317
+  passed** excl. the known `nl.msg` flake; warning-free import + end-to-end smoke
+  (new API, legacy-kwarg warnings, centering, singleton `style`) verified.
+  **Cross-platform is the residual risk — still wants a manual check on win32 +
+  (if available) x11/aqua** before/at merge. **Deferred to a fast-follow (noted
+  here, not done in PR B):** the richer bootstack positioning surface
+  (`place_center_on`/`place_at`/`place_anchor`/`place_dropdown`/`place_cursor`),
+  the `windowtype` unified switch (§5a.9), and routing the dialogs'
+  `internal/utility.center_on_parent` through the new `positioning` module — all
+  out of PR B's minimal scope.
 - **PR C — Tableview fixes + re-export.** §5c. Bug fixes, dead-code removal,
   `print()`→error, re-export. Tests: re-export presence, the two bug regressions,
   no-stdout-on-empty-insert.

--- a/development/2_0_shipped_widget_api_design.md
+++ b/development/2_0_shipped_widget_api_design.md
@@ -315,7 +315,7 @@ gate. Recommended order (smallest-blast-radius first):
   top-level re-exports, `command` de-vestigialize. New/updated tests in a headless
   `tests/test_dialogs_api.py` (result conventions, cancel→None, kwarg normalization).
   Human spot-check: each dialog opens/positions/returns correctly light+dark.
-- **PR B — Window/Toplevel normalization. IMPLEMENTED (branch
+- **PR B — Window/Toplevel normalization. OPEN — PR #1103 (branch
   `feat/2.0-shipped-api-window`).** §5a. `_BaseWindow` mixin (`Window(_BaseWindow,
   tk.Tk)` / `Toplevel(_BaseWindow, tk.Toplevel)`) holding the shared
   icon/geometry/alpha/positioning/`style` logic; `_setup_icon` (unified `None`/`''`/

--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -124,7 +124,7 @@ class Dialog(BaseWidget):
                 title=self._title,
                 resizable=(False, False),
                 minsize=(250, 15),
-                windowtype="dialog",
+                window_type="dialog",
                 iconify=True,
             )
 

--- a/src/ttkbootstrap/internal/positioning.py
+++ b/src/ttkbootstrap/internal/positioning.py
@@ -1,0 +1,125 @@
+"""Window positioning helpers (private plumbing, no back-compat guarantee).
+
+A small, ttkbootstrap-scoped subset of bootstack's ``WindowPositioning``
+(``bootstack/src/bootstack/_runtime/window_utilities.py``) — just the three
+mechanisms ``Window``/``Toplevel`` and the dialogs need: center-on-screen,
+center-on-parent, and clamp-into-the-visible-monitor. Each is a pure geometry
+calculation returning ``(x, y)``; the caller applies the geometry string.
+
+Multi-monitor awareness is optional: if the third-party ``screeninfo`` package
+is importable we resolve the monitor under a point, otherwise we fall back to
+Tk's virtual-root dimensions (single logical screen). No new hard dependency —
+Pillow stays the only required runtime dep.
+"""
+from __future__ import annotations
+
+import tkinter
+from typing import Optional, Tuple
+
+try:
+    from screeninfo import get_monitors  # type: ignore
+    _HAS_SCREENINFO = True
+except Exception:  # pragma: no cover - screeninfo is an optional extra
+    _HAS_SCREENINFO = False
+
+Rect = Tuple[int, int, int, int]  # (x, y, width, height)
+
+
+def _monitor_at_point(x: int, y: int) -> Optional[Rect]:
+    """Return the ``(x, y, w, h)`` bounds of the monitor containing a point.
+
+    Returns ``None`` when ``screeninfo`` is unavailable so callers fall back to
+    Tk's screen/virtual-root metrics. When ``screeninfo`` is present but the
+    point is on no monitor, the first monitor is returned as a sane default.
+    """
+    if not _HAS_SCREENINFO:
+        return None
+    try:
+        monitors = get_monitors()
+        for m in monitors:
+            if m.x <= x < m.x + m.width and m.y <= y < m.y + m.height:
+                return (m.x, m.y, m.width, m.height)
+        if monitors:
+            m = monitors[0]
+            return (m.x, m.y, m.width, m.height)
+    except Exception:
+        pass
+    return None
+
+
+def _window_size(window: tkinter.Misc) -> Tuple[int, int]:
+    """Best-available (width, height): the realized size, or the requested
+    size before the window has been mapped."""
+    width = max(window.winfo_reqwidth(), window.winfo_width())
+    height = max(window.winfo_reqheight(), window.winfo_height())
+    return width, height
+
+
+def center_on_screen(window: tkinter.Misc) -> Tuple[int, int]:
+    """Coordinates that center ``window`` on the screen.
+
+    With ``screeninfo`` installed, centers on the monitor under the mouse
+    cursor (the display the user is most likely looking at); otherwise centers
+    on Tk's single reported screen. Call ``update_idletasks()`` first for an
+    accurate size — this method does so as well.
+    """
+    window.update_idletasks()
+    w_width, w_height = _window_size(window)
+    monitor = _monitor_at_point(window.winfo_pointerx(), window.winfo_pointery())
+    if monitor:
+        mx, my, mw, mh = monitor
+        x = mx + (mw - w_width) // 2
+        y = my + (mh - w_height) // 2
+    else:
+        x = (window.winfo_screenwidth() - w_width) // 2
+        y = (window.winfo_screenheight() - w_height) // 2
+    return int(x), int(y)
+
+
+def center_on_parent(window: tkinter.Misc, parent: tkinter.Misc) -> Tuple[int, int]:
+    """Coordinates (in screen space) that center ``window`` over ``parent``."""
+    window.update_idletasks()
+    parent.update_idletasks()
+    w_width, w_height = _window_size(window)
+    p_x = parent.winfo_rootx()
+    p_y = parent.winfo_rooty()
+    p_width = max(parent.winfo_width(), parent.winfo_reqwidth())
+    p_height = max(parent.winfo_height(), parent.winfo_reqheight())
+    x = p_x + max(0, (p_width - w_width) // 2)
+    y = p_y + max(0, (p_height - w_height) // 2)
+    return int(x), int(y)
+
+
+def ensure_on_screen(
+        window: tkinter.Misc,
+        x: int,
+        y: int,
+        padding: int = 20,
+        titlebar_height: int = 60,
+) -> Tuple[int, int]:
+    """Clamp ``(x, y)`` so the window stays fully visible on its monitor.
+
+    ``titlebar_height`` reserves extra room at the top for window-manager
+    decorations that ``winfo_height`` does not include, keeping the titlebar
+    on-screen. Uses the ``screeninfo`` monitor under the proposed point when
+    available (so a window that legitimately belongs on a secondary monitor is
+    not yanked back to the primary), else Tk's virtual-root bounds.
+    """
+    window.update_idletasks()
+    w_width, w_height = _window_size(window)
+
+    monitor = _monitor_at_point(x, y)
+    if monitor:
+        screen_x0, screen_y0, screen_width, screen_height = monitor
+    else:
+        screen_x0 = window.winfo_vrootx()
+        screen_y0 = window.winfo_vrooty()
+        screen_width = window.winfo_vrootwidth()
+        screen_height = window.winfo_vrootheight()
+
+    screen_x1 = screen_x0 + screen_width
+    screen_y1 = screen_y0 + screen_height
+
+    x = max(screen_x0 + padding, min(x, screen_x1 - w_width - padding))
+    y = max(screen_y0 + padding, min(y, screen_y1 - w_height - titlebar_height))
+    return int(x), int(y)

--- a/src/ttkbootstrap/style/_compat.py
+++ b/src/ttkbootstrap/style/_compat.py
@@ -64,6 +64,37 @@ def warn_deprecated(old: str, new: str, *, removed_in: str = "3.0") -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Window/Toplevel keyword renames (2.0 shipped-widget API pass, PR B).
+# ---------------------------------------------------------------------------
+# The raw-Tk-mirroring constructor kwargs were renamed to snake_case. The old
+# spellings are accepted through 2.x with a DeprecationWarning, removed in 3.0.
+_WINDOW_KWARG_ALIASES = {
+    "overrideredirect": "override_redirect",
+    "windowtype": "window_type",
+    "toolwindow": "tool_window",
+    "hdpi": "high_dpi",
+}
+
+
+def normalize_window_kwargs(kwargs: dict) -> dict:
+    """Pop deprecated raw-Tk-name window kwargs from ``kwargs`` in place.
+
+    Returns a ``{new_name: value}`` dict for any legacy spelling found, emitting
+    the standard deprecation warning for each. The caller merges the result over
+    its explicit parameters, e.g.::
+
+        aliases = normalize_window_kwargs(kwargs)
+        high_dpi = aliases.get("high_dpi", high_dpi)
+    """
+    out = {}
+    for old, new in _WINDOW_KWARG_ALIASES.items():
+        if old in kwargs:
+            warn_deprecated(f"the {old!r} window argument", f"{new!r}")
+            out[new] = kwargs.pop(old)
+    return out
+
+
 def normalize_bootstyle(value, *, warn: bool = False) -> str:
     """Return the canonical dash-joined bootstyle string for a legacy value.
 

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -43,12 +43,16 @@ Example:
     root.mainloop()
     ```
 """
+import sys
 import tkinter
+import warnings
 from typing import Any, Optional, Tuple, Union
 
 from ttkbootstrap import utility
 from ttkbootstrap.constants import *
+from ttkbootstrap.internal import positioning
 from ttkbootstrap.style import Style, Bootstyle
+from ttkbootstrap.style._compat import normalize_window_kwargs
 
 # The default ttkbootstrap window icon (brand logo, 32x32 PNG) used when a
 # Window/Toplevel is created with ``iconphoto=''``. This is a base64-encoded
@@ -194,7 +198,134 @@ def on_select_all(event: tkinter.Event) -> None:
         widget.icursor(END)
 
 
-class Window(tkinter.Tk):
+class _BaseWindow:
+    """Window logic shared by `Window` (root) and `Toplevel` (secondary).
+
+    Used as a mixin alongside `tkinter.Tk`/`tkinter.Toplevel`, so both classes
+    stop duplicating -- and drifting on -- their icon, geometry, alpha, and
+    positioning handling. Mirrors bootstack's `BaseWindow`
+    (`bootstack/src/bootstack/_runtime/base_window.py`); ttkbootstrap borrows
+    the mechanisms only, keeping its own `Window`/`Toplevel` split.
+    """
+
+    winsys: str
+
+    @property
+    def style(self) -> Style:
+        """Return a reference to the `ttkbootstrap.style.Style` object."""
+        return Style.get_instance()
+
+    # -- setup helpers -----------------------------------------------------
+
+    def _setup_icon(self, iconphoto: Optional[str], default_data: Optional[str] = None) -> None:
+        """Configure the titlebar icon uniformly across both window classes.
+
+        Semantics (identical for `Window` and `Toplevel`):
+            None  -> leave the icon untouched (skip).
+            ''    -> use `default_data` if given (the brand icon on `Window`),
+                     otherwise inherit the application default (`Toplevel`).
+            path  -> load the image, falling back to `default_data` on failure.
+
+        A `.ico` path is applied through `wm_iconbitmap` on Windows (mirrors
+        bootstack's platform branch); other formats go through `iconphoto`.
+        """
+        if iconphoto is None:
+            return
+        if iconphoto == '':
+            if default_data is not None:
+                self._icon = tkinter.PhotoImage(master=self, data=default_data)
+                self.iconphoto(True, self._icon)
+            return
+        try:
+            path = str(iconphoto)
+            if path.lower().endswith('.ico') and self.winsys == 'win32':
+                self.wm_iconbitmap(path)
+            else:
+                self._icon = tkinter.PhotoImage(file=path, master=self)
+                self.iconphoto(True, self._icon)
+        except tkinter.TclError:
+            warnings.warn(
+                f"iconphoto path {iconphoto!r} could not be loaded; "
+                "using the default image.",
+                UserWarning,
+                stacklevel=3,
+            )
+            if default_data is not None:
+                self._icon = tkinter.PhotoImage(master=self, data=default_data)
+                self.iconphoto(True, self._icon)
+
+    def _apply_geometry(
+            self,
+            size: Optional[Tuple[int, int]],
+            position: Optional[Tuple[int, int]],
+    ) -> None:
+        """Apply `size` and/or `position` as a single `geometry` call.
+
+        `position` uses a signed format (`f"{x:+d}{y:+d}"`) so negative offsets
+        express edge-relative placement (`position=(-10, -10)` -> near the
+        bottom-right), which the old hardcoded `+{x}+{y}` could not.
+        """
+        geo = ""
+        if size is not None:
+            geo += f"{size[0]}x{size[1]}"
+        if position is not None:
+            x, y = position
+            geo += f"{int(x):+d}{int(y):+d}"
+        if geo:
+            self.geometry(geo)
+
+    def _apply_constraints(
+            self,
+            minsize: Optional[Tuple[int, int]],
+            maxsize: Optional[Tuple[int, int]],
+            resizable: Optional[Tuple[bool, bool]],
+    ) -> None:
+        if minsize is not None:
+            self.minsize(minsize[0], minsize[1])
+        if maxsize is not None:
+            self.maxsize(maxsize[0], maxsize[1])
+        if resizable is not None:
+            self.resizable(resizable[0], resizable[1])
+
+    def _setup_alpha(self, alpha: Optional[float]) -> None:
+        """Set window transparency, platform-aware.
+
+        On X11 alpha must be applied after the window is visible, so it is
+        deferred to the `<Visibility>` event (mirrors bootstack's
+        `on_visibility_alpha`); Windows/aqua set it immediately.
+        """
+        if alpha is None:
+            return
+        if self.winsys == 'x11':
+            self.alpha = alpha
+            self.alpha_bind = self.bind("<Visibility>", on_visibility, '+')
+        else:
+            self.attributes("-alpha", alpha)
+
+    def overrideredirect(self, boolean: Optional[bool] = None):
+        """Get/set override-redirect, guarding the macOS no-op.
+
+        On aqua, enabling override-redirect breaks click handling and can crash
+        Tk/Cocoa, so a truthy request is silently ignored there (bootstack
+        `base_window.py:619-639`).
+        """
+        if boolean and getattr(self, 'winsys', None) == 'aqua':
+            return None
+        return super().overrideredirect(boolean)
+
+    # -- positioning -------------------------------------------------------
+
+    def place_window_center(self) -> None:
+        """Center the window on the screen (monitor under the cursor when
+        `screeninfo` is available), clamped to stay fully visible."""
+        x, y = positioning.center_on_screen(self)
+        x, y = positioning.ensure_on_screen(self, x, y)
+        self.geometry(f'+{x}+{y}')
+
+    position_center = place_window_center  # alias
+
+
+class Window(_BaseWindow, tkinter.Tk):
     """A class that wraps the tkinter.Tk class in order to provide a
     more convenient api with additional bells and whistles. For more
     information on how to use the inherited `Tk` methods, see the
@@ -215,6 +346,7 @@ class Window(tkinter.Tk):
             self,
             title: str = "ttkbootstrap",
             themename: str = "bootstrap-light",
+            *,
             default_button: str = "neutral",
             iconphoto: Optional[str] = '',
             size: Optional[Tuple[int, int]] = None,
@@ -222,10 +354,10 @@ class Window(tkinter.Tk):
             minsize: Optional[Tuple[int, int]] = None,
             maxsize: Optional[Tuple[int, int]] = None,
             resizable: Optional[Tuple[bool, bool]] = None,
-            hdpi: bool = True,
+            high_dpi: bool = True,
             scaling: Optional[float] = None,
             transient: Optional[tkinter.Misc] = None,
-            overrideredirect: bool = False,
+            override_redirect: bool = False,
             alpha: float = 1.0,
             **kwargs: Any,
     ) -> None:
@@ -259,9 +391,10 @@ class Window(tkinter.Tk):
 
             position (tuple[int, int]):
                 The horizontal and vertical position of the window on
-                the screen relative to the top-left coordinate.
-                Internally this is passed to the `Window.geometry`
-                method.
+                the screen relative to the top-left coordinate. Negative
+                values are edge-relative (e.g. `(-10, -10)` places the
+                window near the bottom-right). Internally this is passed
+                to the `Window.geometry` method.
 
             minsize (tuple[int, int]):
                 Specifies the minimum permissible dimensions for the
@@ -280,9 +413,9 @@ class Window(tkinter.Tk):
                 This can be adjusted after the window is created by using
                 the `Window.resizable` method.
 
-            hdpi (bool):
+            high_dpi (bool):
                 Enable high-dpi support for Windows OS. This option is
-                enabled by default.
+                enabled by default. (Renamed from `hdpi` in 2.0.)
 
             scaling (float):
                 Sets the current scaling factor used by Tk to convert
@@ -296,10 +429,12 @@ class Window(tkinter.Tk):
                 transient with regard to the widget master. Internally
                 this is passed to the `Window.transient` method.
 
-            overrideredirect (bool):
+            override_redirect (bool):
                 Instructs the window manager to ignore this widget if
                 True. Internally, this argument is passed to the
-                `Window.overrideredirect(1)` method.
+                `Window.overrideredirect(1)` method. Ignored on macOS
+                (aqua), where it destabilizes Tk. (Renamed from
+                `overrideredirect` in 2.0.)
 
             alpha (float):
                 On Windows, specifies the alpha transparency level of the
@@ -310,13 +445,22 @@ class Window(tkinter.Tk):
                 Any other keyword arguments that are passed through to tkinter.Tk() constructor
                 List of available keywords available at: https://docs.python.org/3/library/tkinter.html#tkinter.Tk
         """
+        # Accept the pre-2.0 raw-Tk kwarg spellings with a deprecation warning.
+        aliases = normalize_window_kwargs(kwargs)
+        high_dpi = aliases.get("high_dpi", high_dpi)
+        override_redirect = aliases.get("override_redirect", override_redirect)
+
         # ttkbootstrap supports a single application root. The Style engine is
         # a process-wide singleton bound to the first root; a second live root
         # would silently no-op all theming. Fail loudly before any side effects.
         _require_single_root(self)
 
-        if hdpi:
+        if high_dpi:
             utility.enable_high_dpi_awareness()
+
+        # On win32, tag the process so the taskbar shows the app icon rather
+        # than the generic python.exe one (bootstack app.py:534-540).
+        self._set_app_user_model_id()
 
         super().__init__(**kwargs)
         self.winsys: str = self.tk.call('tk', 'windowingsystem')
@@ -324,65 +468,35 @@ class Window(tkinter.Tk):
         if scaling is not None:
             utility.enable_high_dpi_awareness(self, scaling)
 
-        if iconphoto is not None:
-            if iconphoto == '':
-                # the default ttkbootstrap icon
-                self._icon = tkinter.PhotoImage(master=self, data=_DEFAULT_ICON_DATA)
-                self.iconphoto(True, self._icon)
-            else:
-                try:
-                    # the user provided an image path
-                    self._icon = tkinter.PhotoImage(file=iconphoto, master=self)
-                    self.iconphoto(True, self._icon)
-                except tkinter.TclError:
-                    # The fallback icon if the user icon fails.
-                    print('iconphoto path is bad; using default image.')
-                    self._icon = tkinter.PhotoImage(data=_DEFAULT_ICON_DATA, master=self)
-                    self.iconphoto(True, self._icon)
-
+        self._setup_icon(iconphoto, default_data=_DEFAULT_ICON_DATA)
         self.title(title)
-
-        if size is not None:
-            width, height = size
-            self.geometry(f"{width}x{height}")
-
-        if position is not None:
-            xpos, ypos = position
-            self.geometry(f"+{xpos}+{ypos}")
-
-        if minsize is not None:
-            width, height = minsize
-            self.minsize(width, height)
-
-        if maxsize is not None:
-            width, height = maxsize
-            self.maxsize(width, height)
-
-        if resizable is not None:
-            width, height = resizable
-            self.resizable(width, height)
+        self._apply_geometry(size, position)
+        self._apply_constraints(minsize, maxsize, resizable)
 
         if transient is not None:
             self.transient(transient)
 
-        if overrideredirect:
+        if override_redirect:
             self.overrideredirect(1)
 
-        if alpha is not None:
-            if self.winsys == 'x11':
-                self.alpha = alpha
-                self.alpha_bind = self.bind("<Visibility>", on_visibility, '+')
-            else:
-                self.attributes("-alpha", alpha)
+        self._setup_alpha(alpha)
 
         apply_class_bindings(self)
         apply_all_bindings(self)
         self._style = Style(themename, default_button=default_button)
 
-    @property
-    def style(self) -> Style:
-        """Return a reference to the `ttkbootstrap.style.Style` object."""
-        return self._style
+    @staticmethod
+    def _set_app_user_model_id() -> None:
+        """On win32, set an explicit AppUserModelID so the taskbar groups this
+        app under its own icon instead of python.exe. No-op elsewhere."""
+        if sys.platform != 'win32':
+            return
+        try:
+            import ctypes
+            ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+                "ttkbootstrap.app")
+        except Exception:
+            pass
 
     def destroy(self) -> None:
         """Destroy the window and all its children."""
@@ -391,22 +505,8 @@ class Window(tkinter.Tk):
         Style.instance = None
         super().destroy()
 
-    def place_window_center(self) -> None:
-        """Position the toplevel in the center of the screen. Does not
-        account for titlebar height."""
-        self.update_idletasks()
-        w_height = self.winfo_height()
-        w_width = self.winfo_width()
-        s_height = self.winfo_screenheight()
-        s_width = self.winfo_screenwidth()
-        xpos = (s_width - w_width) // 2
-        ypos = (s_height - w_height) // 2
-        self.geometry(f'+{xpos}+{ypos}')
 
-    position_center = place_window_center  # alias
-
-
-class Toplevel(tkinter.Toplevel):
+class Toplevel(_BaseWindow, tkinter.Toplevel):
     """A class that wraps the tkinter.Toplevel class in order to
     provide a more convenient api with additional bells and whistles.
     For more information on how to use the inherited `Toplevel`
@@ -426,17 +526,19 @@ class Toplevel(tkinter.Toplevel):
     def __init__(
             self,
             title: str = "ttkbootstrap",
-            iconphoto: str = '',
+            *,
+            iconphoto: Optional[str] = '',
             size: Optional[Tuple[int, int]] = None,
             position: Optional[Tuple[int, int]] = None,
             minsize: Optional[Tuple[int, int]] = None,
             maxsize: Optional[Tuple[int, int]] = None,
             resizable: Optional[Tuple[bool, bool]] = None,
             transient: Optional[tkinter.Misc] = None,
-            overrideredirect: bool = False,
-            windowtype: Optional[str] = None,
+            override_redirect: bool = False,
+            window_type: Optional[str] = None,
             topmost: bool = False,
-            toolwindow: bool = False,
+            tool_window: bool = False,
+            iconify: bool = False,
             alpha: float = 1.0,
             **kwargs: Any,
     ) -> None:
@@ -449,7 +551,8 @@ class Toplevel(tkinter.Toplevel):
             iconphoto (str):
                 A path to the image used for the titlebar icon.
                 Internally this is passed to the `Tk.iconphoto` method.
-                By default the application icon is used.
+                By default the application icon is inherited. Set to
+                `None` to leave the icon untouched.
 
             size (tuple[int, int]):
                 The width and height of the application window.
@@ -458,9 +561,9 @@ class Toplevel(tkinter.Toplevel):
 
             position (tuple[int, int]):
                 The horizontal and vertical position of the window on
-                the screen relative to the top-left coordinate.
-                Internally this is passed to the `Toplevel.geometry`
-                method.
+                the screen relative to the top-left coordinate. Negative
+                values are edge-relative. Internally this is passed to
+                the `Toplevel.geometry` method.
 
             minsize (tuple[int, int]):
                 Specifies the minimum permissible dimensions for the
@@ -484,27 +587,34 @@ class Toplevel(tkinter.Toplevel):
                 transient with regard to the widget master. Internally
                 this is passed to the `Toplevel.transient` method.
 
-            overrideredirect (bool):
+            override_redirect (bool):
                 Instructs the window manager to ignore this widget if
                 True. Internally, this argument is processed as
-                `Toplevel.overrideredirect(1)`.
+                `Toplevel.overrideredirect(1)`. Ignored on macOS (aqua).
+                (Renamed from `overrideredirect` in 2.0.)
 
-            windowtype (str):
+            window_type (str):
                 On X11, requests that the window should be interpreted by
                 the window manager as being of the specified type. Internally,
-                this is passed to the `Toplevel.attributes('-type', windowtype)`.
+                this is passed to the `Toplevel.attributes('-type', window_type)`.
 
                 See the [-type option](https://tcl.tk/man/tcl8.6/TkCmd/wm.htm#M64)
-                for a list of available options.
+                for a list of available options. (Renamed from `windowtype`
+                in 2.0.)
 
             topmost (bool):
                 Specifies whether this is a topmost window (displays above all
                 other windows). Internally, this processed by the window as
                 `Toplevel.attributes('-topmost', 1)`.
 
-            toolwindow (bool):
+            tool_window (bool):
                 On Windows, specifies a toolwindow style. Internally, this is
-                processed as `Toplevel.attributes('-toolwindow', 1)`.
+                processed as `Toplevel.attributes('-toolwindow', 1)`. (Renamed
+                from `toolwindow` in 2.0.)
+
+            iconify (bool):
+                If True, the window starts minimized (iconified). Internally
+                this calls `Toplevel.iconify`.
 
             alpha (float):
                 On Windows, specifies the alpha transparency level of the
@@ -514,10 +624,11 @@ class Toplevel(tkinter.Toplevel):
             **kwargs (Dict):
                 Other optional keyword arguments.
         """
-        if 'iconify' in kwargs:
-            iconify = kwargs.pop('iconify')
-        else:
-            iconify = None
+        # Accept the pre-2.0 raw-Tk kwarg spellings with a deprecation warning.
+        aliases = normalize_window_kwargs(kwargs)
+        override_redirect = aliases.get("override_redirect", override_redirect)
+        window_type = aliases.get("window_type", window_type)
+        tool_window = aliases.get("tool_window", tool_window)
 
         super().__init__(**kwargs)
         self.winsys: str = self.tk.call('tk', 'windowingsystem')
@@ -528,37 +639,12 @@ class Toplevel(tkinter.Toplevel):
         Bootstyle.update_tk_widget_style(self)
         Bootstyle.stamp_theme_version(self)
 
-        if iconphoto != '':
-            try:
-                # the user provided an image path
-                self._icon = tkinter.PhotoImage(file=iconphoto, master=self)
-                self.iconphoto(True, self._icon)
-            except tkinter.TclError:
-                # The fallback icon if the user icon fails.
-                print('iconphoto path is bad; using default image.')
-                pass
-
+        # A Toplevel inherits the application icon by default (iconphoto='');
+        # pass default_data=None so '' means "inherit", not "brand icon".
+        self._setup_icon(iconphoto, default_data=None)
         self.title(title)
-
-        if size is not None:
-            width, height = size
-            self.geometry(f'{width}x{height}')
-
-        if position is not None:
-            xpos, ypos = position
-            self.geometry(f"+{xpos}+{ypos}")
-
-        if minsize is not None:
-            width, height = minsize
-            self.minsize(width, height)
-
-        if maxsize is not None:
-            width, height = maxsize
-            self.maxsize(width, height)
-
-        if resizable is not None:
-            width, height = resizable
-            self.resizable(width, height)
+        self._apply_geometry(size, position)
+        self._apply_constraints(minsize, maxsize, resizable)
 
         if iconify:
             self.iconify()
@@ -566,45 +652,19 @@ class Toplevel(tkinter.Toplevel):
         if transient is not None:
             self.transient(transient)
 
-        if overrideredirect:
+        if override_redirect:
             self.overrideredirect(1)
 
-        if windowtype is not None:
-            if self.winsys == 'x11':
-                self.attributes("-type", windowtype)
+        if window_type is not None and self.winsys == 'x11':
+            self.attributes("-type", window_type)
 
         if topmost:
             self.attributes("-topmost", 1)
 
-        if toolwindow:
-            if self.winsys == 'win32':
-                self.attributes("-toolwindow", 1)
+        if tool_window and self.winsys == 'win32':
+            self.attributes("-toolwindow", 1)
 
-        if alpha is not None:
-            if self.winsys == 'x11':
-                self.alpha = alpha
-                self.alpha_bind = self.bind("<Visibility>", on_visibility, '+')
-            else:
-                self.attributes("-alpha", alpha)
-
-    @property
-    def style(self) -> Style:
-        """Return a reference to the `ttkbootstrap.style.Style` object."""
-        return Style()
-
-    def place_window_center(self) -> None:
-        """Position the toplevel in the center of the screen. Does not
-        account for titlebar height."""
-        self.update_idletasks()
-        w_height = self.winfo_height()
-        w_width = self.winfo_width()
-        s_height = self.winfo_screenheight()
-        s_width = self.winfo_screenwidth()
-        xpos = (s_width - w_width) // 2
-        ypos = (s_height - w_height) // 2
-        self.geometry(f'+{xpos}+{ypos}')
-
-    position_center = place_window_center  # alias
+        self._setup_alpha(alpha)
 
 
 if __name__ == "__main__":

--- a/tests/test_window_api.py
+++ b/tests/test_window_api.py
@@ -1,0 +1,155 @@
+"""Headless tests for the 2.0 Window/Toplevel API normalization (PR B).
+
+Covers the parts that are checkable without a real display:
+- deprecated raw-Tk kwarg spellings normalize to snake_case (with a warning),
+- the combined/edge-relative geometry string construction,
+- the positioning math (center + clamp),
+- the unified icon/`iconphoto` semantics (including the old `Toplevel`
+  `iconphoto=None` crash),
+- the consistent `style` property and the aqua `overrideredirect` guard.
+"""
+import warnings
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.internal import positioning
+from ttkbootstrap.style import Style
+from ttkbootstrap.style._compat import normalize_window_kwargs
+from ttkbootstrap.window import Toplevel, Window, _BaseWindow
+
+
+# --------------------------------------------------------------------------
+# kwarg normalization
+# --------------------------------------------------------------------------
+
+def test_normalize_window_kwargs_maps_and_warns():
+    kwargs = {"hdpi": False, "overrideredirect": True, "master": "x"}
+    with pytest.warns(DeprecationWarning):
+        out = normalize_window_kwargs(kwargs)
+    assert out == {"high_dpi": False, "override_redirect": True}
+    # only the legacy names are consumed; unrelated kwargs are left in place
+    assert kwargs == {"master": "x"}
+
+
+def test_normalize_window_kwargs_noop_when_absent():
+    kwargs = {"background": "red"}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        out = normalize_window_kwargs(kwargs)
+    assert out == {}
+    assert kwargs == {"background": "red"}
+
+
+def test_toplevel_accepts_legacy_windowtype_with_warning(root):
+    with pytest.warns(DeprecationWarning):
+        top = ttk.Toplevel(title="legacy", windowtype="dialog")
+    top.destroy()
+
+
+def test_toplevel_new_names_are_warning_free(root):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        top = ttk.Toplevel(title="modern", window_type="dialog", iconify=True)
+    top.destroy()
+
+
+# --------------------------------------------------------------------------
+# geometry string construction
+# --------------------------------------------------------------------------
+
+class _GeoRecorder(_BaseWindow):
+    """Minimal stand-in that records geometry strings without a real window."""
+
+    def __init__(self):
+        self.calls = []
+
+    def geometry(self, value=None):
+        self.calls.append(value)
+
+
+def test_apply_geometry_size_and_position_combined():
+    rec = _GeoRecorder()
+    rec._apply_geometry((800, 600), (100, 120))
+    assert rec.calls == ["800x600+100+120"]
+
+
+def test_apply_geometry_negative_position_is_edge_relative():
+    rec = _GeoRecorder()
+    rec._apply_geometry(None, (-10, -20))
+    assert rec.calls == ["-10-20"]
+
+
+def test_apply_geometry_size_only():
+    rec = _GeoRecorder()
+    rec._apply_geometry((640, 480), None)
+    assert rec.calls == ["640x480"]
+
+
+def test_apply_geometry_nothing_is_a_noop():
+    rec = _GeoRecorder()
+    rec._apply_geometry(None, None)
+    assert rec.calls == []
+
+
+# --------------------------------------------------------------------------
+# positioning math
+# --------------------------------------------------------------------------
+
+def test_center_on_screen_is_within_bounds(root):
+    x, y = positioning.center_on_screen(root)
+    assert x >= 0 and y >= 0
+    assert x <= root.winfo_screenwidth()
+    assert y <= root.winfo_screenheight()
+
+
+def test_center_on_parent_offsets_from_parent_origin(root):
+    top = ttk.Toplevel(title="child", size=(200, 100))
+    top.update_idletasks()
+    x, y = positioning.center_on_parent(top, root)
+    # centered coordinates never sit above/left of the parent's own origin
+    assert x >= root.winfo_rootx()
+    assert y >= root.winfo_rooty()
+    top.destroy()
+
+
+def test_ensure_on_screen_clamps_far_offscreen(root):
+    x, y = positioning.ensure_on_screen(root, 100000, 100000)
+    assert x < root.winfo_screenwidth()
+    assert y < root.winfo_screenheight()
+
+
+# --------------------------------------------------------------------------
+# icon semantics
+# --------------------------------------------------------------------------
+
+def test_toplevel_iconphoto_none_does_not_crash(root):
+    # Pre-2.0 this raised: iconphoto=None fell into PhotoImage(file=None).
+    top = ttk.Toplevel(title="noicon", iconphoto=None)
+    top.destroy()
+
+
+def test_toplevel_bad_iconphoto_path_warns_not_prints(root):
+    with pytest.warns(UserWarning):
+        top = ttk.Toplevel(title="badicon", iconphoto="/no/such/file.png")
+    top.destroy()
+
+
+# --------------------------------------------------------------------------
+# style property + aqua guard
+# --------------------------------------------------------------------------
+
+def test_style_property_returns_singleton_for_both(root):
+    top = ttk.Toplevel(title="s")
+    assert root.style is Style.get_instance()
+    assert top.style is Style.get_instance()
+    top.destroy()
+
+
+def test_overrideredirect_noop_on_aqua(root):
+    top = ttk.Toplevel(title="aqua")
+    top.winsys = "aqua"  # simulate macOS
+    assert top.overrideredirect(True) is None
+    # the request was ignored: the window is still managed
+    assert not top.overrideredirect()
+    top.destroy()


### PR DESCRIPTION
Second PR of the shipped-widget API normalization pass (after PR A / dialogs, #1102). Implements design §5a of `development/2_0_shipped_widget_api_design.md`. Borrows **mechanisms** (not API) from bootstack for the cross-platform / Tcl-Tk quirks.

## What

Introduce a private `_BaseWindow` mixin shared by `Window(_BaseWindow, tk.Tk)` and `Toplevel(_BaseWindow, tk.Toplevel)`, holding the icon/geometry/alpha/positioning/`style` logic both classes were duplicating and drifting on.

- **Unify `iconphoto`** via `_setup_icon`: `None`=skip, `''`=default (brand icon on `Window`, inherit on `Toplevel`), path=load-with-fallback. Fixes the `Toplevel(iconphoto=None)` crash; a bad path now emits a `UserWarning` instead of `print()`ing to stdout; `.ico` → `wm_iconbitmap` on win32.
- **New private `internal/positioning.py`** — a scoped subset of bootstack's `WindowPositioning` (`center_on_screen`/`center_on_parent`/`ensure_on_screen`), monitor-aware via **optional** `screeninfo` with a graceful single-screen fallback (no new hard dep). Re-points `place_window_center` at it.
- **Snake_case the raw-Tk kwargs** with warn-and-normalize aliases via `_compat.normalize_window_kwargs` (removed in 3.0): `hdpi`→`high_dpi`, `overrideredirect`→`override_redirect`, `windowtype`→`window_type`, `toolwindow`→`tool_window`.
- **Keyword-only constructors** after the leading positional(s) (`Window(title, themename, *, …)`, `Toplevel(title, *, …)`); `iconify` promoted to a real `Toplevel` kwarg; **edge-relative + combined geometry** (`f"{x:+d}{y:+d}"`).
- **aqua `overrideredirect` no-op guard**; **win32 AppUserModelID**; consistent singleton `style` property on both classes.
- Migrate first-party `dialogs/base.py` `windowtype`→`window_type`.

## Breaking changes

Documented in `development/2_0_breaking_changes.md`. Kwargs renamed (old spellings warn through 2.x); constructors are keyword-only after the leading positional(s) — unshimmable, low real-world incidence. `minsize`/`maxsize` intentionally kept (mirror the Tk method names).

## Tests

New `tests/test_window_api.py` (+15): kwarg normalization, geometry construction, positioning math, icon semantics (incl. the `None` crash), style singleton, aqua guard. Suite **317 passed** excl. the known `nl.msg` localization env flake; warning-free import + end-to-end smoke verified.

## Still owed

A **cross-platform visual gate** (win32 + if-available x11/aqua) — the headless suite can't exercise AppUserModelID, the aqua guard, or multi-monitor centering. Deferred fast-follow (not in this PR): the richer bootstack positioning surface (`place_center_on`/`place_at`/`place_anchor`/…), the `windowtype` unified switch (§5a.9), and routing the dialogs' `center_on_parent` through the new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)