### PR TITLE
Theme-aware widget icons: apply_icon + icon=/icon_size= sugar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,6 +304,13 @@ interactive/visual demo in `examples/`, not `tests/`.
 ## Conventions
 
 - Match the style of the file you're editing (comment density, naming).
+- **Public-name casing (2.0 standardization):** ttkbootstrap-authored identifiers
+  (functions, methods, new kwargs) use `snake_case` (`apply_icon`, `icon_size`,
+  `high_dpi`, `window_type`); names that pass through to a real Tk/ttk option or
+  method keep Tk's spelling verbatim (`iconphoto`, `minsize`/`maxsize`, `compound`,
+  `themename`); `bootstyle`/`autostyle` are grandfathered brand tokens, not a
+  template for new names. Test: "am I forwarding a real Tk name?" — yes → Tk
+  spelling; no → snake_case.
 - Custom widgets that need image assets generate them through the style
   builder / Pillow pipeline; favor native ttk/clam mechanisms over images
   where both are viable (perf and cross-platform consistency).

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -359,3 +359,31 @@ normalization is intentionally deferred so names and docs move together.
 `get_date`-style verb rename (`move_row_down`→`move_selected_row_down`,
 `hide/unhide`→`show/hide`, `coldata`/`rowdata` aliases) is a separate, later slice
 with deprecated aliases.
+
+## Theme-aware widget icons: `apply_icon` + `icon=`/`icon_size=`  *(additive)*
+
+**What.** New public surface for putting a theme-aware Bootstrap Icons glyph on a
+widget (design `development/2_0_icon_theme_awareness_design.md`):
+
+- `ttk.apply_icon(widget, name, *, size=16, states=None, compound=None)` — renders
+  the glyph following the widget's style `foreground` (so it inverts on
+  outline/toggle, mutes when disabled) and re-renders on `<<ThemeChanged>>`.
+- `icon=`/`icon_size=` keyword sugar on every blessed ttk widget (`BootMixin`) —
+  routes to `apply_icon` after the base style resolves.
+- Supported on label-image widgets (`Button`/`Label`/`Menubutton`/`Checkbutton`/
+  `Radiobutton`); other classes raise `TypeError`.
+
+**Why.** A bare `Icon(...)` used as `image=` bakes its color once and goes stale on
+a theme switch — style-delivered icons (builder recipes) were theme-aware, inline
+ones were not. This completes the `Icon` feature's theme story.
+
+**The one thing to know (implicit style generation).** `icon=`/`apply_icon`
+*augments the widget's style*: it gives the widget a derived, content-hashed style
+`Icon<hash>.<your style>` that **inherits** your `bootstyle`/`style` (config, map,
+and layout) and adds the glyph. So **`widget.cget("style")` changes** to the
+derived name. `bootstyle` and `icon` compose and re-derive together; `icon=None`
+restores the base style. The static `Icon(...)` escape hatch is unchanged (a raw
+`-image`, no style, not themed).
+
+**Not breaking.** Purely additive; no existing signature changed. First-party: the
+datepicker header carets were migrated onto `apply_icon` (internal, no API change).

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -365,7 +365,7 @@ with deprecated aliases.
 **What.** New public surface for putting a theme-aware Bootstrap Icons glyph on a
 widget (design `development/2_0_icon_theme_awareness_design.md`):
 
