### PR TITLE
Normalize the DateEntry widget API (widget review PR 3)

### DIFF
--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -10,13 +10,14 @@ import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
 from ttkbootstrap.internal.utility import center_on_parent
+from ttkbootstrap.style._compat import normalize_datepicker_kwargs
 
 
 class DatePickerDialog:
     """A dialog that displays a calendar popup and returns the
     selected date as a datetime object.
 
-    The current date is displayed by default unless the `startdate`
+    The current date is displayed by default unless the `start_date`
     parameter is provided.
 
     The month can be changed by clicking the chevrons to the left
@@ -26,7 +27,7 @@ class DatePickerDialog:
     Right-click the arrow to move the calendar by one year.
     Right-click the title to reset the calendar to the start date.
 
-    The starting weekday can be changed with the `firstweekday`
+    The starting weekday can be changed with the `first_weekday`
     parameter for geographies that do not start the calendar on
     Sunday, which is the default.
 
@@ -43,10 +44,11 @@ class DatePickerDialog:
             self,
             parent: Optional[tkinter.Misc] = None,
             title: str = " ",
-            firstweekday: int = 6,
-            startdate: Optional[date] = None,
+            first_weekday: int = 6,
+            start_date: Optional[date] = None,
             bootstyle: str = PRIMARY,
             autoshow: bool = True,
+            **kwargs: Any,
     ) -> None:
         """Create a date picker dialog with a calendar popup.
 
@@ -64,11 +66,11 @@ class DatePickerDialog:
             title (str):
                 The dialog window title (default=' ').
 
-            firstweekday (int):
+            first_weekday (int):
                 First day of the week (0=Monday, 6=Sunday). Adjust this for
                 different geographical conventions (default=6).
 
-            startdate (date):
+            start_date (date):
                 Initial date to display in the calendar. If None, uses today's
                 date. The calendar will open to the month containing this date.
 
@@ -91,6 +93,18 @@ class DatePickerDialog:
             - Click date: Select date and close dialog
             - Click X button: Cancel selection and close dialog
         """
+        # Accept the pre-2.0 `firstweekday`/`startdate` spellings through 2.x
+        # (warn-and-normalize; removed in 3.0). Coordinated with DateEntry /
+        # Querybox.get_date, which were snake_cased in the same PR.
+        aliases = normalize_datepicker_kwargs(kwargs)
+        first_weekday = aliases.get("first_weekday", first_weekday)
+        start_date = aliases.get("start_date", start_date)
+        if kwargs:
+            raise TypeError(
+                f"DatePickerDialog got unexpected keyword arguments: "
+                f"{', '.join(sorted(kwargs))}"
+            )
+
         # Safe locale setup
         try:
             locale.setlocale(locale.LC_TIME, "")
@@ -106,17 +120,17 @@ class DatePickerDialog:
             minsize=(226, 1),
             iconify=True,
         )
-        self.firstweekday = firstweekday
-        self.startdate = startdate or datetime.today().date()
+        self.first_weekday = first_weekday
+        self.start_date = start_date or datetime.today().date()
         self.bootstyle = bootstyle or PRIMARY
 
-        self.date_selected = self.startdate
-        self.date = startdate or self.date_selected
-        self.calendar = calendar.Calendar(firstweekday=firstweekday)
+        self.date_selected = self.start_date
+        self.date = start_date or self.date_selected
+        self.calendar = calendar.Calendar(firstweekday=first_weekday)
         # Track whether the user actually picked a day, so cancellation
         # (closing the window without a selection) is distinguishable from a
         # real selection -- `date_selected` alone cannot tell them apart because
-        # it defaults to `startdate`/today. Read via the `result` property.
+        # it defaults to `start_date`/today. Read via the `result` property.
         self._selection_made = False
 
         self.titlevar = ttk.StringVar()
@@ -280,7 +294,7 @@ class DatePickerDialog:
         self.monthdates = self.calendar.monthdatescalendar(year=self.date.year, month=self.date.month)
 
     def _header_columns(self) -> List[str]:
-        """Create weekday headers based on `firstweekday`."""
+        """Create weekday headers based on `first_weekday`."""
         weekdays = [
             MessageCatalog.translate("Mo"),
             MessageCatalog.translate("Tu"),
@@ -290,7 +304,7 @@ class DatePickerDialog:
             MessageCatalog.translate("Sa"),
             MessageCatalog.translate("Su"),
         ]
-        header = weekdays[self.firstweekday:] + weekdays[: self.firstweekday]
+        header = weekdays[self.first_weekday:] + weekdays[: self.first_weekday]
         return header
 
     def _on_date_selected(self, row: int, col: int) -> None:
@@ -333,7 +347,7 @@ class DatePickerDialog:
 
     @_selection_callback
     def on_reset_date(self, *_: Any) -> None:
-        self.date = self.startdate
+        self.date = self.start_date
 
     def _set_window_position(self, position: Optional[Tuple[int, int]] = None) -> None:
         """Position the popup.

--- a/src/ttkbootstrap/dialogs/query.py
+++ b/src/ttkbootstrap/dialogs/query.py
@@ -8,6 +8,7 @@ from typing import Any, List, Optional, Tuple
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
+from ttkbootstrap.style._compat import normalize_datepicker_kwargs
 from .base import Dialog
 from .datepicker import DatePickerDialog
 from .fontdialog import FontDialog
