### PR TITLE
Tableview: glyph pagination nav buttons + boundary-disable

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -387,3 +387,25 @@ restores the base style. The static `Icon(...)` escape hatch is unchanged (a raw
 
 **Not breaking.** Purely additive; no existing signature changed. First-party: the
 datepicker header carets were migrated onto `apply_icon` (internal, no API change).
+
+## Tableview pagination: glyph nav buttons + boundary-disable  *(behavior)*
+
+**What.** The five `Tableview` pagination controls (first/prev/next/last + reset)
+change from character symbols (`« ‹ › » ⎌`, styled `symbol.Link.TButton`) to
+Bootstrap Icons glyphs on a `ghost` base via the `icon=` sugar
+(`chevron-bar-left`/`chevron-left`/`chevron-right`/`chevron-bar-right` +
+`arrow-counterclockwise`). The four **nav** buttons now **disable at the page
+boundaries** — first/prev on page one, next/last on the last page — driven from
+`load_table_data` (the single funnel that refreshes the page index/limit). The
+searchable-but-unpaginated reset button gets the same glyph for consistency.
+
+**Why.** The character symbols were font-dependent and visually inconsistent with
+the rest of the 2.0 glyph-based indicators; the nav buttons previously stayed
+enabled at the boundaries (a click there was a silent no-op), so there was no
+affordance for "no further pages." Ghost + disabled foreground mutes the glyph, so
+the boundary state now reads.
+
+**Not breaking (API).** No public signature changed; `goto_first_page`/
+`goto_last_page`/`goto_next_page`/`goto_prev_page` are unchanged. A programmatic
+caller can still invoke them at a boundary (they were already guarded no-ops); only
+the button's interactive `state` reflects the boundary now.

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -1235,6 +1235,26 @@ class Tableview(ttk.Frame):
                 row.show(False)
             self._viewdata.append(row)
 
+        self._update_pagination_state()
+
+    def _update_pagination_state(self):
+        """Enable/disable the navigation buttons at the page boundaries.
+
+        Called from `load_table_data` (the single funnel that refreshes the
+        page index/limit): first/prev disable on page one, next/last on the
+        last page. The ghost buttons' disabled foreground mutes their glyph.
+        """
+        if not self._paginated:
+            return
+        pageindex = self._pageindex.get()
+        pagelimit = self._pagelimit.get()
+        at_first = pageindex <= 1
+        at_last = pageindex >= pagelimit
+        self._pagefirst.configure(state=DISABLED if at_first else NORMAL)
+        self._pageprev.configure(state=DISABLED if at_first else NORMAL)
+        self._pagenext.configure(state=DISABLED if at_last else NORMAL)
+        self._pagelast.configure(state=DISABLED if at_last else NORMAL)
+
     def fill_empty_columns(self, fillvalue=""):
         """Fill empty columns with the fillvalue.
 
@@ -2399,9 +2419,9 @@ class Tableview(ttk.Frame):
         if not self._paginated:
             ttk.Button(
                 frame,
-                text=MessageCatalog.translate("⎌"),
+                bootstyle=GHOST,
+                icon="arrow-counterclockwise",
                 command=self.reset_table,
-                style="symbol.Link.TButton",
             ).pack(side=LEFT)
 
     def _build_pagination_frame(self):
@@ -2409,45 +2429,51 @@ class Tableview(ttk.Frame):
         frame is only built if `pagination=True` when creating the
         widget.
         """
-        pageframe = ttk.Frame(self)
+        pageframe = ttk.Frame(self, padding=5)
         pageframe.pack(fill=X, anchor=N)
 
         ttk.Button(
             pageframe,
-            text=MessageCatalog.translate("⎌"),
+            bootstyle=GHOST,
+            icon="arrow-counterclockwise",
             command=self.reset_table,
-            style="symbol.Link.TButton",
-        ).pack(side=RIGHT)
+        ).pack(side=RIGHT, fill=Y)
 
-        ttk.Separator(pageframe, orient=VERTICAL).pack(side=RIGHT, padx=10)
+        self._add_page_separator(pageframe)
 
-        ttk.Button(
+        # keep references: the nav buttons disable at the page boundaries
+        # (see _update_pagination_state, called from load_table_data).
+        self._pagelast = ttk.Button(
             master=pageframe,
-            text="»",
+            bootstyle=GHOST,
+            icon="chevron-bar-right",
             command=self.goto_last_page,
-            style="symbol.Link.TButton",
-        ).pack(side=RIGHT, fill=Y)
-        ttk.Button(
+        )
+        self._pagelast.pack(side=RIGHT, fill=Y)
+        self._pagenext = ttk.Button(
             master=pageframe,
-            text="›",
+            bootstyle=GHOST,
+            icon="chevron-right",
             command=self.goto_next_page,
-            style="symbol.Link.TButton",
-        ).pack(side=RIGHT, fill=Y)
+        )
+        self._pagenext.pack(side=RIGHT, fill=Y)
 
-        ttk.Button(
+        self._pageprev = ttk.Button(
             master=pageframe,
-            text="‹",
+            bootstyle=GHOST,
+            icon="chevron-left",
             command=self.goto_prev_page,
-            style="symbol.Link.TButton",
-        ).pack(side=RIGHT, fill=Y)
-        ttk.Button(
+        )
+        self._pageprev.pack(side=RIGHT, fill=Y)
+        self._pagefirst = ttk.Button(
             master=pageframe,
-            text="«",
+            bootstyle=GHOST,
+            icon="chevron-bar-left",
             command=self.goto_first_page,
-            style="symbol.Link.TButton",
-        ).pack(side=RIGHT, fill=Y)
+        )
+        self._pagefirst.pack(side=RIGHT, fill=Y)
 
