### PR TITLE
Inputs: focus ring on focus only; card/highlight hairline borders

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -35,6 +35,8 @@
 | **`Text` border left to tk default (not themed)** | Visual | this doc, below |
 | **ScrolledText: card border, focus ring, auto-hide fixes** | Visual | this doc, below |
 | **Scrollbar: no trough channel, darker light-mode thumb** | Visual | this doc, below |
+| **Inputs: focus color on focus only (not hover)** | Visual | this doc, below |
+| **`card` / `highlight` frames: hairline border (`RAISED`, no bevel)** | Visual | this doc, below |
 
 ---
 
@@ -836,3 +838,30 @@ entry) was removed — the thumb is drawn procedurally, so the asset was dead.
 **Why.** The faint `border`-colored thumb on a barely-off-white trough was hard to
 see in light mode; dropping the trough tint and darkening the thumb fixes the
 contrast without changing the bar's size.
+
+## Inputs: focus color shows on focus only, not hover  *(Visual)*
+
+**What.** `Entry`, `Combobox`, and `Spinbox` no longer tint their border with the
+focus color on *hover*. The `("hover !disabled", ...)` mapping was dropped from
+each widget's `bordercolor` state map; the border now brightens to the focus color
+(`primary`, or the colored variant) only while the widget actually holds focus.
+Invalid (danger) and readonly states are unchanged.
+
+**Why.** Lighting the focus ring on mere hover is non-standard — the ring should
+signal *where keyboard input goes*, not where the pointer happens to be. Reserving
+it for the real `focus` state matches conventional input behavior and removes a
+distracting hover flicker when the pointer sweeps across a form.
+
+## `card` / `highlight` frames: single hairline border (`RAISED`, bevel suppressed)  *(Visual)*
+
+**What.** The `card` and `highlight` frame variants now draw their border with
+`relief=RAISED` and `lightcolor`/`darkcolor` set to the frame background (instead
+of `relief=SOLID`). Suppressing the clam bevel leaves only the `bordercolor`
+hairline, at the same 1px weight the inputs draw. `highlight` additionally
+state-maps `lightcolor`/`darkcolor` (not just `bordercolor`) to the accent on
+`focus`, so the whole ring brightens uniformly. (Supersedes the `relief=SOLID`
+mechanism noted in the `card`/`highlight` entry above.)
+
+**Why.** The `SOLID` border read slightly heavier than the input borders it sits
+next to; matching the inputs' `RAISED`-with-neutralized-bevel technique gives cards
+and inputs one consistent hairline weight across the theme.

--- a/src/ttkbootstrap/style/builders/combobox.py
+++ b/src/ttkbootstrap/style/builders/combobox.py
@@ -74,7 +74,6 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         bordercolor=[
             ("invalid", builder.colors.danger),
             ("focus !disabled", focus_ring),
-            ("hover !disabled", focus_ring),
         ],
         lightcolor=[
             ("focus invalid", builder.colors.danger),

--- a/src/ttkbootstrap/style/builders/entry.py
+++ b/src/ttkbootstrap/style/builders/entry.py
@@ -51,7 +51,6 @@ def build_entry_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         bordercolor=[
             ("invalid", builder.colors.danger),
             ("focus !disabled", focus_ring),
-            ("hover !disabled", focus_ring),
         ],
         lightcolor=[
             ("focus invalid", builder.colors.danger),

--- a/src/ttkbootstrap/style/builders/frame.py
+++ b/src/ttkbootstrap/style/builders/frame.py
@@ -36,9 +36,11 @@ def build_card_frame(builder: StyleBuilderTTK, colorname=DEFAULT):
     """A simple inert bordered surface (a "card").
 
     A container that owns a single flat 1px border so its contents sit inside
-    one frame. `relief=SOLID` draws the border in `bordercolor`. Give the frame
-    a little widget `padding` so its children don't paint over the border (ttk
-    frames inset from the widget's padding, not the style's).
+    one frame. `relief=RAISED` with `lightcolor`/`darkcolor` blended into the
+    background suppresses the bevel, leaving just the `bordercolor` hairline --
+    the same border weight the inputs draw. Give the frame a little widget
+    `padding` so its children don't paint over the border (ttk frames inset from
+    the widget's padding, not the style's).
     """
     ttk_class = "Card.TFrame"
     if any([colorname == DEFAULT, colorname == ""]):
@@ -54,8 +56,10 @@ def build_card_frame(builder: StyleBuilderTTK, colorname=DEFAULT):
     builder.configure(
         ttk_style,
         background=background,
+        darkcolor=background,
+        lightcolor=background,
         bordercolor=border,
-        relief=SOLID,
+        relief=RAISED,
         borderwidth=builder.scale_size(1),
     )
 
@@ -88,10 +92,17 @@ def build_highlight_frame(builder: StyleBuilderTTK, colorname=DEFAULT):
         ttk_style,
         background=background,
         bordercolor=resting,
-        relief=SOLID,
+        darkcolor=background,
+        lightcolor=background,
+        relief=RAISED,
         borderwidth=builder.scale_size(1),
     )
-    builder.style.map(ttk_style, bordercolor=[("focus", accent)])
+    builder.style.map(
+        ttk_style,
+        bordercolor=[("focus", accent)],
+        lightcolor=[("focus", accent)],
+        darkcolor=[("focus", accent)],
+    )
 
     # register style
     builder.register_ttkstyle(ttk_style)

--- a/src/ttkbootstrap/style/builders/spinbox.py
+++ b/src/ttkbootstrap/style/builders/spinbox.py
@@ -98,7 +98,6 @@ def build_spinbox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         bordercolor=[
             ("invalid", builder.colors.danger),
             ("focus !disabled", focus_color),
-            ("hover !disabled", focus_color),
         ],
     )
 


### PR DESCRIPTION
## Summary

Two small visual-consistency adjustments to the 2.0 input/frame styling.

**Inputs (entry / combobox / spinbox)** — drop the `("hover !disabled", ...)` entry from each `bordercolor` map so the focus color shows **only on focus, not hover**, consistent with standard input behavior. The `lightcolor`/`darkcolor` maps only ever keyed off `focus`/`pressed`/`readonly`, so there's no leftover hover tinting.

**Card / highlight frames** — switch `relief=SOLID` → `RAISED` with `lightcolor`/`darkcolor` blended into the background. This suppresses the clam bevel and leaves a single `bordercolor` hairline that matches the inputs' border weight (the "thinner standard borders"). Highlight also state-maps `lightcolor`/`darkcolor` to the accent on focus so the whole ring brightens uniformly. Stale `card` docstring updated to describe the new mechanism.

## Test plan

- `python -m pytest -q` → 481 passed (only the known `nl.msg` localization env flake fails, unrelated).
- Visual: focus ring appears on focus (not hover) for entry/combobox/spinbox; card/highlight frames render a crisp 1px hairline matching input borders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)