@@ -231,24 +232,36 @@ class Querybox:
     def get_date(
             parent: Optional[tkinter.Misc] = None,
             title: str = " ",
-            firstweekday: int = 6,
-            startdate: Optional[date] = None,
+            first_weekday: int = 6,
+            start_date: Optional[date] = None,
             bootstyle: str = "primary",
             *,
             position: Optional[Tuple[int, int]] = None,
+            **kwargs: Any,
     ) -> Optional[date]:
         """Show a calendar and return the selected ``date``.
 
         2.0 change: returns ``None`` when the picker is cancelled (closed
         without choosing a day). Previously it always returned a ``date`` --
-        falling back to ``startdate``/today -- so cancellation was
+        falling back to ``start_date``/today -- so cancellation was
         indistinguishable from a real selection.
+
+        The pre-2.0 ``firstweekday``/``startdate`` spellings are accepted
+        through 2.x with a ``DeprecationWarning`` (removed in 3.0).
         """
+        aliases = normalize_datepicker_kwargs(kwargs)
+        first_weekday = aliases.get("first_weekday", first_weekday)
+        start_date = aliases.get("start_date", start_date)
+        if kwargs:
+            raise TypeError(
+                f"get_date() got unexpected keyword arguments: "
+                f"{', '.join(sorted(kwargs))}"
+            )
         chooser = DatePickerDialog(
             parent=parent,
             title=title,
-            firstweekday=firstweekday,
-            startdate=startdate,
+            first_weekday=first_weekday,
+            start_date=start_date,
             bootstyle=bootstyle,
             autoshow=False,
         )

--- a/src/ttkbootstrap/style/_compat.py
+++ b/src/ttkbootstrap/style/_compat.py
@@ -157,6 +157,47 @@ def normalize_meter_option(name: str) -> str:
     return name
 
 
+# DateEntry authored-option renames (2.0 shipped-widget API pass, PR 3).
+_DATEENTRY_KWARG_ALIASES = {
+    "dateformat": "date_format",
+    "firstweekday": "first_weekday",
+    "startdate": "start_date",
+}
+
+
+def normalize_dateentry_kwargs(kwargs: dict) -> dict:
+    """Pop deprecated DateEntry option names from ``kwargs``; return ``{new: value}``."""
+    return normalize_option_names(kwargs, _DATEENTRY_KWARG_ALIASES, "DateEntry")
+
+
+def normalize_dateentry_option(name: str) -> str:
+    """Map a single legacy DateEntry option name to its 2.0 spelling (warns).
+
+    Used by ``configure``/``cget``/item access so a legacy option string
+    (``dateentry.cget("dateformat")``) still resolves. Non-legacy names pass
+    through unchanged.
+    """
+    new = _DATEENTRY_KWARG_ALIASES.get(name)
+    if new is not None:
+        warn_deprecated(f"the {name!r} DateEntry option", f"{new!r}")
+        return new
+    return name
+
+
+# Date-picker dialog keyword renames (2.0 shipped-widget API pass, PR 3). The
+# DateEntry rename is coordinated across the dialog layer: `Querybox.get_date`
+# and `DatePickerDialog` carried the same legacy spellings.
+_DATEPICKER_KWARG_ALIASES = {
+    "firstweekday": "first_weekday",
+    "startdate": "start_date",
+}
+
+
+def normalize_datepicker_kwargs(kwargs: dict) -> dict:
+    """Pop deprecated date-picker kwargs from ``kwargs``; return ``{new: value}``."""
+    return normalize_option_names(kwargs, _DATEPICKER_KWARG_ALIASES, "date picker")
+
+
 def normalize_bootstyle(value, *, warn: bool = False) -> str:
     """Return the canonical dash-joined bootstyle string for a legacy value.
 

--- a/src/ttkbootstrap/widgets/__init__.py
+++ b/src/ttkbootstrap/widgets/__init__.py
@@ -23,7 +23,7 @@ Example:
     root = ttk.Window()
 
     # Create various custom widgets
-    date_entry = ttk.DateEntry(root, firstweekday=0)
+    date_entry = ttk.DateEntry(root, first_weekday=0)
     date_entry.pack(padx=10, pady=5)
 
     floodgauge = ttk.Floodgauge(root, maximum=100, mask="{}% Complete")

--- a/src/ttkbootstrap/widgets/dateentry.py
+++ b/src/ttkbootstrap/widgets/dateentry.py
@@ -11,10 +11,10 @@ Example:
     root = ttk.Window()
 
     # Create a date entry widget
-    date_entry = ttk.DateEntry(root, firstweekday=0, startdate=datetime.now())
+    date_entry = ttk.DateEntry(root, first_weekday=0, start_date=datetime.now())
     date_entry.pack(padx=10, pady=10)
 
-    # Get the selected date
+    # Get the selected date (reads the live entry text)
     selected_date = date_entry.get_date()
 
     # Handle date selection events
@@ -28,14 +28,22 @@ Example:
 """
 from datetime import date, datetime
 from tkinter import Misc
-from typing import Any, Optional, Union
+from typing import Any, Optional, Tuple, Union
 
 from ttkbootstrap import Button, Entry, Frame
 from ttkbootstrap.constants import END, LEFT, X, YES
 from ttkbootstrap.dialogs import Querybox
