### PR TITLE
Normalize ToastNotification + concurrent-toast stack (widget review PR 7)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -29,6 +29,7 @@
 | **Floodgauge: DoubleVar value, `start(interval)`, live mode/orient** | Breaking/additive | this doc, below (PR 4) |
 | **Scrolled: Canvas-viewport rewrite, `auto_hide`, keyword-only** | Breaking/additive | this doc, below (PR 5) |
 | **LabeledScale + ToolTip: DoubleVar, lifecycle, `configure`/`cget`** | Breaking/additive | this doc, below (PR 6) |
+| **ToastNotification: glyph icon, stack manager, keyword-only** | Breaking/additive | this doc, below (PR 7) |
 
 ---
 
@@ -618,3 +619,45 @@ int. Nothing warns — these are source-level breaks, not deprecations.
   `internal/positioning.ensure_on_screen` (multi-monitor clamping) instead of a bare
   `except:` 200×50 guess. The embedded `__main__` demo was removed from the package
   source and a bare `except:` narrowed to `except tkinter.TclError`.
+
+## ToastNotification: glyph icon, stack manager, keyword-only  *(breaking + additive)*
+
+**What.** `ToastNotification` (widget-review PR 7) was normalized.
+
+*Breaking.*
+- **The `icon` parameter is now a Bootstrap-Icons glyph name** (e.g.
+  `"bell-fill"`, `"info-circle-fill"`), not a raw Unicode/PUA character. It is
+  rendered from the built-in icon font (theme-matched, recolorable), so it
+  follows the theme instead of depending on an OS symbol font. Default is a bell
+  glyph; pass `icon=""` to suppress it. The old PUA defaults (``/`◰`) are gone.
+- **`iconfont` (and `icon_font`) is removed** — it was dead (the constructor
+  overwrote it before it could render). Passing either is accepted through 2.x
+  with a `DeprecationWarning` and ignored (removed in 3.0).
+- **The constructor is keyword-only** after `title, message`.
+- **A bad `position` anchor now raises `ValueError`** (was silently dropped to
+  the OS default). `position` stays a 3-tuple `(x, y, anchor)`.
+- **`set_geometry()` is now private (`_set_geometry` internals)** — it was public
+  but always internal. `titlefont` internal attribute → `title_font`.
+
+*Additive.*
+- **Concurrent toasts no longer overlap.** Toasts anchored to the same screen
+  corner are **stacked** and offset so each is fully visible; dismissing one
+  **reflows** the rest to close the gap.
+- **`show_toast()` returns the toast** as a dismiss handle, and a new idempotent
+  **`hide()`** dismisses it programmatically (safe to call twice / before shown).
+  `hide_toast()` remains as an alias.
+
+*Fixed.*
+- Every `show_toast()` used to emit a `DeprecationWarning` (it force-injected the
+  legacy `overrideredirect` kwarg) — now uses the internal `override_redirect`.
+- The duration timer and fade loop `after` ids are stored and cancelled on
+  dismiss (they could double-fire); `self.toplevel` is reset to `None` after
+  destroy; the bare `except:` in the fade is narrowed to `tkinter.TclError`.
+- The withdrawn-window mismeasure (`winfo_height()==1`) is fixed by measuring the
+  requested size before placing. The embedded `__main__` demo was removed and the
+  `"ne = top-left"` docstring corrected (`ne` is top-**right**).
+
+**Migration.** Replace a Unicode `icon="◰"` with a glyph name
+(`icon="bell-fill"`); drop any `iconfont=`. Pass toast options by keyword. If you
+called `set_geometry()` directly, don't (it is internal). Capture the return of
+`show_toast()` if you want to dismiss a toast early: `t = toast.show_toast(); t.hide()`.

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -1,8 +1,10 @@
 """Toast notification popup widgets for ttkbootstrap.
 
 This module provides a semi-transparent toast notification system for displaying
-temporary alerts or messages. Toasts appear as popup windows that can be configured
-to automatically close after a duration or require user interaction to dismiss.
+temporary alerts or messages. Toasts appear as popup windows that can be
+configured to automatically close after a duration or require user interaction
+to dismiss. Concurrent toasts anchored to the same screen corner are stacked so
+they do not overlap, and the stack reflows when one is dismissed.
 
 Classes:
     ToastNotification: Semi-transparent popup for alerts and messages
@@ -10,20 +12,20 @@ Classes:
 Features:
     - Configurable display duration or click-to-close behavior
     - Bootstrap styling support (primary, secondary, success, danger, etc.)
-    - Customizable icon and font support
-    - Flexible positioning (anchored to screen corners)
+    - A theme-aware icon rendered from the built-in Bootstrap-Icons font
+    - Flexible positioning (anchored to screen corners) with non-overlapping
+      stacking of concurrent toasts
     - Optional audible alert bell
-    - Smooth fade-out animation on close
+    - Smooth (cancellable) fade-out animation on close
 
 Example:
     ```python
     import ttkbootstrap as ttk
-    from ttkbootstrap.widgets.toast import ToastNotification
 
     app = ttk.Window()
 
     # Toast with auto-close after 3 seconds
-    toast = ToastNotification(
+    toast = ttk.ToastNotification(
         title="ttkbootstrap toast message",
         message="This is a toast message",
         duration=3000,
@@ -31,27 +33,66 @@ Example:
     )
     toast.show_toast()
 
-    # Toast that requires click to close
-    toast2 = ToastNotification(
-        title="Important Notice",
-        message="Click to dismiss this message",
-        bootstyle="warning",
-        alert=True,  # Ring bell when shown
-    )
-    toast2.show_toast()
-
     app.mainloop()
     ```
 """