-- `ttk.apply_icon(widget, name, *, size=16, states=None, compound=None)` — renders
+- `ttk.apply_icon(widget, name, *, size=14, states=None, compound=None)` — renders
   the glyph following the widget's style `foreground` (so it inverts on
   outline/toggle, mutes when disabled) and re-renders on `<<ThemeChanged>>`.
 - `icon=`/`icon_size=` keyword sugar on every blessed ttk widget (`BootMixin`) —

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,7 +3,30 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
-_Last updated: 2026-07-07 (**shipped-widget API pass — PR C (Tableview)
+_Last updated: 2026-07-07 (**Theme-aware widget icons — OPENED as #1105 against
+`2.0`**). Closes the inline-icon theme-awareness gap (a bare `Icon(...)` `image=`
+baked its color once and went stale on a theme switch). New `ttk.apply_icon` +
+`icon=`/`icon_size=` mixin sugar: renders a glyph following the widget's style
+`foreground` (inverts on outline/toggle, mutes disabled), re-renders on
+`<<ThemeChanged>>` (per-widget bind, no engine change), by augmenting the widget
+with a derived content-hashed `Icon<hash>.<base>` style that inherits its
+`bootstyle`/`style` (config/map/layout via ttk fallback). Supported on label-image
+widgets (Button/Label/Menubutton/Check/Radio); others raise. Datepicker carets
+migrated as dogfood. **Render tuning from the live gate:** glyph pad 10%→4% + snap
+draw origin (sharpens all font-glyph icons — the 10% pad was rendering glyphs at
+~80% of frame), default `icon_size`→14, `calendar3` trimmed 21→18/19 + date-button
++1px vertical pad. Raster indicators (check/radio/toggle/scale/scrollbar) unaffected.
+`tests/test_icon_theme.py` (+12); suite **330 passed** excl. the `nl.msg` flake;
+warning-free import. Design `development/2_0_icon_theme_awareness_design.md`.
+**Follow-ups logged (not blockers):** eyeball `grip-horizontal` on a Sizegrip;
+theme-wide **control-height parity** (buttons == inputs, memory
+`control-height-parity`) before docs screenshots. Also recorded the 2.0 naming
+convention (snake_case authored / Tk-spelling pass-throughs; `CLAUDE.md` +
+memory). **NEXT → Tableview pagination buttons on the icon path** (ghost base +
+glyph; disabled first/prev arrows get muting for free), then docs Workstream H.
+Prior entry (PR C) follows._
+
+_Prior 2026-07-07 (**shipped-widget API pass — PR C (Tableview)
 OPENED as #1104 against `2.0`; the pass's LAST PR**). Fixes only per design §5c
 (the method-verb rename stays a deferred later slice). Re-export
 `Tableview`/`TableColumn`/`TableRow` at top level (`ttk.Tableview`) + from

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -18,9 +18,10 @@ draw origin (sharpens all font-glyph icons — the 10% pad was rendering glyphs 
 +1px vertical pad. Raster indicators (check/radio/toggle/scale/scrollbar) unaffected.
 `tests/test_icon_theme.py` (+12); suite **330 passed** excl. the `nl.msg` flake;
 warning-free import. Design `development/2_0_icon_theme_awareness_design.md`.
-**Follow-ups logged (not blockers):** eyeball `grip-horizontal` on a Sizegrip;
-theme-wide **control-height parity** (buttons == inputs, memory
-`control-height-parity`) before docs screenshots. Also recorded the 2.0 naming
+**Follow-ups logged (not blockers):** move the Sizegrip onto a **recolor raster
+asset** (retires its `grip-horizontal` font glyph — the conversion is the fix, no
+glyph-size trim needed); theme-wide **control-height parity** (buttons == inputs,
+memory `control-height-parity`) before docs screenshots. Also recorded the 2.0 naming
 convention (snake_case authored / Tk-spelling pass-throughs; `CLAUDE.md` +
 memory). **NEXT → Tableview pagination buttons on the icon path** (ghost base +
 glyph; disabled first/prev arrows get muting for free), then docs Workstream H.

--- a/development/2_0_icon_theme_awareness_design.md
+++ b/development/2_0_icon_theme_awareness_design.md
@@ -6,9 +6,16 @@
 > `2_0_icons_design.md` (the icon engine), `2_0_engine_design.md` (the no-`Publisher`
 > theme walk), and `CLAUDE.md`.
 >
-> **Status: CONFIRMED (author sign-off 2026-07-07).** Worked out interactively;
-> all three §7 forks resolved (states=: include; datepicker: migrate now;
-> unsupported widgets: raise). Implementation proceeds per §5.
+> **Status: IMPLEMENTED (2026-07-07).** Confirmed with the author, then built on
+> `feat/2.0-icon-theme-aware`: `style/icons.py` `apply_icon` + derived-style/
+> `<<ThemeChanged>>` machinery; `BootMixin` `icon=`/`icon_size=` sugar (compose +
+> re-derive on bootstyle change); top-level + `ttkbootstrap.style` re-exports;
+> datepicker carets migrated; `tests/test_icon_theme.py` (+12); preview
+> `examples/icon_button_preview.py`. Suite 330 passed excl. the `nl.msg` flake;
+> warning-free import. All three §7 forks resolved (states=: include; datepicker:
+> migrate now; unsupported widgets: raise). **Still owed: a human light↔dark visual
+> spot-check** (the preview) before docs screenshots — headless asserts the image
+> is wired + re-rendered, not that it looks right.
 
 ## 1. Why this, why now
 
@@ -239,8 +246,19 @@ documentation §1's gap analysis called for.
   light↔dark switch, plus an outline/toggle icon button.
 - **PR (follow-on) — Tableview pagination buttons on icons.** Ghost base + glyph via
   the same path (their disabled first/prev arrows get muting for free). Own small PR.
-- **Docs (Workstream H).** §4.1 becomes a "Theme-aware icons" How-To/Guide section;
-  the `Icon` vs `icon=` vs `icon_element` three-tier split is the teaching frame.
+- **Docs (Workstream H) — two distinct impacts, not just a How-To.**
+  1. **API-reference surface extends.** `icon=`/`icon_size=` on `BootMixin` are a
+     new *cross-cutting kwarg* on **every blessed ttk widget** — the same category
+     as `bootstyle`/`autostyle`. Wherever the docs describe "what ttkbootstrap adds
+     to a ttk widget" (the mixin's shared keyword surface), that list must now
+     include `icon`/`icon_size`. This is a genuine extension of the ttk widget API,
+     so the mixin's own signature + docstring must carry these kwargs (they feed the
+     autogen API reference); the per-widget catalog pages that mention the mixin
+     kwargs pick them up centrally, not per widget.
+  2. **New guide.** §4.1 becomes a "Theme-aware icons" How-To/Guide; the `Icon` vs
+     `icon=` vs `icon_element` three-tier split is the teaching frame; §4.1's
+     hashed-style contract is documented loudly there.
+  Both go into the Workstream-H rewrite (`2_0_docs_design.md`), tracked there.
 
 ## 6. Compat
 

--- a/development/2_0_icon_theme_awareness_design.md
+++ b/development/2_0_icon_theme_awareness_design.md
@@ -1,0 +1,259 @@
+# ttkbootstrap 2.0 — Theme-aware icons (design pass)
+
+> Design pass for closing the **inline-icon theme-awareness gap**: an icon placed
+> on a widget instance today bakes its color once and goes stale on a theme
+> switch. Follows the 2.0 hard rule (design before implementation). Pair with
+> `2_0_icons_design.md` (the icon engine), `2_0_engine_design.md` (the no-`Publisher`
+> theme walk), and `CLAUDE.md`.
+>
+> **Status: CONFIRMED (author sign-off 2026-07-07).** Worked out interactively;
+> all three §7 forks resolved (states=: include; datepicker: migrate now;
+> unsupported widgets: raise). Implementation proceeds per §5.
+
+## 1. Why this, why now
+
+The icon engine (`style/icons.py`, PR 6a/6b) delivers glyphs two ways:
+
+- **Style-delivered** — `icon_element`/`assets.icon` called inside a
+  `@register_builder` recipe (checkbox, radio, toggle, date button, carets,
+  sizegrip). The 2.0 theme walk rebuilds each mounted widget's `(theme, style)`
+  on `theme_use`, which re-runs the recipe and **re-renders the glyph in the new
+  theme's colors**. These are theme-aware, automatically.
+- **Inline** — `image=ttk.Icon(name, size, color)` set on a widget instance
+  (what a user reaches for, and what `dialogs/datepicker.py` does for its header
+  carets). `Icon` resolves the color **once** (its docstring says so) and returns
+  a bare image name; the walk repaints the widget's *style* but never touches the
+  widget-level `-image`. **These are not theme-aware.**
+
+So a user writing `ttk.Button(image=ttk.Icon("gear", 16, "primary"))` sees the
+glyph keep its old color after a theme switch. The image cache is content-addressed
+and keyed on the resolved color (`engine.py`), and is **not** cleared on
+`theme_use`, so nothing breaks — the widget just points at a stale-color image.
+The only fix today is the user binding `<<ThemeChanged>>` themselves (the
+`Meter`/`Floodgauge` pattern) — undiscoverable.
+
+This is a **gap in an existing 2.0 feature**, not a net-new capability, so it fits
+the "no new features" rule as *completing* the `Icon` theme story.
+
+## 2. Ground truth (verified 2026-07-07)
+
+- `Icon(name, size, color)` (`style/icons.py`): resolves color once; "no auto-follow
+  on a later theme switch (a re-render is the engine's job, or a fresh call)."
+- The image cache (`Style._image_cache`, `_get_or_create_image`) is keyed on the
+  resolved color + scaled size + geometry; **never cleared on `theme_use`**. So
+  identical-color glyphs dedupe across styles *and* themes and render exactly once.
+- `theme_use` calls `super().theme_use()`, so Tk fires `<<ThemeChanged>>` to **every**
+  widget natively. Exactly three first-party widgets rely on it today:
+  `meter.py:336`, `floodgauge.py:149,607` — the blessed pattern for widgets that
+  own visuals outside the ttk style system.
+- The theme walk (`engine.py:_theme_walk`) DFSes `winfo_children()`; it has known
+  reachability holes (the combobox popdown is repainted out-of-band because the
+  DFS can't reach it).
+- `icon_element(style, name, ...)` (`style/icons.py`) already **augments an existing
+  style**: a bare-string per-state spec renders the glyph in the color the style's
+  `foreground` map defines for that state (`_state_foreground`). This is the
+  mechanism we build on — not a new approach.
+
+## 3. Decisions
+
+### 3.1 Mechanism = per-widget `<<ThemeChanged>>` bind (not the engine walk)
+
+The re-render is triggered by binding `<<ThemeChanged>>` **on the widget**, in the
+apply helper; the handler rebuilds the icon in the new theme. Chosen over threading
+icon logic through the engine's theme walk because:
+
+- **Zero engine change** — the theme walk is delicate, carefully-tuned code.
+- **No reachability caveat** — Tk broadcasts `<<ThemeChanged>>` to every widget;
+  the walk's DFS does not reach everything (see the popdown).
+- **Leak-free** — a widget-scoped binding is auto-removed by Tk on destroy; no
+  registry, so it does not reintroduce the `Publisher` leak class 2.0 deleted.
+- It's the **already-blessed pattern** (`Meter`/`Floodgauge`).
+- Redundant rebuilds across many identical icons are **cheap**: the content-addressed
+  image cache renders each unique glyph once; extra rebuilds just re-reference the
+  cached bitmap.
+
+The bind is added **only** on the themed path (`apply_icon`/`icon=`), never for a
+static `Icon(...)`.
+
+### 3.2 Layering = three tiers, split by intent
+
+| Tier | Surface | Behavior |
+|---|---|---|
+| 1 | `Icon(name, size, color)` | Static image, explicit color, **no style, not themed**. The escape hatch for "a raw glyph, my color, don't manage it." |
+| 2 | `apply_icon(widget, name, ...)` + mixin `icon=`/`icon_size=` | **Themed + stateful.** Follows the foreground; **always** generates/reuses a derived style; binds `<<ThemeChanged>>`. No color param. |
+| 3 | `icon_element(style, name, ...)` | Full per-state control incl. explicit `{name, color}` specs. For authoring custom styles. |
+
+### 3.3 The sugar follows the foreground — no `icon_color`
+
+Tier-2 has **no color parameter**. The glyph color is always derived from the
+style's per-state `foreground` map, which is what makes every case correct by
+construction:
+
+- **Invert** (outline/toggle: accent text on surface at rest → on-accent text on
+  accent fill when active) — the glyph flips to the contrast color exactly when the
+  fill appears, because it follows the same `foreground` map.
+- **Disabled** — glyph goes muted (the disabled foreground).
+- **Hover/pressed** — follows whatever the foreground map does.
+- **Theme change** — re-derived from the new theme's foreground.
+
+A pinned color would re-break the inverting case (accent-on-accent → invisible), so
+it is deliberately excluded from the sugar. Needs:
+
+- *A fixed/odd color, unmanaged* → tier 1 (`Icon(...)` as `image=`).
+- *Explicit per-state colors* (e.g. accent-when-selected, as the built-in radio-on
+  does) → tier 3 (`icon_element`, which keeps `{name, color}`).
+
+### 3.4 `icon=` always generates a style (consistency over minimizing)
+
+Tier 2 **always** ensures a derived style exists — it never falls back to a bare
+`-image` "shortcut" for the simple case. Rationale: a sometimes-`-image`,
+sometimes-style split is confusing and makes behavior depend on invisible
+conditions. One consistent rule ("`icon=` → a themed style") is clearer, and it is
+essentially free (§3.1: the image cache means "a new style" rarely means "a new
+render", and identical images serve multiple themes when the resolved color
+matches). The `-image`-only path remains available, but only via the **explicit**
+tier-1 `Icon(...)` — so the two are separated by user intent, not by a hidden
+heuristic.
+
+### 3.5 Naming = snake_case (project convention, recorded separately)
+
+Authored identifiers are snake_case (`apply_icon`, `icon_size`); Tk pass-through
+option names stay verbatim (`compound`, `size`); `bootstyle`/`autostyle` are
+grandfathered brand tokens and are **not** a template for new names. (The general
+rule is recorded in `CLAUDE.md` Conventions + memory `naming-convention`.)
+
+## 4. API spec
+
+```python
+def apply_icon(widget, name, *, size=16, states=None, compound=None) -> str | None:
+    """Put a theme-aware Bootstrap Icons glyph on `widget`.
+
+    Unlike a bare `Icon(...)` used as `image=`, this tracks the active theme and
+    the widget's states: the glyph color follows the widget's style `foreground`
+    (so it inverts on outline/toggle, mutes when disabled, and re-colors on a
+    theme switch). It does so by ensuring a derived style exists on the widget
+    (see "What this does to your widget's style"). `name=None`/"" removes it.
+
+    Parameters:
+        widget:    any ttk widget with an image-bearing layout (Button, Label,
+                   Menubutton, Checkbutton, Radiobutton, ...).
+        name:      a Bootstrap Icons glyph name; None/"" clears the icon.
+        size:      logical UI size (converted by the root-bound scaling service).
+        states:    optional {state_string: glyph_name} to show a *different glyph*
+                   per state (color still follows the foreground). Advanced.
+        compound:  the ttk `-compound` option (icon/text arrangement) if the
+                   widget also has text.
+
+    Returns the resolved (derived) ttk style name, or None if the icon was cleared.
+    """
+```
+
+Mixin sugar on the blessed widgets (`BootMixin`):
+
+```python
+ttk.Button(master, text="Settings", icon="gear", icon_size=18, bootstyle="primary")
+```
+
+- `icon=` / `icon_size=` are intercepted by the mixin and routed to `apply_icon`
+  **after** `bootstyle`/`style` resolve, so the derived style inherits the right base.
+- Re-exported top level: `ttk.apply_icon`.
+
+### 4.0 Supported widgets
+
+`icon=`/`apply_icon` works on ttk widgets whose layout has a **label element that
+honors the style `image` option + `compound`** — verified empirically (a derived
+dotted style inherits the base layout/config/map via ttk fallback, and a style
+`image` + per-state `image` map render through the existing `*.label` element,
+exactly like the built-in date button):
+
+- **In scope:** `Button` (incl. Outline/Toolbutton/link/ghost variants), `Label`,
+  `Menubutton`, `Checkbutton`, `Radiobutton` (icon on the *label*, alongside the
+  indicator — it does not replace the check/radio box).
+- **Out — no label image:** `Entry`, `Combobox`, `Spinbox`, `Progressbar`, `Scale`,
+  `Scrollbar`, `Separator`, `Sizegrip`, `Panedwindow`, `Frame`, `Labelframe`.
+- **Out — per-item image API instead:** `Treeview` (`item(image=)`/`heading(image=)`)
+  and `Notebook` (`add(image=)`) support images only per row/tab, a granularity
+  `icon=` cannot address; they keep their own image parameter.
+
+Setting a style `image` on an unsupported widget **silently no-ops** at the Tcl
+level (its layout has no consuming element — no error is raised). So `apply_icon`
+cannot rely on a Tcl failure: it checks the widget class against a **supported
+allowlist and raises a clear `TypeError`/`ValueError`** otherwise (resolves §7.3).
+
+### 4.1 What this does to your widget's style (the explicit contract)
+
+`icon=`/`apply_icon` is *implicitly* a style operation — this section is the loud
+documentation §1's gap analysis called for.
+
+- **It augments your current style, never replaces it with a from-scratch one.**
+  The generated style is `Icon<hash>.<your current style>` (e.g.
+  `Icon<hash>.primary.Outline.TButton`, or `Icon<hash>.MyCustom.TButton` for an
+  explicit `style=`). Config, state map, **and layout** all **inherit** via ttk's
+  dotted-name fallback (verified: a derived name resolves the base's full layout,
+  incl. its `*.label` element). We add only the `image` config + per-state `image`
+  map on the derived style — the inherited label element renders it. So even a
+  custom-layout `style=` is preserved; the icon'd widget matches its non-icon'd
+  siblings exactly.
+- **`widget.cget("style")` changes** to the derived name. Code that introspects or
+  scripts the style will see the hash.
+- **Content-hashed, so widgets dedupe.** The hash is over
+  `(base style, glyph name, size, states)` — N identical `icon="gear"` primary
+  buttons share **one** derived style; the count is bounded by config variety, not
+  widget count.
+- **`bootstyle`/`style` and `icon` compose and re-derive together.** Changing the
+  base (`bootstyle=`/`style=`) regenerates the derived style on the new base; the
+  mixin does this automatically. A user who manually `configure(style=...)`s *after*
+  `icon=` replaces the derived style and **drops the icon** — documented.
+- **Removal restores the base.** `apply_icon(widget, None)` / `icon=None` drops the
+  derived style and returns the widget to its plain base style.
+- **Customize the base, not the hash.** `Style.configure("primary.Outline.TButton",
+  ...)` flows through by inheritance. The generated hashed style has an unstable name
+  and is rebuilt on theme change — don't hand-edit it.
+
+### 4.2 Mechanism detail
+
+- On apply: read the base style's `foreground` state map (`style.map(base,
+  "foreground")`) to enumerate the distinct states; render one glyph per state in
+  that state's foreground color; set them on the derived style via
+  `style.configure(derived, image=<rest>)` + `style.map(derived, image=[(state,
+  img), ...])` (the inherited `*.label` element renders them — the date-button
+  pattern, no custom element/layout needed); set `compound`;
+  `widget.configure(style=derived)`.
+- Bind `<<ThemeChanged>>` on the widget → rebuild the derived style for the new
+  theme (idempotent: guard with `style_exists_in_theme` before `element_create`,
+  exactly as the built-in recipes do; A→B→A cycles must not double-create). Store a
+  single funcid so repeated `apply_icon` calls **replace**, never stack, the bind.
+- Track the icon spec + base on the widget (e.g. `widget._tb_icon`) so the mixin's
+  `bootstyle`/`style` setter can re-derive.
+
+## 5. Scope & PR sequence
+
+- **PR — theme-aware icon primitive + sugar.** `apply_icon`, the `icon=`/`icon_size=`
+  mixin kwargs, top-level re-export, the derived-style + `<<ThemeChanged>>`
+  machinery. Migrate the **datepicker** header carets onto it as first-party
+  dogfooding (they have the same latent staleness if the theme changes while the
+  modal is open). Headless tests: apply an icon, switch theme, assert the widget's
+  `-image`/derived style re-renders to the new-theme color; assert `bootstyle`+`icon`
+  compose; assert removal restores the base; assert the inverting (outline/toggle)
+  case renders on-accent when active. Human spot-check: an icon button through a
+  light↔dark switch, plus an outline/toggle icon button.
+- **PR (follow-on) — Tableview pagination buttons on icons.** Ghost base + glyph via
+  the same path (their disabled first/prev arrows get muting for free). Own small PR.
+- **Docs (Workstream H).** §4.1 becomes a "Theme-aware icons" How-To/Guide section;
+  the `Icon` vs `icon=` vs `icon_element` three-tier split is the teaching frame.
+
+## 6. Compat
+
+- Purely additive public surface (`apply_icon`, `icon=`/`icon_size=`); no existing
+  signature changes. `Icon(...)` is unchanged (still the static escape hatch).
+- `import ttkbootstrap` stays warning-free.
+- Datepicker migration is internal (no API change).
+
+## 7. Open questions — all RESOLVED (author, 2026-07-07)
+
+1. **`states=` in v1 → INCLUDE.** The per-state *glyph* override ships in v1 (a thin
+   pass-through to `icon_element`'s `states`; color still follows the foreground).
+2. **Datepicker in this PR → YES.** Migrate its header carets onto `apply_icon` as
+   first-party dogfooding.
+3. **Non-image-bearing widgets → RAISE.** An unsupported widget silently no-ops at
+   the Tcl level, so `apply_icon` class-checks against the §4.0 allowlist and raises.

--- a/development/2_0_icon_theme_awareness_design.md
+++ b/development/2_0_icon_theme_awareness_design.md
@@ -26,10 +26,11 @@
 >
 > **Visual gate outcome:** author confirmed the carets (spinbox/combobox/menubutton/
 > datepicker), the 14px button default, and the date button (glyph + height). **Two
-> follow-ups logged, not blockers:** (1) eyeball `grip-horizontal` on a Sizegrip and
-> trim if it reads large (the one font glyph that grew and was not spot-checked);
-> (2) theme-wide **control-height parity** (buttons == inputs), memory
-> `control-height-parity` — do before docs screenshots.
+> follow-ups logged, not blockers:** (1) the **Sizegrip** is planned to move onto a
+> **recolorable raster asset** (like the check/radio/scrollbar structural assets),
+> which retires its `grip-horizontal` font glyph — so no glyph-size trim is needed,
+> the conversion is the fix (deferred); (2) theme-wide **control-height parity**
+> (buttons == inputs), memory `control-height-parity` — do before docs screenshots.
 
 ## 1. Why this, why now
 

--- a/development/2_0_icon_theme_awareness_design.md
+++ b/development/2_0_icon_theme_awareness_design.md
@@ -132,7 +132,7 @@ rule is recorded in `CLAUDE.md` Conventions + memory `naming-convention`.)
 ## 4. API spec
 
 ```python
-def apply_icon(widget, name, *, size=16, states=None, compound=None) -> str | None:
+def apply_icon(widget, name, *, size=14, states=None, compound=None) -> str | None:
     """Put a theme-aware Bootstrap Icons glyph on `widget`.
 
     Unlike a bare `Icon(...)` used as `image=`, this tracks the active theme and

--- a/development/2_0_icon_theme_awareness_design.md
+++ b/development/2_0_icon_theme_awareness_design.md
@@ -6,16 +6,30 @@
 > `2_0_icons_design.md` (the icon engine), `2_0_engine_design.md` (the no-`Publisher`
 > theme walk), and `CLAUDE.md`.
 >
-> **Status: IMPLEMENTED (2026-07-07).** Confirmed with the author, then built on
+> **Status: IMPLEMENTED + visual-gated (2026-07-07).** Built on
 > `feat/2.0-icon-theme-aware`: `style/icons.py` `apply_icon` + derived-style/
 > `<<ThemeChanged>>` machinery; `BootMixin` `icon=`/`icon_size=` sugar (compose +
 > re-derive on bootstyle change); top-level + `ttkbootstrap.style` re-exports;
 > datepicker carets migrated; `tests/test_icon_theme.py` (+12); preview
 > `examples/icon_button_preview.py`. Suite 330 passed excl. the `nl.msg` flake;
 > warning-free import. All three §7 forks resolved (states=: include; datepicker:
-> migrate now; unsupported widgets: raise). **Still owed: a human light↔dark visual
-> spot-check** (the preview) before docs screenshots — headless asserts the image
-> is wired + re-rendered, not that it looks right.
+> migrate now; unsupported widgets: raise).
+>
+> **Render-tuning that landed during the visual gate** (see §4.2): the crispness
+> problem at button-icon sizes traced to the **10% glyph pad** rendering the glyph
+> at ~80% of the frame — dropped to **4%** (+ integer-snapped the metrics-path draw
+> origin), which sharpens all font-glyph icons; **default `icon_size` → 14** (16 read
+> large on a text button); the built-in **`calendar3`** was trimmed 21→18/19 and the
+> **date button** regained +1px vertical padding (both because the lower pad renders
+> a font glyph larger per unit size). The check/radio/toggle/scale/scrollbar
+> indicators are **raster** assets — unaffected.
+>
+> **Visual gate outcome:** author confirmed the carets (spinbox/combobox/menubutton/
+> datepicker), the 14px button default, and the date button (glyph + height). **Two
+> follow-ups logged, not blockers:** (1) eyeball `grip-horizontal` on a Sizegrip and
+> trim if it reads large (the one font glyph that grew and was not spot-checked);
+> (2) theme-wide **control-height parity** (buttons == inputs), memory
+> `control-height-parity` — do before docs screenshots.
 
 ## 1. Why this, why now
 

--- a/examples/icon_button_preview.py
+++ b/examples/icon_button_preview.py
@@ -1,0 +1,58 @@
+"""Visual spot-check for theme-aware widget icons (apply_icon + icon=).
+
+Shows a grid of icon buttons across the button variants that matter for the
+foreground-follow contract -- solid, outline (inverts), toggle (inverts), ghost,
+link -- plus a label and check/radio. Flip the theme with the switcher and watch
+every glyph re-color to the new theme (and the outline/toggle glyphs invert to
+the on-accent color on hover/press) with no code touching the icons.
+
+    python examples/icon_button_preview.py
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+
+app = ttk.Window("Theme-aware icons", themename="bootstrap-light")
+
+top = ttk.Frame(app, padding=10)
+top.pack(fill=X)
+ttk.Label(top, text="Theme:").pack(side=LEFT, padx=(0, 6))
+theme_var = ttk.StringVar(value=app.style.theme.name)
+themes = sorted(app.style.theme_names())
+ttk.Combobox(top, textvariable=theme_var, values=themes, width=22,
+             bootstyle="primary").pack(side=LEFT)
+ttk.Button(top, text="Apply", bootstyle="primary", icon="check-lg",
+           command=lambda: app.style.theme_use(theme_var.get())).pack(side=LEFT, padx=6)
+
+body = ttk.Frame(app, padding=10)
+body.pack(fill=BOTH, expand=YES)
+
+# (label, bootstyle) for the button variants; icon= sugar on each
+variants = [
+    ("Solid", "primary"),
+    ("Outline (inverts)", "primary-outline"),
+    ("Toggle (inverts)", "primary-toggle"),
+    ("Ghost", "primary-ghost"),
+    ("Link", "primary-link"),
+    ("Danger", "danger"),
+    ("Success outline", "success-outline"),
+    ("Disabled", "primary"),
+]
+for i, (label, boot) in enumerate(variants):
+    b = ttk.Button(body, text=label, bootstyle=boot, icon="gear-fill", icon_size=16)
+    if label == "Disabled":
+        b.configure(state=DISABLED)
+    b.grid(row=i // 4, column=i % 4, padx=6, pady=6, sticky=EW)
+for c in range(4):
+    body.columnconfigure(c, weight=1)
+
+# label + check/radio also carry the mixin sugar
+row = ttk.Frame(app, padding=10)
+row.pack(fill=X)
+ttk.Label(row, text="Label with icon", icon="info-circle-fill",
+          bootstyle="info").pack(side=LEFT, padx=6)
+ttk.Checkbutton(row, text="Check", icon="star",
+                bootstyle="warning").pack(side=LEFT, padx=6)
+ttk.Radiobutton(row, text="Radio", icon="bookmark",
+                bootstyle="success").pack(side=LEFT, padx=6)
+
+app.mainloop()

--- a/examples/icon_button_preview.py
+++ b/examples/icon_button_preview.py
@@ -38,7 +38,7 @@ variants = [
     ("Disabled", "primary"),
 ]
 for i, (label, boot) in enumerate(variants):
-    b = ttk.Button(body, text=label, bootstyle=boot, icon="gear-fill", icon_size=16)
+    b = ttk.Button(body, text=label, bootstyle=boot, icon="gear-fill")  # default size 14
     if label == "Disabled":
         b.configure(state=DISABLED)
     b.grid(row=i // 4, column=i % 4, padx=6, pady=6, sticky=EW)

--- a/examples/widget_styles/button.py
+++ b/examples/widget_styles/button.py
@@ -1,8 +1,6 @@
 import tkinter as tk
 import ttkbootstrap as ttk
 from random import choice
-from ttkbootstrap import utility
-utility.enable_high_dpi_awareness()
 
 DARK = 'bootstrap-light'
 LIGHT = 'bootstrap-dark'
@@ -16,29 +14,32 @@ def button_style_frame(bootstyle, style, widget_name):
         text=widget_name,
         anchor=tk.CENTER
     )
-    title.pack(padx=5, pady=2, fill=tk.BOTH)
+    title.pack(padx=5, pady=2, fill='both')
 
-    ttk.Separator(frame).pack(padx=5, pady=5, fill=tk.X)
+    ttk.Separator(frame).pack(padx=5, pady=5, fill='x')
 
     ttk.Button(
         master=frame,
         text='default',
-        bootstyle=bootstyle
-    ).pack(padx=5, pady=5, fill=tk.BOTH)
+        icon="bootstrap",
+        bootstyle=bootstyle,
+    ).pack(padx=5, pady=5, fill='both')
 
     for color in style.colors:
         ttk.Button(
             master=frame,
             text=color,
+            icon="house-fill",
             bootstyle=f'{color}-{bootstyle}'
-        ).pack(padx=5, pady=5, fill=tk.BOTH)
+        ).pack(padx=5, pady=5, fill='both')
 
     ttk.Button(
         master=frame,
         text='disabled',
         state=tk.DISABLED,
+        icon="house-fill",
         bootstyle=bootstyle
-    ).pack(padx=5, pady=5, fill=tk.BOTH)
+    ).pack(padx=5, pady=5, fill='both')
 
     return frame
 
@@ -51,13 +52,13 @@ def change_style():
 
 if __name__ == '__main__':
     # create visual widget style tests
-    root = tk.Tk()
+    root = ttk.Window()
     style = ttk.Style()
 
-    button_style_frame('outline', style, 'Outline Button').pack(side=tk.LEFT)
-    button_style_frame('', style, 'Solid Button').pack(side=tk.LEFT)
-    button_style_frame('ghost', style, 'Ghost Button').pack(side=tk.LEFT)
-    button_style_frame('link', style, 'Link Button').pack(side=tk.LEFT)
+    button_style_frame('outline', style, 'Outline Button').pack(side='left')
+    button_style_frame('', style, 'Solid Button').pack(side='left')
+    button_style_frame('ghost', style, 'Ghost Button').pack(side='left')
+    button_style_frame('link', style, 'Link Button').pack(side='left')
     ttk.Button(text="Change Theme", command=change_style).pack(padx=10, pady=10)
 
     root.mainloop()

--- a/examples/widgets/date_entry_widget.py
+++ b/examples/widgets/date_entry_widget.py
@@ -8,6 +8,8 @@ frame.pack(padx=10, pady=10)
 
 de = ttk.DateEntry(frame)
 
+ttk.Button(frame, text="TtkBootstrap", icon="house", icon_size=14).pack()
+
 de.pack(fill=X)
 
 root.mainloop()

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -64,8 +64,9 @@ from ttkbootstrap.style import (
     # Style-construction toolkit (Workstream I): the public "build your own
     # style" surface, dogfooded by the builders.
     Assets, El, layout, register_style, image_element, statespec, state_map, StyleName,
-    # Icon-rendered assets: glyph atoms + per-state icon element sugar.
-    Icon, icon_element,
+    # Icon-rendered assets: glyph atoms + per-state icon element sugar + the
+    # theme-aware widget-icon helper (also the icon=/icon_size= mixin kwargs).
+    Icon, apply_icon, icon_element,
     # Canonical bootstyle grammar strictness (Workstream D).
     set_bootstyle_strict, is_bootstyle_strict,
 )
@@ -260,6 +261,7 @@ __all__ = [
     "state_map",
     "StyleName",
     "Icon",
+    "apply_icon",
     "icon_element",
     "set_bootstyle_strict",
     "is_bootstyle_strict",

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -179,14 +179,12 @@ class DatePickerDialog:
         self.title.configure(bootstyle=f"{self.bootstyle}-inverse")
         self.prev_period.configure(style=f"Chevron.{self.bootstyle}.TButton")
         self.next_period.configure(style=f"Chevron.{self.bootstyle}.TButton")
-        # caret-fill nav arrows, in the header's contrasting on-accent color.
-        # (Use on_color, not colors.get_foreground(), which returns black on a
-        # saturated dark-theme accent -- wrong on the accent-colored title bar.)
-        style = ttk.Style.get_instance()
-        accent = style.colors.get(self.bootstyle)
-        arrow_color = style._get_builder().on_color(accent)
-        self.prev_period.configure(image=ttk.Icon("caret-left-fill", 14, arrow_color))
-        self.next_period.configure(image=ttk.Icon("caret-right-fill", 14, arrow_color))
+        # caret nav arrows: apply_icon renders them following the chevron style's
+        # foreground -- which is on_color(accent), the header's contrasting
+        # on-accent color -- and re-renders on a theme switch, replacing a
+        # baked-once ttk.Icon image.
+        ttk.apply_icon(self.prev_period, "caret-left-fill", size=14)
+        ttk.apply_icon(self.next_period, "caret-right-fill", size=14)
 
     def _draw_calendar(self) -> None:
         self._update_widget_bootstyle()

--- a/src/ttkbootstrap/style/__init__.py
+++ b/src/ttkbootstrap/style/__init__.py
@@ -29,7 +29,7 @@ from ttkbootstrap.style.layout import (
     state_map,
     StyleName,
 )
-from ttkbootstrap.style.icons import Icon, icon_element, IconRenderer
+from ttkbootstrap.style.icons import Icon, apply_icon, icon_element, IconRenderer
 from ttkbootstrap.style._compat import (
     set_bootstyle_strict,
     is_bootstyle_strict,
@@ -61,6 +61,7 @@ __all__ = [
     "StyleName",
     # Icon-rendered assets (Workstream I, Tier 1.5)
     "Icon",
+    "apply_icon",
     "icon_element",
     "IconRenderer",
     # bootstyle grammar strictness (Workstream D)

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -782,6 +782,9 @@ class Bootstyle:
         return __init__wrapper
 
 
+_UNSET = object()  # sentinel: distinguish "icon kwarg omitted" from "icon=None"
+
+
 class BootMixin:
     """Mixin that adds the ``bootstyle`` API to a ttk widget class.
 
@@ -792,6 +795,8 @@ class BootMixin:
     class:
 
     - a ``bootstyle=`` (and bare ``style=``) keyword on the constructor,
+    - an ``icon=``/``icon_size=`` keyword for a theme-aware glyph (see
+      `ttkbootstrap.apply_icon`) on the widgets that carry a label image,
     - ``configure``/``config`` that accept and report ``bootstyle``,
     - ``widget["bootstyle"]`` / ``widget["bootstyle"] = ...`` access.
 
@@ -803,9 +808,11 @@ class BootMixin:
     """
 
     def __init__(self, *args, **kwargs):
-        # capture bootstyle and style arguments
+        # capture bootstyle, style, and icon arguments
         bootstyle = kwargs.pop("bootstyle", "")
         style = kwargs.pop("style", "") or ""
+        icon = kwargs.pop("icon", None)
+        icon_size = kwargs.pop("icon_size", 16)
 
         # instantiate the underlying ttk widget first so winfo_class() is
         # available to the resolver below
@@ -833,6 +840,11 @@ class BootMixin:
             # Stamp the widget current so the next theme walk only repaints it
             # once the theme actually changes.
             Bootstyle.stamp_theme_version(self)
+            # Apply a theme-aware icon last, so it derives from the resolved base
+            # style (see ttkbootstrap.apply_icon).
+            if icon:
+                from ttkbootstrap.style.icons import apply_icon
+                apply_icon(self, icon, size=icon_size)
         except AttributeError:
             # Third-party widgets (e.g. tkcalendar.Calendar) override
             # configure() and may touch instance attributes not yet set when
@@ -847,8 +859,13 @@ class BootMixin:
         if cnf is not None:
             return super().configure(cnf)
 
+        # capture icon changes; applied after the base style resolves below
+        icon = kwargs.pop("icon", _UNSET)
+        icon_size = kwargs.pop("icon_size", _UNSET)
+
         # set configuration
         bootstyle = kwargs.pop("bootstyle", "")
+        base_changed = bool(bootstyle) or ("style" in kwargs)
         if "style" in kwargs:
             style = kwargs.get("style")
             Bootstyle.update_ttk_widget_style(self, style, **kwargs)
@@ -858,7 +875,28 @@ class BootMixin:
             )
             kwargs.update(style=ttkstyle)
 
-        return super().configure(cnf, **kwargs)
+        result = super().configure(cnf, **kwargs)
+
+        # Icon handling. An explicit icon=/icon_size= applies or clears the glyph;
+        # otherwise a base-style change under an existing icon re-derives it onto
+        # the new base. The _tb_applying_icon guard skips the re-derive while
+        # apply_icon is itself setting the derived style (avoids recursion).
+        if icon is not _UNSET or icon_size is not _UNSET:
+            from ttkbootstrap.style.icons import apply_icon
+            existing = getattr(self, "_tb_icon", None)
+            name = icon if icon is not _UNSET else (existing["name"] if existing else None)
+            size = icon_size if icon_size is not _UNSET else (existing["size"] if existing else 16)
+            states = existing["states"] if existing else None
+            compound = existing["compound"] if existing else None
+            apply_icon(self, name, size=size, states=states, compound=compound)
+        elif (base_changed and getattr(self, "_tb_icon", None)
+                and not getattr(self, "_tb_applying_icon", False)):
+            from ttkbootstrap.style.icons import apply_icon
+            spec = self._tb_icon
+            apply_icon(self, spec["name"], size=spec["size"],
+                       states=spec["states"], compound=spec["compound"])
+
+        return result
 
     config = configure
 

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -812,7 +812,7 @@ class BootMixin:
         bootstyle = kwargs.pop("bootstyle", "")
         style = kwargs.pop("style", "") or ""
         icon = kwargs.pop("icon", None)
-        icon_size = kwargs.pop("icon_size", 16)
+        icon_size = kwargs.pop("icon_size", 14)
 
         # instantiate the underlying ttk widget first so winfo_class() is
         # available to the resolver below
@@ -885,7 +885,7 @@ class BootMixin:
             from ttkbootstrap.style.icons import apply_icon
             existing = getattr(self, "_tb_icon", None)
             name = icon if icon is not _UNSET else (existing["name"] if existing else None)
-            size = icon_size if icon_size is not _UNSET else (existing["size"] if existing else 16)
+            size = icon_size if icon_size is not _UNSET else (existing["size"] if existing else 14)
             states = existing["states"] if existing else None
             compound = existing["compound"] if existing else None
             apply_icon(self, name, size=size, states=states, compound=compound)

--- a/src/ttkbootstrap/style/builders/button.py
+++ b/src/ttkbootstrap/style/builders/button.py
@@ -363,8 +363,10 @@ def build_date_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         background = builder.colors.get(colorname)
         on_background = builder.on_color(background)
 
-    # Calendar icon in the button foreground color.
-    size = [21, 22]
+    # Calendar icon in the button foreground color. Sized against the 4% glyph
+    # pad (icons.py): ~18 keeps the prior visual size (the old 21 was tuned to the
+    # larger 10% pad; the reduced pad now renders the glyph bigger per unit size).
+    size = [18, 19]
     img_normal = builder.assets.icon("calendar3", size, on_background)
     img_disabled = builder.assets.icon("calendar3", size, on_disabled)
 

--- a/src/ttkbootstrap/style/builders/button.py
+++ b/src/ttkbootstrap/style/builders/button.py
@@ -397,7 +397,10 @@ def build_date_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=0,
         focuscolor=on_background,
-        padding=builder.scale_size((2, 2)),
+        # +1px vertical vs horizontal: the smaller calendar glyph (18/19, trimmed
+        # for the 4% pad) shortened the button; restore its height to match the
+        # adjacent entry.
+        padding=builder.scale_size((2, 3)),
         anchor=tk.CENTER,
         image=img_normal,
     )

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -43,10 +43,12 @@ from ttkbootstrap.style.layout import statespec, image_element
 _ICONS_DIR = Path(__file__).parent.parent / "assets" / "icons"
 
 # A small downward nudge -- icon fonts sit slightly high in their em box; this
-# (and the 10% inner pad) match bootstack's tuned render so glyphs optically
-# center in a square frame.
+# and the small inner pad keep glyphs optically centered in a square frame. The
+# pad is kept low (4%): at button-icon sizes (~16px) a larger pad renders the
+# glyph at only ~80% of the frame, starving thin strokes of pixels and reading
+# blurry -- 4% lets the glyph nearly fill the frame and stay crisp.
 _ICON_Y_BIAS = 0.02
-_ICON_PAD_FACTOR = 0.10
+_ICON_PAD_FACTOR = 0.04
 
 
 def _physical_size(size):
@@ -175,8 +177,11 @@ class IconRenderer:
             )))
             font = cls._get_font(font_size)
             ink_w, ink_h = nw * font_size, nh * font_size