+from ttkbootstrap.internal.configure_delegation import (
+    ConfigureDelegationMixin,
+    configure_delegate,
+)
+from ttkbootstrap.style._compat import (
+    normalize_dateentry_kwargs,
+    normalize_dateentry_option,
+)
 
 
-class DateEntry(Frame):
+class DateEntry(ConfigureDelegationMixin, Frame):
     """A date entry widget combines an Entry field and a Button for date selection.
 
     When the button is pressed, a calendar popup is displayed allowing the user
@@ -48,11 +56,14 @@ class DateEntry(Frame):
         - Configurable date format using strftime format strings
         - Customizable starting weekday (0=Monday, 6=Sunday)
         - Style customization via bootstyle parameter
-        - Date validation with optional exception raising
+        - Typed-text aware: `get_date()` / the `value` property parse the live
+          entry text, so manual keyboard edits are honored
+        - Blur validation: the entry is flagged `invalid` when its text cannot
+          be parsed as a date
         - Access to entry and button widgets via instance attributes
 
     The date chooser popup will use the date in the entry field as the initial
-    focus date if it matches the specified dateformat. By default, the format
+    focus date if it matches the specified date_format. By default, the format
     is locale-specific ("%x").
 
     The bootstyle parameter can be used to change the widget colors. Available
@@ -65,15 +76,21 @@ class DateEntry(Frame):
     ![](../../assets/widgets/date-entry.png)
     """
 
+    # Common fallback formats tried (after the widget's own `date_format`) when
+    # coercing the live entry text to a date.
+    _FALLBACK_FORMATS = ("%Y-%m-%d", "%m/%d/%Y")
+
     def __init__(
             self,
             master: Optional[Misc] = None,
-            dateformat: str = r"%x",
-            firstweekday: int = 6,
-            startdate: Optional[Union[datetime, date]] = None,
+            *,
+            date_format: str = r"%x",
+            first_weekday: int = 6,
+            start_date: Optional[Union[datetime, date]] = None,
             bootstyle: str = "",
             popup_title: str = 'Select new date',
             raise_exception: bool = False,
+            position: Optional[Tuple[int, int]] = None,
             **kwargs: Any,
     ) -> None:
         """
@@ -82,16 +99,16 @@ class DateEntry(Frame):
             master (Widget, optional):
                 The parent widget.
 
-            dateformat (str, optional):
+            date_format (str, optional):
                 The format string used to render the text in the entry widget.
                 Defaults to "%x" (locale's appropriate date representation).
                 For more information on acceptable formats, see https://strftime.org/
 
-            firstweekday (int, optional):
+            first_weekday (int, optional):
                 Specifies the first day of the week. 0=Monday, 1=Tuesday,
                 etc...
 
-            startdate (datetime, optional):
+            start_date (datetime, optional):
                 The date that is in focus when the widget is displayed. Default is
                 current date.
 
@@ -105,33 +122,45 @@ class DateEntry(Frame):
                 Title for PopUp window (Default: `Select new date`)
 
             raise_exception (bool, optional):
-                If a `ValueError` should be raised, if the user enters an invalid date string. If this is set to `False`,
-                faulty date strings will be ignored. Only a warning on the terminal/console will be printed. (Default: `False`)
+                If a `ValueError` should be raised when the user enters an
+                invalid date string. If this is set to `False`, faulty date
+                strings are ignored (only a warning is printed). (Default: `False`)
+
+            position (tuple[int, int], optional):
+                Optional ``(x, y)`` screen coordinates passed through to the
+                date-picker popup.
 
             **kwargs (dict[str, Any], optional):
                 Other keyword arguments passed to the frame containing the
-                entry and date button.
+                entry and date button. A ``width`` here is applied to the entry
+                field (not the frame).
         """
+        # Accept the pre-2.0 dateformat/firstweekday/startdate spellings
+        # (warn-and-normalize through 2.x; removed in 3.0).
+        aliases = normalize_dateentry_kwargs(kwargs)
+        date_format = aliases.get("date_format", date_format)
+        first_weekday = aliases.get("first_weekday", first_weekday)
+        start_date = aliases.get("start_date", start_date)
 
         self.__enabled = True  # User/Programmer should NOT be able to change this, therefore double underscores
-        self.__dateformat = self._validate_dateformat(
-            dateformat)  # User/Programmer should NOT be able to change this, therefore double underscores
-        self._firstweekday = firstweekday
-
-        self._startdate = startdate or datetime.today()
+        self.__dateformat = self._validate_dateformat(date_format)
+        self._firstweekday = first_weekday
+        self._startdate = start_date or datetime.today()
         self._bootstyle = bootstyle
         self._popup_title = popup_title
         self._raise_exception = raise_exception
+        self._position = position
+        self._picker_open = False  # re-entrancy guard for the popup
+
+        # Kwarg partitioning: `width` belongs to the entry field, everything
+        # else to the frame. (Previously `width` was applied to both.)
+        entry_width = kwargs.pop("width", None)
         super().__init__(master, **kwargs)
 
