### PR TITLE
Fix theme-walk crash on composite widgets delegating cget("style")

### DIFF
--- a/src/ttkbootstrap/internal/configure_delegation.py
+++ b/src/ttkbootstrap/internal/configure_delegation.py
@@ -38,6 +38,7 @@ This module is internal (`ttkbootstrap.internal`): no back-compat guarantee.
 """
 from __future__ import annotations
 
+from tkinter import TclError
 from typing import Any, Callable
 
 # Marker attribute stamped on a delegate method by the decorator. Namespaced to
@@ -142,7 +143,13 @@ class ConfigureDelegationMixin:
                 return self._spec(cnf, value)
             target = self._configure_delegate_target()
             if target is not None:
-                return target.configure(cnf)
+                try:
+                    return target.configure(cnf)
+                except TclError:
+                    # An option the inner widget lacks but the outer ttk widget
+                    # owns (e.g. `style`/`class` on a composite Frame) -- fall
+                    # back so theming can read it back off the wrapper.
+                    return super().configure(cnf)
             return super().configure(cnf)
 
         # No-arg query: full option dict, with the delegated options merged in.
@@ -160,7 +167,13 @@ class ConfigureDelegationMixin:
             return value
         target = self._configure_delegate_target()
         if target is not None:
-            return target.cget(key)
+            try:
+                return target.cget(key)
+            except TclError:
+                # An option the inner widget lacks but the outer ttk widget
+                # owns (e.g. `style` on a composite Frame): read it off the
+                # wrapper so the theme walk's cget("style") doesn't crash.
+                return super().cget(key)
         return super().cget(key)
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -178,7 +191,10 @@ class ConfigureDelegationMixin:
             return value
         target = self._configure_delegate_target()
         if target is not None:
-            return target[key]
+            try:
+                return target[key]
+            except TclError:
+                return super().__getitem__(key)
         return super().__getitem__(key)
 
     def keys(self) -> list:

--- a/tests/test_scrolled_api.py
+++ b/tests/test_scrolled_api.py
@@ -134,6 +134,30 @@ def test_configure_and_cget_reach_the_text(root):
     assert str(st.cget("wrap")) == "word"
 
 
+def test_style_cget_reads_the_outer_frame(root):
+    # `style` is an option of the outer ttk Frame, not the inner Text; the
+    # delegation must fall back to the wrapper instead of routing it to the
+    # Text (which has no -style option and would raise TclError).
+    st = ScrolledText(root, height=5)
+    st.pack()
+    assert st.cget("style") == "TFrame"
+    assert st.configure("style") == "TFrame"
+
+
+def test_theme_switch_repaints_scrolledtext(root):
+    # Regression: the theme walk repaints ScrolledText as a ttk.Widget and reads
+    # widget.cget("style"); routing that to the inner Text raised
+    # `unknown option "-style"` and aborted the switch.
+    st = ScrolledText(root, height=5, autohide=True)
+    st.pack()
+    st.update_idletasks()
+    style = ttk.Style()
+    for name in ("bootstrap-dark", "bootstrap-light"):
+        style.theme_use(name)
+        st.update_idletasks()
+    assert st.cget("style") == "TFrame"
+
+
 def test_method_delegation_to_text(root):
     st = ScrolledText(root, height=5)
     st.pack()


### PR DESCRIPTION
## Problem

Switching themes crashes when a composite ttkbootstrap widget (e.g. `ScrolledText`) is mounted:

```
File ".../style/bootstyle.py", line 583, in update_ttk_widget_style
    style_string = widget.cget("style")
  ...
_tkinter.TclError: unknown option "-style"
```

Reproduces from the `python -m ttkbootstrap` demo by selecting a different theme (the demo mounts a `ScrolledText`).

## Root cause

The version-stamped theme walk (`engine._theme_walk` → `_repaint_widget`) repaints every mounted `ttk.Widget` by calling `Bootstyle.update_ttk_widget_style(widget)`, which reads `widget.cget("style")`.

`ScrolledText` is a ttk `Frame` whose `ConfigureDelegationMixin` routes **non-delegated** options to its inner `tk.Text` (so `st.cget("font")`/`st.cget("wrap")` reach the Text). `style` isn't a delegated key, so `cget("style")` was routed to the `Text` — which has no `-style` option — raising `TclError` and aborting the whole theme switch.

## Fix

`style`/`class` are options of the **outer** ttk widget, not the inner content widget. The delegation read paths (`cget`, `configure(name)`, `__getitem__`) now fall back to `super()` when the delegate target raises `TclError` for an option it doesn't own. Content options (`font`, `wrap`, …) still route to the inner widget; identity options resolve off the wrapper.

General fix for any composite proxying to a non-ttk inner widget, not just `ScrolledText`.

## Verification

- `st.cget("style")` → `"TFrame"`; `st.cget("font")` still reads the inner Text.
- Theme switches over a live `ScrolledText` no longer crash.
- New regression tests in `test_scrolled_api.py`: `test_style_cget_reads_the_outer_frame`, `test_theme_switch_repaints_scrolledtext`.
- Headless suite: `test_scrolled_api.py` 19 passed; full suite unchanged (same 3 pre-existing display/ordering-dependent failures in `test_toast_api.py` / `test_tableview_api.py`, present on `2.0` before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)