### PR TITLE
Tableview: theme the right-click menus (ttk.Menu, not raw tk.Menu)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -726,3 +726,12 @@ The `Sizegrip` grip is now drawn from a recolorable raster asset
 (`assets/elements/sizegrip.png` + the `sizegrip` manifest entry) via
 `Assets.recolor`, replacing the `grip-horizontal` font glyph. The default grip
 color is derived from the surface (`border(colors.bg)`). No API change.
+
+## Tableview: right-click menus follow the theme  *(Visual)*
+
+The Tableview's top-level cell/header right-click menus subclassed raw `tk.Menu`,
+so they rendered in the OS palette (`SystemMenu` background, `SystemHighlight`
+selection) while their own cascade submenus — built with `ttk.Menu` — were
+theme-styled, giving the outer menu a mismatched look. Both menu classes now
+subclass `ttk.Menu`, so background/foreground/selection match the cascades and the
+active theme. No API change.

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -2606,7 +2606,7 @@ class Tableview(ttk.Frame):
             self._rightclickmenu_cell.tk_popup(event)
 
 
-class TableCellRightClickMenu(tk.Menu):
+class TableCellRightClickMenu(ttk.Menu):
     """A right-click menu object for the tableview cells - INTERNAL"""
 
     def __init__(self, master: Tableview):
@@ -2831,7 +2831,7 @@ class TableCellRightClickMenu(tk.Menu):
             self.view.selection_set(prev_item)
 
 
-class TableHeaderRightClickMenu(tk.Menu):
+class TableHeaderRightClickMenu(ttk.Menu):
     """A right-click menu object for the tableview header - INTERNAL"""
 
     def __init__(self, master: Tableview):

--- a/tests/test_tableview_api.py
+++ b/tests/test_tableview_api.py
@@ -197,3 +197,22 @@ def test_sort_shows_glyph_icon_not_ascii_arrow(root):
     assert "⬆" not in text and "⬇" not in text   # no ⬆/⬇ in the text
     tv._column_sort_header_reset()
     assert tv.view.heading(cid, "image") in ("", ())       # cleared on reset
+
+
+# --------------------------------------------------------------------------
+# right-click menus use the themed ttk.Menu (not raw tk.Menu)
+# --------------------------------------------------------------------------
+
+def test_rightclick_menus_are_themed(root):
+    """The top-level cell/header menus must be themed like their cascades
+    (they were raw tk.Menu -> OS colors, mismatched with the ttk.Menu submenus)."""
+    tv = Tableview(root, coldata=["A", "B"], rowdata=[[1, 2]],
+                   disable_right_click=False)
+    root.update_idletasks()
+    ref = ttk.Menu(root)  # a themed ttkbootstrap Menu
+    root.update_idletasks()
+    for menu in (tv._rightclickmenu_cell, tv._rightclickmenu_head):
+        assert isinstance(menu, ttk.Menu)
+        # themed background matches a plain ttk.Menu (not the OS "SystemMenu")
+        assert str(menu.cget("background")) == str(ref.cget("background"))
+        assert str(menu.cget("activebackground")) == str(ref.cget("activebackground"))


### PR DESCRIPTION
## Problem
The Tableview's top-level cell/header right-click menus subclassed raw **`tk.Menu`**, which ttkbootstrap doesn't style — so the outer menu fell back to the OS palette (`SystemMenu` background, `SystemHighlight` selection). Their own **cascade submenus** were built with **`ttk.Menu`** (ttkbootstrap's themed `Menu(AutoStyleMixin, tk.Menu)`), so the outer menu looked mismatched next to its own submenus (background, selection, etc.).

## Fix
Both `TableCellRightClickMenu` and `TableHeaderRightClickMenu` now subclass **`ttk.Menu`**, so the top-level menus get the same `AutoStyleMixin` theming as the cascades. `ttk.Menu` is still a `tk.Menu`, so all menu behavior (`add_command`/`add_cascade`/`tk_popup`) is unchanged. No API/behavior change.

## Verification
- Confirmed the top-level menu background/active colors now match a plain `ttk.Menu` exactly (`#ffffff` / `#686d71` on `bootstrap-light`), where before they were `SystemMenu` / `SystemHighlight`.
- `tests/test_tableview_api.py` (+1: menus are themed, not OS colors); the `master is tv` regression test still holds; menus still post. Suite green.

**Needs a visual spot-check**: right-click a cell and a header, light↔dark — the outer menu and its cascades should look identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)