+import tkinter
 from tkinter import font
-from typing import Any, TYPE_CHECKING, Optional, Union
+from typing import Any, Optional
 
 from ttkbootstrap.constants import *
+from ttkbootstrap.style._compat import warn_deprecated
 
-# https://www.fontspace.com/freeserif-font-f13277
+#: The valid ``position`` anchors (compass points).
+_VALID_ANCHORS = {"n", "e", "s", "w", "nw", "ne", "sw", "se"}
 
-DEFAULT_ICON_WIN32 = "\ue154"
-DEFAULT_ICON = "\u25f0"
+#: Default notification glyph (a Bootstrap-Icons name). Rendered by the built-in
+#: font engine so it is theme-matched and recolorable.
+_DEFAULT_ICON = "bell-fill"
+
+
+class _ToastStack:
+    """Keeps concurrent toasts from overlapping.
+
+    Toasts are grouped by their resolved anchor corner. Each toast is offset
+    along the anchor's vertical axis by the cumulative height of the toasts
+    ahead of it in that corner (plus a gap), so they stack away from the
+    anchored edge -- downward for a top anchor, upward for a bottom anchor.
+    Dismissing a toast removes it from its corner and reflows the rest so the
+    stack closes the gap.
+    """
+
+    _GAP = 10  # logical px between stacked toasts
+
+    def __init__(self) -> None:
+        self._corners: dict = {}  # anchor(str) -> [ToastNotification, ...]
+
+    def add(self, toast: "ToastNotification") -> None:
+        self._corners.setdefault(toast._anchor, []).append(toast)
+
+    def remove(self, toast: "ToastNotification") -> None:
+        lst = self._corners.get(toast._anchor)
+        if lst and toast in lst:
+            lst.remove(toast)
+            self._reflow(toast._anchor)
+
+    def offset_for(self, toast: "ToastNotification") -> int:
+        """Along-axis pixel offset for ``toast`` from the toasts ahead of it."""
+        lst = self._corners.get(toast._anchor, [])
+        offset = 0
+        for other in lst:
+            if other is toast:
+                break
+            offset += other._height + toast._scaled_gap()
+        return offset
+
+    def _reflow(self, anchor: str) -> None:
+        for toast in list(self._corners.get(anchor, [])):
+            toast._reposition()
+
+
+#: Process-wide stack manager (one screen, shared corners).
+_TOAST_STACK = _ToastStack()
 
 
 class ToastNotification:
@@ -59,22 +100,26 @@ class ToastNotification:
     You may choose to display the toast for a specified period of time,
     otherwise you must click the toast to close it.
 
+    Concurrent toasts anchored to the same corner stack without overlapping and
+    reflow when one is dismissed. ``show_toast()`` returns the toast so it can be
+    dismissed programmatically with :meth:`hide`.
+
     ![toast notification](../assets/toast/toast.png)
 
     Examples:
 
         ```python
         import ttkbootstrap as ttk
-        from ttkbootstrap.widgets.toast import ToastNotification
 
         app = ttk.Window()
 
-        toast = ToastNotification(
+        toast = ttk.ToastNotification(
             title="ttkbootstrap toast message",
             message="This is a toast message",
             duration=3000,
         )
-        toast.show_toast()
+        handle = toast.show_toast()
+        # handle.hide()   # dismiss early
 
         app.mainloop()
         ```