-        # add visual components
-        entry_kwargs = {
-            "bootstyle": self._bootstyle,
-        }
-        if "width" in kwargs:
-            entry_kwargs["width"] = kwargs.pop("width")
-
-        # Build date Widget button (this shows the date in the wanted format)
+        # Build the date entry (this shows the date in the wanted format)
+        entry_kwargs = {"bootstyle": self._bootstyle}
+        if entry_width is not None:
+            entry_kwargs["width"] = entry_width
         self.entry = Entry(self, **entry_kwargs)
         self.entry.pack(side=LEFT, fill=X, expand=YES)
 
@@ -143,83 +172,95 @@ class DateEntry(Frame):
         )
         self.button.pack(side=LEFT)
 
+        # Mark the entry `invalid` on blur when its text is not a valid date.
+        self.entry.bind("<FocusOut>", self._on_entry_blur, add="+")
+
         # Initialize this widget
         self.set_date(self._startdate)
 
-    def __getitem__(self, key: str) -> Any:
-        return self.configure(cnf=key)
+    # -- configure delegates ------------------------------------------------- #
+    # One get/set handler per custom option (value=None queries, else sets).
+    # The ConfigureDelegationMixin wires these into configure/cget/keys/
+    # __getitem__/__setitem__.
 
-    def __setitem__(self, key: str, value: Any) -> None:
-        self.configure(cnf=None, **{key: value})
-
-    def _configure_set(self, **kwargs: Any) -> None:
-        """Override configure method to allow for setting custom DateEntry parameters.
-
-        Handles special configuration options like 'state', 'dateformat', 'firstweekday',
-        'startdate', 'bootstyle', and 'width'.
-        """
-
-        if "state" in kwargs:
-            state = kwargs.pop("state")
-            if state in ["readonly", "invalid"]:
-                self.entry.configure(state=state)
-            elif state in ("disabled", "normal"):
-                self.entry.configure(state=state)
-                self.button.configure(state=state)
-            else:
-                kwargs[state] = state
-        if "dateformat" in kwargs:
-            self.__dateformat = kwargs.pop("dateformat")
-        if "firstweekday" in kwargs:
-            self._firstweekday = kwargs.pop("firstweekday")
-        if "startdate" in kwargs:
-            self._startdate = kwargs.pop("startdate")
-        if "bootstyle" in kwargs:
-            self._bootstyle = kwargs.pop("bootstyle")
-            self.entry.configure(bootstyle=self._bootstyle)
-            self.button.configure(bootstyle=f"{self._bootstyle}-date")
-        if "width" in kwargs:
-            width = kwargs.pop("width")
-            self.entry.configure(width=width)
-
-        super(Frame, self).configure(**kwargs)
-
-    def _configure_get(self, cnf: str) -> Any:
-        """Override the configure get method.
-
-        Returns configuration values for DateEntry-specific options.
-        """
-        if cnf == "state":
-            entrystate = self.entry.cget("state")
-            buttonstate = self.button.cget("state")
-            return {"Entry": entrystate, "Button": buttonstate}
-        if cnf == "dateformat":
+    @configure_delegate("date_format")
+    def _cfg_date_format(self, value):
+        if value is None:
             return self.__dateformat
-        if cnf == "firstweekday":
-            return self._firstweekday
-        if cnf == "startdate":
-            return self._startdate
-        if cnf == "bootstyle":
-            return self._bootstyle
-        else:
-            return super(Frame, self).configure(cnf=cnf)
+        # Read the current date with the OLD format before switching, then
+        # re-render it with the validated NEW format.
+        current = self.get_date()
+        self.__dateformat = self._validate_dateformat(value)
+        if current is not None:
+            self._write_entry(current.strftime(self.__dateformat))
 
-    def configure(self, cnf: Optional[str] = None, **kwargs: Any) -> Any:
+    @configure_delegate("first_weekday")
+    def _cfg_first_weekday(self, value):
+        if value is None:
+            return self._firstweekday
+        self._firstweekday = value
+
+    @configure_delegate("start_date")
+    def _cfg_start_date(self, value):
+        if value is None:
+            return self._startdate
+        self._startdate = value
+
+    @configure_delegate("bootstyle")
+    def _cfg_bootstyle(self, value):
+        if value is None:
+            return self._bootstyle
+        self._bootstyle = value
+        self.entry.configure(bootstyle=self._bootstyle)
+        self.button.configure(bootstyle=f"{self._bootstyle}-date")
+
+    @configure_delegate("state")
+    def _cfg_state(self, value):
+        # Canonical single-string state: query returns the entry's state; a set
+        # fans out to entry (+ button, for the shared normal/disabled states).
+        if value is None:
+            return str(self.entry.cget("state"))
+        self.entry.configure(state=value)
+        if value in ("disabled", "normal"):
+            self.button.configure(state=value)
+
+    @configure_delegate("width")
+    def _cfg_width(self, value):
+        # `width` is an entry option here, not a frame option (kills the
+        # historical double-apply).
+        if value is None:
+            return self.entry.cget("width")
+        self.entry.configure(width=value)
+
+    # -- configure/cget wrappers (accept legacy option spellings) ------------ #
+    def configure(self, cnf: Any = None, **kwargs: Any) -> Any:
         """Configure the options for this widget.
 
-        Parameters:
-
-            cnf (dict[str, Any], optional):
-                A dictionary of configuration options.
-
-            **kwargs:
-                Optional keyword arguments.
+        Accepts the legacy ``dateformat``/``firstweekday``/``startdate``
+        spellings (with a ``DeprecationWarning``) in addition to the canonical
+        snake_case names.
         """
