### PR TITLE
StyleBuilderTK: use string literals for relief (cleanup)

### DIFF
--- a/src/ttkbootstrap/style/builders_tk.py
+++ b/src/ttkbootstrap/style/builders_tk.py
@@ -106,7 +106,7 @@ class StyleBuilderTK:
         widget.configure(
             background=background,
             foreground=foreground,
-            relief=tk.FLAT,
+            relief="flat",
             borderwidth=0,
             activebackground=activebackground,
             highlightbackground=foreground,
@@ -175,7 +175,7 @@ class StyleBuilderTK:
         bordercolor = self.colors.border
 
         widget.configure(
-            relief=tk.FLAT,
+            relief="flat",
             highlightthickness=self.style.scaling.logical(1),
             foreground=self.colors.inputfg,
             highlightbackground=bordercolor,
@@ -199,7 +199,7 @@ class StyleBuilderTK:
         widget.configure(
             background=self.colors.primary,
             showvalue=False,
-            sliderrelief=tk.FLAT,
+            sliderrelief="flat",
             borderwidth=0,
             activebackground=activecolor,
             highlightthickness=self.style.scaling.logical(1),
@@ -219,7 +219,7 @@ class StyleBuilderTK:
         bordercolor = self.colors.border
 
         widget.configure(
-            relief=tk.FLAT,
+            relief="flat",
             highlightthickness=self.style.scaling.logical(1),
             foreground=self.colors.inputfg,
             highlightbackground=bordercolor,
@@ -229,8 +229,8 @@ class StyleBuilderTK:
             insertbackground=self.colors.inputfg,
             insertwidth=self.style.scaling.logical(1),
             # these options should work, but do not have any affect
-            buttonuprelief=tk.FLAT,
-            buttondownrelief=tk.SUNKEN,
+            buttonuprelief="flat",
+            buttondownrelief="sunken",
         )
 
     def update_listbox_style(self, widget: tk.Listbox):
@@ -252,7 +252,7 @@ class StyleBuilderTK:
             highlightbackground=bordercolor,
             highlightthickness=self.style.scaling.logical(1),
             activestyle="none",
-            relief=tk.FLAT,
+            relief="flat",
         )
 
     def update_menubutton_style(self, widget: tk.Menubutton):
@@ -287,7 +287,7 @@ class StyleBuilderTK:
             foreground=self.colors.fg,
             selectcolor=self.colors.primary,
             background=self.colors.bg,
-            relief=tk.FLAT,
+            relief="flat",
             borderwidth=0,
         )
 
@@ -334,8 +334,7 @@ class StyleBuilderTK:
             selectforeground=self.colors.selectfg,
             insertwidth=self.style.scaling.logical(1),
             highlightthickness=self.style.scaling.logical(1),
-            relief=tk.FLAT,
+            relief="flat",
             padx=self.style.scaling.logical(5),
-            pady=self.style.scaling.logical(5),
-            # font="TkDefaultFont",
+            pady=self.style.scaling.logical(5)
         )


### PR DESCRIPTION
Small cleanup in `StyleBuilderTK`: replace the `tk.FLAT` / `tk.SUNKEN` constants with their string-literal equivalents (`"flat"` / `"sunken"`) across the tk-widget style recipes, and drop a dead commented-out `font=` line. `tk` is still imported (used for the widget type hints elsewhere).

**No behavior change** — `tkinter.FLAT` *is* `"flat"` and `tkinter.SUNKEN` *is* `"sunken"`.

Full suite: 473 passed; the two failures are unrelated and pre-existing on `2.0` — the known `zh_cn.msg` localization flake, and an order-fragile assertion in `test_menu_labels_have_no_decorative_glyphs` (from #1121, fails after the localization test flips the locale). Both are being addressed separately; neither involves this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)