### PR TITLE
Fluent geometry: pack/grid/place return the widget

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -1021,6 +1021,12 @@ to one line without changing semantics.
 
 **Scope.** Delivered by a new `FluentGeometryMixin` shared by `BootMixin` (ttk)
 and `AutoStyleMixin` (tk), so every shipped widget and anything wrapped with
-`bootify()` gets it. A raw `tk`/`ttk` widget constructed directly does not —
-same scoping as the rest of the `bootstyle` API. `FluentGeometryMixin` is
-re-exported from `ttkbootstrap` and `ttkbootstrap.style` for custom subclasses.
+`bootify()` gets it by default. A raw `tk`/`ttk` widget constructed directly
+does not — same scoping as the rest of the `bootstyle` API. `FluentGeometryMixin`
+is re-exported from `ttkbootstrap` and `ttkbootstrap.style` for custom subclasses.
+
+**Global opt-in.** `enable_global_api()` now also patches tkinter's shared
+`Pack`/`Grid`/`Place` mixins, so `pack`/`grid`/`place` return the widget on
+*stock, native, and third-party* widgets too — consistent with how the global
+`bootstyle` patch already works. Importing ttkbootstrap stays side-effect-free;
+the geometry patch only happens when you explicitly opt in.

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -17,6 +17,7 @@
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
+| **Fluent geometry (`pack`/`grid`/`place` return the widget)** | New | this doc, below |
 | **`neutral` color** | New | this doc, below |
 | **`ghost` button variant** | New | this doc, below |
 | **`thin` scrollbar variant** | New | this doc, below |
@@ -997,3 +998,29 @@ Only those two are packaged; the source PNGs are build inputs, not shipped.
 titlebar/taskbar icon looked soft at larger sizes. A packed `.ico` lets Windows
 pick the crisp frame per DPI/context; macOS/Linux take a full-size PNG. Rebuild
 the `.ico` with `python tools/make_app_ico.py` after changing the source PNGs.
