### PR TITLE
Normalize LabeledScale + ToolTip (widget review PR 6)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -28,6 +28,7 @@
 | **DateEntry: snake_case (cross-layer), live-text read, string `state`** | Breaking/additive | this doc, below (PR 3 / #1111) |
 | **Floodgauge: DoubleVar value, `start(interval)`, live mode/orient** | Breaking/additive | this doc, below (PR 4) |
 | **Scrolled: Canvas-viewport rewrite, `auto_hide`, keyword-only** | Breaking/additive | this doc, below (PR 5) |
+| **LabeledScale + ToolTip: DoubleVar, lifecycle, `configure`/`cget`** | Breaking/additive | this doc, below (PR 6) |
 
 ---
 
@@ -577,3 +578,43 @@ and its `hbar=True, vbar=False` **AttributeError** outright; its `configure`/`cg
 and unknown-method access now delegate to the inner `Text` (via the shared
 `ConfigureDelegationMixin` target hook), so `st.configure(font=…)` / `st.cget("wrap")`
 round-trip. Four bare `except:` clauses were narrowed to `except tkinter.TclError`.
+
+---
+
+## LabeledScale + ToolTip: DoubleVar, lifecycle, `configure`/`cget`  *(breaking + additive)*
+
+**What.** `LabeledScale` and `ToolTip` (widget-review PR 6) were normalized. No
+option *renames* (both widgets' option names were already clean).
+
+- **Constructors are keyword-only** after the first positional
+  (`LabeledScale(master, *, …)`, `ToolTip(widget, *, …)`), and `compound` is now a
+  real named `LabeledScale` parameter (it was only read from `**kwargs`).
+- **`LabeledScale` value backing `IntVar` → `DoubleVar`** (matches Meter /
+  ttk.Progressbar): fractional scales are honored, so `value` / the value label can
+  now be a float. The value label is rendered with `:g` formatting, so an integer
+  scale still reads as integers (`4`, not `4.0`).
+- **`ToolTip` gained `configure`/`cget`** (and `tip["text"]` item access) over its
+  options (`text`, `bootstyle`, `position`, `delay`, `wraplength`, `justify`,
+  `image`, `padding`); a currently-visible popup is reconfigured in place. Previously
+  these were only reachable by poking undocumented attributes.
+
+**Migration.** The keyword-only constructors and the `IntVar`→`DoubleVar` change
+cannot be shimmed: pass `LabeledScale`/`ToolTip` options by keyword (already the
+norm), and expect a float back from `LabeledScale.value` where you previously got an
+int. Nothing warns — these are source-level breaks, not deprecations.
+
+**Fixes bundled.**
+- `LabeledScale(compound="bottom")` no longer raises `TclError` (the `compound`
+  option was forwarded to `ttk.Frame` before being popped) and the Frame is
+  initialized **once** (was twice — an orphaned frame leaked per instance).
+- `LabeledScale.destroy()` cancels its pending `after_idle` label-adjust, fixing a
+  use-after-destroy `AttributeError` when the idle callback fired into a
+  half-torn-down widget.
+- `ToolTip` binds with `add="+"` (a second tooltip, or the user's own `<Enter>`
+  handler, is no longer silently clobbered), gained a `destroy()` that unbinds those
+  handlers + cancels the pending timer + drops a live popup, and **self-releases when
+  its target widget is destroyed** (`<Destroy>`), fixing the orphaned-timer-into-a-
+  dead-widget leak. Placement now measures the real popup size and routes through
+  `internal/positioning.ensure_on_screen` (multi-monitor clamping) instead of a bare
+  `except:` 200×50 guess. The embedded `__main__` demo was removed from the package
+  source and a bare `except:` narrowed to `except tkinter.TclError`.

--- a/src/ttkbootstrap/widgets/labeledscale.py
+++ b/src/ttkbootstrap/widgets/labeledscale.py
@@ -19,11 +19,11 @@ Example:
     root.mainloop()
     ```
 """
-from tkinter import Misc
+from tkinter import Misc, TclError, Variable
 from typing import Any, Optional, Union
 
 from ttkbootstrap import (
-    Frame, IntVar, Label, Scale
+    DoubleVar, Frame, Label, Scale
 )
 from ttkbootstrap.constants import DEFAULT, Side
 
@@ -37,15 +37,20 @@ class LabeledScale(Frame):
 
     The label position can be configured to appear above or below the scale
     using the 'compound' parameter.
+
+    The value is backed by a ``DoubleVar`` (fractional scales are honored) and
+    is exposed as the read/write ``value`` property.
     """
 
     def __init__(
             self,
             master: Optional[Misc] = None,
-            variable: Optional[IntVar] = None,
+            *,
+            variable: Optional[Variable] = None,
             from_: Union[int, float] = 0,
             to: Union[int, float] = 10,
             bootstyle: str = DEFAULT,
+            compound: str = "top",
             **kwargs: Any
     ) -> None:
         """Construct a horizontal LabeledScale.
@@ -55,14 +60,15 @@ class LabeledScale(Frame):
             master (Widget, optional):
                 The parent widget.
 
-            variable (tk.IntVar, optional):
+            variable (tk.Variable, optional):
                 A tkinter variable to be associated with the Scale widget.
-                If not specified, a tkinter.IntVar is created automatically.
+                If not specified, a ``tkinter.DoubleVar`` is created
+                automatically.
 
-            from_ (int, optional):
+            from_ (int or float, optional):
                 The minimum value of the scale. Defaults to 0.
 
-            to (int, optional):
+            to (int or float, optional):
                 The maximum value of the scale. Defaults to 10.
 
             bootstyle (str, optional):
@@ -77,14 +83,17 @@ class LabeledScale(Frame):
             **kwargs (dict[str, Any], optional):
                 Other keyword arguments passed to the Frame widget.
         """
+        # Pop the composite option BEFORE initializing the Frame -- forwarding
+        # `compound` to ttk.Frame raises TclError -- and initialize the Frame
+        # exactly once.
+        self._label_top = compound == "top"
         super().__init__(master=master, **kwargs)
-        self._label_top = kwargs.pop('compound', 'top') == 'top'
 
-        Frame.__init__(self, master, **kwargs)
-        self._variable = variable or IntVar(master)
+        self._variable: Variable = variable if variable is not None else DoubleVar(master)
         self._variable.set(from_)
-        self._last_valid = from_
+        self._last_valid: Union[int, float] = from_
         self._bootstyle = bootstyle
+        self._adjust_id: Optional[str] = None  # pending after_idle for the label
 
         self.label = Label(self, bootstyle=bootstyle)
         self.scale = Scale(self, variable=self._variable, from_=from_, to=to, bootstyle=bootstyle)
@@ -106,7 +115,17 @@ class LabeledScale(Frame):
         self.bind('<Map>', self._adjust)
 
     def destroy(self) -> None:
-        """Destroy this widget and possibly its associated variable."""
+        """Destroy this widget and possibly its associated variable.
+
+        Cancels any pending label-adjust idle callback first, so it cannot fire
+        into the half-torn-down widget (use-after-destroy ``AttributeError``).
+        """
+        if self._adjust_id is not None:
+            try:
+                self.after_cancel(self._adjust_id)
+            except (ValueError, TclError):
+                pass
+            self._adjust_id = None
         try:
             self._variable.trace_remove('write', self.__tracecb)
         except AttributeError:
@@ -137,9 +156,17 @@ class LabeledScale(Frame):
         """Adjust the label position and text according to the scale value."""
 
         def adjust_label() -> None:
-            self.update_idletasks()  # ensure geometry info is current
-
-            x, y = self.scale.coords()
+            self._adjust_id = None
+            # The idle callback can outlive a destroy(); bail if we are gone.
+            if self.scale is None or self.label is None:
+                return
+            try:
+                if not self.winfo_exists():
+                    return
+                self.update_idletasks()  # ensure geometry info is current
+                x, y = self.scale.coords()
+            except TclError:
+                return
 
             # Vertical placement above or below the scale
             if self._label_top:
@@ -171,8 +198,17 @@ class LabeledScale(Frame):
             return
 
         self._last_valid = newval
-        self.label['text'] = newval
-        self.after_idle(adjust_label)
+        # `:g` renders 4.0 as "4" and 3.7 as "3.7" -- a DoubleVar-backed integer
+        # scale still reads as integers.
+        self.label['text'] = f"{newval:g}"
+        # Coalesce repeated adjusts (trace + <Configure> + <Map>) into one idle
+        # callback, and keep its id so destroy() can cancel it.
+        if self._adjust_id is not None:
+            try:
+                self.after_cancel(self._adjust_id)
+            except (ValueError, TclError):
+                pass
+        self._adjust_id = self.after_idle(adjust_label)
 
     @property
     def value(self) -> Union[int, float]:

--- a/src/ttkbootstrap/widgets/tooltip.py
+++ b/src/ttkbootstrap/widgets/tooltip.py
@@ -9,17 +9,17 @@ Classes:
 
 Features:
     - Automatic show/hide on mouse enter/leave events
-    - Configurable delay before tooltip appears
+    - Configurable delay before the tooltip appears
     - Bootstrap styling support
-    - Flexible positioning (follows mouse or anchored to widget)
+    - Flexible positioning (follows the mouse or anchored to the widget)
     - Text wrapping and justification options
-    - Optional image display with text
+    - Optional image display with the text
+    - `configure`/`cget` for live reconfiguration; self-releasing lifecycle
 
 Example:
     ```python
     import ttkbootstrap as ttk
     from ttkbootstrap.constants import *
-    from ttkbootstrap.widgets.tooltip import ToolTip
 
     app = ttk.Window()
 
@@ -29,26 +29,30 @@ Example:
     b2 = ttk.Button(app, text="styled tooltip")
     b2.pack(side=LEFT, padx=20, pady=20)
 
-    # Default tooltip (follows mouse)
-    ToolTip(b1, text="This is the default style")
+    # Default tooltip (follows the mouse)
+    ttk.ToolTip(b1, text="This is the default style")
 
-    # Styled tooltip anchored to widget
-    ToolTip(
+    # Styled tooltip anchored to the widget
+    ttk.ToolTip(
         b2,
         text="This is dangerous",
         bootstyle="danger-inverse",
-        position="top right"
+        position="top right",
     )
 
     app.mainloop()
     ```
 """
+import tkinter
 from tkinter import Event, Misc
 from typing import Any, Literal, Optional
 
 import ttkbootstrap as ttk
 from ttkbootstrap import utility
 from ttkbootstrap.constants import *
+from ttkbootstrap.internal.positioning import ensure_on_screen
+
+_POSITION_TOKENS = {"top", "bottom", "left", "right", "center"}
 
 
 class ToolTip:
@@ -57,6 +61,11 @@ class ToolTip:
     longer hovering over the widget. Clicking a mouse button will also
     close the tooltip.
 
+    The tooltip releases itself automatically when its target widget is
+    destroyed; call :meth:`destroy` to remove it explicitly. Its options can be
+    changed after construction with :meth:`configure` / :meth:`cget` (or item
+    access), and a currently-visible popup is reconfigured in place.
+
     ![](../assets/tooltip/tooltip.gif)
 
     Examples:
@@ -64,27 +73,28 @@ class ToolTip:
         ```python
         import ttkbootstrap as ttk
         from ttkbootstrap.constants import *
-        from ttkbootstrap.widgets.tooltip import ToolTip
 
         app = ttk.Window()
         b1 = ttk.Button(app, text="default tooltip")
         b1.pack()
-        b2 = ttk.Button(app, text="styled tooltip")
-        b2.pack()
 
-        # default tooltip
-        ToolTip(b1, text="This is the default style")
-
-        # styled tooltip
-        ToolTip(b2, text="This is dangerous", bootstyle="danger-inverse")
+        tip = ttk.ToolTip(b1, text="This is the default style")
+        tip.configure(text="Updated text")   # live reconfigure
 
         app.mainloop()
         ```
     """
 
+    #: Options that :meth:`configure`/:meth:`cget` understand.
+    _OPTIONS = (
+        "text", "bootstyle", "position", "delay",
+        "wraplength", "justify", "image", "padding",
+    )
+
     def __init__(
             self,
             widget: Misc,
+            *,
             text: str = "widget info",
             padding: int = 10,
             justify: Literal["left", "center", "right"] = "left",
@@ -106,22 +116,34 @@ class ToolTip:
                 The text to display in the tooltip window.
 
             padding (int):
-                The padding between the text and the border of the tooltip (default=10).
+                The padding between the text and the border of the tooltip
+                (default=10).
+
+            justify ('left', 'center', 'right'):
+                How to justify multi-line tooltip text (default='left').
 
             bootstyle (str):
                 The style to apply to the tooltip label. You can use
                 any of the standard ttkbootstrap label styles.
 
             wraplength (int):
-                The width of the tooltip window in screenunits before the
+                The width of the tooltip window in screen units before the
                 text is wrapped to the next line. By default, this will be
                 a scaled factor of 300.
 
+            delay (int):
+                The delay in milliseconds before the tooltip appears on hover
+                (default=250).
+
+            image (PhotoImage):
+                An optional image shown below the text in the tooltip.
+
             position (str):
-                If provided, will set the position of the tooltip relative to the widget.
-                Valid options include combinations of "left", "right", "top", "bottom",
-                and "center" separated by a space. For example: "top left" or "bottom right".
-                If not provided, the tooltip will be offset from the mouse pointer.
+                If provided, sets the position of the tooltip relative to the
+                widget. Valid options include combinations of "left", "right",
+                "top", "bottom", and "center" separated by a space, e.g.
+                "top left" or "bottom right". If not provided, the tooltip is
+                offset from the mouse pointer.
 
             **kwargs (Dict):
                 Other keyword arguments passed to the `Toplevel` window.
@@ -138,12 +160,10 @@ class ToolTip:
         self.position = position.lower() if position else None
         self.id = None
 
-        if self.position:
-            valid_tokens = {"top", "bottom", "left", "right", "center"}
-            if not all(part in valid_tokens for part in self.position.split()):
-                raise ValueError(f"Invalid position string: '{self.position}'")
+        self._validate_position(self.position)
 
-        # set keyword arguments
+        # Toplevel options -- copy the caller's dict before mutating it.
+        kwargs = dict(kwargs)
         kwargs["override_redirect"] = True
         kwargs["master"] = self.widget
         kwargs["window_type"] = "tooltip"
@@ -151,12 +171,32 @@ class ToolTip:
             kwargs["alpha"] = 0.95
         self.toplevel_kwargs = kwargs
 
-        # event binding
-        self.widget.bind("<Enter>", self.enter)
-        self.widget.bind("<Leave>", self.leave)
-        self.widget.bind("<Motion>", self.move_tip)
-        self.widget.bind("<ButtonPress>", self.leave)
+        # the live popup label, held so a visible tooltip can be reconfigured
+        self._label: Optional[ttk.Label] = None
 
+        # event binding -- add="+" so a second ToolTip (or the user's own
+        # handlers) are not silently clobbered; keep the funcids to unbind them
+        # in destroy().
+        self._funcids: dict = {}
+        for seq, handler in (
+            ("<Enter>", self.enter),
+            ("<Leave>", self.leave),
+            ("<Motion>", self.move_tip),
+            ("<ButtonPress>", self.leave),
+        ):
+            self._funcids[seq] = self.widget.bind(seq, handler, add="+")
+        # release ourselves when the target widget is destroyed
+        self._destroy_funcid = self.widget.bind(
+            "<Destroy>", self._on_widget_destroy, add="+"
+        )
+
+    # -- validation ---------------------------------------------------------- #
+    @staticmethod
+    def _validate_position(position: Optional[str]) -> None:
+        if position and not all(p in _POSITION_TOKENS for p in position.split()):
+            raise ValueError(f"Invalid position string: '{position}'")
+
+    # -- scheduling ---------------------------------------------------------- #
     def enter(self, event: Optional[Event] = None) -> None:
         self.schedule()
 
@@ -172,18 +212,28 @@ class ToolTip:
         _id = self.id
         self.id = None
         if _id:
-            self.widget.after_cancel(_id)
+            try:
+                self.widget.after_cancel(_id)
+            except (ValueError, tkinter.TclError):
+                pass
 
+    # -- show / hide --------------------------------------------------------- #
     def show_tip(self, *_: Any) -> None:
-        """Create and show the tooltip window"""
+        """Create and show the tooltip window."""
         if self.toplevel:
+            return
+        # An orphaned timer can fire after the widget is gone -- no-op then.
+        try:
+            if not self.widget.winfo_exists():
+                return
+        except tkinter.TclError:
             return
 
         # Create the tooltip window at a temporary position
         self.toplevel = ttk.window.Toplevel(position=(0, 0), **self.toplevel_kwargs)
-
         self.toplevel.withdraw()
-        lbl = ttk.Label(
+
+        self._label = ttk.Label(
             master=self.toplevel,
             text=self.text,
             image=self.image,
@@ -192,52 +242,137 @@ class ToolTip:
             wraplength=self.wraplength,
             padding=self.padding,
         )
-        lbl.pack(fill=BOTH, expand=YES)
-
-        if self.bootstyle:
-            lbl.configure(bootstyle=self.bootstyle)
-        else:
-            lbl.configure(style="tooltip.TLabel")
+        self._label.pack(fill=BOTH, expand=YES)
+        self._apply_label_style()
 
         # Wait until size is known, then position
         self.toplevel.update_idletasks()
+        self._place()
+        self.toplevel.deiconify()
 
+    def move_tip(self, *_: Any) -> None:
+        """Move the tooltip window to track the pointer/anchor."""
+        if self.toplevel:
+            self._place()
+
+    def hide_tip(self, *_: Any) -> None:
+        """Destroy the tooltip window (the target widget stays)."""
+        if self.toplevel:
+            try:
+                self.toplevel.destroy()
+            except tkinter.TclError:
+                pass
+            self.toplevel = None
+            self._label = None
+
+    # -- lifecycle ----------------------------------------------------------- #
+    def _on_widget_destroy(self, event: Event) -> None:
+        # Ignore the <Destroy> of child widgets bubbling up.
+        if event.widget is self.widget:
+            self.destroy()
+
+    def destroy(self) -> None:
+        """Release the tooltip: cancel timers, drop the popup, unbind handlers.
+
+        Idempotent and safe to call from the target widget's ``<Destroy>``.
+        """
+        self.unschedule()
+        self.hide_tip()
+        for seq, funcid in list(self._funcids.items()):
+            try:
+                self.widget.unbind(seq, funcid)
+            except tkinter.TclError:
+                pass
+        self._funcids.clear()
+        if self._destroy_funcid is not None:
+            try:
+                self.widget.unbind("<Destroy>", self._destroy_funcid)
+            except tkinter.TclError:
+                pass
+            self._destroy_funcid = None
+
+    # -- configure / cget ---------------------------------------------------- #
+    def configure(self, cnf: Any = None, **kwargs: Any) -> Any:
+        """Query or set tooltip options.
+
+        With a single option name and no keyword arguments, returns that
+        option's value (like :meth:`cget`). Otherwise applies the given
+        options; a currently-visible popup is reconfigured in place.
+        """
+        if cnf is not None and not kwargs and isinstance(cnf, str):
+            return self.cget(cnf)
+        if isinstance(cnf, dict):
+            kwargs = {**cnf, **kwargs}
+        for key, value in kwargs.items():
+            if key not in self._OPTIONS:
+                raise ValueError(f"unknown tooltip option: {key!r}")
+            if key == "position":
+                value = value.lower() if value else None
+                self._validate_position(value)
+            setattr(self, key, value)
+        if kwargs:
+            self._reconfigure_live()
+        return None
+
+    config = configure
+
+    def cget(self, key: str) -> Any:
+        """Return the value of a tooltip option."""
+        if key not in self._OPTIONS:
+            raise ValueError(f"unknown tooltip option: {key!r}")
+        return getattr(self, key)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.cget(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.configure(**{key: value})
+
+    # -- placement / styling helpers ----------------------------------------- #
+    def _apply_label_style(self) -> None:
+        if self._label is None:
+            return
+        if self.bootstyle:
+            self._label.configure(bootstyle=self.bootstyle)
+        else:
+            self._label.configure(style="tooltip.TLabel")
+
+    def _reconfigure_live(self) -> None:
+        """Push option changes onto a visible popup (no-op when hidden)."""
+        if not self.toplevel or self._label is None:
+            return
+        try:
+            self._label.configure(
+                text=self.text,
+                image=self.image,
+                justify=self.justify,
+                wraplength=self.wraplength,
+                padding=self.padding,
+            )
+            self._apply_label_style()
+            self.toplevel.update_idletasks()
+            self._place()
+        except tkinter.TclError:
+            pass
+
+    def _place(self) -> None:
+        """Position the popup, clamped to the monitor it lands on."""
+        if not self.toplevel:
+            return
         if self.position:
             x, y = self._calculate_position()
         else:
             x = self.widget.winfo_pointerx() + 25
             y = self.widget.winfo_pointery() + 10
-
+        # A tooltip has no titlebar; clamp so it stays fully on-screen.
+        x, y = ensure_on_screen(self.toplevel, x, y, padding=8, titlebar_height=0)
         self.toplevel.geometry(f"+{x}+{y}")
-        self.toplevel.deiconify()
-
-    def move_tip(self, *_: Any) -> None:
-        """Move the tooltip window"""
-        if self.toplevel:
-            if self.position:
-                x, y = self._calculate_position()
-            else:
-                x = self.widget.winfo_pointerx() + 25
-                y = self.widget.winfo_pointery() + 10
-            self.toplevel.geometry(f"+{x}+{y}")
-
-    def hide_tip(self, *_: Any) -> None:
-        """Destroy the tooltip window."""
-        if self.toplevel:
-            self.toplevel.destroy()
-            self.toplevel = None
 
     def _calculate_position(self) -> tuple[int, int]:
         w = self.widget
-        tip_w = 200  # fallback size
-        tip_h = 50
-
-        try:
-            self.toplevel.update_idletasks()
-            tip_w = self.toplevel.winfo_width()
-            tip_h = self.toplevel.winfo_height()
-        except:
-            pass
+        self.toplevel.update_idletasks()
+        tip_w = self.toplevel.winfo_reqwidth()
+        tip_h = self.toplevel.winfo_reqheight()
 
         widget_x = w.winfo_rootx()
         widget_y = w.winfo_rooty()
@@ -246,9 +381,7 @@ class ToolTip:
 
         horiz = "center"
         vert = "bottom"
-        tokens = self.position.split()
-
-        for token in tokens:
+        for token in self.position.split():
             if token in ("top", "bottom", "center"):
                 vert = token
             if token in ("left", "right", "center"):
@@ -271,26 +404,3 @@ class ToolTip:
             x = widget_x + (widget_w // 2) - (tip_w // 2)
 
         return x, y
-
-
-if __name__ == "__main__":
-    app = ttk.Window()
-
-    b1 = ttk.Button(app, text="default tooltip")
-    b1.pack(side=LEFT, padx=20, pady=20, fill=X, expand=YES)
-
-    b2 = ttk.Button(app, text="styled tooltip")
-    b2.pack(side=LEFT, padx=20, pady=20, fill=X, expand=YES)
-
-    ToolTip(
-        b1,
-        text="Following the mouse pointer.",
-    )
-    ToolTip(
-        b2,
-        text="Anchored to the top right corner.",
-        bootstyle="danger-inverse",
-        position="top right"
-    )
-
-    app.mainloop()

--- a/tests/test_labeledscale_tooltip_api.py
+++ b/tests/test_labeledscale_tooltip_api.py
@@ -1,0 +1,201 @@
+"""API tests for the LabeledScale + ToolTip normalization (widget review PR 6).
+
+Headless (uses the shared ``root`` fixture from conftest). Covers the
+LabeledScale double-init/compound/idle-leak fixes + DoubleVar backing, and the
+ToolTip binding-lifecycle + self-release + configure/cget surface. Popup-visual
+behavior (actual placement) is only structurally checked here.
+"""
+import tkinter
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.style import Style
+from ttkbootstrap.widgets.labeledscale import LabeledScale
+from ttkbootstrap.widgets.tooltip import ToolTip
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _clear_image_cache_after_module():
+    """Release the scale-thumb images these tests add to the process-global
+    ``Style._image_cache``.
+
+    LabeledScale creates a Scale whose (default -> primary) thumb populates the
+    same cache key that ``widget_styles/test_image_cache`` asserts is freshly
+    rendered; clearing on teardown keeps this module from imposing a test-order
+    dependency on that suite.
+    """
+    yield
+    try:
+        Style.get_instance().clear_image_cache()
+    except Exception:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# LabeledScale
+# --------------------------------------------------------------------------- #
+
+def test_compound_bottom_constructs(root):
+    """`compound` was dead-on-arrival (forwarded to Frame -> TclError)."""
+    ls = LabeledScale(root, from_=0, to=10, compound="bottom")
+    ls.pack()
+    root.update_idletasks()
+    assert ls._label_top is False
+
+
+def test_compound_top_default(root):
+    ls = LabeledScale(root, from_=0, to=10)
+    assert ls._label_top is True
+
+
+def test_single_frame_init_children(root):
+    """One Frame init -> exactly the scale, value label, and height dummy."""
+    ls = LabeledScale(root, from_=0, to=10)
+    ls.pack()
+    root.update_idletasks()
+    # label + scale + dummy label
+    assert len(ls.winfo_children()) == 3
+
+
+def test_value_roundtrip(root):
+    ls = LabeledScale(root, from_=0, to=10)
+    ls.value = 7
+    assert ls.value == 7
+
+
+def test_doublevar_fractional_and_label_format(root):
+    """DoubleVar honors fractions; the label renders cleanly (`:g`)."""
+    ls = LabeledScale(root, from_=0, to=10)
+    ls.pack()
+    ls.value = 3.5
+    root.update_idletasks()
+    assert ls.value == 3.5
+    assert ls.label["text"] == "3.5"      # fractional shown
+    ls.value = 4.0
+    root.update_idletasks()
+    assert ls.label["text"] == "4"        # whole value has no ".0"
+
+
+def test_explicit_variable_respected(root):
+    var = ttk.DoubleVar(value=2)
+    ls = LabeledScale(root, from_=0, to=10, variable=var)
+    assert ls.value == 0  # ctor sets the var to from_
+    ls.value = 5
+    assert var.get() == 5
+
+
+def test_destroy_with_pending_idle_is_safe(root):
+    """A queued after_idle(adjust_label) must not fire into a dead widget."""
+    ls = LabeledScale(root, from_=0, to=10)
+    ls.pack()
+    ls._adjust()            # schedules an after_idle
+    ls.destroy()            # must cancel it
+    root.update_idletasks()  # flush idle queue -> would raise if not cancelled
+    assert ls.scale is None
+
+
+# --------------------------------------------------------------------------- #
+# ToolTip
+# --------------------------------------------------------------------------- #
+
+def test_binding_does_not_clobber_existing_handler(root):
+    """add='+' binds: a pre-existing <Enter> handler still fires."""
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    hits = []
+    btn.bind("<Enter>", lambda e: hits.append(1), add="+")
+    ToolTip(btn, text="tip")
+    btn.event_generate("<Enter>")
+    root.update_idletasks()
+    assert hits == [1]
+
+
+def test_two_tooltips_coexist(root):
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    t1 = ToolTip(btn, text="one")
+    t2 = ToolTip(btn, text="two")
+    assert t1._funcids and t2._funcids
+    assert t1._funcids != t2._funcids
+
+
+def test_destroy_is_idempotent_and_unbinds(root):
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    tip = ToolTip(btn, text="tip")
+    tip.destroy()
+    assert tip._funcids == {}
+    tip.destroy()  # idempotent -- must not raise
+
+
+def test_self_release_on_widget_destroy(root):
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    tip = ToolTip(btn, text="tip")
+    btn.destroy()            # <Destroy> -> tip.destroy()
+    root.update_idletasks()
+    assert tip._funcids == {}
+
+
+def test_invalid_position_raises(root):
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    with pytest.raises(ValueError):
+        ToolTip(btn, position="sideways")
+
+
+def test_configure_invalid_position_raises(root):
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    tip = ToolTip(btn, text="tip")
+    with pytest.raises(ValueError):
+        tip.configure(position="nope")
+
+
+def test_configure_cget_roundtrip(root):
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    tip = ToolTip(btn, text="one")
+    tip.configure(text="two", delay=500)
+    assert tip.cget("text") == "two"
+    assert tip["delay"] == 500
+    tip["text"] = "three"
+    assert tip["text"] == "three"
+
+
+def test_cget_unknown_option_raises(root):
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    tip = ToolTip(btn, text="tip")
+    with pytest.raises(ValueError):
+        tip.cget("nonsense")
+
+
+def test_show_tip_after_widget_destroyed_is_noop(root):
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    tip = ToolTip(btn, text="tip")
+    # simulate an orphaned timer: drop the popup guard, kill the widget
+    btn.destroy()
+    tip.show_tip()           # must be a no-op, not an error
+    assert tip.toplevel is None
+
+
+def test_configure_reconfigures_live_popup(root):
+    """A visible popup's label updates in place on configure()."""
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+    root.update_idletasks()
+    tip = ToolTip(btn, text="one")
+    try:
+        tip.show_tip()
+        root.update_idletasks()
+    except tkinter.TclError:
+        pytest.skip("cannot realize a tooltip Toplevel headlessly here")
+    if tip._label is None:
+        pytest.skip("tooltip popup not realized headlessly")
+    tip.configure(text="updated")
+    assert tip._label.cget("text") == "updated"
+    tip.hide_tip()
+    assert tip.toplevel is None


### PR DESCRIPTION
PR 6 of the 2.0 shipped-widget API review (design §3d/§8g + §3f/§8e). Two self-contained widgets: LabeledScale bug fixes and a ToolTip lifecycle + `configure`/`cget` overhaul.

## LabeledScale
- **Fix the `compound` dead-on-arrival crash + double Frame init**: `compound` (now a named keyword-only param) is popped before the Frame is initialized **once**. `LabeledScale(compound="bottom")` no longer raises `TclError`.
- **`IntVar` → `DoubleVar`** (matches Meter): fractional scales honored; the label formats with `:g` so a whole value still reads as `"4"`, not `"4.0"`. An explicitly-passed `variable` is respected.
- **Fix the `after_idle` use-after-destroy leak**: the pending idle id is tracked (adjusts coalesced) and `destroy()` cancels it; `adjust_label` guards on `winfo_exists()`/None.
- Keyword-only ctor. Scope kept minimal per §8g (no mixin).

## ToolTip
- **Lifecycle**: all binds now `add="+"` with stored funcids (a second ToolTip or the user's own `<Enter>`/`<Leave>` handlers are no longer silently clobbered); new **idempotent `destroy()`** unbinds them, cancels the pending timer, drops a live popup. A `<Destroy>` handler (guarded by `event.widget is self.widget`) **self-releases** when the target widget dies; `show_tip` re-checks `winfo_exists()` so an orphan timer firing into a dead widget is a no-op.
- **On-screen placement**: routes through `internal/positioning.ensure_on_screen` after measuring `winfo_reqwidth/reqheight` — the bare-`except` 200×50 guess is gone; popups clamp to the monitor (multi-monitor safe).
- **`configure`/`cget`/item access** over its 8 options; a visible popup is reconfigured in place (held `_label` ref).
- Rot: `.copy()` kwargs before mutating; deleted the embedded `__main__` demo; bare `except:` → `except tkinter.TclError`; docstrings now cover `justify`/`delay`/`image`. Keyword-only ctor.

## Breaking / deprecation
Logged in `development/2_0_breaking_changes.md` (combined entry, breaking vs bundled-fixes). Breaking: LabeledScale value is now `DoubleVar` (label values float-formatted via `:g`); keyword-only ctors. No option renames (both widgets' names are clean).

## Tests & verification
- `tests/test_labeledscale_tooltip_api.py` (+17). Full suite **446 passed**.
- **Test-verified (headless):** LabeledScale `compound="bottom"` constructs; single init; `value` round-trip; DoubleVar fractional + `:g` label; explicit-variable respected; destroy-with-pending-idle safe. ToolTip: no-clobber of an existing handler; two tooltips coexist; idempotent `destroy()` unbinds; `<Destroy>` self-release; invalid `position` raises (ctor + configure); `configure`/`cget`/item round-trip + **live-popup reconfigure** (a real Toplevel realized headlessly); unknown-option raises; `show_tip` after widget death is a no-op.
- **Needs a visual spot-check:** actual on-screen tooltip placement/anchoring (`position="top right"` etc.) + multi-monitor clamping; LabeledScale value-label tracking during a drag.

**Note (pre-existing test fragility handled):** a default `LabeledScale`'s inner Scale thumb populates the same process-global `Style._image_cache` key that `widget_styles/test_image_cache::test_identical_widgets_share_one_image` asserts is freshly rendered. Rather than edit that unrelated test, this module clears the image cache on teardown so it imposes no order dependency (verified both orderings pass). Follow-up worth considering: have `test_image_cache` clear the cache at its own start.

Excludes the known `zh_cn.msg`/`nl.msg` localization flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)