### PR TITLE
Add shared configure/cget delegation mixin (widget review PR 1.5)

### DIFF
--- a/src/ttkbootstrap/internal/configure_delegation.py
+++ b/src/ttkbootstrap/internal/configure_delegation.py
@@ -1,0 +1,196 @@
+"""Configure/cget delegation for ttkbootstrap's custom widgets.
+
+Custom widgets (Meter, Floodgauge, DateEntry, ...) add their own options on top
+of a real ttk/tk widget. Historically each hand-maintained two parallel `if/else`
+ladders — one in a `configure` override to *set*, one to *get* — and often forgot
+a `cget` override entirely, so an option could be set but never read back (or a
+construction-only option had no `configure` branch at all). Those ladders are
+where the round-trip bugs live.
+
+This mixin replaces them. A widget marks one method per option with
+`@configure_delegate("name")`; `__init_subclass__` collects every such method in
+the MRO into a `key -> handler` map at class-creation time; and `configure`,
+`config`, `cget`, `keys`, `__getitem__`, and `__setitem__` all route delegated
+keys through that map (returning proper Tk 5-tuple specs), falling back to the
+real widget for everything else. A single handler serves both directions:
+
+```python
+class Meter(ConfigureDelegationMixin, Frame):
+    @configure_delegate("amountused")
+    def _amountused(self, value):
+        if value is None:                 # query
+            return self._amountusedvar.get()
+        self._amountusedvar.set(value)    # set
+```
+
+`cget("amountused")`, `configure("amountused")`, `meter["amountused"]`,
+`configure(amountused=…)`, and `meter["amountused"] = …` now all work and stay in
+sync, with no ladder to keep aligned.
+
+**Inner-widget fallthrough** (the piece bootstack's original lacks): a composite
+that proxies to an inner widget — e.g. `ScrolledText` wrapping a `Text` — can
+override `_configure_delegate_target()` to return that inner widget. Non-delegated
+options then route to it instead of the outer frame, so `st.configure(font=…)` /
+`st.cget("wrap")` reach the `Text`. The default returns `None` (use the widget
+itself), which is what the non-composite widgets want.
+
+This module is internal (`ttkbootstrap.internal`): no back-compat guarantee.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+# Marker attribute stamped on a delegate method by the decorator. Namespaced to
+# ttkbootstrap so it never collides with a real attribute or bootstack's marker.
+_DELEGATE_KEYS_ATTR = "_tb_configure_keys"
+
+
+def configure_delegate(*names: str) -> Callable[[Callable], Callable]:
+    """Mark a method as the get/set handler for one or more configure options.
+
+    The decorated method takes a single ``value`` argument: called with ``None``
+    it returns the option's current value (query); called with a value it applies
+    it (set). Registering several names on one method is allowed (aliases).
+    """
+    def _decorator(func: Callable) -> Callable:
+        keys = set(getattr(func, _DELEGATE_KEYS_ATTR, ()))
+        keys.update(names)
+        setattr(func, _DELEGATE_KEYS_ATTR, tuple(keys))
+        return func
+
+    return _decorator
+
+
+class ConfigureDelegationMixin:
+    """Dispatch delegated configure/cget keys to `@configure_delegate` handlers.
+
+    Place it **before** the base widget in the bases, e.g.
+    ``class Meter(ConfigureDelegationMixin, Frame)`` — so its `configure`/`cget`
+    resolve first and delegate to `super()` (the real widget) for everything they
+    do not own.
+    """
+
+    #: key -> handler-method-name, built per subclass in __init_subclass__.
+    _configure_delegate_map: dict[str, str] = {}
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        mapping: dict[str, str] = {}
+        # Reversed MRO so a subclass override of a delegate wins over its base.
+        for base in reversed(cls.__mro__):
+            for name, member in getattr(base, "__dict__", {}).items():
+                keys = getattr(member, _DELEGATE_KEYS_ATTR, None)
+                if keys:
+                    for key in keys:
+                        mapping[str(key)] = name
+        cls._configure_delegate_map = mapping
+
+    # -- extension point ----------------------------------------------------- #
+    def _configure_delegate_target(self):
+        """Widget that receives *non-delegated* options, or ``None`` for ``self``.
+
+        Override in a composite to proxy pass-through options to an inner widget
+        (e.g. `ScrolledText` returning its inner `Text`). The default keeps the
+        base-widget behavior (route to ``super()``).
+        """
+        return None
+
+    # -- delegation core ----------------------------------------------------- #
+    def _config_delegate_set(self, key: str, value: Any) -> bool:
+        method_name = self._configure_delegate_map.get(key)
+        if method_name is None:
+            return False
+        getattr(self, method_name)(value)
+        return True
+
+    def _config_delegate_get(self, key: str) -> tuple[bool, Any]:
+        method_name = self._configure_delegate_map.get(key)
+        if method_name is None:
+            return False, None
+        value = getattr(self, method_name)(None)
+        # A tk Variable renders as its Tcl name, matching cget() on a real option.
+        if key in ("variable", "textvariable") and hasattr(value, "_name"):
+            return True, str(value)
+        return True, value
+
+    @staticmethod
+    def _spec(key: str, value: Any) -> tuple:
+        """A Tk configure spec: (name, dbName, dbClass, default, current)."""
+        return (key, key, key.capitalize(), None, value)
+
+    # -- public tk-style surface --------------------------------------------- #
+    def configure(self, cnf: Any = None, **kwargs: Any) -> Any:
+        if isinstance(cnf, dict):
+            kwargs = {**cnf, **kwargs}
+            cnf = None
+
+        if kwargs:
+            for key in list(kwargs):
+                if key in self._configure_delegate_map:
+                    self._config_delegate_set(key, kwargs.pop(key))
+            if kwargs:
+                target = self._configure_delegate_target()
+                if target is not None:
+                    target.configure(**kwargs)
+                else:
+                    super().configure(**kwargs)
+            return None
+
+        if isinstance(cnf, str):
+            if cnf in self._configure_delegate_map:
+                _, value = self._config_delegate_get(cnf)
+                return self._spec(cnf, value)
+            target = self._configure_delegate_target()
+            if target is not None:
+                return target.configure(cnf)
+            return super().configure(cnf)
+
+        # No-arg query: full option dict, with the delegated options merged in.
+        base = super().configure() or {}
+        for key in self._configure_delegate_map:
+            _, value = self._config_delegate_get(key)
+            base[key] = self._spec(key, value)
+        return base
+
+    config = configure
+
+    def cget(self, key: str) -> Any:
+        if key in self._configure_delegate_map:
+            _, value = self._config_delegate_get(key)
+            return value
+        target = self._configure_delegate_target()
+        if target is not None:
+            return target.cget(key)
+        return super().cget(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        if self._config_delegate_set(key, value):
+            return
+        target = self._configure_delegate_target()
+        if target is not None:
+            target[key] = value
+        else:
+            super().__setitem__(key, value)
+
+    def __getitem__(self, key: str) -> Any:
+        if key in self._configure_delegate_map:
+            _, value = self._config_delegate_get(key)
+            return value
+        target = self._configure_delegate_target()
+        if target is not None:
+            return target[key]
+        return super().__getitem__(key)
+
+    def keys(self) -> list:
+        """Option names, including the delegated custom options (for discovery)."""
+        try:
+            names = list(super().keys())
+        except AttributeError:
+            names = []
+        for key in self._configure_delegate_map:
+            if key not in names:
+                names.append(key)
+        return names
+
+
+__all__ = ["configure_delegate", "ConfigureDelegationMixin"]

--- a/tests/test_configure_delegation.py
+++ b/tests/test_configure_delegation.py
@@ -1,0 +1,143 @@
+"""Tests for the shared configure/cget delegation mixin
+(`ttkbootstrap.internal.configure_delegation`) — the backbone the custom-widget
+API review (Meter/Floodgauge/DateEntry/Scrolled) builds on.
+"""
+import tkinter as tk
+from tkinter import ttk
+
+import pytest
+
+from ttkbootstrap.internal.configure_delegation import (
+    ConfigureDelegationMixin,
+    configure_delegate,
+)
+
+
+class _Widget(ConfigureDelegationMixin, ttk.Label):
+    """A ttk.Label with one delegated option (`foo`) and one variable option."""
+
+    def __init__(self, master, **kw):
+        self._foo = 0
+        self._var = tk.IntVar(master=master, value=3)
+        super().__init__(master, **kw)
+
+    @configure_delegate("foo")
+    def _foo_handler(self, value):
+        if value is None:
+            return self._foo
+        self._foo = value
+
+    @configure_delegate("variable")
+    def _var_handler(self, value):
+        if value is None:
+            return self._var
+        self._var = value
+
+
+class _Composite(ConfigureDelegationMixin, ttk.Frame):
+    """A composite that routes non-delegated options to an inner Label."""
+
+    def __init__(self, master):
+        self._bar = 1
+        super().__init__(master)
+        self.inner = ttk.Label(self, text="x")
+
+    def _configure_delegate_target(self):
+        return self.inner
+
+    @configure_delegate("bar")
+    def _bar_handler(self, value):
+        if value is None:
+            return self._bar
+        self._bar = value
+
+
+# --------------------------------------------------------------------------
+# delegated option round-trips through every access path
+# --------------------------------------------------------------------------
+
+def test_delegated_set_and_get_via_configure(root):
+    w = _Widget(root)
+    w.configure(foo=5)
+    assert w.cget("foo") == 5
+    assert w["foo"] == 5
+
+
+def test_delegated_set_via_item_assignment(root):
+    w = _Widget(root)
+    w["foo"] = 7
+    assert w.cget("foo") == 7
+
+
+def test_configure_query_returns_tk_five_tuple(root):
+    w = _Widget(root)
+    w.configure(foo=9)
+    spec = w.configure("foo")
+    # (name, dbName, dbClass, default, current) — the malformed 4-tuple bug fixed.
+    assert spec == ("foo", "foo", "Foo", None, 9)
+    assert len(spec) == 5
+
+
+def test_configure_accepts_dict_cnf(root):
+    w = _Widget(root)
+    w.configure({"foo": 11})
+    assert w.cget("foo") == 11
+
+
+def test_variable_option_returns_tcl_name(root):
+    w = _Widget(root)
+    # a tk Variable renders as its Tcl name string, like a real cget option
+    assert w.cget("variable") == str(w._var)
+
+
+# --------------------------------------------------------------------------
+# non-delegated options fall through to the real widget
+# --------------------------------------------------------------------------
+
+def test_non_delegated_option_falls_through_to_widget(root):
+    w = _Widget(root)
+    w.configure(text="hello")
+    assert w.cget("text") == "hello"
+
+
+def test_unknown_option_raises(root):
+    w = _Widget(root)
+    with pytest.raises(tk.TclError):
+        w.cget("definitely_not_an_option")
+
+
+# --------------------------------------------------------------------------
+# discovery: keys() and the no-arg configure() dict include delegated options
+# --------------------------------------------------------------------------
+
+def test_keys_include_delegated_options(root):
+    w = _Widget(root)
+    keys = w.keys()
+    assert "foo" in keys and "variable" in keys
+    assert "text" in keys  # real ttk.Label option still present
+
+
+def test_configure_no_arg_dict_includes_delegated(root):
+    w = _Widget(root)
+    w.configure(foo=4)
+    full = w.configure()
+    assert full["foo"] == ("foo", "foo", "Foo", None, 4)
+    assert "text" in full  # real options still there
+
+
+# --------------------------------------------------------------------------
+# inner-widget fallthrough (composite proxying to an inner widget)
+# --------------------------------------------------------------------------
+
+def test_composite_routes_passthrough_to_inner_widget(root):
+    c = _Composite(root)
+    c.configure(text="hey")  # ttk.Frame has no 'text'; must reach the inner Label
+    assert c.cget("text") == "hey"
+    assert c.inner.cget("text") == "hey"
+
+
+def test_composite_still_handles_its_own_delegated_option(root):
+    c = _Composite(root)
+    c.configure(bar=9)
+    assert c.cget("bar") == 9
+    assert c["bar"] == 9


### PR DESCRIPTION
The shared backbone (PR 1.5) of the shipped-widget API review (design: `development/2_0_widget_api_review_design.md` §8.0). Targets `2.0`.

## What

New `src/ttkbootstrap/internal/configure_delegation.py` — a `ConfigureDelegationMixin` + `@configure_delegate(...)` decorator. A custom widget declares **one get/set handler per custom option**:

```python
class Meter(ConfigureDelegationMixin, Frame):
    @configure_delegate("amountused")
    def _amountused(self, value):
        if value is None:                  # query
            return self._amountusedvar.get()
        self._amountusedvar.set(value)     # set
```

`__init_subclass__` collects every decorated handler across the MRO into a `key → handler` map at class-creation; `configure` / `config` / `cget` / `keys` / `__getitem__` / `__setitem__` all route delegated keys through it (returning proper Tk **5-tuple** specs) and fall back to the real widget for everything else.

## Why

This is the fix for the configure/cget-parity theme the review found across Meter, Floodgauge, and DateEntry: today each hand-maintains **two parallel get/set `if/else` ladders** (and often no `cget` override at all), which is exactly where the round-trip bugs live — options settable but not gettable, construction-only options, malformed 4-tuples. One declarative registration per option replaces all of that.

Came back as the **#1 borrow for Meter, Floodgauge, and Scrolled** in the bootstack mechanism survey.

## Borrowed vs added

Ported from bootstack's `ConfigureDelegationMixin` (mechanism, not API). Two additions bootstack's original lacks:
- **discovery** — dict-`cnf` support + `keys()` / no-arg `configure()` surface the delegated options;
- **inner-widget fallthrough** — a `_configure_delegate_target()` hook so a composite like `ScrolledText` can route non-delegated options to its inner `Text` (the gap the Scrolled survey flagged).

## Impact

**Pure addition — no widget consumes it yet** (PRs 2/4/5 wire it in), so there is no behavior change. Internal module (`ttkbootstrap.internal`), no back-compat guarantee.

## Tests

`tests/test_configure_delegation.py` (+11): round-trip via every access path, 5-tuple shape, dict-cnf, variable→Tcl-name, fallthrough to `super()`, unknown-key raises, `keys()`/no-arg dict discovery, and inner-widget fallthrough. Full suite **355 passed** (excl. the known localization env flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