+
+---
+
+## Fluent geometry — `pack`/`grid`/`place` return the widget  *(New)*
+
+**What.** On ttkbootstrap's widgets the geometry managers now return the widget
+instead of `None`, so a widget can be created and placed in one expression:
+
+```python
+btn = ttk.Button(root, text="Save", bootstyle="success").pack(padx=10, pady=10)
+```
+
+Both the short names (`pack`/`grid`/`place`) and the `*_configure` spellings
+return `self`. Additive and backwards compatible — tkinter's managers returned
+`None`, which nothing consumed, so returning `self` only *adds* a usable value;
+existing `w.pack()` calls are unaffected.
+
+**Why.** The common construct-then-place pattern otherwise costs two statements
+(and a name binding) even for throwaway widgets. Returning `self` collapses it
+to one line without changing semantics.
+
+**Scope.** Delivered by a new `FluentGeometryMixin` shared by `BootMixin` (ttk)
+and `AutoStyleMixin` (tk), so every shipped widget and anything wrapped with
+`bootify()` gets it. A raw `tk`/`ttk` widget constructed directly does not —
+same scoping as the rest of the `bootstyle` API. `FluentGeometryMixin` is
+re-exported from `ttkbootstrap` and `ttkbootstrap.style` for custom subclasses.

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -57,7 +57,7 @@ from tkinter.ttk import (
 # (colorutils, constants, themes); it does not depend on the widget classes
 # defined below, so it is safe this early in package init.
 from ttkbootstrap.style import (
-    Bootstyle, Style, BootMixin, AutoStyleMixin,
+    Bootstyle, Style, FluentGeometryMixin, BootMixin, AutoStyleMixin,
     bootify, apply_bootstyle, enable_global_api,
     # Semantic-anchor theme authoring (Workstream E).
     Theme,
@@ -247,6 +247,7 @@ __all__ = [
     # Styling API
     "Bootstyle",
     "Style",
+    "FluentGeometryMixin",
     "BootMixin",
     "AutoStyleMixin",
     "bootify",

--- a/src/ttkbootstrap/__main__.py
+++ b/src/ttkbootstrap/__main__.py
@@ -35,8 +35,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     style = ttk.Style()
     theme_names = style.theme_names()
 
-    theme_selection = ttk.Frame(root, padding=(10, 10, 10, 0))
-    theme_selection.pack(fill=X, expand=YES)
+    theme_selection = ttk.Frame(root, padding=(10, 10, 10, 0)).pack(fill=X, expand=YES)
 
     theme_selected = ttk.Label(
         master=theme_selection, text="litera", font="-size 24 -weight bold"
@@ -63,11 +62,9 @@ Namespaces are one honking great idea -- let's do more of those!"""
 
     theme_cbo.bind("<<ComboboxSelected>>", change_theme)
 
-    lframe = ttk.Frame(root, padding=5)
-    lframe.pack(side=LEFT, fill=BOTH, expand=YES)
+    lframe = ttk.Frame(root, padding=5).pack(side=LEFT, fill=BOTH, expand=YES)
 
-    rframe = ttk.Frame(root, padding=5)
-    rframe.pack(side=RIGHT, fill=BOTH, expand=YES)
+    rframe = ttk.Frame(root, padding=5).pack(side=RIGHT, fill=BOTH, expand=YES)
 
     color_group = ttk.Labelframe(
         master=lframe, text="Theme color options", padding=10
@@ -75,8 +72,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     color_group.pack(fill=X, side=TOP)
 
     for color in style.colors:
-        cb = ttk.Button(color_group, text=color, bootstyle=color)
-        cb.pack(side=LEFT, expand=YES, padx=5, fill=X)
+        cb = ttk.Button(color_group, text=color, bootstyle=color).pack(side=LEFT, expand=YES, padx=5, fill=X)
 
     rb_group = ttk.Labelframe(
         lframe, text="Checkbuttons & radiobuttons", padding=10
@@ -110,8 +106,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     )
     radio3.pack(side=LEFT, expand=YES, padx=5)
 
-    ttframe = ttk.Frame(lframe)
-    ttframe.pack(pady=5, fill=X, side=TOP)
+    ttframe = ttk.Frame(lframe).pack(pady=5, fill=X, side=TOP)
 
     table_data = [
         ("South Island, New Zealand", 1),
@@ -133,8 +128,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     tv.pack(side=LEFT, anchor=NE, fill=X)
 
     # # notebook with table and text tabs
-    nb = ttk.Notebook(ttframe)
-    nb.pack(side=LEFT, padx=(10, 0), expand=YES, fill=BOTH)
+    nb = ttk.Notebook(ttframe).pack(side=LEFT, padx=(10, 0), expand=YES, fill=BOTH)
     nb_text = "This is a notebook tab.\nYou can put any widget you want here."
     nb.add(ttk.Label(nb, text=nb_text), text="Tab 1", sticky=NW)
     nb.add(
@@ -148,8 +142,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     txt = ScrolledText(master=lframe, height=5, width=50, autohide=True)
     txt.insert(END, ZEN)
     txt.pack(side=LEFT, anchor=NW, pady=5, fill=BOTH, expand=YES)
-    lframe_inner = ttk.Frame(lframe)
-    lframe_inner.pack(fill=BOTH, expand=YES, padx=10)
+    lframe_inner = ttk.Frame(lframe).pack(fill=BOTH, expand=YES, padx=10)
     s1 = ttk.Scale(
         master=lframe_inner, orient=HORIZONTAL, value=75, from_=100, to=0
     )
@@ -262,16 +255,14 @@ Namespaces are one honking great idea -- let's do more of those!"""
         master=rframe, text="Other input widgets", padding=10
     )
     input_group.pack(fill=BOTH, pady=(10, 5), expand=YES)
-    entry = ttk.Entry(input_group)
-    entry.pack(fill=X)
+    entry = ttk.Entry(input_group).pack(fill=X)
     entry.insert(END, "entry widget")
 
     password = ttk.Entry(master=input_group, show="•")
     password.pack(fill=X, pady=5)
     password.insert(END, "password")
 
-    spinbox = ttk.Spinbox(master=input_group, from_=0, to=100)
-    spinbox.pack(fill=X)
+    spinbox = ttk.Spinbox(master=input_group, from_=0, to=100).pack(fill=X)
     spinbox.set(45)
 
     cbo = ttk.Combobox(

--- a/src/ttkbootstrap/dialogs/colorchooser.py
+++ b/src/ttkbootstrap/dialogs/colorchooser.py
@@ -123,13 +123,10 @@ class ColorChooser(ttk.Frame):
                 default padding.
         """
         super().__init__(master, padding=padding)
-        self.tframe = ttk.Frame(self, padding=5)
-        self.tframe.pack(fill=X)
-        self.bframe = ttk.Frame(self, padding=(5, 0, 5, 5))
-        self.bframe.pack(fill=X)
+        self.tframe = ttk.Frame(self, padding=5).pack(fill=X)
+        self.bframe = ttk.Frame(self, padding=(5, 0, 5, 5)).pack(fill=X)
 
-        self.notebook = ttk.Notebook(self.tframe)
-        self.notebook.pack(fill=BOTH)
+        self.notebook = ttk.Notebook(self.tframe).pack(fill=BOTH)
 
         self.style = ttk.Style.get_instance()
         self.colors = self.style.colors
@@ -333,20 +330,13 @@ class ColorChooser(ttk.Frame):
         rgb_cnf = {'master': container, 'from_': 0, 'to': 255, 'width': 3}
         sl_cnf = {'master': container, 'from_': 0, 'to': 100, 'width': 3}
         hue_cnf = {'master': container, 'from_': 0, 'to': 360, 'width': 3}
-        sb_hue = ttk.Spinbox(**hue_cnf, textvariable=self.hue)
-        sb_hue.grid(row=0, column=1, padx=4, pady=2, sticky=EW)
-        sb_sat = ttk.Spinbox(**sl_cnf, textvariable=self.sat)
-        sb_sat.grid(row=1, column=1, padx=4, pady=2, sticky=EW)
-        sb_lum = ttk.Spinbox(**sl_cnf, textvariable=self.lum)
-        sb_lum.grid(row=2, column=1, padx=4, pady=2, sticky=EW)
-        sb_red = ttk.Spinbox(**rgb_cnf, textvariable=self.red)
-        sb_red.grid(row=0, column=3, padx=4, pady=2, sticky=EW)
-        sb_grn = ttk.Spinbox(**rgb_cnf, textvariable=self.grn)
-        sb_grn.grid(row=1, column=3, padx=4, pady=2, sticky=EW)
-        sb_blu = ttk.Spinbox(**rgb_cnf, textvariable=self.blu)
-        sb_blu.grid(row=2, column=3, padx=4, pady=2, sticky=EW)
-        ent_hex = ttk.Entry(container, textvariable=self.hex)
-        ent_hex.grid(row=3, column=1, padx=4, columnspan=3, pady=2, sticky=EW)
+        sb_hue = ttk.Spinbox(**hue_cnf, textvariable=self.hue).grid(row=0, column=1, padx=4, pady=2, sticky=EW)
+        sb_sat = ttk.Spinbox(**sl_cnf, textvariable=self.sat).grid(row=1, column=1, padx=4, pady=2, sticky=EW)
+        sb_lum = ttk.Spinbox(**sl_cnf, textvariable=self.lum).grid(row=2, column=1, padx=4, pady=2, sticky=EW)
+        sb_red = ttk.Spinbox(**rgb_cnf, textvariable=self.red).grid(row=0, column=3, padx=4, pady=2, sticky=EW)
+        sb_grn = ttk.Spinbox(**rgb_cnf, textvariable=self.grn).grid(row=1, column=3, padx=4, pady=2, sticky=EW)
+        sb_blu = ttk.Spinbox(**rgb_cnf, textvariable=self.blu).grid(row=2, column=3, padx=4, pady=2, sticky=EW)
+        ent_hex = ttk.Entry(container, textvariable=self.hex).grid(row=3, column=1, padx=4, columnspan=3, pady=2, sticky=EW)
 
         # add input validation
         add_validation(ent_hex, validate_color)

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -306,12 +306,9 @@ class DatePickerDialog:
         """Setup the calendar widget"""
         # create the widget containers
         frm_style = "Card.TFrame" if self.root.tk.call('tk', 'windowingsystem') != 'aqua' else  "TFrame"
-        self.frm_calendar = ttk.Frame(master=self.root, padding=2, style=frm_style)
-        self.frm_calendar.pack(fill=BOTH, expand=YES)
-        self.frm_title = ttk.Frame(self.frm_calendar, padding=(3, 3))
-        self.frm_title.pack(fill=X)
-        self.frm_header = ttk.Frame(self.frm_calendar)
-        self.frm_header.pack(fill=X)
+        self.frm_calendar = ttk.Frame(master=self.root, padding=2, style=frm_style).pack(fill=BOTH, expand=YES)
+        self.frm_title = ttk.Frame(self.frm_calendar, padding=(3, 3)).pack(fill=X)
+        self.frm_header = ttk.Frame(self.frm_calendar).pack(fill=X)
 
         # setup the toplevel widget
         self.root.withdraw()  # reset the iconify state
@@ -329,8 +326,7 @@ class DatePickerDialog:
     def _draw_calendar(self) -> None:
         self._set_title()
         self._current_month_days()
-        self.frm_dates = ttk.Frame(self.frm_calendar)
-        self.frm_dates.pack(fill=BOTH, expand=YES)
+        self.frm_dates = ttk.Frame(self.frm_calendar).pack(fill=BOTH, expand=YES)
 
         for row, weekday_list in enumerate(self.monthdays):
             for col, day in enumerate(weekday_list):

--- a/src/ttkbootstrap/dialogs/fontdialog.py
+++ b/src/ttkbootstrap/dialogs/fontdialog.py
@@ -87,16 +87,14 @@ class FontDialog(Dialog):
         # instead, so the (thin) scrollbar sits *inside* the border with the list.
         ttk.Style.get_instance().configure("Flat.Treeview", borderwidth=0)
 
-        family_size_frame = ttk.Frame(master, padding=10)
-        family_size_frame.pack(fill=X, anchor=N)
+        family_size_frame = ttk.Frame(master, padding=10).pack(fill=X, anchor=N)
         self._initial_focus = self._font_families_selector(family_size_frame)
         self._font_size_selector(family_size_frame)
         self._font_options_selectors(master, padding=10)
         self._font_preview(master, padding=10)
 
     def create_buttonbox(self, master: tkinter.Misc) -> None:
-        container = ttk.Frame(master, padding=(5, 10))
-        container.pack(fill=X)
+        container = ttk.Frame(master, padding=(5, 10)).pack(fill=X)
 
         ok_btn = ttk.Button(
             master=container,
@@ -120,8 +118,7 @@ class FontDialog(Dialog):
         self._toplevel.protocol("WM_DELETE_WINDOW", func=cancel_btn.invoke)
 
     def _font_families_selector(self, master: tkinter.Misc) -> ttk.Treeview:
-        container = ttk.Frame(master)
-        container.pack(fill=BOTH, expand=YES, side=LEFT)
+        container = ttk.Frame(master).pack(fill=BOTH, expand=YES, side=LEFT)
 
         header = ttk.Label(
             container,
@@ -131,8 +128,7 @@ class FontDialog(Dialog):
         header.pack(fill=X, pady=(0, 2), anchor=N)
 
         # bordered box wrapping the list + its thin scrollbar as one unit
-        listbox_frame = ttk.Frame(container, relief=SOLID, borderwidth=1)
-        listbox_frame.pack(fill=BOTH, expand=YES)
+        listbox_frame = ttk.Frame(container, relief=SOLID, borderwidth=1).pack(fill=BOTH, expand=YES)
 
         listbox = ttk.Treeview(
             master=listbox_frame,
@@ -166,8 +162,7 @@ class FontDialog(Dialog):
         return listbox
 
     def _font_size_selector(self, master: tkinter.Misc) -> None:
-        container = ttk.Frame(master)
-        container.pack(side=LEFT, fill=Y, padx=(10, 0))
+        container = ttk.Frame(master).pack(side=LEFT, fill=Y, padx=(10, 0))
 
         header = ttk.Label(
             container,
@@ -177,8 +172,7 @@ class FontDialog(Dialog):
         header.pack(fill=X, pady=(0, 2), anchor=N)
 
         # bordered box wrapping the list + its thin scrollbar as one unit
-        sizes_frame = ttk.Frame(container, relief=SOLID, borderwidth=1)
-        sizes_frame.pack(fill=BOTH, expand=YES)
+        sizes_frame = ttk.Frame(container, relief=SOLID, borderwidth=1).pack(fill=BOTH, expand=YES)
 
         sizes_listbox = ttk.Treeview(
             sizes_frame, height=7, columns=[0], show="", style="Flat.Treeview")
@@ -205,8 +199,7 @@ class FontDialog(Dialog):
         sizes_listbox.pack(side=LEFT, fill=BOTH, expand=YES)
 
     def _font_options_selectors(self, master: tkinter.Misc, padding: int) -> None:
-        container = ttk.Frame(master, padding=padding)
-        container.pack(fill=X, padx=2, pady=2, anchor=N)
+        container = ttk.Frame(master, padding=padding).pack(fill=X, padx=2, pady=2, anchor=N)
 
         weight_lframe = ttk.Labelframe(container, text=MessageCatalog.translate("Weight"), padding=5)
         weight_lframe.pack(side=LEFT, fill=X, expand=YES)
@@ -260,8 +253,7 @@ class FontDialog(Dialog):
         opt_overstrike.pack(side=LEFT, padx=5, pady=5)
 
     def _font_preview(self, master: tkinter.Misc, padding: int) -> None:
-        container = ttk.Frame(master, padding=padding)
-        container.pack(fill=BOTH, expand=YES, anchor=N)
+        container = ttk.Frame(master, padding=padding).pack(fill=BOTH, expand=YES, anchor=N)
 
         header = ttk.Label(
             container,

--- a/src/ttkbootstrap/dialogs/message.py
+++ b/src/ttkbootstrap/dialogs/message.py
@@ -143,8 +143,7 @@ class MessageDialog(Dialog):
         if self._message:
             for msg in self._message.split("\n"):
                 message = "\n".join(textwrap.wrap(msg, width=self._width))
-                message_label = ttk.Label(container, text=message)
-                message_label.pack(pady=(0, 3), fill=X, anchor=N)
+                ttk.Label(container, text=message).pack(pady=(0, 3), fill=X, anchor=N)
         container.pack(fill=X, expand=True)
 
     def _create_icon_label(self, container: tkinter.Misc) -> "Optional[ttk.Label]":

--- a/src/ttkbootstrap/dialogs/query.py
+++ b/src/ttkbootstrap/dialogs/query.py
@@ -91,8 +91,7 @@ class QueryDialog(Dialog):
         if self._prompt:
             for p in self._prompt.split("\n"):
                 prompt = "\n".join(textwrap.wrap(p, width=self._width))
-                prompt_label = ttk.Label(frame, text=prompt)
-                prompt_label.pack(pady=(0, 5), fill=X, anchor=N)
+                ttk.Label(frame, text=prompt).pack(pady=(0, 5), fill=X, anchor=N)
         if self._items is None or len(self._items) == 0:
             entry = ttk.Entry(master=frame)
         else:

--- a/src/ttkbootstrap/style/__init__.py
+++ b/src/ttkbootstrap/style/__init__.py
@@ -13,6 +13,7 @@ from ttkbootstrap.style.engine import Style
 from ttkbootstrap.style.bootstyle import (
     Keywords,
     Bootstyle,
+    FluentGeometryMixin,
     BootMixin,
     AutoStyleMixin,
     bootify,
@@ -45,6 +46,7 @@ __all__ = [
     "Style",
     "Keywords",
     "Bootstyle",
+    "FluentGeometryMixin",
     "BootMixin",
     "AutoStyleMixin",
     "bootify",

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -8,7 +8,7 @@ out of the monolithic `style.py` in 2.0.
 """
 import difflib
 import re
-from tkinter import TclError, ttk
+from tkinter import Grid, Pack, Place, TclError, ttk
 
 from ttkbootstrap.constants import (
     BOOTSTYLE_COLORS,
@@ -699,6 +699,43 @@ class Bootstyle:
             _init = Bootstyle.override_tk_widget_constructor(widget.__init__)
             widget.__init__ = _init
 
+        # Make the geometry managers fluent on every stock/native/third-party
+        # widget too, matching `FluentGeometryMixin` (which only covers the
+        # blessed subclasses).
+        Bootstyle.patch_geometry_managers()
+
+    @staticmethod
+    def patch_geometry_managers():
+        """Make tkinter's geometry managers return the widget (opt-in global).
+
+        The global-API counterpart to `FluentGeometryMixin`: it patches the
+        shared ``Pack``/``Grid``/``Place`` mixin methods that every tk and ttk
+        widget inherits, so ``pack``/``grid``/``place`` return ``self`` on
+        stock, native, and third-party widgets — not just the blessed
+        subclasses. Idempotent: a patched method is tagged so a repeat call is
+        a no-op.
+        """
+        for klass, configure_name in (
+            (Pack, "pack_configure"),
+            (Grid, "grid_configure"),
+            (Place, "place_configure"),
+        ):
+            orig = klass.__dict__.get(configure_name)
+            if orig is None or getattr(orig, "_tb_returns_self", False):
+                continue
+
+            def make_wrapper(orig):
+                def wrapper(self, *args, **kwargs):
+                    orig(self, *args, **kwargs)
+                    return self
+                wrapper._tb_returns_self = True
+                return wrapper
+
+            patched = make_wrapper(orig)
+            setattr(klass, configure_name, patched)
+            # pack/grid/place are class-body aliases of the *_configure methods
+            setattr(klass, configure_name.split("_")[0], patched)
+
     @staticmethod
     def stamp_theme_version(widget):
         """Stamp a widget with the current theme version.
@@ -1016,7 +1053,10 @@ def enable_global_api():
     the stock ``tkinter``/``tkinter.ttk`` classes. Call this once if you have
     code that creates *vanilla* ttk/tk widgets (e.g. ``from tkinter import
     ttk; ttk.Button(..., bootstyle=...)``) and want the ``bootstyle``/
-    ``autostyle`` keywords on them anyway.
+    ``autostyle`` keywords on them anyway. It also makes ``pack``/``grid``/
+    ``place`` return the widget on every widget (see
+    `Bootstyle.patch_geometry_managers`), extending `FluentGeometryMixin`
+    beyond the blessed subclasses.
 
     Idempotent. The installed wrappers defer to `BootMixin`/`AutoStyleMixin`
     instances (the blessed subclasses), so enabling the global API never

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -785,7 +785,37 @@ class Bootstyle:
 _UNSET = object()  # sentinel: distinguish "icon kwarg omitted" from "icon=None"
 
 
-class BootMixin:
+class FluentGeometryMixin:
+    """Mixin that makes the geometry managers return the widget.
+
+    tkinter's ``pack``/``grid``/``place`` return ``None``; returning ``self``
+    instead lets a widget be constructed and placed in a single expression::
+
+        btn = ttk.Button(root, text="Save").pack(padx=10)
+
+    ``pack``/``grid``/``place`` are tkinter aliases for the ``*_configure``
+    methods, so overriding the configure variants (and re-aliasing) covers both
+    call names. Shared by `BootMixin` (ttk) and `AutoStyleMixin` (tk).
+    """
+
+    def pack_configure(self, cnf={}, **kwargs):
+        super().pack_configure(cnf, **kwargs)
+        return self
+
+    def grid_configure(self, cnf={}, **kwargs):
+        super().grid_configure(cnf, **kwargs)
+        return self
+
+    def place_configure(self, cnf={}, **kwargs):
+        super().place_configure(cnf, **kwargs)
+        return self
+
+    pack = pack_configure
+    grid = grid_configure
+    place = place_configure
+
+
+class BootMixin(FluentGeometryMixin):
     """Mixin that adds the ``bootstyle`` API to a ttk widget class.
 
     This is the 2.0 delivery vehicle for the styling API. Instead of
@@ -911,7 +941,7 @@ class BootMixin:
         return super().__getitem__(key)
 
 
-class AutoStyleMixin:
+class AutoStyleMixin(FluentGeometryMixin):
     """Mixin that auto-applies the theme to a legacy ``tk`` widget class.
 
     The tk counterpart to `BootMixin`. Legacy tk widgets have no ttk style;

--- a/src/ttkbootstrap/validation.py
+++ b/src/ttkbootstrap/validation.py
@@ -338,10 +338,8 @@ if __name__ == "__main__":
         return True
 
 
-    entry = ttk.Entry()
-    entry.pack(padx=10, pady=10)
-    entry2 = ttk.Entry()
-    entry2.pack(padx=10, pady=10)
+    entry = ttk.Entry().pack(padx=10, pady=10)
+    entry2 = ttk.Entry().pack(padx=10, pady=10)
     # add_validation(entry, validate_range, startrange=5, endrange=10)
     # add_validation(entry, validate_regex, pattern="israel")
     add_text_validation(entry, when="key")  # prevents from using any numbers

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -2420,8 +2420,7 @@ class Tableview(ttk.Frame):
         if self._searchable:
             self._build_search_frame()
 
-        table_frame = ttk.Frame(self)
-        table_frame.pack(fill=BOTH, expand=YES, side=TOP)
+        table_frame = ttk.Frame(self).pack(fill=BOTH, expand=YES, side=TOP)
 
         self.view = ttk.Treeview(
             master=table_frame,
@@ -2469,11 +2468,9 @@ class Tableview(ttk.Frame):
         frame is only created if `searchable=True` when creating the
         widget.
         """
-        frame = ttk.Frame(self, padding=5)
-        frame.pack(fill=X, side=TOP)
+        frame = ttk.Frame(self, padding=5).pack(fill=X, side=TOP)
         ttk.Label(frame, text=MessageCatalog.translate("Search")).pack(side=LEFT, padx=5)
-        searchterm = ttk.Entry(frame, textvariable=self._searchcriteria)
-        searchterm.pack(fill=X, side=LEFT, expand=YES)
+        searchterm = ttk.Entry(frame, textvariable=self._searchcriteria).pack(fill=X, side=LEFT, expand=YES)
         searchterm.bind("<Return>", self._search_table_data)
         searchterm.bind("<KP_Enter>", self._search_table_data)
         if not self._paginated:
@@ -2489,8 +2486,7 @@ class Tableview(ttk.Frame):
         frame is only built if `pagination=True` when creating the
         widget.
         """
-        pageframe = ttk.Frame(self, padding=5)
-        pageframe.pack(fill=X, anchor=N)
+        pageframe = ttk.Frame(self, padding=5).pack(fill=X, anchor=N)
 
         ttk.Button(
             pageframe,
@@ -2535,12 +2531,10 @@ class Tableview(ttk.Frame):
 
         self._add_page_separator(pageframe)
 
-        lbl = ttk.Label(pageframe, textvariable=self._pagelimit)
-        lbl.pack(side=RIGHT, padx=(0, 5))
+        lbl = ttk.Label(pageframe, textvariable=self._pagelimit).pack(side=RIGHT, padx=(0, 5))
         ttk.Label(pageframe, text=MessageCatalog.translate("of")).pack(side=RIGHT, padx=(5, 0))
 
-        index = ttk.Entry(pageframe, textvariable=self._pageindex, width=4)
-        index.pack(side=RIGHT)
+        index = ttk.Entry(pageframe, textvariable=self._pageindex, width=4).pack(side=RIGHT)
         index.bind("<Return>", self.goto_page, "+")
         index.bind("<KP_Enter>", self.goto_page, "+")
 

--- a/tests/test_mixin_api.py
+++ b/tests/test_mixin_api.py
@@ -93,6 +93,46 @@ def test_optionmenu_constructs_and_keeps_item_access(root):
 
 
 # --------------------------------------------------------------------------- #
+# fluent geometry: pack/grid/place return the widget
+# --------------------------------------------------------------------------- #
+def test_pack_returns_self_and_places_widget(root):
+    b = ttk.Button(root)
+    assert b.pack(padx=5) is b
+    assert b.winfo_manager() == "pack"
+    # the *_configure spelling is covered too
+    assert b.pack_configure(padx=10) is b
+
+
+def test_grid_returns_self_and_places_widget(root):
+    f = ttk.Frame(root)
+    b = ttk.Button(f)
+    assert b.grid(row=0, column=0) is b
+    assert b.winfo_manager() == "grid"
+    assert b.grid_configure(padx=2) is b
+
+
+def test_place_returns_self_and_places_widget(root):
+    f = ttk.Frame(root)
+    b = ttk.Button(f)
+    assert b.place(x=0, y=0) is b
+    assert b.winfo_manager() == "place"
+    assert b.place_configure(x=5) is b
+
+
+def test_fluent_geometry_on_autostyle_tk_widget(root):
+    c = ttk.Canvas(root)
+    assert c.pack() is c
+    assert c.winfo_manager() == "pack"
+
+
+def test_construct_and_pack_in_one_expression(root):
+    b = ttk.Button(root, text="Save", bootstyle="success").pack(padx=10)
+    assert isinstance(b, ttk.Button)
+    assert b.cget("style") == "success.TButton"
+    assert b.winfo_manager() == "pack"
+
+
+# --------------------------------------------------------------------------- #
 # autostyle (tk) path + opt-out
 # --------------------------------------------------------------------------- #
 def test_autostyle_widget_is_stamped(root):

--- a/tests/test_mixin_api.py
+++ b/tests/test_mixin_api.py
@@ -176,3 +176,9 @@ def test_enable_global_api_is_idempotent_and_styles_stock_widgets(root):
     # the blessed subclass still resolves exactly once (guard defers to mixin)
     b2 = ttk.Button(root, bootstyle="info")
     assert b2.cget("style") == "info.TButton"
+
+    # fluent geometry now reaches stock/native widgets too (opt-in global);
+    # a plain tk widget's pack/grid/place return the widget
+    stock = tkinter.Frame(root)
+    assert stock.pack() is stock
+    assert stock.winfo_manager() == "pack"


### PR DESCRIPTION
## Summary

Adds fluent geometry to ttkbootstrap widgets — `pack`/`grid`/`place` (and the
`*_configure` spellings) return the widget instead of `None`, so a widget can be
constructed and placed in one expression:

```python
btn = ttk.Button(root, text="Save", bootstyle="success").pack(padx=10, pady=10)
```

Additive and fully backwards compatible: tkinter's geometry managers returned
`None`, which nothing consumed, so returning `self` only adds a usable value.
Scoped as a *utility* addition consistent with the 2.0 "no new widgets" posture.

## What's in it

1. **`FluentGeometryMixin`** — a small shared mixin whose `pack`/`grid`/`place`
   call `super()` and return `self`. Mixed into both `BootMixin` (ttk) and
   `AutoStyleMixin` (tk), so every shipped widget and anything wrapped with
   `bootify()` gets it. Re-exported from `ttkbootstrap` and `ttkbootstrap.style`
   for custom subclasses.
2. **Opt-in global reach** — `enable_global_api()` now also patches tkinter's
   shared `Pack`/`Grid`/`Place` mixins, extending fluent geometry to stock,
   native, and third-party widgets. Importing ttkbootstrap stays
   side-effect-free; the patch only happens on the explicit opt-in. Idempotent.
3. **Sweep cleanup** — folds 39 two-line `w = ttk.X(...); w.pack(...)` pairs into
   single-line `w = ttk.X(...).pack(...)` across the dialogs, Tableview, the
   validation demo, and the `__main__` gallery (net **-41 lines**). Bindings are
   kept so every downstream `.bind()`/`.insert()`/`.set()`/parent reference and
   `add_validation()` call still resolves; only two throwaway loop labels drop
   their name. Only single-line-construct pairs on blessed `ttk.*` widgets were
   collapsed.

## Tests

- +6 cases in `tests/test_mixin_api.py`: `pack`/`grid`/`place` each return the
  widget *and* place it, the `*_configure` spelling, the tk (`AutoStyleMixin`)
  path, the one-expression chain, and the global-API path reaching stock widgets.
- Full headless suite green apart from two **pre-existing** env flakes
  (`test_msgcat` nl.msg localization; `test_center_on_screen` multi-monitor),
  both confirmed failing identically on pristine `2.0`.
- Build smoke of ColorChooser/FontDialog/DatePicker/Tableview: all edited paths
  construct cleanly and bindings resolve through the fluent return.

Logged in `development/2_0_breaking_changes.md` (New).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