-        ttk.Separator(pageframe, orient=VERTICAL).pack(side=RIGHT, padx=10)
+        self._add_page_separator(pageframe)
 
         lbl = ttk.Label(pageframe, textvariable=self._pagelimit)
         lbl.pack(side=RIGHT, padx=(0, 5))
@@ -2459,6 +2485,20 @@ class Tableview(ttk.Frame):
         index.bind("<KP_Enter>", self.goto_page, "+")
 
         ttk.Label(pageframe, text=MessageCatalog.translate("Page")).pack(side=RIGHT, padx=5)
+
+    def _add_page_separator(self, parent):
+        """Pack a short vertical divider into the pagination bar.
+
+        A bare vertical ``ttk.Separator`` requests its full drawn length (the
+        style's baked ~40px), which would make it the tallest child and force
+        an oversized bar. Bounding it in a fixed, DPI-scaled height frame keeps
+        the divider inset and lets the (shorter) controls set the bar height.
+        """
+        height, width = utility.scale_size(self, [20, 1])
+        box = ttk.Frame(parent, height=height, width=width)
+        box.pack_propagate(False)
+        box.pack(side=RIGHT, padx=10)
+        ttk.Separator(box, orient=VERTICAL).pack(fill=BOTH, expand=YES)
 
     # PRIVATE METHODS - WIDGET BINDING
 

--- a/tests/test_tableview_api.py
+++ b/tests/test_tableview_api.py
@@ -85,3 +85,57 @@ def test_insert_row_empty_values_raises(root):
 def test_dead_code_removed():
     for name in ("reset_row_sort", "_build_table_rows", "_build_table_columns"):
         assert not hasattr(Tableview, name)
+
+
+# --------------------------------------------------------------------------
+# pagination navigation buttons (glyph icons + boundary-disable)
+# --------------------------------------------------------------------------
+
+def _make_paginated_table(root):
+    # pagesize=2 over 6 rows -> 3 pages, so every boundary is reachable.
+    return Tableview(
+        root,
+        coldata=["A", "B"],
+        rowdata=[[f"a{i}", f"b{i}"] for i in range(6)],
+        paginated=True,
+        pagesize=2,
+    )
+
+
+def _nav_disabled(tv):
+    return {
+        "first": tv._pagefirst.instate(["disabled"]),
+        "prev": tv._pageprev.instate(["disabled"]),
+        "next": tv._pagenext.instate(["disabled"]),
+        "last": tv._pagelast.instate(["disabled"]),
+    }
+
+
+def test_pagination_nav_buttons_are_ghost_icon_buttons(root):
+    tv = _make_paginated_table(root)
+    for btn in (tv._pagefirst, tv._pageprev, tv._pagenext, tv._pagelast):
+        # apply_icon derives an ``Icon<hash>.`` style off the ghost base.
+        assert "Ghost.TButton" in str(btn.cget("style"))
+
+
+def test_pagination_first_page_disables_backward(root):
+    tv = _make_paginated_table(root)
+    tv.goto_first_page()
+    state = _nav_disabled(tv)
+    assert state["first"] and state["prev"]
+    assert not state["next"] and not state["last"]
+
+
+def test_pagination_last_page_disables_forward(root):
+    tv = _make_paginated_table(root)
+    tv.goto_last_page()
+    state = _nav_disabled(tv)
+    assert state["next"] and state["last"]
+    assert not state["first"] and not state["prev"]
+
+
+def test_pagination_middle_page_all_enabled(root):
+    tv = _make_paginated_table(root)
+    tv.goto_first_page()
+    tv.goto_next_page()  # page 2 of 3
+    assert not any(_nav_disabled(tv).values())


### PR DESCRIPTION
Migrates the `Tableview` pagination controls onto the 2.0 font-glyph icon path and tidies the bar layout. Targets `2.0`.

## What

- **Glyph nav buttons on a ghost base** via the `icon=` sugar, replacing the five character symbols (`« ‹ › » ⎌`, styled `symbol.Link.TButton`):
  - first → `chevron-bar-left`, prev → `chevron-left`, next → `chevron-right`, last → `chevron-bar-right`, reset → `arrow-counterclockwise`.
  - The unpaginated (searchable) reset button gets the same glyph for consistency.
- **Boundary-disable**: the four nav buttons now disable at the page boundaries — first/prev on page one, next/last on the last page — driven from `_update_pagination_state`, called by `load_table_data` (the single funnel that refreshes the page index/limit). The ghost disabled-foreground mutes the glyph, so the boundary state reads. (Previously a click at a boundary was a silent no-op with no affordance.)
- **Bar layout**: the bar was pinned at ~40px because a bare vertical `ttk.Separator` requests the style's baked ~40px length (the old 16pt-font symbol buttons matched it). Each divider is now bounded in a fixed, DPI-scaled height frame so the shorter controls (buttons 30px, entry 29px) set the height; the reset button gains `fill=Y` so all five buttons are uniform; and `padding=5` on the page frame (matching the search frame) keeps the controls off the edges.

No public method signature changed — `goto_first_page`/`goto_last_page`/`goto_next_page`/`goto_prev_page` are unchanged and still safe to call at a boundary; only the button's interactive `state` reflects the boundary now.

## Tests

`tests/test_tableview_api.py` +4 (ghost-icon base, both boundaries, middle page). Full headless suite **340 passed**.

## Notes

Rationale/entry added to `development/2_0_breaking_changes.md`. A light↔dark visual eyeball of the pagination bar (glyphs + disabled muting) is worth a look before docs screenshots — the headless suite asserts the image is wired and the boundary state, not that it looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
