### PR TITLE
Tableview: restore row spacing + refine header/body borders

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -726,3 +726,13 @@ The `Sizegrip` grip is now drawn from a recolorable raster asset
 (`assets/elements/sizegrip.png` + the `sizegrip` manifest entry) via
 `Assets.recolor`, replacing the `grip-horizontal` font glyph. The default grip
 color is derived from the surface (`border(colors.bg)`). No API change.
+
+## Tableview: header/body border + row-height restyle  *(Visual)*
+
+The `Table.Treeview` styling was refined: **row spacing is restored to match 1.0**
+— a 2.0 Treeview styling change had shrunk the effective row height to just the
+text `linespace`, so `rowheight = linespace + ascent` brings the vertical space
+back (it is not taller than 1.0). The header border derives from the heading
+background (`border(background)`) and follows the hover color on the active
+heading, and the body border derives from `inputbg` at a 1px (was 2px) width.
+No API change.

--- a/src/ttkbootstrap/style/builders/treeview.py
+++ b/src/ttkbootstrap/style/builders/treeview.py
@@ -23,8 +23,8 @@ def build_table_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     ttk_class = "Table.Treeview"
 
     f = font.nametofont("TkDefaultFont")
-    row_height = f.metrics()["linespace"]
-    border = builder.border(builder.colors.bg)
+    metrics = f.metrics()
+    row_height = metrics['linespace'] + metrics['ascent']
     on_disabled = builder.disabled("text", builder.colors.inputbg)
 
     if any([colorname == DEFAULT, colorname == ""]):
@@ -43,6 +43,8 @@ def build_table_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         tb_ttk_style = f"{colorname}.{ttk_class}"
         th_ttk_style = f"{colorname}.{ttk_class}.Heading"
     hover = builder.active(background)
+    header_border = builder.border(background)
+    body_border = builder.border(builder.colors.inputbg)
 
     # treeview header
     builder.configure(
@@ -51,33 +53,28 @@ def build_table_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         foreground=on_background,
         relief=RAISED,
         borderwidth=builder.scale_size(1),
-        darkcolor=background,
-        bordercolor=border,
+        darkcolor=header_border,
+        bordercolor=background,
         lightcolor=background,
         padding=builder.scale_size(5),
     )
     builder.style.map(
         th_ttk_style,
         foreground=[("disabled", on_disabled)],
-        background=[
-            ("active !disabled", hover),
-        ],
-        darkcolor=[
-            ("active !disabled", hover),
-        ],
-        lightcolor=[
-            ("active !disabled", hover),
-        ],
+        background=[("active !disabled", hover)],
+        lightcolor=[("active !disabled", hover)],
+        darkcolor=[("active !disabled", hover)],
+        bordercolor=[("active !disabled", hover)]
     )
     builder.configure(
         tb_ttk_style,
         background=builder.colors.inputbg,
         fieldbackground=builder.colors.inputbg,
         foreground=builder.colors.inputfg,
-        bordercolor=border,
+        bordercolor=body_border,
         lightcolor=builder.colors.inputbg,
         darkcolor=builder.colors.inputbg,
-        borderwidth=builder.scale_size(2),
+        borderwidth=builder.scale_size(1),
         padding=0,
         rowheight=row_height,
         relief=tk.RAISED,


### PR DESCRIPTION
A visual refinement of the `Table.Treeview` styling (from local WIP).

## What
- **Restore the row spacing to match 1.0** — a 2.0 Treeview styling change had shrunk the effective row height to just the text `linespace`, cramping the rows. `rowheight = linespace + ascent` brings the vertical space back. **This is a restoration, not taller-than-1.0 rows.**
- **Header border** — derives from the heading background (`border(background)`) and now **follows the hover color** on the active heading (`bordercolor` added to the state map); the dark/border assignments were swapped so the seam reads correctly.
- **Body border** — derives from `inputbg` (was `bg`) at **1px** (was 2px).

No API change — appearance only.

## Verification
- A `Tableview` builds cleanly (`rowheight` resolves to 27 at 100%); full suite **470 passed** (excl. the known `zh_cn.msg`/`nl.msg` localization flake), including the scaling AST guard.
- **Needs a visual spot-check**: row spacing vs 1.0, header border/hover, body border light↔dark and against a colored `bootstyle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)