@@ -84,12 +129,12 @@ class ToastNotification:
             self,
             title: str,
             message: str,
+            *,
             duration: Optional[int] = None,
             bootstyle: str = LIGHT,
             alert: bool = False,
             icon: Optional[str] = None,
-            iconfont: Optional[Union[font.Font, str]] = None,
-            position: Optional[tuple[int, int, str]] = None,
+            position: Optional[tuple] = None,
             **kwargs: Any,
     ) -> None:
         """
@@ -106,82 +151,122 @@ class ToastNotification:
                 (default), then you must click the toast to close it.
 
             bootstyle (str):
-                Style keywords used to updated the label style. One of
-                the accepted color keywords.
+                Style keywords used to update the label style. One of the
+                accepted color keywords.
 
             alert (bool):
-                Indicates whether to ring the display bell when the
-                toast is shown.
+                Indicates whether to ring the display bell when the toast is
+                shown.
 
             icon (str):
-                A UNICODE character to display on the top-left hand
-                corner of the toast. The default symbol is OS specific.
-                Pass an empty string to remove the symbol.
-
-            iconfont (Union[str, Font]):
-                The font used to render the icon. By default, this is
-                OS specific. You may need to change the font to enable
-                better character or emoji support for the icon you
-                want to use. Windows (Segoe UI Symbol),
-                Linux (FreeSerif), macOS (Apple Symbol)
+                A Bootstrap-Icons glyph name (e.g. ``"bell-fill"``,
+                ``"info-circle-fill"``) to show in the top-left corner. Rendered
+                from the built-in icon font, so it follows the theme. Defaults
+                to a bell glyph; pass an empty string to remove the icon.
 
             position (tuple[int, int, str]):
-                A tuple that controls the position of the toast. Default
-                is OS specific. The tuple cooresponds to
-                (horizontal, vertical, anchor), where the horizontal and
-                vertical elements represent the position of the toplevel
-                releative to the anchor, which is "ne" or top-left by
-                default. Acceptable anchors include: n, e, s, w, nw, ne,
-                sw, se. For example: (100, 100, 'ne').
+                A tuple ``(x, y, anchor)`` controlling the toast position.
+                Default is OS specific. ``x``/``y`` are the offset of the
+                toplevel relative to ``anchor``. Acceptable anchors: n, e, s, w,
+                nw, ne, sw, se (e.g. ``ne`` is the top-right corner). For
+                example: ``(100, 100, 'ne')``.
 
             **kwargs (Dict):
                 Other keyword arguments passed to the `Toplevel` window.
         """
-        self.container = None
-        self.message = message
+        # `iconfont`/`icon_font` are dead in 2.0 -- icons render from the
+        # built-in Bootstrap-Icons font. Accept-and-warn so old calls don't blow
+        # up on the unexpected keyword.
+        for legacy in ("iconfont", "icon_font"):
+            if legacy in kwargs:
+                kwargs.pop(legacy)
+                warn_deprecated(
+                    f"the {legacy!r} ToastNotification option",
+                    "the built-in Bootstrap-Icons font (icons render automatically)",
+                )
+
         self.title = title
+        self.message = message
         self.duration = duration
         self.bootstyle = bootstyle
-        self.icon = icon
-        self.iconfont = iconfont
-        self.iconfont = None
-        self.titlefont = None
-        self.toplevel = None
-        self.kwargs = kwargs
         self.alert = alert
+        self.icon = _DEFAULT_ICON if icon is None else icon
         self.position = position
+        self.kwargs = dict(kwargs)  # copy -- we mutate this, not the caller's
 
+        self.toplevel = None
+        self.container = None
+        self.title_font = None
+
+        # lifecycle bookkeeping
+        self._anchor: Optional[str] = None
+        self._height: int = 0
+        self._duration_id: Optional[str] = None
+        self._fade_id: Optional[str] = None
+        self._hidden = False
+
+        # internal Toplevel options (snake_case -- avoid the compat shim's
+        # DeprecationWarning that the old ``overrideredirect`` spelling tripped).
         if "override_redirect" not in self.kwargs:
             self.kwargs["override_redirect"] = True
         if "alpha" not in self.kwargs:
             self.kwargs["alpha"] = 0.95
 
         if position is not None:
-            if len(position) != 3:
-                self.position = None
+            self._validate_position(position)
 
-    def show_toast(self, *_: Any) -> None:
-        """Create and show the toast window."""
-        # Late import to avoid circular import during package initialization
-        from ttkbootstrap import Frame, Label, Toplevel, utility
+    # -- validation ---------------------------------------------------------- #
+    @staticmethod
+    def _validate_position(position: tuple) -> None:
+        if len(position) != 3:
+            raise ValueError(
+                f"position must be a (x, y, anchor) tuple, got: {position!r}"
+            )
+        anchor = str(position[2]).lower()
+        if anchor not in _VALID_ANCHORS:
+            raise ValueError(
+                f"Invalid position anchor: {position[2]!r} "
+                f"(expected one of {sorted(_VALID_ANCHORS)})"
+            )
 
-        # build toast
+    # -- show / hide --------------------------------------------------------- #
+    def show_toast(self, *_: Any) -> "ToastNotification":
+        """Create, place, and show the toast; returns ``self`` (a dismiss handle)."""
+        from tkinter import _default_root
+
+        from ttkbootstrap import Frame, Label, Toplevel, apply_icon, utility
+
+        self._hidden = False
+
+        # On aqua a borderless popup should be a 'tooltip' window type (parity
+        # with the tooltip); set it at construction, so probe the windowing
+        # system from the existing root before creating the Toplevel.
+        if _default_root is not None and "window_type" not in self.kwargs:
+            if _default_root.tk.call("tk", "windowingsystem") == "aqua":
+                self.kwargs["window_type"] = "tooltip"
+
         self.toplevel = Toplevel(**self.kwargs)
+        self.toplevel.withdraw()
         self._setup(self.toplevel)
 
         self.container = Frame(self.toplevel, bootstyle=self.bootstyle)
         self.container.pack(fill=BOTH, expand=YES)
-        Label(
+
+        icon_lbl = Label(
             self.container,
-            text=self.icon,
-            font=self.iconfont,
             bootstyle=f"{self.bootstyle}-inverse",
             anchor=NW,
-        ).grid(row=0, column=0, rowspan=2, sticky=NSEW, padx=(5, 0))
+        )
+        icon_lbl.grid(row=0, column=0, rowspan=2, sticky=NSEW, padx=(5, 0))
+        if self.icon:
+            # Theme-aware glyph: follows the (inverse) label foreground and
+            # re-renders on a theme switch.
+            apply_icon(icon_lbl, self.icon, size=24)
+
         Label(
             self.container,
             text=self.title,
-            font=self.titlefont,
+            font=self.title_font,
             bootstyle=f"{self.bootstyle}-inverse",
             anchor=NW,
         ).grid(row=0, column=1, sticky=NSEW, padx=10, pady=(5, 0))
@@ -193,105 +278,154 @@ class ToastNotification:
             anchor=NW,
         ).grid(row=1, column=1, sticky=NSEW, padx=10, pady=(0, 5))
 
-        self.toplevel.bind("<ButtonPress>", self.hide_toast)
+        self.toplevel.bind("<ButtonPress>", self.hide)
 
-        # alert toast
+        # measure the requested size (valid even while withdrawn) BEFORE placing,
+        # so the stack offset is correct and there is no reposition flash.
+        self.toplevel.update_idletasks()
+        self._height = self.toplevel.winfo_reqheight()
+
+        _TOAST_STACK.add(self)
+        self._reposition()
+        self.toplevel.deiconify()
+
         if self.alert:
             self.toplevel.bell()
-
-        # specified duration to close
         if self.duration:
-            self.toplevel.after(self.duration, self.hide_toast)
+            self._duration_id = self.toplevel.after(self.duration, self.hide)
+        return self
 
+    def hide(self, *_: Any) -> None:
+        """Dismiss the toast (idempotent, safe if never shown).
+
+        Removes the toast from its corner stack (reflowing the rest so they
+        close the gap), then fades out and destroys the window.
+        """
+        if self._hidden:
+            return
+        self._hidden = True
+
+        if self._duration_id is not None:
+            self._cancel(self._duration_id)
+            self._duration_id = None
+
+        # reflow the siblings first so they slide up while this one fades
+        _TOAST_STACK.remove(self)
+
+        if self.toplevel is None:
+            return
+        self._fade_out()
+
+    #: Back-compat alias for :meth:`hide`.
     def hide_toast(self, *_: Any) -> None:
-        """Destroy and close the toast window."""
+        self.hide()
+
+    def _fade_out(self) -> None:
+        if self.toplevel is None:
+            return
         try:
+            if not self.toplevel.winfo_exists():
+                return self._finalize()
             alpha = float(self.toplevel.attributes("-alpha"))
             if alpha <= 0.1:
-                self.toplevel.destroy()
+                self._finalize()
             else:
                 self.toplevel.attributes("-alpha", alpha - 0.1)
-                self.toplevel.after(25, self.hide_toast)
-        except:
-            if self.toplevel:
+                self._fade_id = self.toplevel.after(25, self._fade_out)
+        except tkinter.TclError:
+            self._finalize()
+
+    def _finalize(self) -> None:
+        """Cancel the fade timer and destroy the window; drop the handles."""
+        if self._fade_id is not None:
+            self._cancel(self._fade_id)
+            self._fade_id = None
+        if self.toplevel is not None:
+            try:
                 self.toplevel.destroy()
+            except tkinter.TclError:
+                pass
+        self.toplevel = None
+        self.container = None
 
+    def _cancel(self, after_id: str) -> None:
+        try:
+            if self.toplevel is not None:
+                self.toplevel.after_cancel(after_id)
+        except (tkinter.TclError, ValueError):
+            pass
+
+    # -- setup / geometry ---------------------------------------------------- #
     def _setup(self, window) -> None:
-        winsys = window.tk.call("tk", "windowingsystem")
+        from ttkbootstrap import utility
 
+        winsys = window.tk.call("tk", "windowingsystem")
         self.toplevel.configure(relief=RAISED)
 
-        # minsize
         if "minsize" not in self.kwargs:
-            # Late import to avoid circular import for utility
-            from ttkbootstrap import utility
             w, h = utility.scale_size(self.toplevel, [300, 75])
             self.toplevel.minsize(w, h)
 
         # heading font
         _font = font.nametofont("TkDefaultFont")