-        if cnf is not None:
-            return self._configure_get(cnf)
-        else:
-            return self._configure_set(**kwargs)
+        if kwargs:
+            kwargs.update(normalize_dateentry_kwargs(kwargs))
+        if isinstance(cnf, dict):
+            cnf = dict(cnf)
+            cnf.update(normalize_dateentry_kwargs(cnf))
+        elif isinstance(cnf, str):
+            cnf = normalize_dateentry_option(cnf)
+        return super().configure(cnf, **kwargs)
 
+    config = configure
+
+    def cget(self, key: str) -> Any:
+        return super().cget(normalize_dateentry_option(key))
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        super().__setitem__(normalize_dateentry_option(key), value)
+
+    def __getitem__(self, key: str) -> Any:
+        return super().__getitem__(normalize_dateentry_option(key))
+
+    # -- properties ---------------------------------------------------------- #
     @property
     def enabled(self) -> bool:
         """Check if the date picker is enabled.
@@ -230,23 +271,86 @@ class DateEntry(Frame):
         """
         return self.__enabled
 
+    # NOTE: `date_format` (like start_date/first_weekday/bootstyle/state/width)
+    # is a configure option, not a property -- read/write it via
+    # `cget("date_format")` / `configure(date_format=...)` / `de["date_format"]`
+    # (the legacy `dateformat` spelling still resolves there, with a warning).
+    # Only the canonical `value` handle and the computed `enabled` state are
+    # exposed as properties.
+
     @property
-    def dateformat(self) -> str:
-        """Get the date format string.
+    def value(self) -> Optional[datetime]:
+        """The currently selected date (synonym for :meth:`get_date`).
 
-        Returns:
-            str: The strftime format string used to convert between
-                 strings and datetime objects.
+        Reads the live entry text, falling back to the last set date when the
+        text is empty or unparseable. Assigning is equivalent to
+        :meth:`set_date`.
         """
-        return self.__dateformat
+        return self.get_date()
 
-    def get_date(self) -> datetime:
+    @value.setter
+    def value(self, new_date: Union[datetime, date]) -> None:
+        self.set_date(new_date)
+
+    # -- date access --------------------------------------------------------- #
+    def get_date(self) -> Optional[datetime]:
         """Get the currently selected date.
+
+        Parses the **live entry text** so typed keyboard edits are honored. If
+        the text is empty or cannot be parsed, the last date set on the widget
+        is returned as a fallback.
 
         Returns:
             datetime: The currently selected date as a datetime object.
         """
-        return self.configure(cnf='startdate')
+        parsed = self._coerce_date(self.entry.get())
+        if parsed is not None:
+            return parsed
+        return self._startdate
+
+    def set_date(self, new_date: Union[datetime, date]) -> None:
+        """Set the currently selected date.
+
+        Updates the entry field and internal state with the new date.
+        Time components (hours, minutes, seconds, microseconds) are ignored
+        and will be stripped from datetime objects.
+
+        Parameters:
+            new_date (datetime | date): The new date to set.
+        """
+        _date: datetime = self._clean_datetime(new_date)
+        self._startdate = _date
+        self._write_entry(_date.strftime(self.__dateformat))
+        # A freshly set date is valid by construction.
+        self.entry.state(['!invalid'])
+
+    def _coerce_date(self, text: str) -> Optional[datetime]:
+        """Tolerantly parse ``text`` to a ``datetime``, or ``None``.
+
+        Tries the widget's configured ``date_format`` first, then a couple of
+        common formats, then ISO-8601. Never raises.
+        """
+        if not text:
+            return None
+        for fmt in (self.__dateformat, *self._FALLBACK_FORMATS):
+            try:
+                return datetime.strptime(text, fmt)
+            except (ValueError, TypeError):
+                continue
+        try:
+            return datetime.fromisoformat(text)
+        except (ValueError, TypeError):
+            return None
+
+    def _write_entry(self, text: str) -> None:
+        """Replace the entry text, transparently toggling the disabled state."""
+        was_disabled = not self.__enabled
+        if was_disabled:
+            self.enable()
+        self.entry.delete(first=0, last=END)
+        self.entry.insert(END, text)
+        if was_disabled:
+            self.disable()
 
     @staticmethod
     def _validate_dateformat(dateformat: str) -> str:
@@ -310,29 +414,6 @@ class DateEntry(Frame):
         else:
             return datetime(new_date.year, new_date.month, new_date.day)
 
-    def set_date(self, new_date: Union[datetime, date]) -> None:
-        """Set the currently selected date.
-
-        Updates the entry field and internal state with the new date.
-        Time components (hours, minutes, seconds, microseconds) are ignored
-        and will be stripped from datetime objects.
-
-        Parameters:
-            new_date (datetime | date): The new date to set.
-        """
-
-        _date: datetime = self._clean_datetime(new_date)
-        if self.__enabled:
-            self.configure(startdate=_date)
-            self.entry.delete(first=0, last=END)
-            self.entry.insert(END, new_date.strftime(self.__dateformat))
-        else:
-            self.enable()
-            self.configure(startdate=_date)
-            self.entry.delete(first=0, last=END)
-            self.entry.insert(END, new_date.strftime(self.__dateformat))
-            self.disable()
-
     def disable(self) -> None:
         """Disable the date picker.
 
