### PR TITLE
Property/accessor consistency pass (deprecate, don't break)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -530,6 +530,17 @@ text** rather than the masked string. `FloodgaugeLegacy` (unchanged API, 3.0-rem
 gained a `destroy()` that detaches its value/text write traces (leak parity with the
 #1070 fix).
 
+**Follow-up (property-consistency pass) — *deprecated*, not breaking.** Floodgauge's
+option backing fields (`maximum`, `mode`, `orient`, `mask`, `font`, `length`,
+`thickness`) are now **private**; they were bare public attributes that paralleled the
+`configure`/`cget` surface (and `fg.maximum = 50` bypassed the redraw). The canonical
+surface is `configure`/`cget`/item-access (or `fg.value`), but the old bare-attribute
+**read and write still work through 2.x with a `DeprecationWarning`** (via `__getattr__`
+/`__setattr__` — a write now routes through `configure`, so it takes effect instead of
+silently shadowing). The `variable`/`textvariable` handles stay public. This aligns
+Floodgauge with Meter/DateEntry — the rule is: options through `configure`/`cget` only,
+properties only for the canonical `value` and genuinely-computed state.
+
 ## Scrolled: Canvas-viewport rewrite, `auto_hide`, keyword-only  *(breaking + additive)*
 
 **What.** `ScrolledText` and `ScrolledFrame` (widget-review PR 5) were normalized,
@@ -661,3 +672,23 @@ int. Nothing warns — these are source-level breaks, not deprecations.
 (`icon="bell-fill"`); drop any `iconfont=`. Pass toast options by keyword. If you
 called `set_geometry()` directly, don't (it is internal). Capture the return of
 `show_toast()` if you want to dismiss a toast early: `t = toast.show_toast(); t.hide()`.
+
+## Property/accessor consistency pass  *(mostly deprecated, not breaking)*
+
+A cross-widget sweep so options live only on `configure`/`cget`/item-access and the
+attribute surface stays minimal (widget/Variable handles + `value`/computed state).
+Old spellings keep working through 2.x with a `DeprecationWarning` (removed in 3.0):
+
+- **Floodgauge** — the option backing fields (`maximum`, `mode`, `orient`, `mask`,
+  `font`, `length`, `thickness`) are private; the old bare-attribute read/write still
+  works (deprecated) — a write now routes through `configure` (see the Floodgauge
+  section above).
+- **Meter** — the subtext/text-position Label handles gained collision-free names
+  (`subtext_label`, `text_left_label`, `text_right_label`, `text_center_label`); the
+  old `subtext`/`textleft`/`textright`/`textcenter` attributes are deprecated aliases.
+  (The bare `subtext` name is now unambiguously the *option*: `cget("subtext")` →
+  string; `meter.subtext_label` → the Label.)
+- **DateEntry** — the pre-2.0 `dateformat` attribute is a deprecated read alias for
+  `cget("date_format")`.
+- **Scrolled** — `ScrolledFrame.vbar` is the vertical-scrollbar handle (matching
+  `ScrolledText`); the old `vscroll` attribute is a deprecated alias.

--- a/src/ttkbootstrap/widgets/dateentry.py
+++ b/src/ttkbootstrap/widgets/dateentry.py
@@ -40,6 +40,7 @@ from ttkbootstrap.internal.configure_delegation import (
 from ttkbootstrap.style._compat import (
     normalize_dateentry_kwargs,
     normalize_dateentry_option,
+    warn_deprecated,
 )
 
 
@@ -237,8 +238,8 @@ class DateEntry(ConfigureDelegationMixin, Frame):
         """Configure the options for this widget.
 
         Accepts the legacy ``dateformat``/``firstweekday``/``startdate``
-        spellings (with a ``DeprecationWarning``) in addition to the canonical
-        snake_case names.
+        spellings (with a ``DeprecationWarning``) in addition to the snake_case
+        names.
         """
         if kwargs:
             kwargs.update(normalize_dateentry_kwargs(kwargs))
@@ -277,6 +278,12 @@ class DateEntry(ConfigureDelegationMixin, Frame):
     # (the legacy `dateformat` spelling still resolves there, with a warning).
     # Only the canonical `value` handle and the computed `enabled` state are
     # exposed as properties.
+
+    @property
+    def dateformat(self) -> str:
+        """Deprecated alias for ``cget('date_format')``."""
+        warn_deprecated("the 'dateformat' DateEntry attribute", "cget('date_format')")
+        return self.__dateformat
 
     @property
     def value(self) -> Optional[datetime]:

--- a/src/ttkbootstrap/widgets/floodgauge.py
+++ b/src/ttkbootstrap/widgets/floodgauge.py
@@ -43,7 +43,7 @@ from ttkbootstrap.internal.configure_delegation import (
     configure_delegate,
 )
 from ttkbootstrap.style import Colors, Style
-from ttkbootstrap.style._compat import normalize_floodgauge_start_args
+from ttkbootstrap.style._compat import normalize_floodgauge_start_args, warn_deprecated
 
 
 class Floodgauge(ConfigureDelegationMixin, Canvas):
@@ -62,7 +62,7 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
     The widget's value is backed by a ``DoubleVar`` (matching ttk.Progressbar),
     so fractional values are honored. All options are reachable through the
     tk-native ``configure``/``cget``/item surface; ``value`` is also exposed as a
-    canonical read/write property.
+    read/write property.
 
     Parameters:
         master (Widget, optional):
@@ -123,15 +123,15 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
         self.variable = kwargs.pop("variable", DoubleVar(value=value))
         self.textvariable = kwargs.pop("textvariable", StringVar(value=text))
 
-        self.length = length
-        self.thickness = thickness
-        self.orient = orient
+        self._length = length
+        self._thickness = thickness
+        self._orient = orient
         canvas_kwargs = dict(highlightthickness=0, **kwargs)
 
-        if self.orient == "horizontal":
-            canvas_kwargs.update(width=self.length, height=self.thickness)
+        if self._orient == "horizontal":
+            canvas_kwargs.update(width=self._length, height=self._thickness)
         else:
-            canvas_kwargs.update(width=self.thickness, height=self.length)
+            canvas_kwargs.update(width=self._thickness, height=self._length)
 
         super().__init__(master, **canvas_kwargs)
 
@@ -140,10 +140,10 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
         self._bind_variable(self.variable)
         self._bind_textvariable(self.textvariable)
 
-        self.maximum = maximum
-        self.mode = mode
-        self.mask = mask
-        self.font = font
+        self._maximum = maximum
+        self._mode = mode
+        self._mask = mask
+        self._font = font
         self._step_size = 1
         self._running = False
         self._after_id = None
@@ -160,13 +160,45 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
     # -- value access -------------------------------------------------------- #
     @property
     def value(self) -> float:
-        """The current progress value (canonical read/write handle)."""
+        """The current progress value."""
         return self.variable.get()
 
     @value.setter
     def value(self, amount: Union[int, float]) -> None:
         # Setting the bound variable fires its write trace -> redraw.
         self.variable.set(amount)
+
+    #: Options that were bare public attributes before 2.0 -- now private,
+    #: reachable through configure/cget. Read access is kept (deprecated) so
+    #: nothing hard-breaks; the canonical surface is configure/cget.
+    _LEGACY_OPTION_ATTRS = (
+        "maximum", "mode", "orient", "mask", "font", "length", "thickness",
+    )
+
+    def __getattr__(self, name: str) -> Any:
+        # Only reached when normal lookup fails. Keep the pre-2.0 bare-attribute
+        # reads working (deprecated); the canonical read is cget.
+        if name in type(self)._LEGACY_OPTION_ATTRS:
+            warn_deprecated(
+                f"reading the {name!r} Floodgauge attribute",
+                f"cget({name!r})",
+            )
+            return getattr(self, f"_{name}")
+        raise AttributeError(name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # Route pre-2.0 bare-attribute writes through configure (deprecated) so
+        # they still take effect (redraw) instead of silently shadowing the
+        # private field. Only triggers for a user setting the bare name -- we
+        # only ever assign the private `_name` internally.
+        if name in type(self)._LEGACY_OPTION_ATTRS:
+            warn_deprecated(
+                f"setting the {name!r} Floodgauge attribute",
+                f"configure({name}=...)",
+            )
+            self.configure(**{name: value})
+            return
+        super().__setattr__(name, value)
 
     def _update_theme_colors(self) -> None:
         style = Style.get_instance()
@@ -176,20 +208,20 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
         self._draw()
 
     def _on_resize(self, event: Event) -> None:
-        if self.orient == "horizontal":
-            self.length = event.width
-            self.thickness = event.height
+        if self._orient == "horizontal":
+            self._length = event.width
+            self._thickness = event.height
         else:
-            self.length = event.height
-            self.thickness = event.width
+            self._length = event.height
+            self._thickness = event.width
         self._draw()
 
     def _apply_geometry(self) -> None:
         """Resize the canvas to match the current orient/length/thickness."""
-        if self.orient == "horizontal":
-            super().configure(width=self.length, height=self.thickness)
+        if self._orient == "horizontal":
+            super().configure(width=self._length, height=self._thickness)
         else:
-            super().configure(width=self.thickness, height=self.length)
+            super().configure(width=self._thickness, height=self._length)
 
     def _draw(self) -> None:
         self.delete("all")
@@ -199,20 +231,20 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
         self.create_rectangle(0, 0, w, h, fill=self.trough_color, width=0)
 
         value = self.variable.get()
-        if self.mode == "determinate":
+        if self._mode == "determinate":
             # Zero-range guard: a 0 maximum has no meaningful ratio.
-            if self.maximum == 0:
+            if self._maximum == 0:
                 ratio = 0.0
             else:
-                ratio = max(0.0, min(1.0, value / self.maximum))
-            if self.orient == "horizontal":
+                ratio = max(0.0, min(1.0, value / self._maximum))
+            if self._orient == "horizontal":
                 fill = int(ratio * w)
                 self.create_rectangle(0, 0, fill, h, fill=self.bar_color, width=0)
             else:
                 fill = int(ratio * h)
                 self.create_rectangle(0, h - fill, w, h, fill=self.bar_color, width=0)
         else:
-            if self.orient == "horizontal":
+            if self._orient == "horizontal":
                 pulse_width = max(10, int(w * 0.2))
                 x = self._pulse_pos
                 self.create_rectangle(x, 0, x + pulse_width, h, fill=self.bar_color, width=0)
@@ -224,8 +256,8 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
         # Derive the display label. A mask formats the numeric value for
         # *display only* -- it must never be written back onto the user's
         # textvariable (that would clobber cget("text")).
-        if self.mask:
-            label = self.mask.format(int(value))
+        if self._mask:
+            label = self._mask.format(int(value))
         else:
             label = self.textvariable.get()
 
@@ -234,7 +266,7 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
                 w // 2,
                 h // 2,
                 text=label,
-                font=self.font,
+                font=self._font,
                 fill=self.text_color,
                 anchor="center"
             )
@@ -303,7 +335,7 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
             amount (int or float, optional): The amount to increment. Defaults
                 to 1. Value wraps around after reaching maximum.
         """
-        self.value = (self.value + amount) % (self.maximum + 1)
+        self.value = (self.value + amount) % (self._maximum + 1)
 
     def start(self, *args: Any, **kwargs: Any) -> None:
         """Start the progress animation.
@@ -311,7 +343,7 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
         For indeterminate mode, starts the bouncing animation. For determinate
         mode, starts auto-incrementing the value.
 
-        The canonical signature mirrors ``ttk.Progressbar.start``:
+        The signature mirrors ``ttk.Progressbar.start``:
 
             start(interval=None)
 
@@ -326,9 +358,9 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
         if step_size is not None:
             self._step_size = step_size
         else:
-            self._step_size = 8 if self.mode == "indeterminate" else 1
+            self._step_size = 8 if self._mode == "indeterminate" else 1
         if interval is None:
-            interval = 20 if self.mode == "indeterminate" else 50
+            interval = 20 if self._mode == "indeterminate" else 50
 
         self._running = True
         self._pulse_direction = 1
@@ -348,7 +380,7 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
         if not self._running:
             return
 
-        if self.mode == "indeterminate":
+        if self._mode == "indeterminate":
             self._animate_indeterminate(interval)
         else:
             self.step(self._step_size)
@@ -358,7 +390,7 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
         if not self._running:
             return
 
-        if self.orient == "horizontal":
+        if self._orient == "horizontal":
             w = self.winfo_width()
             pulse_width = max(10, int(w * 0.2))
             max_pos = w - pulse_width
@@ -398,30 +430,30 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
     @configure_delegate("maximum")
     def _cfg_maximum(self, value):
         if value is None:
-            return self.maximum
-        self.maximum = value
+            return self._maximum
+        self._maximum = value
         self._draw()
 
     @configure_delegate("mode")
     def _cfg_mode(self, value):
         if value is None:
-            return self.mode
-        self.mode = value
+            return self._mode
+        self._mode = value
         self._draw()
 
     @configure_delegate("orient")
     def _cfg_orient(self, value):
         if value is None:
-            return self.orient
-        self.orient = value
+            return self._orient
+        self._orient = value
         self._apply_geometry()
         self._draw()
 
     @configure_delegate("mask")
     def _cfg_mask(self, value):
         if value is None:
-            return self.mask
-        self.mask = value
+            return self._mask
+        self._mask = value
         self._draw()
 
     @configure_delegate("text")
@@ -433,8 +465,8 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
     @configure_delegate("font")
     def _cfg_font(self, value):
         if value is None:
-            return self.font
-        self.font = value
+            return self._font
+        self._font = value
         self._draw()
 
     @configure_delegate("bootstyle")
@@ -447,16 +479,16 @@ class Floodgauge(ConfigureDelegationMixin, Canvas):
     @configure_delegate("length")
     def _cfg_length(self, value):
         if value is None:
-            return self.length
-        self.length = value
+            return self._length
+        self._length = value
         self._apply_geometry()
         self._draw()
 
     @configure_delegate("thickness")
     def _cfg_thickness(self, value):
         if value is None:
-            return self.thickness
-        self.thickness = value
+            return self._thickness
+        self._thickness = value
         self._apply_geometry()
         self._draw()
 

--- a/src/ttkbootstrap/widgets/meter.py
+++ b/src/ttkbootstrap/widgets/meter.py
@@ -141,6 +141,14 @@ class Meter(ConfigureDelegationMixin, Frame):
         "labelvar": "label_var",
         "meterframe": "meter_frame",
         "textframe": "text_frame",
+        # The subtext/text-position Label handles kept their pre-2.0 spellings
+        # while the sibling frames were snake_cased; give them collision-free
+        # `*_label` names (the bare `subtext`/`text_left` names are the string
+        # *options*) and deprecate the old attribute spellings.
+        "subtext": "subtext_label",
+        "textleft": "text_left_label",
+        "textright": "text_right_label",
+        "textcenter": "text_center_label",
     }
 
     def __init__(
@@ -318,7 +326,7 @@ class Meter(ConfigureDelegationMixin, Frame):
     # -- value access -------------------------------------------------------- #
     @property
     def value(self) -> Union[int, float]:
-        """The current meter value (canonical read/write handle)."""
+        """The current meter value."""
         return self.amount_used_var.get()
 
     @value.setter
@@ -370,7 +378,7 @@ class Meter(ConfigureDelegationMixin, Frame):
         self.meter_frame = Frame(master=self, width=size, height=size)
         self.indicator = Label(self.meter_frame)
         self.text_frame = Frame(self.meter_frame)
-        self.textleft = Label(
+        self.text_left_label = Label(
             master=self.text_frame,
             text=self._text_left,
             font=self._subtext_font,
@@ -378,13 +386,13 @@ class Meter(ConfigureDelegationMixin, Frame):
             anchor=S,
             padding=(0, 5),
         )
-        self.textcenter = Label(
+        self.text_center_label = Label(
             master=self.text_frame,
             textvariable=self.amount_used_display_var,
             bootstyle=f"{self._bootstyle}-meter",
             font=self._text_font,
         )
-        self.textright = Label(
+        self.text_right_label = Label(
             master=self.text_frame,
             text=self._text_right,
             font=self._subtext_font,
@@ -392,7 +400,7 @@ class Meter(ConfigureDelegationMixin, Frame):
             anchor=S,
             padding=(0, 5),
         )
-        self.subtext = Label(
+        self.subtext_label = Label(
             master=self.meter_frame,
             text=self._subtext,
             bootstyle=f"{self._subtext_style}-metersubtxt",
@@ -431,17 +439,17 @@ class Meter(ConfigureDelegationMixin, Frame):
         """Position the subtext label below the center text."""
         if self._subtext:
             if self._show_text:
-                self.subtext.place(relx=0.5, rely=0.6, anchor=CENTER)
+                self.subtext_label.place(relx=0.5, rely=0.6, anchor=CENTER)
             else:
-                self.subtext.place(relx=0.5, rely=0.5, anchor=CENTER)
+                self.subtext_label.place(relx=0.5, rely=0.5, anchor=CENTER)
 
     def _set_show_text(self) -> None:
         """Show or hide the text labels based on the show_text setting."""
         self.text_frame.pack_forget()
-        self.textcenter.pack_forget()
-        self.textleft.pack_forget()
-        self.textright.pack_forget()
-        self.subtext.pack_forget()
+        self.text_center_label.pack_forget()
+        self.text_left_label.pack_forget()
+        self.text_right_label.pack_forget()
+        self.subtext_label.pack_forget()
 
         if self._show_text:
             if self._subtext:
@@ -457,18 +465,18 @@ class Meter(ConfigureDelegationMixin, Frame):
     def _set_text_left(self) -> None:
         """Pack the left text label if configured."""
         if self._show_text and self._text_left:
-            self.textleft.pack(side=LEFT, fill=Y)
+            self.text_left_label.pack(side=LEFT, fill=Y)
 
     def _set_text_center(self) -> None:
         """Pack the center text label showing the current value."""
         if self._show_text:
-            self.textcenter.pack(side=LEFT, fill=Y)
+            self.text_center_label.pack(side=LEFT, fill=Y)
 
     def _set_text_right(self) -> None:
         """Pack the right text label if configured."""
-        self.textright.configure(text=self._text_right)
+        self.text_right_label.configure(text=self._text_right)
         if self._show_text and self._text_right:
-            self.textright.pack(side=RIGHT, fill=Y)
+            self.text_right_label.pack(side=RIGHT, fill=Y)
 
     def _set_interactive_bind(self) -> None:
         """Bind or unbind mouse events for interactive mode."""
@@ -678,7 +686,7 @@ class Meter(ConfigureDelegationMixin, Frame):
         if value is None:
             return self._bootstyle
         self._bootstyle = value
-        self.textcenter.configure(bootstyle=f"{self._bootstyle}-meter")
+        self.text_center_label.configure(bootstyle=f"{self._bootstyle}-meter")
 
     @configure_delegate("arc_range")
     def _cfg_arc_range(self, value):
@@ -769,7 +777,7 @@ class Meter(ConfigureDelegationMixin, Frame):
         if value is None:
             return self._text_left
         self._text_left = value
-        self.textleft.configure(text=self._text_left)
+        self.text_left_label.configure(text=self._text_left)
 
     @configure_delegate("text_right")
     def _cfg_text_right(self, value):
@@ -782,7 +790,7 @@ class Meter(ConfigureDelegationMixin, Frame):
         if value is None:
             return self._text_font
         self._text_font = value
-        self.textcenter.configure(font=self._text_font)
+        self.text_center_label.configure(font=self._text_font)
 
     @configure_delegate("subtext")
     def _cfg_subtext(self, value):
@@ -798,7 +806,7 @@ class Meter(ConfigureDelegationMixin, Frame):
         self._subtext_style = value
         # Recolor every subtext label (not just the center subtext) with the
         # same style suffix used at construction.
-        for label in (self.subtext, self.textleft, self.textright):
+        for label in (self.subtext_label, self.text_left_label, self.text_right_label):
             label.configure(bootstyle=f"{self._subtext_style}-metersubtxt")
 
     @configure_delegate("subtext_font")
@@ -806,9 +814,9 @@ class Meter(ConfigureDelegationMixin, Frame):
         if value is None:
             return self._subtext_font
         self._subtext_font = value
-        self.subtext.configure(font=self._subtext_font)
-        self.textleft.configure(font=self._subtext_font)
-        self.textright.configure(font=self._subtext_font)
+        self.subtext_label.configure(font=self._subtext_font)
+        self.text_left_label.configure(font=self._subtext_font)
+        self.text_right_label.configure(font=self._subtext_font)
 
     @configure_delegate("step_size")
     def _cfg_step_size(self, value):

--- a/src/ttkbootstrap/widgets/scrolled.py
+++ b/src/ttkbootstrap/widgets/scrolled.py
@@ -42,7 +42,7 @@ from typing import Any, Callable, Optional, Tuple
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
 from ttkbootstrap.internal.configure_delegation import ConfigureDelegationMixin
-from ttkbootstrap.style._compat import normalize_scrolled_kwargs
+from ttkbootstrap.style._compat import normalize_scrolled_kwargs, warn_deprecated
 
 
 class ScrolledText(ConfigureDelegationMixin, ttk.Frame):
@@ -367,14 +367,14 @@ class ScrolledFrame(ttk.Frame):
         )
         self._canvas.grid(row=0, column=0, sticky=NSEW)
 
-        self.vscroll: ttk.Scrollbar = ttk.Scrollbar(
+        self._vbar: ttk.Scrollbar = ttk.Scrollbar(
             master=self.container,
             command=self._canvas.yview,
             orient=VERTICAL,
             bootstyle=bootstyle,
         )
-        self.vscroll.grid(row=0, column=1, sticky=NS)
-        self._canvas.configure(yscrollcommand=self.vscroll.set)
+        self._vbar.grid(row=0, column=1, sticky=NS)
+        self._canvas.configure(yscrollcommand=self._vbar.set)
 
         # content frame lives inside the canvas -> native scroll fractions +
         # native destroy cascade.
@@ -528,7 +528,13 @@ class ScrolledFrame(ttk.Frame):
     @property
     def vbar(self) -> ttk.Scrollbar:
         """The vertical scrollbar."""
-        return self.vscroll
+        return self._vbar
+
+    @property
+    def vscroll(self) -> ttk.Scrollbar:
+        """Deprecated alias for :attr:`vbar` (removed in 3.0)."""
+        warn_deprecated("the 'vscroll' ScrolledFrame attribute", "'vbar'")
+        return self._vbar
 
     @property
     def hbar(self) -> None:
@@ -537,11 +543,11 @@ class ScrolledFrame(ttk.Frame):
 
     def hide_scrollbars(self) -> None:
         """Hide the scrollbar."""
-        self.vscroll.grid_remove()
+        self._vbar.grid_remove()
 
     def show_scrollbars(self) -> None:
         """Show the scrollbar."""
-        self.vscroll.grid()
+        self._vbar.grid()
 
     def autohide_scrollbar(self) -> None:
         """Toggle the auto-hide behavior.

--- a/tests/test_dateentry_api.py
+++ b/tests/test_dateentry_api.py
@@ -253,3 +253,12 @@ def test_datepicker_dialog_legacy_names_warn(root):
 def test_datepicker_dialog_rejects_unknown_kwarg(root):
     with pytest.raises(TypeError):
         DatePickerDialog(parent=root, autoshow=False, bogus=1)
+
+def test_legacy_dateformat_attribute_is_deprecated(root):
+    """The pre-2.0 `dateformat` attribute still reads, with a warning."""
+    import warnings
+    de = DateEntry(root, date_format="%Y-%m-%d")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert de.dateformat == "%Y-%m-%d"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/tests/test_floodgauge_api.py
+++ b/tests/test_floodgauge_api.py
@@ -168,3 +168,28 @@ def test_start_unknown_keyword_raises(root):
     with pytest.raises(TypeError):
         fg.start(bogus=1)
     fg.stop()
+
+# --- property/accessor consistency (2.0 property-consistency pass) ----------
+
+def test_options_backed_privately_and_read_via_cget(root):
+    """The option backing fields are private; the canonical read is cget."""
+    fg = Floodgauge(root, maximum=100)
+    for opt in ("maximum", "mode", "orient", "mask", "font", "length", "thickness"):
+        assert opt not in vars(fg), f"{opt!r} is still a bare public instance attr"
+        assert hasattr(fg, f"_{opt}")  # private backing field
+        fg.cget(opt)                   # round-trips through configure/cget
+    # The value handle and Variable handles remain public by design.
+    assert isinstance(fg.value, float)
+    assert fg.variable is not None and fg.textvariable is not None
+
+
+def test_legacy_bare_option_attrs_are_deprecated_not_removed(root):
+    """Pre-2.0 bare-attribute read/write still works but warns (non-breaking)."""
+    fg = Floodgauge(root, maximum=100)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert fg.maximum == 100                 # deprecated read
+        fg.maximum = 50                          # deprecated write -> configure
+    cats = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(cats) >= 2                         # one for the read, one for the write
+    assert fg.cget("maximum") == 50              # the write actually took effect

--- a/tests/test_meter_api.py
+++ b/tests/test_meter_api.py
@@ -139,3 +139,33 @@ def test_import_is_warning_free():
         warnings.simplefilter("error")
         importlib.import_module("ttkbootstrap")
         importlib.import_module("ttkbootstrap.widgets.meter")
+
+
+# --------------------------------------------------------------------------
+# label handles: clean *_label names + deprecated old spellings
+# (property-consistency pass)
+# --------------------------------------------------------------------------
+
+def test_label_handles_have_clean_names(root):
+    """The subtext/text-position Label handles use collision-free *_label names."""
+    m = _make(root, subtext="hi", text_left="L", text_right="R")
+    for attr in ("subtext_label", "text_left_label",
+                 "text_right_label", "text_center_label"):
+        assert isinstance(getattr(m, attr), ttk.Label)
+    # the option and the handle are now distinct: cget -> string, attr -> Label
+    assert m.cget("subtext") == "hi"
+    assert isinstance(m.subtext_label, ttk.Label)
+
+
+def test_legacy_label_attrs_are_deprecated(root):
+    """Old handle spellings still resolve (to the renamed Label) but warn."""
+    m = _make(root, subtext="hi")
+    for old, new in (("subtext", "subtext_label"),
+                     ("textleft", "text_left_label"),
+                     ("textright", "text_right_label"),
+                     ("textcenter", "text_center_label")):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            got = getattr(m, old)
+        assert got is getattr(m, new)
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught)

--- a/tests/test_scrolled_api.py
+++ b/tests/test_scrolled_api.py
@@ -164,3 +164,13 @@ def test_scrolledtext_autohide_scrollbar_toggles(root):
     assert st.auto_hide is False
     st.autohide_scrollbar()
     assert st.auto_hide is True
+
+def test_scrolledframe_vscroll_is_deprecated_alias_of_vbar(root):
+    """`vbar` is canonical; the old `vscroll` still resolves but warns."""
+    import warnings
+    from ttkbootstrap.widgets.scrolled import ScrolledFrame
+    sf = ScrolledFrame(root)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert sf.vscroll is sf.vbar
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)


### PR DESCRIPTION
A cross-widget consistency sweep of the normalized widgets against one rule: **options are reachable only via `configure`/`cget`/item-access; the attribute surface stays minimal (widget/Variable handles + `value`/computed state).** Following the project's tiered-deprecation policy, old spellings keep working through 2.x with a `DeprecationWarning` (removed in 3.0) — **deprecate the smell, don't hard-break.**

## Changes
- **Floodgauge** — the option backing fields (`maximum`, `mode`, `orient`, `mask`, `font`, `length`, `thickness`) were bare public attributes paralleling `configure`/`cget` (and `fg.maximum = 50` bypassed the redraw). They're now private; a `__getattr__`/`__setattr__` pair keeps the old bare-attribute **read and write** working (deprecated), and a write now **routes through `configure`** so it takes effect instead of silently shadowing.
- **Meter** — the subtext/text-position Label handles collided with option names (`meter.subtext` was the Label, `cget("subtext")` the string). They gained collision-free names — `subtext_label`, `text_left_label`, `text_right_label`, `text_center_label` — via the existing `_LEGACY_ATTRS` shim; the old `subtext`/`textleft`/`textright`/`textcenter` attributes are deprecated aliases. `subtext` as an attribute no longer collides with the option.
- **DateEntry** — the pre-2.0 `dateformat` attribute (a removed property) is restored as a deprecated read alias for `cget("date_format")`.
- **Scrolled** — `ScrolledFrame.vbar` is the vertical-scrollbar handle (matching `ScrolledText`); the old `vscroll` attribute is a deprecated alias.

Also trims API-design meta-commentary ("canonical", rationale) out of the value/handle docstrings.

## Rest of the sweep was clean
Meter/DateEntry/LabeledScale expose only `value` (+ DateEntry's computed `enabled`) and handles; Toast/ToolTip are plain classes; no camelCase/non-snake public names remain. Toast's `set_geometry`→private is left as-is (it was flagged "public despite being internal" — privatizing an accidentally-public internal isn't the kind of break the policy guards).

## Tests & verification
Added legacy-attribute deprecation coverage across the meter/floodgauge/dateentry/scrolled suites (old name still resolves + warns; write takes effect). Full suite **466 passed** (excl. the known `zh_cn.msg`/`nl.msg` localization flake); warning-free import. `development/2_0_breaking_changes.md` gets a consolidated property-consistency note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)