-        self.titlefont = font.Font(
+        self.title_font = font.Font(
             family=_font["family"],
             size=_font["size"] + 1,
             weight="bold",
         )
-        # symbol font
-        self.iconfont = font.Font(size=30, weight="bold")
-        if winsys == "win32":
-            self.iconfont["family"] = "Segoe UI Symbol"
-            self.icon = DEFAULT_ICON_WIN32 if self.icon is None else self.icon
-            if self.position is None:
-                from ttkbootstrap import utility
+
+        # default position by windowing system
+        if self.position is None:
+            if winsys == "win32":
                 x, y = utility.scale_size(self.toplevel, [5, 50])
                 self.position = (x, y, SE)
-        elif winsys == "x11":
-            self.iconfont["family"] = "FreeSerif"
-            self.icon = DEFAULT_ICON if self.icon is None else self.icon
-            if self.position is None:
-                from ttkbootstrap import utility
+            elif winsys == "x11":
                 x, y = utility.scale_size(self.toplevel, [0, 0])
                 self.position = (x, y, SE)
-        else:
-            self.iconfont["family"] = "Apple Symbols"
-            self.toplevel.update_idletasks()
-            self.icon = DEFAULT_ICON if self.icon is None else self.icon
-            if self.position is None:
-                from ttkbootstrap import utility
+            else:  # aqua (window_type='tooltip' was set at construction)
                 x, y = utility.scale_size(self.toplevel, [50, 50])
                 self.position = (x, y, NE)
 
-        self.set_geometry()
+        self._anchor = str(self.position[-1]).lower()
 
-    def set_geometry(self) -> None:
-        self.toplevel.update_idletasks()  # actualize geometry
-        anchor = self.position[-1]
-        x_anchor = "-" if "w" not in anchor else "+"
-        y_anchor = "-" if "n" not in anchor else "+"
-        screen_w = self.toplevel.winfo_screenwidth() // 2
-        screen_h = self.toplevel.winfo_screenheight() // 2
-        top_w = self.toplevel.winfo_width() // 2
-        top_h = self.toplevel.winfo_height() // 2
+    def _scaled_gap(self) -> int:
+        from ttkbootstrap import utility
+        try:
+            return utility.scale_size(self.toplevel, _ToastStack._GAP)
+        except Exception:
+            return _ToastStack._GAP
 
-        if all(["e" not in anchor, "w" not in anchor]):
+    def _reposition(self) -> None:
+        """Place the toast at its anchored position plus its stack offset."""
+        if self.toplevel is None:
+            return
+        try:
+            offset = _TOAST_STACK.offset_for(self)
+            self.toplevel.geometry(self._compute_geometry(offset))
+        except tkinter.TclError:
+            pass
+
+    def _compute_geometry(self, offset: int) -> str:
+        tl = self.toplevel
+        tl.update_idletasks()  # actualize the requested geometry
+        anchor = self._anchor
+        x_anchor = "+" if "w" in anchor else "-"
+        y_anchor = "+" if "n" in anchor else "-"
+
+        screen_w = tl.winfo_screenwidth() // 2
+        screen_h = tl.winfo_screenheight() // 2
+        top_w = tl.winfo_reqwidth() // 2
+        top_h = tl.winfo_reqheight() // 2
+
+        if "e" not in anchor and "w" not in anchor:
             xpos = screen_w - top_w
         else:
             xpos = self.position[0]
-        if all(["n" not in anchor, "s" not in anchor]):
+        if "n" not in anchor and "s" not in anchor:
             ypos = screen_h - top_h
         else:
             ypos = self.position[1]
 
-        self.toplevel.geometry(f"{x_anchor}{xpos}{y_anchor}{ypos}")
-
-
-if __name__ == "__main__":
-    from ttkbootstrap import Window
-
-    app = Window()
-
-    ToastNotification(
-        "ttkbootstrap toast message",
-        "This is a toast message; you can place a symbol on the top-left that is supported by the selected font. You can either make it appear for a specified period of time, or click to close.",
-    ).show_toast()
-
-    app.mainloop()
+        # the stack offset moves the toast away from its anchored edge
+        ypos += offset
+        return f"{x_anchor}{xpos}{y_anchor}{ypos}"

--- a/tests/test_toast_api.py
+++ b/tests/test_toast_api.py
@@ -1,0 +1,201 @@
+"""API tests for the ToastNotification normalization (widget review PR 7).
+
+Headless (uses the shared ``root`` fixture from conftest). Covers the
+self-deprecation fix, the font-glyph icon, the timer/fade lifecycle, and the
+concurrent-toast stack manager. Actual on-screen fade/animation is only
+structurally checked here.
+"""
+import re
+import warnings
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.style import Style
+from ttkbootstrap.widgets.toast import ToastNotification, _TOAST_STACK, _DEFAULT_ICON
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _clear_image_cache_after_module():
+    """The glyph icons these toasts render populate the process-global
+    ``Style._image_cache``; clear it on teardown so this module imposes no
+    test-order dependency on ``widget_styles/test_image_cache``.
+    """
+    yield
+    try:
+        Style.get_instance().clear_image_cache()
+    except Exception:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_stack():
+    """Keep each test's toasts from leaking into the shared corner registry."""
+    _TOAST_STACK._corners.clear()
+    yield
+    _TOAST_STACK._corners.clear()
+
+
+def _ypos(toast):
+    """The signed y offset from a toast's geometry string (e.g. '300x75-5-110')."""
+    m = re.search(r"([+-]\d+)([+-]\d+)$", toast.toplevel.geometry())
+    return int(m.group(2))
+
+
+# --------------------------------------------------------------------------- #
+# construction / options
+# --------------------------------------------------------------------------- #
+
+def test_show_toast_returns_handle(root):
+    t = ToastNotification("T", "M", position=(5, 50, "se"))
+    handle = t.show_toast()
+    root.update_idletasks()
+    assert handle is t
+    t.hide()
+
+
+def test_show_emits_no_deprecation_warning(root):
+    """show_toast() used to inject legacy `overrideredirect` -> a warning/show."""
+    t = ToastNotification("T", "M", position=(5, 50, "se"))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        t.show_toast()
+        root.update_idletasks()
+    assert t.kwargs.get("override_redirect") is True
+    assert "overrideredirect" not in t.kwargs
+    t.hide()
+
+
+def test_legacy_iconfont_warns_and_is_ignored(root):
+    with pytest.warns(DeprecationWarning):
+        t = ToastNotification("T", "M", iconfont="Segoe UI Symbol", position=(5, 50, "se"))
+    assert "iconfont" not in t.kwargs  # not forwarded to the Toplevel
+    t.show_toast()
+    root.update_idletasks()
+    t.hide()
+
+
+def test_bad_position_anchor_raises(root):
+    with pytest.raises(ValueError):
+        ToastNotification("T", "M", position=(5, 50, "middle"))
+
+
+def test_bad_position_length_raises(root):
+    with pytest.raises(ValueError):
+        ToastNotification("T", "M", position=(5, 50))
+
+
+# --------------------------------------------------------------------------- #
+# icon (font glyph, not a PUA char)
+# --------------------------------------------------------------------------- #
+
+def test_icon_renders_via_font_engine(root):
+    t = ToastNotification("T", "M", bootstyle="info", position=(5, 50, "se"))
+    t.show_toast()
+    root.update_idletasks()
+    icon_lbl = t.container.winfo_children()[0]
+    # apply_icon augments the widget with a derived "Icon..." style; the glyph is
+    # in the style's image element, and there is no PUA text on the label.
+    assert "Icon" in str(icon_lbl.cget("style"))
+    assert icon_lbl.cget("text") == ""
+    assert t.icon == _DEFAULT_ICON
+    t.hide()
+
+
+def test_empty_icon_suppressed(root):
+    t = ToastNotification("T", "M", icon="", position=(5, 50, "se"))
+    t.show_toast()
+    root.update_idletasks()
+    icon_lbl = t.container.winfo_children()[0]
+    assert "Icon" not in str(icon_lbl.cget("style"))
+    t.hide()
+
+
+# --------------------------------------------------------------------------- #
+# lifecycle: timers, idempotent hide
+# --------------------------------------------------------------------------- #
+
+def test_hide_cancels_duration_timer(root):
+    t = ToastNotification("T", "M", duration=10000, position=(5, 50, "se"))
+    t.show_toast()
+    root.update_idletasks()
+    assert t._duration_id is not None
+    t.hide()
+    assert t._hidden is True
+    assert t._duration_id is None  # cancelled
+
+
+def test_hide_is_idempotent(root):
+    t = ToastNotification("T", "M", position=(5, 50, "se"))
+    t.show_toast()
+    root.update_idletasks()
+    t.hide()
+    t.hide()  # must not raise
+    assert t._hidden is True
+
+
+def test_hide_before_show_is_safe(root):
+    t = ToastNotification("T", "M", position=(5, 50, "se"))
+    t.hide()  # never shown -> no raise
+    assert t._hidden is True
+
+
+# --------------------------------------------------------------------------- #
+# stack manager
+# --------------------------------------------------------------------------- #
+
+def test_two_toasts_stack_without_overlap(root):
+    t1 = ToastNotification("One", "first", position=(5, 50, "se"))
+    t2 = ToastNotification("Two", "second", position=(5, 50, "se"))
+    t1.show_toast()
+    t2.show_toast()
+    root.update_idletasks()
+
+    y1, y2 = _ypos(t1), _ypos(t2)
+    assert y1 != y2  # non-overlapping
+    # t2 is offset from t1 by ~t1's height + the gap
+    expected = t1._height + t1._scaled_gap()
+    assert abs((abs(y2) - abs(y1)) - expected) <= 2
+    assert len(_TOAST_STACK._corners["se"]) == 2
+    t1.hide()
+    t2.hide()
+
+
+def test_dismiss_reflows_remaining(root):
+    t1 = ToastNotification("One", "first", position=(5, 50, "se"))
+    t2 = ToastNotification("Two", "second", position=(5, 50, "se"))
+    t1.show_toast()
+    t2.show_toast()
+    root.update_idletasks()
+    base = _ypos(t1)
+
+    t1.hide()  # removes t1 + reflows the corner
+    root.update_idletasks()
+    # t2 slides up into t1's (base) slot
+    assert abs(abs(_ypos(t2)) - abs(base)) <= 2
+    assert len(_TOAST_STACK._corners["se"]) == 1
+    t2.hide()
+
+
+def test_toast_leaves_registry_on_hide(root):
+    t = ToastNotification("T", "M", position=(5, 50, "se"))
+    t.show_toast()
+    root.update_idletasks()
+    assert t in _TOAST_STACK._corners["se"]
+    t.hide()
+    assert t not in _TOAST_STACK._corners.get("se", [])
+
+
+def test_separate_corners_are_independent(root):
+    t1 = ToastNotification("A", "a", position=(5, 50, "se"))
+    t2 = ToastNotification("B", "b", position=(5, 50, "ne"))
+    t1.show_toast()
+    t2.show_toast()
+    root.update_idletasks()
+    # each is the sole (unoffset) toast in its own corner
+    assert len(_TOAST_STACK._corners["se"]) == 1
+    assert len(_TOAST_STACK._corners["ne"]) == 1
+    assert _TOAST_STACK.offset_for(t1) == 0
+    assert _TOAST_STACK.offset_for(t2) == 0
+    t1.hide()
+    t2.hide()


### PR DESCRIPTION
The **final PR** of the 2.0 shipped-widget API review (design §3g/§8f + the §7 Q7 stack expansion).

## Fixes
- **Self-deprecation gone:** internal `override_redirect` (no more `DeprecationWarning` per `show_toast()`); the caller's kwargs are `.copy()`d before mutation; aqua sets `window_type="tooltip"` at construction.
- **Leak/teardown:** the duration **and** fade `after` ids are stored and `after_cancel`'d; `toplevel`/`container` reset to `None`; bare `except:` → `except tkinter.TclError`; `winfo_exists()` guards. Off-screen mismeasure fixed by measuring `winfo_reqheight` before placing.

## API / features
- **Icon via the font-glyph engine:** the PUA icon chars and the **dead `iconfont`** param are gone; `icon` is now a Bootstrap-Icons glyph name (default `"bell-fill"`) rendered with `ttk.apply_icon` on the inverse label, so it follows the theme and recolors on a theme switch. Legacy `iconfont`/`icon_font` warns and is ignored.
- **`show_toast()` returns a dismiss handle** (`self`); new **idempotent `hide()`** (`hide_toast` kept as an alias).
- **Concurrent-toast stack** (`_ToastStack`, the approved §7 Q7 expansion): toasts anchored to the same corner are offset by the cumulative height+gap of those ahead of them (top corners stack down, bottom up) so they **don't overlap**; dismissing one **reflows** the rest to close the gap.
- Keyword-only ctor; `position` stays a `(x, y, anchor)` 3-tuple (distinct from `Window` per §9) and a **bad anchor now raises `ValueError`** (was silently nulled); the contradictory `"ne = top-left"` docstring corrected (`ne` is top-right); `set_geometry` is now private; the `__main__` demo removed.

## Breaking / deprecation
Logged in `development/2_0_breaking_changes.md` — breaking (`icon` is a glyph name not a unicode char; `iconfont` removed→warned-ignored; keyword-only ctor; `set_geometry` private; bad `position` anchor raises) / additive (stack manager; dismiss handle; idempotent `hide()`) / fixed (self-deprecation; timer+fade leaks; off-screen mismeasure; PUA icons → font glyphs).

## Tests & verification
- `tests/test_toast_api.py` (+14). Full suite **460 passed**.
- **Test-verified (headless):** handle return; **no `DeprecationWarning` on show** + `override_redirect` used; legacy `iconfont=` warns and isn't forwarded; bad `position` anchor **and** length raise; icon renders via a derived `Icon…` style (no PUA text); `icon=""` suppresses; `hide()` cancels the duration timer; idempotent `hide()`; hide-before-show safe; **two toasts stack non-overlapping** (offset ≈ first height+gap — verified `-10-10` vs `-10-70`); **dismiss reflows** the remaining toast (offset → 0); toast leaves the registry on `hide()`; separate corners independent.
- **Needs a visual spot-check:** the actual on-screen fade smoothness + reflow "slide"; real multi-monitor placement; glyph size on a colored toast; aqua `window_type`.

## Deviations (deliberate)
1. `icon=None` → the default bell glyph; `icon=""` → suppress (the only way to keep a visible default while honoring "'' suppresses").
2. Off-screen measure uses `winfo_reqheight` while withdrawn (valid after `update_idletasks`) rather than physically deiconifying at 2×screen — same no-flash result, simpler.
3. `set_geometry` was split into private `_compute_geometry(offset)` + `_reposition()` (intent — no longer public — holds).

Excludes the known `zh_cn.msg`/`nl.msg` localization flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)