@@ -351,12 +432,24 @@ class DateEntry(Frame):
         self.entry.state(['!disabled'])
         self.button.state(['!disabled'])
 
+    def _on_entry_blur(self, event: Any = None) -> None:
+        """Flag the entry `invalid` when its text is not a parseable date.
+
+        An empty field is treated as valid (no date entered). A non-empty,
+        unparseable field is marked `invalid` so the styling reflects it.
+        """
+        text = self.entry.get()
+        if text and self._coerce_date(text) is None:
+            self.entry.state(['invalid'])
+        else:
+            self.entry.state(['!invalid'])
+
     def _on_date_ask(self) -> None:
         """Handle the calendar button click event.
 
         Opens the date selection popup and updates the entry field with the
         selected date. Generates the <<DateEntrySelected>> event when a date
-        is chosen.
+        is chosen. Reads the initial focus date from the live entry text.
 
         Raises:
             ValueError: If raise_exception is True and the entry text doesn't
@@ -364,26 +457,36 @@ class DateEntry(Frame):
         """
         from warnings import warn
 
-        currently_selected_date: str = self.entry.get() or datetime.today().strftime(self.__dateformat)
-        try:
-            self._startdate: datetime = datetime.strptime(currently_selected_date, self.__dateformat)
-        except ValueError as exc:
-            warn(f"Date entry text does not match with date format: {self.__dateformat}\n")
-            if self._raise_exception:
-                raise exc
+        # Re-entrancy guard: ignore a click while the picker is already open.
+        if self._picker_open:
             return
-        old_date = datetime.strptime(currently_selected_date, self.__dateformat)
+        self._picker_open = True
+        try:
+            text = self.entry.get()
+            old_date = self._coerce_date(text)
+            if old_date is None:
+                if text:
+                    warn(f"Date entry text does not match with date format: {self.__dateformat}\n")
+                    if self._raise_exception:
+                        raise ValueError(
+                            f"time data {text!r} does not match format {self.__dateformat!r}"
+                        )
+                old_date = self._startdate or datetime.today()
+            self._startdate = old_date
 
-        # get the new date and insert into the entry
-        new_date = Querybox.get_date(
-            parent=self.entry,
-            title=self._popup_title,
-            startdate=old_date,
-            firstweekday=self._firstweekday,
-            bootstyle=self._bootstyle,
-        )
-        # get_date returns None when the picker is cancelled (2.0); leave the
-        # field unchanged rather than resetting it.
-        if new_date is not None:
-            self.set_date(new_date)
-            self.event_generate("<<DateEntrySelected>>")
+            # get the new date and insert into the entry
+            new_date = Querybox.get_date(
+                parent=self.entry,
+                title=self._popup_title,
+                start_date=old_date,
+                first_weekday=self._firstweekday,
+                bootstyle=self._bootstyle,
+                position=self._position,
+            )
+            # get_date returns None when the picker is cancelled (2.0); leave
+            # the field unchanged rather than resetting it.
+            if new_date is not None:
+                self.set_date(new_date)
+                self.event_generate("<<DateEntrySelected>>")
+        finally:
+            self._picker_open = False

