### PR TITLE
Normalize the Floodgauge widget API (widget review PR 4)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -26,6 +26,7 @@
 | **Dialog API normalization (Messagebox/Querybox)** | API | `development/2_0_shipped_widget_api_design.md` (PR A) |
 | **Meter: snake_case options, DoubleVar, `value`** | Breaking/additive | this doc, below (PR 2 / #1110) |
 | **DateEntry: snake_case (cross-layer), live-text read, string `state`** | Breaking/additive | this doc, below (PR 3 / #1111) |
+| **Floodgauge: DoubleVar value, `start(interval)`, live mode/orient** | Breaking/additive | this doc, below (PR 4) |
 
 ---
 
@@ -484,3 +485,44 @@ to the frame and entry); `date_format` reconfigure now re-validates and re-rende
 a picker re-entrancy guard prevents a second popup while one is open; unknown keyword
 arguments to `Querybox.get_date`/`DatePickerDialog` now raise `TypeError` (typos fail
 loudly instead of being swallowed).
+
+---
+
+## Floodgauge: DoubleVar value, `start(interval)`, live mode/orient  *(breaking + additive)*
+
+**What.** The canvas-based `Floodgauge` widget was normalized (widget-review PR 4).
+Its options mirror `ttk.Progressbar` and are **not** renamed; the changes are
+contract/behavior:
+
+*Breaking:*
+- **Value backing is now `DoubleVar`** (was `IntVar`), matching `ttk.Progressbar`.
+  `value` / `cget("value")` / the new `value` property return **float**, and
+  `configure(value=33.3)` is honored instead of truncated. An externally supplied
+  `variable=IntVar(...)` still binds.
+- **`start()` realigned to `ttk.Progressbar.start(interval)`.** The canonical
+  signature is now `start(interval=None)`; a single positional is the *interval*
+  (previously it was the step size). The per-mode step size is now an internal
+  default. Unknown keyword arguments raise `TypeError`.
+
+*Deprecated (works through 2.x, removed in 3.0):*
+- The pre-2.0 **`start(step_size, interval)`** call shape — two positionals, or a
+  `step_size=` keyword — is accepted with a `DeprecationWarning` (via
+  `style/_compat.normalize_floodgauge_start_args`).
+
+*Additive:*
+- New canonical **`value`** property (get/set).
+
+**Migration.** Expect `float` back from `value`/`cget("value")` where you previously
+got `int`. Update `start(step, interval)` calls to `start(interval)` (set the step
+via the mode default); the old form keeps working with a warning through 2.x. A bare
+`start(20)` now means *interval=20*, not *step_size=20* — this positional-meaning
+change cannot be shimmed.
+
+**Fixes bundled.** `mode` and `orient` are now **live** `configure`/`cget` options
+(they were construction-only and raised `TclError`; `orient` now also swaps the
+canvas width/height); `configure(opt)` returns a proper **5-tuple** spec (was a
+malformed 4-tuple); `maximum=0` no longer raises `ZeroDivisionError`; a `mask` no
+longer clobbers the user's `textvariable`, so **`cget("text")` returns the user's
+text** rather than the masked string. `FloodgaugeLegacy` (unchanged API, 3.0-removal)
+gained a `destroy()` that detaches its value/text write traces (leak parity with the
+#1070 fix).

--- a/src/ttkbootstrap/style/_compat.py
+++ b/src/ttkbootstrap/style/_compat.py
@@ -198,6 +198,45 @@ def normalize_datepicker_kwargs(kwargs: dict) -> dict:
     return normalize_option_names(kwargs, _DATEPICKER_KWARG_ALIASES, "date picker")
 
 
+# Floodgauge.start() signature realignment (2.0 shipped-widget API pass, PR 4).
+# 2.0 realigns start() to ttk.Progressbar's start(interval); the pre-2.0
+# start(step_size, interval) form is accepted through 2.x with a warning.
+def normalize_floodgauge_start_args(args: list, kwargs: dict) -> tuple:
+    """Resolve ``Floodgauge.start()`` arguments across the 2.x signature change.
+
+    Returns ``(interval, step_size)``. ``step_size`` is ``None`` unless the
+    legacy ``start(step_size, interval)`` form -- two positionals, or a
+    ``step_size=`` keyword -- was used, in which case a ``DeprecationWarning``
+    is emitted. A single positional is the new ``interval``.
+    """
+    interval = None
+    step_size = None
+    legacy = False
+
+    if "step_size" in kwargs:
+        step_size = kwargs.pop("step_size")
+        legacy = True
+    if "interval" in kwargs:
+        interval = kwargs.pop("interval")
+    if kwargs:
+        raise TypeError(
+            f"start() got unexpected keyword arguments: {', '.join(sorted(kwargs))}"
+        )
+
+    if len(args) >= 2:
+        step_size, interval = args[0], args[1]
+        legacy = True
+    elif len(args) == 1:
+        interval = args[0]
+
+    if legacy:
+        warn_deprecated(
+            "Floodgauge.start(step_size, interval)",
+            "start(interval)",
+        )
+    return interval, step_size
+
+
 def normalize_bootstyle(value, *, warn: bool = False) -> str:
     """Return the canonical dash-joined bootstyle string for a legacy value.
 

--- a/src/ttkbootstrap/widgets/floodgauge.py
+++ b/src/ttkbootstrap/widgets/floodgauge.py
@@ -35,13 +35,18 @@ import warnings
 from tkinter import Event, Misc, TclError
 from typing import Any, Optional, Union
 
-from ttkbootstrap import Canvas, IntVar, Progressbar, StringVar
+from ttkbootstrap import Canvas, DoubleVar, IntVar, Progressbar, StringVar
 from ttkbootstrap.colorutils import contrast_color
 from ttkbootstrap.constants import DETERMINATE, HORIZONTAL, PRIMARY
+from ttkbootstrap.internal.configure_delegation import (
+    ConfigureDelegationMixin,
+    configure_delegate,
+)
 from ttkbootstrap.style import Colors, Style
+from ttkbootstrap.style._compat import normalize_floodgauge_start_args
 
 
-class Floodgauge(Canvas):
+class Floodgauge(ConfigureDelegationMixin, Canvas):
     """
     A canvas-based widget that displays progress in determinate or indeterminate mode,
     styled using ttkbootstrap's color system.
@@ -54,14 +59,19 @@ class Floodgauge(Canvas):
     - Auto-updating label based on mask or textvariable
     - Theme-reactive color updates via <<ThemeChanged>> event
 
+    The widget's value is backed by a ``DoubleVar`` (matching ttk.Progressbar),
+    so fractional values are honored. All options are reachable through the
+    tk-native ``configure``/``cget``/item surface; ``value`` is also exposed as a
+    canonical read/write property.
+
     Parameters:
         master (Widget, optional):
             Parent widget.
 
-        value (int):
+        value (int or float):
             Initial value of the progress bar.
 
-        maximum (int):
+        maximum (int or float):
             The maximum value for the determinate range.
 
         mode (str):
@@ -74,7 +84,7 @@ class Floodgauge(Canvas):
             A static fallback label (used if no mask is specified).
 
         font (Font or tuple):
-            The font used for the label (default: Helvetica 14 bold).
+            The font used for the label (default: ("Helvetica", 12)).
 
         bootstyle (str):
             A ttkbootstrap style keyword such as 'primary', 'info', etc.
@@ -88,7 +98,7 @@ class Floodgauge(Canvas):
         thickness (int):
             The short axis of the widget (height if horizontal, width if vertical). Defaults to 50.
 
-        variable (tk.IntVar, optional):
+        variable (tk.DoubleVar, optional):
             Bound variable for the current value.
 
         textvariable (tk.StringVar, optional):
@@ -98,8 +108,8 @@ class Floodgauge(Canvas):
     def __init__(
             self,
             master: Optional[Misc] = None,
-            value: int = 0,
-            maximum: int = 100,
+            value: Union[int, float] = 0,
+            maximum: Union[int, float] = 100,
             mode: str = "determinate",
             mask: Optional[str] = None,
             text: str = "",
@@ -110,7 +120,7 @@ class Floodgauge(Canvas):
             thickness: int = 50,
             **kwargs: Any
     ) -> None:
-        self.variable = kwargs.pop("variable", IntVar(value=value))
+        self.variable = kwargs.pop("variable", DoubleVar(value=value))
         self.textvariable = kwargs.pop("textvariable", StringVar(value=text))
 
         self.length = length
@@ -130,8 +140,6 @@ class Floodgauge(Canvas):
         self._bind_variable(self.variable)
         self._bind_textvariable(self.textvariable)
 
-        self.value = self.variable.get()
-        self.text = self.textvariable.get()
         self.maximum = maximum
         self.mode = mode
         self.mask = mask
@@ -149,6 +157,17 @@ class Floodgauge(Canvas):
         self.bind("<<ThemeChanged>>", lambda e: self._update_theme_colors())
         self._draw()
 
+    # -- value access -------------------------------------------------------- #
+    @property
+    def value(self) -> float:
+        """The current progress value (canonical read/write handle)."""
+        return self.variable.get()
+
+    @value.setter
+    def value(self, amount: Union[int, float]) -> None:
+        # Setting the bound variable fires its write trace -> redraw.
+        self.variable.set(amount)
+
     def _update_theme_colors(self) -> None:
         style = Style.get_instance()
         self.bar_color = style.colors.get(self._bootstyle)
@@ -165,6 +184,13 @@ class Floodgauge(Canvas):
             self.thickness = event.width
         self._draw()
 
+    def _apply_geometry(self) -> None:
+        """Resize the canvas to match the current orient/length/thickness."""
+        if self.orient == "horizontal":
+            super().configure(width=self.length, height=self.thickness)
+        else:
+            super().configure(width=self.thickness, height=self.length)
+
     def _draw(self) -> None:
         self.delete("all")
         w = self.winfo_width()
@@ -172,8 +198,13 @@ class Floodgauge(Canvas):
 
         self.create_rectangle(0, 0, w, h, fill=self.trough_color, width=0)
 
+        value = self.variable.get()
         if self.mode == "determinate":
-            ratio = max(0.0, min(1.0, self.value / self.maximum))
+            # Zero-range guard: a 0 maximum has no meaningful ratio.
+            if self.maximum == 0:
+                ratio = 0.0
+            else:
+                ratio = max(0.0, min(1.0, value / self.maximum))
             if self.orient == "horizontal":
                 fill = int(ratio * w)
                 self.create_rectangle(0, 0, fill, h, fill=self.bar_color, width=0)
@@ -190,13 +221,13 @@ class Floodgauge(Canvas):
                 y = self._pulse_pos
                 self.create_rectangle(0, y - pulse_height, w, y, fill=self.bar_color, width=0)
 
+        # Derive the display label. A mask formats the numeric value for
+        # *display only* -- it must never be written back onto the user's
+        # textvariable (that would clobber cget("text")).
         if self.mask:
-            label = self.mask.format(int(self.value))
-            self.textvariable.set(label)
-        elif self.textvariable:
-            label = self.textvariable.get()
+            label = self.mask.format(int(value))
         else:
-            label = self.text
+            label = self.textvariable.get()
 
         if label:
             self.create_text(
@@ -209,14 +240,12 @@ class Floodgauge(Canvas):
             )
 
     def _on_var_change(self) -> None:
-        self.value = self.variable.get()
         self._draw()
 
     def _on_text_change(self) -> None:
-        self.text = self.textvariable.get()
         self._draw()
 
-    def _bind_variable(self, variable: IntVar) -> None:
+    def _bind_variable(self, variable: Union[IntVar, DoubleVar]) -> None:
         """Trace `variable` for value changes, dropping any prior trace.
 
         The trace id is retained so it can be removed when the variable is
@@ -267,38 +296,39 @@ class Floodgauge(Canvas):
         self._textvar_traceid = None
         super().destroy()
 
-    def step(self, amount: int = 1) -> None:
+    def step(self, amount: Union[int, float] = 1) -> None:
         """Increment the progress value.
 
         Parameters:
-            amount (int, optional): The amount to increment. Defaults to 1.
-                                   Value wraps around after reaching maximum.
+            amount (int or float, optional): The amount to increment. Defaults
+                to 1. Value wraps around after reaching maximum.
         """
         self.value = (self.value + amount) % (self.maximum + 1)
-        self.variable.set(self.value)
-        self._draw()
 
-    def start(self, step_size: Optional[int] = None, interval: Optional[int] = None) -> None:
+    def start(self, *args: Any, **kwargs: Any) -> None:
         """Start the progress animation.
 
         For indeterminate mode, starts the bouncing animation. For determinate
         mode, starts auto-incrementing the value.
 
-        Parameters:
-            step_size (int, optional): Amount to increment per animation step.
-                                      Defaults to 8 for indeterminate mode,
-                                      1 for determinate mode.
+        The canonical signature mirrors ``ttk.Progressbar.start``:
 
-            interval (int, optional): Time in milliseconds between animation steps.
-                                     Defaults to 20ms for indeterminate mode,
-                                     50ms for determinate mode.
+            start(interval=None)
+
+        where ``interval`` is the time in milliseconds between animation steps
+        (defaults to 20ms for indeterminate mode, 50ms for determinate mode).
+
+        The pre-2.0 ``start(step_size, interval)`` form is still accepted
+        through 2.x with a ``DeprecationWarning`` (removed in 3.0); the per-mode
+        step size is now an internal default.
         """
-        if self.mode == "indeterminate":
-            self._step_size = step_size if step_size is not None else 8
-            interval = interval if interval is not None else 20
+        interval, step_size = normalize_floodgauge_start_args(list(args), dict(kwargs))
+        if step_size is not None:
+            self._step_size = step_size
         else:
-            self._step_size = step_size if step_size is not None else 1
-            interval = interval if interval is not None else 50
+            self._step_size = 8 if self.mode == "indeterminate" else 1
+        if interval is None:
+            interval = 20 if self.mode == "indeterminate" else 50
 
         self._running = True
         self._pulse_direction = 1
@@ -354,111 +384,96 @@ class Floodgauge(Canvas):
         self._draw()
         self._after_id = self.after(interval, lambda: self._animate_indeterminate(interval))
 
-    def configure(self, cnf: Optional[str] = None, **kwargs: Any) -> Any:
-        """Configure the options for this widget.
+    # -- configure delegates ------------------------------------------------- #
+    # One get/set handler per option (value=None queries, else sets). The
+    # ConfigureDelegationMixin wires these into configure/cget/keys/item access
+    # and emits proper Tk 5-tuple specs.
 
-        Parameters:
-            cnf (str, optional): Option name to query. If provided without
-                                kwargs, returns the current value.
-
-            **kwargs: Widget options to set (value, maximum, mask, text, font,
-                     bootstyle, length, thickness, variable, textvariable).
-        """
-        if cnf is not None and not kwargs:
-            custom = {
-                "value": ("value", "value", "Value", self.variable.get()),
-                "maximum": ("maximum", "maximum", "Maximum", self.maximum),
-                "mask": ("mask", "mask", "Mask", self.mask),
-                "text": ("text", "text", "Text", self.textvariable.get()),
-                "font": ("font", "font", "Font", self.font),
-                "bootstyle": ("bootstyle", "bootstyle", "Bootstyle", self._bootstyle),
-                "variable": ("variable", "variable", "Variable", str(self.variable)),
-                "textvariable": ("textvariable", "textvariable", "Textvariable", str(self.textvariable)),
-                "length": ("length", "length", "Length", self.length),
-                "thickness": ("thickness", "thickness", "Thickness", self.thickness),
-            }
-            if cnf in custom:
-                return custom[cnf]
-            else:
-                raise TclError(f"unknown option '{cnf}'")
-
-        if "value" in kwargs:
-            self.value = kwargs.pop("value")
-            self.variable.set(self.value)
-        if "maximum" in kwargs:
-            self.maximum = kwargs.pop("maximum")
-        if "mask" in kwargs:
-            self.mask = kwargs.pop("mask")
-        if "text" in kwargs:
-            self.text = kwargs.pop("text")
-            self.textvariable.set(self.text)
-        if "font" in kwargs:
-            self.font = kwargs.pop("font")
-        if "bootstyle" in kwargs:
-            self._bootstyle = kwargs.pop("bootstyle")
-            self._update_theme_colors()
-        if "length" in kwargs:
-            self.length = kwargs.pop("length")
-            if self.orient == "horizontal":
-                self.configure(width=self.length)
-            else:
-                self.configure(height=self.length)
-        if "thickness" in kwargs:
-            self.thickness = kwargs.pop("thickness")
-            if self.orient == "horizontal":
-                self.configure(height=self.thickness)
-            else:
-                self.configure(width=self.thickness)
-        if "variable" in kwargs:
-            self._bind_variable(kwargs.pop("variable"))
-        if "textvariable" in kwargs:
-            self._bind_textvariable(kwargs.pop("textvariable"))
-
-        result = super().configure(**kwargs)
-        self._draw()
-        return result
-
-    def cget(self, key: str) -> Any:
-        """Get the current value of a configuration option.
-
-        Parameters:
-            key (str): The option name to query.
-
-        Returns:
-            The current value of the specified option.
-        """
-        if key == "value":
+    @configure_delegate("value")
+    def _cfg_value(self, value):
+        if value is None:
             return self.variable.get()
-        if key == "text":
-            return self.textvariable.get()
-        if key == "maximum":
+        self.variable.set(value)  # trace -> _on_var_change -> _draw
+
+    @configure_delegate("maximum")
+    def _cfg_maximum(self, value):
+        if value is None:
             return self.maximum
-        if key == "mask":
+        self.maximum = value
+        self._draw()
+
+    @configure_delegate("mode")
+    def _cfg_mode(self, value):
+        if value is None:
+            return self.mode
+        self.mode = value
+        self._draw()
+
+    @configure_delegate("orient")
+    def _cfg_orient(self, value):
+        if value is None:
+            return self.orient
+        self.orient = value
+        self._apply_geometry()
+        self._draw()
+
+    @configure_delegate("mask")
+    def _cfg_mask(self, value):
+        if value is None:
             return self.mask
-        if key == "bootstyle":
-            return self._bootstyle
-        if key == "font":
+        self.mask = value
+        self._draw()
+
+    @configure_delegate("text")
+    def _cfg_text(self, value):
+        if value is None:
+            return self.textvariable.get()
+        self.textvariable.set(value)  # trace -> _on_text_change -> _draw
+
+    @configure_delegate("font")
+    def _cfg_font(self, value):
+        if value is None:
             return self.font
-        if key == "length":
+        self.font = value
+        self._draw()
+
+    @configure_delegate("bootstyle")
+    def _cfg_bootstyle(self, value):
+        if value is None:
+            return self._bootstyle
+        self._bootstyle = value
+        self._update_theme_colors()  # redraws
+
+    @configure_delegate("length")
+    def _cfg_length(self, value):
+        if value is None:
             return self.length
-        if key == "thickness":
+        self.length = value
+        self._apply_geometry()
+        self._draw()
+
+    @configure_delegate("thickness")
+    def _cfg_thickness(self, value):
+        if value is None:
             return self.thickness
-        if key == "variable":
-            return str(self.variable)
-        if key == "textvariable":
-            return str(self.textvariable)
-        return super().cget(key)
+        self.thickness = value
+        self._apply_geometry()
+        self._draw()
 
-    def keys(self) -> list[str]:
-        """Get the list of valid configuration option names.
+    @configure_delegate("variable")
+    def _cfg_variable(self, value):
+        # Queried: return the object; the mixin renders it as its Tcl name.
+        if value is None:
+            return self.variable
+        self._bind_variable(value)
+        self._draw()
 
-        Returns:
-            list: List of configuration option names.
-        """
-        return [
-            "value", "maximum", "mask", "text", "font",
-            "bootstyle", "length", "thickness", "variable", "textvariable"
-        ]
+    @configure_delegate("textvariable")
+    def _cfg_textvariable(self, value):
+        if value is None:
+            return self.textvariable
+        self._bind_textvariable(value)
+        self._draw()
 
     def items(self) -> Any:
         """Get all configuration options as key-value pairs.
@@ -467,9 +482,6 @@ class Floodgauge(Canvas):
             dict_items: Iterator of (option, value) pairs.
         """
         return {k: self.cget(k) for k in self.keys()}.items()
-
-    __getitem__ = lambda self, key: self.cget(key)
-    __setitem__ = lambda self, key, value: self.configure(**{key: value})
 
 
 class FloodgaugeLegacy(Progressbar):
@@ -584,7 +596,11 @@ class FloodgaugeLegacy(Progressbar):
         else:
             self._textvariable = StringVar(value=text)
 
-        self._textvariable.trace_add("write", self._set_widget_text)
+        # Retain the textvariable write trace id so it can be detached on
+        # destroy (otherwise it leaks and pins the widget alive).
+        self._textvar_traceid = self._textvariable.trace_add(
+            "write", self._set_widget_text
+        )
         self._bootstyle = bootstyle
         self._font = font or "helvetica 10"
         self._mask = mask
@@ -609,6 +625,26 @@ class FloodgaugeLegacy(Progressbar):
 
         if self._mask is not None:
             self._set_mask()
+
+    def destroy(self) -> None:
+        """Detach the value/text write traces before teardown.
+
+        The traces' write callbacks hold a reference back to the widget, so
+        leaving them attached keeps it alive after destroy (and, for an external
+        variable, keeps firing a callback pointed at a dead widget).
+        """
+        for variable, traceid in (
+            (self._textvariable, getattr(self, "_textvar_traceid", None)),
+            (self._variable, self._traceid),
+        ):
+            if traceid is not None:
+                try:
+                    variable.trace_remove("write", traceid)
+                except TclError:
+                    pass
+        self._textvar_traceid = None
+        self._traceid = None
+        super().destroy()
 
     def _set_widget_text(self, *_: Any) -> None:
         ttkstyle = self.cget("style")

--- a/tests/test_floodgauge_api.py
+++ b/tests/test_floodgauge_api.py
@@ -1,0 +1,170 @@
+"""Headless API tests for the normalized Floodgauge widget (2.0 PR 4).
+
+Covers the ConfigureDelegationMixin adoption (5-tuple specs + cget parity),
+DoubleVar value backing, live mode/orient, the maximum=0 zero-range guard, the
+value-vs-display split (cget("text") no longer returns the mask output), the
+value property, and the start() signature realignment. Nothing here runs an
+animation loop for long -- start() is immediately stopped.
+"""
+import warnings
+
+import pytest
+
+from ttkbootstrap import IntVar
+from ttkbootstrap.widgets.floodgauge import Floodgauge
+
+
+# --- configure/cget parity via the mixin -----------------------------------
+
+def test_configure_query_returns_5_tuple(root):
+    fg = Floodgauge(root)
+    for name in ("value", "maximum", "mode", "orient", "mask", "text",
+                 "font", "bootstyle", "length", "thickness",
+                 "variable", "textvariable"):
+        spec = fg.configure(name)
+        assert isinstance(spec, tuple)
+        assert len(spec) == 5, f"{name} spec not a 5-tuple: {spec}"
+        assert spec[0] == name
+
+
+def test_cget_parity_for_every_option(root):
+    fg = Floodgauge(root, maximum=50, value=10, bootstyle="info",
+                    length=180, thickness=30)
+    assert fg.cget("maximum") == 50
+    assert fg.cget("value") == 10
+    assert fg.cget("bootstyle") == "info"
+    assert fg.cget("length") == 180
+    assert fg.cget("thickness") == 30
+    assert fg.cget("mode") == "determinate"
+    assert fg.cget("orient") == "horizontal"
+    # variable/textvariable render as their Tcl names
+    assert fg.cget("variable") == str(fg.variable)
+    assert fg.cget("textvariable") == str(fg.textvariable)
+
+
+def test_mode_and_orient_in_keys(root):
+    fg = Floodgauge(root)
+    keys = fg.keys()
+    for name in ("value", "maximum", "mode", "orient", "mask",
+                 "length", "thickness"):
+        assert name in keys
+
+
+# --- DoubleVar value backing -----------------------------------------------
+
+def test_value_is_float_and_not_truncated(root):
+    fg = Floodgauge(root, maximum=100)
+    fg.configure(value=33.3)
+    assert fg.cget("value") == pytest.approx(33.3)
+    assert fg.value == pytest.approx(33.3)
+
+
+def test_value_property_get_set(root):
+    fg = Floodgauge(root, maximum=100)
+    fg.value = 42.5
+    assert fg.value == pytest.approx(42.5)
+    assert fg.cget("value") == pytest.approx(42.5)
+
+
+def test_external_intvar_still_binds(root):
+    iv = IntVar(value=5)
+    fg = Floodgauge(root, variable=iv, maximum=10)
+    assert fg.cget("value") == 5
+    iv.set(7)
+    assert fg.value == 7
+
+
+# --- live mode / orient ----------------------------------------------------
+
+def test_mode_is_live(root):
+    fg = Floodgauge(root, mode="determinate")
+    fg.configure(mode="indeterminate")
+    assert fg.cget("mode") == "indeterminate"
+
+
+def test_orient_swaps_width_height(root):
+    fg = Floodgauge(root, orient="horizontal", length=200, thickness=40)
+    fg.pack()
+    root.update_idletasks()
+    fg.configure(orient="vertical")
+    root.update_idletasks()
+    assert fg.cget("orient") == "vertical"
+    # vertical: width=thickness, height=length
+    assert fg.winfo_reqwidth() == 40
+    assert fg.winfo_reqheight() == 200
+
+
+# --- zero-range guard ------------------------------------------------------
+
+def test_maximum_zero_does_not_crash(root):
+    fg = Floodgauge(root, maximum=0, value=0)
+    fg.pack()
+    root.update_idletasks()  # forces a _draw with maximum == 0
+    # reconfigure to 0 at runtime + a step must not raise
+    fg.configure(value=5)
+    fg.configure(maximum=0)
+    fg.step()
+    root.update_idletasks()
+
+
+# --- value-vs-display split (the cget("text") fix) -------------------------
+
+def test_mask_does_not_clobber_text(root):
+    fg = Floodgauge(root, maximum=100, mask="{}%", text="Loading", value=25)
+    fg.pack()
+    root.update_idletasks()
+    # A mask formats the *display* only; the user's text is untouched.
+    assert fg.cget("text") == "Loading"
+    fg.configure(value=60)
+    root.update_idletasks()
+    assert fg.cget("text") == "Loading"
+
+
+def test_text_roundtrips_without_mask(root):
+    fg = Floodgauge(root, maximum=100)
+    fg.configure(text="Done")
+    assert fg.cget("text") == "Done"
+
+
+# --- start() realignment ---------------------------------------------------
+
+def test_start_new_interval_form(root):
+    fg = Floodgauge(root, mode="indeterminate")
+    fg.pack()
+    root.update_idletasks()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # new form must NOT warn
+        fg.start(30)
+    assert fg._running is True
+    fg.stop()
+    assert fg._running is False
+
+
+def test_start_legacy_form_warns_and_runs(root):
+    fg = Floodgauge(root, mode="indeterminate")
+    fg.pack()
+    root.update_idletasks()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fg.start(8, 20)
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+    assert fg._running is True
+    assert fg._step_size == 8
+    fg.stop()
+
+
+def test_start_legacy_keyword_warns(root):
+    fg = Floodgauge(root, mode="determinate")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fg.start(step_size=3, interval=40)
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+    assert fg._step_size == 3
+    fg.stop()
+
+
+def test_start_unknown_keyword_raises(root):
+    fg = Floodgauge(root)
+    with pytest.raises(TypeError):
+        fg.start(bogus=1)
+    fg.stop()


### PR DESCRIPTION
PR 4 of the 2.0 shipped-widget API review (design §3b/§8b). Adopts the shared `ConfigureDelegationMixin` for `Floodgauge` and closes its contract gaps + crashers. **No option renames** — Floodgauge's options mirror `ttk.Progressbar` and stay as-is.

## Changes
- **`ConfigureDelegationMixin`** — one `@configure_delegate` handler per option, so `configure`/`cget`/`keys`/item-access stay in sync and emit proper Tk **5-tuple** specs (was hand-rolled ladders returning malformed **4-tuples**; `cget` was partial).
- **`IntVar` → `DoubleVar`** value backing (matches Meter + `ttk.Progressbar`) — fractional values honored; `value`/`cget("value")`/the new `value` property return float. An external `variable=IntVar(...)` still binds.
- **Live `mode` and `orient`** — were construction-only (absent from `keys()`, raised on `configure`); now redraw, and `orient` swaps the canvas width/height.
- **`maximum=0` zero-range guard** in `_draw` (was `ZeroDivisionError`).
- **Value-vs-display split** — a `mask` formats the numeric value for display only and never writes back onto `textvariable`, so **`cget("text")` returns the user's text** (was clobbered by the mask output).
- **`start()` realigned to `start(interval)`** (ttk parity); the pre-2.0 `start(step_size, interval)` form is accepted through 2.x with a `DeprecationWarning`.
- New canonical **`value`** property (get/set); docstring font-default rot fixed.
- **FloodgaugeLegacy**: API untouched (still warns, 3.0-bound); added a `destroy()` that detaches its value/text write traces (the one defensible leak fix, parity with #1070).

## Breaking / deprecation
Logged in `development/2_0_breaking_changes.md`, split:
- **Breaking** — `value` is now `float` (`IntVar`→`DoubleVar`); `start()` signature realigned.
- **Deprecated** — `start(step_size, interval)` accepted through 2.x with a warning (removed 3.0).
- **Fixes bundled** — `cget("text")`, live `mode`/`orient`, 5-tuple specs, zero-range guard.

## Tests & verification
- `tests/test_floodgauge_api.py` (+15).
- Full suite **412 passed**; independent 8-path smoke (5-tuple, float round-trip, `cget("text")` un-clobbered, orient w/h swap, `maximum=0`, both `start()` forms + the legacy warning, external `IntVar` binding); warning-free import.
- Two unrelated failures excluded: the known `zh_cn.msg` localization flake, and a **pre-existing** order-dependent multi-monitor `test_center_on_screen_is_within_bounds` (fails on `2.0` without this change; passes in isolation — a latent `center_on_screen` negative-origin bug, not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)