-            dx = (cw - ink_w) / 2 - nl * font_size
-            dy = (ch - ink_h) / 2 - nt * font_size + ch * _ICON_Y_BIAS
+            # Snap the draw origin to whole pixels (the fallback branch already
+            # does via //) so the ink lands on the grid rather than half-pixels,
+            # which softens straight strokes on the LANCZOS downscale.
+            dx = round((cw - ink_w) / 2 - nl * font_size)
+            dy = round((ch - ink_h) / 2 - nt * font_size + ch * _ICON_Y_BIAS)
             draw.text((dx, dy), glyph, font=font, fill=color)
         else:
             # Fallback for glyphs absent from icon_metrics.json: measure with

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -23,8 +23,11 @@ modules (`assets`, `layout`); it carries **no module-level engine edge** (the
 and imports standalone. Asset loading is lazy: `import ttkbootstrap` does not read
 the font -- `IconRenderer` loads it on first `render`.
 """
+import hashlib
 import io
 import json
+import re
+import tkinter as tk
 from pathlib import Path
 
 from PIL import Image, ImageDraw, ImageFilter, ImageFont
@@ -346,3 +349,212 @@ def icon_element(style, name, *, size, default, states=None, **options):
     if states:
         state_images = {s: resolve(spec, s) for s, spec in states.items()}
     image_element(style, name, default=default_image, states=state_images, **options)
+
+
+# --------------------------------------------------------------------------- #
+# Theme-aware widget icons (apply_icon)
+# --------------------------------------------------------------------------- #
+# ttk classes whose layout has a label element that renders the style `image`
+# option + honors `compound`. apply_icon works on these; anything else silently
+# no-ops at the Tcl level, so we class-check and raise instead.
+_ICON_WIDGET_CLASSES = frozenset({
+    "TButton", "Toolbutton", "TLabel", "TMenubutton",
+    "TCheckbutton", "TRadiobutton",
+})
+
+# A derived icon style is named "Icon<8 hex>.<base style>"; this strips the
+# prefix back to the base so re-applies are idempotent.
+_ICON_STYLE_PREFIX = re.compile(r"^Icon[0-9a-f]{8}\.")
+
+
+def _icon_base_style(widget):
+    """The widget's current style with any Icon<hash>. prefix removed.
+
+    Falls back to the widget's ttk class (e.g. ``TButton``) when no style is set.
+    """
+    current = _ICON_STYLE_PREFIX.sub("", str(widget.cget("style") or ""))
+    return current or widget.winfo_class()
+
+
+def _widget_has_text(widget):
+    try:
+        return bool(str(widget.cget("text") or ""))
+    except tk.TclError:
+        return False
+
+
+def _build_icon_style(style, base, name, size, states, compound):
+    """(Re)configure a derived ``Icon<hash>.<base>`` style and return its name.
+
+    Renders one glyph per state in that state's *base foreground* color (so the
+    icon inverts / mutes exactly as the label text does); ``states`` overrides the
+    glyph name per state, never its color. The images are set as the derived
+    style's ``image`` option + map, which the inherited ``*.label`` element renders
+    (the built-in date-button pattern -- no custom element/layout). configure/map
+    overwrite, so a theme-change rebuild is just a re-call (idempotent).
+    """
+    assets = Assets(style)
+    states = states or {}
+
+    key = f"{base}|{name}|{size}|{sorted(states.items())}|{compound}"
+    digest = hashlib.md5(key.encode("utf-8")).hexdigest()[:8]
+    derived = f"Icon{digest}.{base}"
+
+    def render(glyph, state_tokens):
+        color = style.lookup(base, "foreground", state=state_tokens or None)
+        return assets.icon(glyph, size, color or style.colors.fg)
+
+    rest_image = render(states.get("", name), [])
+
+    image_map = []
+    seen = set()
+    for entry in style.map(base, "foreground"):
+        *tokens, _color = entry
+        state_str = " ".join(tokens)
+        if not tokens or state_str in seen:
+            continue
+        seen.add(state_str)
+        image_map.append((state_str, render(states.get(state_str, name), tokens)))
+    # states= keys the base foreground map doesn't remap still need an image
+    for state_str, glyph in states.items():
+        if state_str and state_str not in seen:
+            seen.add(state_str)
+            image_map.append((state_str, render(glyph, state_str.split())))
+
+    config = {"image": rest_image}
+    if compound is not None:
+        config["compound"] = compound
+    style.configure(derived, **config)
+    if image_map:
+        style.map(derived, image=image_map)
+    return derived
+
+
+def _set_icon_style(widget, derived):
+    """Set the widget's style to ``derived``, guarding `BootMixin.configure` from
+    re-deriving the icon on the resulting style change (which would recurse)."""
+    widget._tb_applying_icon = True
+    try:
+        widget.configure(style=derived)
+    finally:
+        widget._tb_applying_icon = False
+
+
+def _rebuild_widget_icon(widget):
+    """Re-render a widget's icon for the active theme (``<<ThemeChanged>>``)."""
+    spec = getattr(widget, "_tb_icon", None)
+    if not spec:
+        return
+    from ttkbootstrap.style.engine import Style  # back-edge; keeps this a leaf
+    style = Style.get_instance()
+    if style is None:
+        return
+    try:
+        derived = _build_icon_style(
+            style, spec["base"], spec["name"], spec["size"],
+            spec["states"], spec["compound"],
+        )
+        _set_icon_style(widget, derived)
+    except tk.TclError:
+        pass  # widget torn down mid-switch
+
+
+def _clear_widget_icon(widget):
+    """Remove an applied icon: restore the base style, drop the theme bind."""
+    spec = getattr(widget, "_tb_icon", None)
+    # Clear the spec *before* restoring the base style: the configure() below
+    # routes through BootMixin.configure, whose base-change branch would otherwise
+    # see a live _tb_icon and re-derive the icon we are removing.
+    widget._tb_icon = None
+    if spec is not None:
+        base = spec["base"]
+        try:
+            widget.configure(
+                style="" if base == widget.winfo_class() else base)
+        except tk.TclError:
+            pass
+    bindid = getattr(widget, "_tb_icon_bindid", None)
+    if bindid is not None:
+        try:
+            widget.unbind("<<ThemeChanged>>", bindid)
+        except tk.TclError:
+            pass
+        widget._tb_icon_bindid = None
+    return None
+
+
+def apply_icon(widget, name, *, size=16, states=None, compound=None):
+    """Put a theme-aware Bootstrap Icons glyph on ``widget``.
+
+    Unlike a bare `Icon(...)` used as ``image=``, this tracks the active theme and
+    the widget's states: the glyph color follows the widget's style ``foreground``,
+    so it inverts on ``outline``/``toggle`` buttons, mutes when disabled, and
+    re-colors on a theme switch. It does so by giving the widget a derived,
+    content-hashed style that augments (inherits) its current ``style``/
+    ``bootstyle`` -- see the design doc's "What this does to your widget's style".
+
+    Parameters:
+
+        widget:
+            A ttk ``Button`` (incl. Toolbutton/Outline/link/ghost variants),
+            ``Label``, ``Menubutton``, ``Checkbutton``, or ``Radiobutton``. Any
+            other class raises ``TypeError`` (it has no image-bearing label
+            element; use a per-item image API for Treeview/Notebook).
+
+        name (str | None):
+            A Bootstrap Icons glyph name (e.g. ``"gear-fill"``). ``None``/``""``
+            removes the icon and restores the base style.
+
+        size (int | tuple[int, int]):
+            The logical UI size (converted by the root-bound scaling service).
+
+        states (dict[str, str] | None):
+            Optional ``{state_string: glyph_name}`` to show a *different glyph*
+            per state (e.g. ``{"selected": "check-square-fill"}``). The color still
+            follows the foreground. State strings are ttk state specs
+            (``"disabled"``, ``"pressed !disabled"``, ...).
+
+        compound (str | None):
+            The ttk ``-compound`` option (icon/text arrangement). Defaults to
+            ``LEFT`` when the widget has text, else icon-only.
+
+    Returns the derived ttk style name, or ``None`` when the icon was cleared.
+    """
+    from ttkbootstrap.style.engine import Style  # back-edge; keeps this a leaf
+
+    style = Style.get_instance() or Style()
+
+    if not name:
+        return _clear_widget_icon(widget)
+
+    if widget.winfo_class() not in _ICON_WIDGET_CLASSES:
+        raise TypeError(
+            f"apply_icon: {widget.winfo_class()!r} has no image-bearing label "
+            f"element. Supported: Button, Label, Menubutton, Checkbutton, "
+            f"Radiobutton. (Treeview/Notebook take images via their own per-item "
+            f"API, not a widget-level style.)"
+        )
+
+    if compound is None and _widget_has_text(widget):
+        compound = tk.LEFT
+
+    base = _icon_base_style(widget)
+    derived = _build_icon_style(style, base, name, size, states, compound)
+    _set_icon_style(widget, derived)
+
+    # remember the spec so a <<ThemeChanged>> (or a bootstyle change that re-calls
+    # apply_icon) can rebuild the glyphs for the new theme
+    widget._tb_icon = {
+        "base": base, "name": name, "size": size,
+        "states": states, "compound": compound,
+    }
+    # single bind: replace, never stack, on repeated apply_icon calls
+    old = getattr(widget, "_tb_icon_bindid", None)
+    if old is not None:
+        try:
+            widget.unbind("<<ThemeChanged>>", old)
+        except tk.TclError:
+            pass
+    widget._tb_icon_bindid = widget.bind(
+        "<<ThemeChanged>>", lambda _e: _rebuild_widget_icon(widget), "+")
+    return derived

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -488,7 +488,7 @@ def _clear_widget_icon(widget):
     return None
 
 