--- a/tests/test_dateentry_api.py
+++ b/tests/test_dateentry_api.py
@@ -1,0 +1,255 @@
+"""Headless tests for the 2.0 DateEntry API normalization (widget review PR 3).
+
+Covers the snake_case rename + legacy aliasing (coordinated across the dialog
+layer), the ConfigureDelegationMixin adoption (cget/configure round-trip +
+canonical single-string ``state``), the read-from-live-text bug fix, blur
+validation, the ``width`` double-apply fix, the ``value`` property, and
+``date_format`` reconfigure. Nothing here opens the modal picker.
+"""
+import inspect
+import warnings
+from datetime import date, datetime
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.dialogs import Querybox
+from ttkbootstrap.dialogs.datepicker import DatePickerDialog
+from ttkbootstrap.widgets.dateentry import DateEntry
+
+
+# --- constructor: snake_case + keyword-only + legacy aliasing --------------
+
+def test_ctor_is_keyword_only_after_master(root):
+    sig = inspect.signature(DateEntry.__init__)
+    params = sig.parameters
+    assert params["master"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    for name in ("date_format", "first_weekday", "start_date", "bootstyle",
+                 "popup_title", "raise_exception", "position"):
+        assert params[name].kind is inspect.Parameter.KEYWORD_ONLY, name
+
+
+def test_ctor_accepts_snake_case(root):
+    de = DateEntry(root, first_weekday=0, start_date=datetime(2021, 6, 15))
+    assert de.cget("first_weekday") == 0
+    assert de.get_date() == datetime(2021, 6, 15)
+
+
+def test_ctor_legacy_names_warn_and_normalize(root):
+    with pytest.warns(DeprecationWarning):
+        de = DateEntry(root, firstweekday=0, startdate=datetime(2020, 1, 2))
+    assert de.cget("first_weekday") == 0
+    assert de.get_date() == datetime(2020, 1, 2)
+
+
+def test_ctor_legacy_dateformat_warns(root):
+    with pytest.warns(DeprecationWarning):
+        de = DateEntry(root, dateformat="%Y-%m-%d")
+    assert de.cget("date_format") == "%Y-%m-%d"
+
+
+# --- configure/cget round-trip via the delegation mixin --------------------
+
+@pytest.mark.parametrize("key,value", [
+    ("first_weekday", 3),
+    ("start_date", datetime(2019, 3, 4)),
+    ("bootstyle", "success"),
+    ("date_format", "%Y-%m-%d"),
+    ("width", 24),
+])
+def test_configure_cget_roundtrip(root, key, value):
+    de = DateEntry(root)
+    de.configure(**{key: value})
+    assert de.cget(key) == value
+    # configure(key) returns a Tk-style 5-tuple spec whose last element is value
+    assert de.configure(key)[-1] == value
+    # item access mirrors cget
+    assert de[key] == value
+
+
+def test_keys_include_custom_options(root):
+    de = DateEntry(root)
+    keys = de.keys()
+    for name in ("first_weekday", "start_date", "bootstyle", "date_format",
+                 "state", "width"):
+        assert name in keys
+
+
+def test_legacy_option_string_still_resolves(root):
+    de = DateEntry(root, date_format="%Y-%m-%d")
+    with pytest.warns(DeprecationWarning):
+        assert de.cget("dateformat") == "%Y-%m-%d"
+    with pytest.warns(DeprecationWarning):
+        de.configure(firstweekday=2)
+    assert de.cget("first_weekday") == 2
+
+
+# --- canonical single-string state -----------------------------------------
+
+def test_state_returns_string_not_dict(root):
+    de = DateEntry(root)
+    st = de.cget("state")
+    assert isinstance(st, str)
+    assert st in ("normal", "readonly", "disabled")
+
+
+def test_state_set_fans_out_to_entry_and_button(root):
+    de = DateEntry(root)
+    de.configure(state="disabled")
+    assert str(de.entry.cget("state")) == "disabled"
+    assert str(de.button.cget("state")) == "disabled"
+    de.configure(state="normal")
+    assert str(de.entry.cget("state")) == "normal"
+    assert str(de.button.cget("state")) == "normal"
+
+
+def test_state_readonly_targets_entry_only(root):
+    de = DateEntry(root)
+    de.configure(state="readonly")
+    assert str(de.entry.cget("state")) == "readonly"
+
+
+# --- the core bug: read from live entry text -------------------------------
+
+def test_get_date_reads_typed_text(root):
+    de = DateEntry(root, date_format="%Y-%m-%d", start_date=datetime(2000, 1, 1))
+    de.entry.delete(0, "end")
+    de.entry.insert(0, "2023-12-25")
+    assert de.get_date() == datetime(2023, 12, 25)
+
+
+def test_get_date_falls_back_to_shadow_when_unparseable(root):
+    de = DateEntry(root, date_format="%Y-%m-%d", start_date=datetime(2000, 1, 1))
+    de.entry.delete(0, "end")
+    de.entry.insert(0, "not a date")
+    assert de.get_date() == datetime(2000, 1, 1)
+
+
+def test_coerce_tries_fallback_formats(root):
+    de = DateEntry(root, date_format="%Y-%m-%d")
+    # ISO fallback even though it does not match the configured format exactly
+    assert de._coerce_date("2022-02-02") == datetime(2022, 2, 2)
+    # MM/DD/YYYY fallback
+    assert de._coerce_date("03/04/2022") == datetime(2022, 3, 4)
+    assert de._coerce_date("garbage") is None
+    assert de._coerce_date("") is None
+
+
+# --- blur validation --------------------------------------------------------
+
+def test_blur_marks_invalid_then_clears(root):
+    de = DateEntry(root, date_format="%Y-%m-%d")
+    de.entry.delete(0, "end")
+    de.entry.insert(0, "xxx")
+    de._on_entry_blur()
+    assert "invalid" in de.entry.state()
+    de.entry.delete(0, "end")
+    de.entry.insert(0, "2021-01-01")
+    de._on_entry_blur()
+    assert "invalid" not in de.entry.state()
+
+
+def test_blur_empty_is_valid(root):
+    de = DateEntry(root, date_format="%Y-%m-%d")
+    de.entry.delete(0, "end")
+    de._on_entry_blur()
+    assert "invalid" not in de.entry.state()
+
+
+# --- width double-apply fix -------------------------------------------------
+
+def test_width_applies_to_entry_not_frame(root):
+    de = DateEntry(root, width=17)
+    assert int(de.entry.cget("width")) == 17
+    # the frame itself keeps its natural (geometry-driven) width, not 17
+    assert de.cget("width") == 17  # delegated to the entry
+
+
+# --- value property ---------------------------------------------------------
+
+def test_value_property_get_and_set(root):
+    de = DateEntry(root, date_format="%Y-%m-%d")
+    de.value = datetime(2024, 7, 4)
+    assert de.value == datetime(2024, 7, 4)
+    assert de.entry.get() == "2024-07-04"
+    # reads live text like get_date
+    de.entry.delete(0, "end")
+    de.entry.insert(0, "2024-08-09")
+    assert de.value == datetime(2024, 8, 9)
+
+
+# --- date_format reconfigure re-renders + validates ------------------------
+
+def test_date_format_reconfigure_rerenders(root):
+    de = DateEntry(root, date_format="%Y-%m-%d", start_date=datetime(2022, 5, 6))
+    assert de.entry.get() == "2022-05-06"
+    de.configure(date_format="%m/%d/%Y")
+    assert de.entry.get() == "05/06/2022"
+    assert de.cget("date_format") == "%m/%d/%Y"
+
+
+def test_date_format_reconfigure_validates(root):
+    de = DateEntry(root)
+    with pytest.raises(ValueError):
+        de.configure(date_format="%H:%M")  # no date component
+
+
+# --- set_date / get_date semantics unchanged -------------------------------
+
+def test_set_date_accepts_date_and_datetime(root):
+    de = DateEntry(root, date_format="%Y-%m-%d")
+    de.set_date(date(2020, 2, 29))
+    assert de.get_date() == datetime(2020, 2, 29)
+    de.set_date(datetime(2021, 3, 1, 13, 45))  # time stripped
+    assert de.get_date() == datetime(2021, 3, 1)
+
+
+def test_set_date_clears_invalid(root):
+    de = DateEntry(root, date_format="%Y-%m-%d")
+    de.entry.state(["invalid"])
+    de.set_date(datetime(2021, 1, 1))
+    assert "invalid" not in de.entry.state()
+
+
+# --- re-entrancy guard flag exists -----------------------------------------
+
+def test_picker_reentrancy_guard(root):
+    de = DateEntry(root)
+    assert de._picker_open is False
+    # while "open", a second call is a no-op (returns immediately)
+    de._picker_open = True
+    de._on_date_ask()  # must not raise / block
+    assert de._picker_open is True
+
+
+# --- cross-layer rename: Querybox.get_date / DatePickerDialog --------------
+
+def test_get_date_signature_uses_snake_case():
+    params = inspect.signature(Querybox.get_date).parameters
+    assert "first_weekday" in params
+    assert "start_date" in params
+    assert "position" in params
+
+
+def test_datepicker_dialog_accepts_snake_case(root):
+    dlg = DatePickerDialog(
+        parent=root, first_weekday=0, start_date=date(2021, 9, 9), autoshow=False,
+    )
+    assert dlg.first_weekday == 0
+    assert dlg.start_date == date(2021, 9, 9)
+    dlg.root.destroy()
+
+
+def test_datepicker_dialog_legacy_names_warn(root):
+    with pytest.warns(DeprecationWarning):
+        dlg = DatePickerDialog(
+            parent=root, firstweekday=0, startdate=date(2021, 9, 9), autoshow=False,
+        )
+    assert dlg.first_weekday == 0
+    assert dlg.start_date == date(2021, 9, 9)
+    dlg.root.destroy()
+
+
+def test_datepicker_dialog_rejects_unknown_kwarg(root):
+    with pytest.raises(TypeError):
+        DatePickerDialog(parent=root, autoshow=False, bogus=1)


### PR DESCRIPTION
PR 3 of the 2.0 shipped-widget API review (design §8c/§3c). Adopts the shared `ConfigureDelegationMixin` for `DateEntry` and fixes the long-standing typed-input bug.

## The core fix
`get_date()` returned the stored `_startdate` shadow and **silently ignored manual keyboard edits**. Now `get_date()` and the new `value` property parse the **live entry text** via a tolerant, non-throwing `_coerce_date` (configured `date_format` → `%Y-%m-%d`/`%m/%d/%Y` → ISO), falling back to the shadow only when the text is empty/unparseable.

## Changes
- **`ConfigureDelegationMixin`** — one `@configure_delegate` handler per custom option (`date_format`/`first_weekday`/`start_date`/`bootstyle`/`state`/`width`); `cget`/`config`/`keys`/item-access come free and stay in sync (replaces the hand-maintained get/set ladders).
- **Canonical single-string `state`** — drops the `{"Entry":…,"Button":…}` dict; `cget("state")` returns the entry's state string; a set fans out to entry (+ button for `normal`/`disabled`).
- **snake_case renames via `_compat`, coordinated across the dialog layer** — `dateformat`→`date_format`, `firstweekday`→`first_weekday`, `startdate`→`start_date` on `DateEntry` **and** `Querybox.get_date` / `DatePickerDialog`. Pre-2.0 spellings warn-and-normalize through 2.x (removed in 3.0); unknown kwargs on the dialogs raise `TypeError` (typos still fail loudly).
- **Keyword-only ctor**; explicit kwarg partitioning fixes the **`width` double-apply** (entry only); `date_format` reconfigure routes through `_validate_dateformat` + re-renders; `<FocusOut>` **blur validation** marks the entry `invalid` on unparseable text; **picker re-entrancy guard**; `position=` passthrough; **`value` property** (get/set).

## Breaking / migration
- Constructor is keyword-only after `master`; option names snake_cased. Old spellings accepted through 2.x with a `DeprecationWarning`.
- `configure(cnf="state")` / `cget("state")` now return a **string**, not a dict.

## Tests & verification
- `tests/test_dateentry_api.py` (+30).
- Full suite **398 passed** (excl. the known `zh_cn.msg` localization env flake); warning-free import; independent headless smoke of typed-read, state fan-out, width, format re-render, blur-invalid, legacy-warn, and the cross-layer dialog signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)