### PR TITLE
Re-export ToolTip/Toast/Scrolled widgets at top level (widget review PR 1)

### DIFF
--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -206,9 +206,13 @@ from ttkbootstrap.widgets import (
     LabeledScale,
     M,
     Meter,
+    ScrolledFrame,
+    ScrolledText,
     TableColumn,
     TableRow,
     Tableview,
+    ToastNotification,
+    ToolTip,
 )
 from ttkbootstrap.window import Toplevel, Window
 
@@ -276,9 +280,13 @@ __all__ = [
     "FloodgaugeLegacy",
     "LabeledScale",
     "Meter",
+    "ScrolledText",
+    "ScrolledFrame",
     "Tableview",
     "TableColumn",
     "TableRow",
+    "ToolTip",
+    "ToastNotification",
     "M",
 
     # Dialogs

--- a/src/ttkbootstrap/widgets/__init__.py
+++ b/src/ttkbootstrap/widgets/__init__.py
@@ -51,6 +51,7 @@ from ttkbootstrap.widgets.dateentry import DateEntry
 from ttkbootstrap.widgets.floodgauge import Floodgauge, FloodgaugeLegacy
 from ttkbootstrap.widgets.labeledscale import LabeledScale
 from ttkbootstrap.widgets.meter import Meter
+from ttkbootstrap.widgets.scrolled import ScrolledFrame, ScrolledText
 from ttkbootstrap.widgets.tableview import TableColumn, TableRow, Tableview
 from ttkbootstrap.widgets.toast import ToastNotification
 from ttkbootstrap.widgets.tooltip import ToolTip
@@ -107,6 +108,8 @@ __all__ = [
     'FloodgaugeLegacy',
     'Meter',
     'LabeledScale',
+    'ScrolledText',
+    'ScrolledFrame',
     'Tableview',
     'TableColumn',
     'TableRow',

--- a/tests/test_widget_reexports.py
+++ b/tests/test_widget_reexports.py
@@ -1,0 +1,36 @@
+"""Re-export coverage for the shipped widgets that were unreachable as
+``ttk.<Name>`` before the 2.0 widget-API review (PR 1).
+
+Before this pass ``ToolTip`` and ``ToastNotification`` were only importable from
+``ttkbootstrap.widgets``, and ``ScrolledText``/``ScrolledFrame`` were not exported
+from the widgets package at all (only via ``ttkbootstrap.widgets.scrolled``). They
+now match every other shipped widget: reachable at the top level and listed in the
+relevant ``__all__``.
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap import widgets as _widgets
+from ttkbootstrap.widgets.scrolled import ScrolledFrame, ScrolledText
+from ttkbootstrap.widgets.toast import ToastNotification
+from ttkbootstrap.widgets.tooltip import ToolTip
+
+
+def test_popup_widgets_reexported_at_top_level():
+    assert ttk.ToolTip is ToolTip
+    assert ttk.ToastNotification is ToastNotification
+    for name in ("ToolTip", "ToastNotification"):
+        assert name in ttk.__all__
+
+
+def test_scrolled_widgets_reexported_at_top_level():
+    assert ttk.ScrolledText is ScrolledText
+    assert ttk.ScrolledFrame is ScrolledFrame
+    for name in ("ScrolledText", "ScrolledFrame"):
+        assert name in ttk.__all__
+
+
+def test_scrolled_widgets_reexported_from_widgets_package():
+    # These were previously not imported into the widgets package at all.
+    assert _widgets.ScrolledText is ScrolledText
+    assert _widgets.ScrolledFrame is ScrolledFrame
+    for name in ("ScrolledText", "ScrolledFrame"):
+        assert name in _widgets.__all__


### PR DESCRIPTION
Second slice (PR 1) of the remaining shipped-widget API review (design: `development/2_0_widget_api_review_design.md`). Targets `2.0`.

## What

Four shipped widgets couldn't be reached as `ttk.<Name>` like every other widget:
- **`ToolTip`** and **`ToastNotification`** — only importable via `ttkbootstrap.widgets` (top-level-absent).
- **`ScrolledText`** / **`ScrolledFrame`** — not exported from the `ttkbootstrap.widgets` package **at all**; the only path was `ttkbootstrap.widgets.scrolled`.

This makes them consistent with the rest:
- `widgets/__init__.py` imports `ScrolledText`/`ScrolledFrame` and adds them to `__all__`.
- top-level `ttkbootstrap` imports `ToolTip`/`ToastNotification`/`ScrolledText`/`ScrolledFrame` and adds them to `__all__`.

Purely additive — the existing `ttkbootstrap.widgets.*` and `ttkbootstrap.widgets.scrolled` paths still work; `import ttkbootstrap` stays warning-free. Mirrors PR C's `Tableview` re-export.

## Tests

`tests/test_widget_reexports.py` (+3): `ttk.<Name>` identity + `__all__` membership at both levels. Full suite **344 passed** (excl. the known localization env flake).

## Note

The deeper normalization of these widgets (lifecycle, configure/cget, the toast stack, `ScrolledFrame` Canvas-viewport rewrite) lands in later PRs of the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