-def apply_icon(widget, name, *, size=16, states=None, compound=None):
+def apply_icon(widget, name, *, size=14, states=None, compound=None):
     """Put a theme-aware Bootstrap Icons glyph on ``widget``.
 
     Unlike a bare `Icon(...)` used as ``image=``, this tracks the active theme and

--- a/tests/test_icon_theme.py
+++ b/tests/test_icon_theme.py
@@ -1,0 +1,138 @@
+"""Headless tests for theme-aware widget icons (apply_icon + icon=/icon_size=).
+
+Covers the parts checkable without a display:
+- apply_icon gives the widget a derived, image-bearing style,
+- inverting styles (outline) render on-accent when active (foreground-follow),
+- a theme switch re-renders the glyph (the <<ThemeChanged>> bind),
+- the states= per-state glyph override,
+- clearing restores the base style; unsupported widgets raise,
+- the mixin icon=/icon_size= sugar composes with bootstyle and re-derives,
+- content-hashed derived styles dedupe across identical widgets,
+- apply_icon is re-exported, and the datepicker carets use the path.
+"""
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap import apply_icon
+from ttkbootstrap.style import apply_icon as apply_icon_style
+
+
+def _img(style, style_name, state=None):
+    return style.lookup(style_name, "image", state=state)
+
+
+# --------------------------------------------------------------------------
+# apply_icon primitive
+# --------------------------------------------------------------------------
+
+def test_apply_icon_sets_derived_image_style(root):
+    b = ttk.Button(root, text="Settings", bootstyle="primary")
+    derived = apply_icon(b, "gear-fill", size=16)
+    assert b.cget("style") == derived
+    assert derived.startswith("Icon")
+    assert derived.endswith("primary.TButton")
+    assert _img(root.style, derived)  # image configured
+    assert str(root.style.lookup(derived, "compound")) == "left"  # text kept
+
+
+def test_apply_icon_outline_inverts_when_active(root):
+    b = ttk.Button(root, bootstyle="primary-outline")
+    derived = apply_icon(b, "funnel-fill", size=16)
+    rest = _img(root.style, derived)
+    pressed = _img(root.style, derived, state=["pressed", "!disabled"])
+    # rest follows the accent fg; pressed follows the on-accent fg -> different image
+    assert rest != pressed
+
+
+def test_apply_icon_rerenders_on_theme_change(root):
+    # a bare button follows colors.fg, which flips between light and dark themes
+    b = ttk.Button(root, text="x")
+    apply_icon(b, "gear-fill", size=16)
+    before = _img(root.style, b.cget("style"))
+    root.style.theme_use("bootstrap-dark")
+    root.update()  # process <<ThemeChanged>>
+    after = _img(root.style, b.cget("style"))
+    assert before != after
+
+
+def test_apply_icon_states_glyph_override(root):
+    b = ttk.Checkbutton(root, text="Fav", bootstyle="warning")
+    derived = apply_icon(b, "star", size=16, states={"selected": "star-fill"})
+    rest = _img(root.style, derived)
+    selected = _img(root.style, derived, state=["selected"])
+    assert rest != selected
+
+
+def test_apply_icon_none_restores_base(root):
+    b = ttk.Button(root, bootstyle="primary")
+    apply_icon(b, "gear-fill")
+    assert b.cget("style").startswith("Icon")
+    assert apply_icon(b, None) is None
+    assert b.cget("style") == "primary.TButton"
+    assert getattr(b, "_tb_icon", None) is None
+
+
+def test_apply_icon_unsupported_widget_raises(root):
+    with pytest.raises(TypeError):
+        apply_icon(ttk.Entry(root), "gear-fill")
+
+
+def test_apply_icon_dedupes_identical_configs(root):
+    a = ttk.Button(root, bootstyle="primary")
+    b = ttk.Button(root, bootstyle="primary")
+    sa = apply_icon(a, "gear-fill", size=16)
+    sb = apply_icon(b, "gear-fill", size=16)
+    assert sa == sb  # same (base, glyph, size) -> one content-hashed style
+
+
+# --------------------------------------------------------------------------
+# mixin sugar
+# --------------------------------------------------------------------------
+
+def test_icon_kwarg_on_constructor(root):
+    b = ttk.Button(root, text="Save", bootstyle="primary", icon="floppy", icon_size=18)
+    assert b.cget("style").startswith("Icon")
+    assert b._tb_icon["name"] == "floppy"
+    assert b._tb_icon["size"] == 18
+    assert _img(root.style, b.cget("style"))
+
+
+def test_bootstyle_change_rederives_icon(root):
+    b = ttk.Button(root, bootstyle="primary", icon="floppy")
+    b.configure(bootstyle="danger")
+    style_name = b.cget("style")
+    assert style_name.endswith("danger.TButton")
+    assert _img(root.style, style_name)  # icon carried onto the new base
+
+
+def test_configure_icon_change_and_clear(root):
+    b = ttk.Button(root, bootstyle="primary", icon="floppy")
+    b.configure(icon="trash")
+    assert b._tb_icon["name"] == "trash"
+    b.configure(icon_size=24)
+    assert b._tb_icon["size"] == 24
+    b.configure(icon=None)
+    assert b.cget("style") == "primary.TButton"
+    assert getattr(b, "_tb_icon", None) is None
+
+
+# --------------------------------------------------------------------------
+# re-exports + first-party dogfood
+# --------------------------------------------------------------------------
+
+def test_apply_icon_reexports():
+    assert apply_icon is apply_icon_style
+    assert "apply_icon" in ttk.__all__
+
+
+def test_datepicker_carets_use_apply_icon(root):
+    # autoshow=False builds the widget tree (incl. _update_widget_bootstyle) in
+    # __init__ without the modal show()/wait_window, so this stays headless.
+    from ttkbootstrap.dialogs.datepicker import DatePickerDialog
+    dp = DatePickerDialog(parent=root, autoshow=False)
+    try:
+        assert dp.prev_period.cget("style").startswith("Icon")
+        assert dp.next_period.cget("style").startswith("Icon")
+        assert getattr(dp.prev_period, "_tb_icon", None)
+    finally:
+        dp.root.destroy()


### PR DESCRIPTION
Closes the inline-icon **theme-awareness gap**: a bare `Icon(...)` used as `image=` baked its color once and went stale on a theme switch, while style-delivered icons (builder recipes) were theme-aware. Design: `development/2_0_icon_theme_awareness_design.md`.

## What's new

- **`ttk.apply_icon(widget, name, *, size=14, states=None, compound=None)`** — renders a glyph following the widget's style `foreground`, so it **inverts on outline/toggle**, mutes when disabled, and **re-renders on `<<ThemeChanged>>`** (per-widget bind, no engine change — the `Meter`/`Floodgauge` pattern).
- **`icon=`/`icon_size=` mixin sugar** on every blessed widget (`BootMixin`) — routes to `apply_icon` after the base style resolves; a `bootstyle` change re-derives the icon onto the new base; `icon=None` restores the base. Re-entrancy guarded.
- Supported on label-image widgets (`Button`/`Label`/`Menubutton`/`Checkbutton`/`Radiobutton`); other classes raise `TypeError` (a style image silently no-ops otherwise).

### The one implicit behavior (documented loudly, design §4.1)
`icon=`/`apply_icon` **augments the widget's style**: it gives the widget a derived, content-hashed style `Icon<hash>.<your style>` that **inherits** your `bootstyle`/`style` (config, map, *and* layout via ttk dotted fallback) and adds the glyph — so it matches its siblings exactly. `widget.cget("style")` therefore changes to the derived name; identical configs dedupe to one style. The static `Icon(...)` escape hatch is unchanged.

## Render tuning (from the live visual gate)
Button-icon crispness traced to the **10% glyph pad** rendering the glyph at ~80% of the frame — dropped to **4%** + integer-snapped the metrics-path draw origin, sharpening all font-glyph icons. Default `icon_size` → **14**. Built-in `calendar3` trimmed 21→18/19 and the date button regained +1px vertical padding (the lower pad renders font glyphs larger per unit size). Check/radio/toggle/scale/scrollbar indicators are **raster** assets — unaffected.

## First-party dogfood
Datepicker header carets migrated onto `apply_icon` (the Chevron style's foreground is already `on_color(accent)`, so the color is unchanged — now theme-aware).

## Tests / gate
- `tests/test_icon_theme.py` (+12): derived style, outline invert, theme re-render, `states` override, clear, raise, dedupe, mixin sugar, re-exports, datepicker.
- Suite **330 passed** excl. the known `nl.msg` flake; warning-free import.
- Human light↔dark gate: carets, 14px button default, date button (glyph + height) confirmed.

## Follow-ups (logged, not blockers)
1. Eyeball `grip-horizontal` on a Sizegrip; trim if large (the one font glyph that grew, unchecked).
2. Theme-wide **control-height parity** (buttons == inputs) — before docs screenshots (memory `control-height-parity`).

Also records the 2.0 public-name casing convention (`CLAUDE.md` Conventions + memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)