### PR TITLE
Fix ColorChooser crash without global API; add blessed TkLabel

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -18,6 +18,7 @@
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
 | **Fluent geometry (`pack`/`grid`/`place` return the widget)** | New | this doc, below |
+| **`TkLabel` blessed tk.Label + ColorChooser default-mode fix** | New/Fix | this doc, below |
 | **`neutral` color** | New | this doc, below |
 | **`ghost` button variant** | New | this doc, below |
 | **`thin` scrollbar variant** | New | this doc, below |
@@ -1030,3 +1031,29 @@ is re-exported from `ttkbootstrap` and `ttkbootstrap.style` for custom subclasse
 *stock, native, and third-party* widgets too — consistent with how the global
 `bootstyle` patch already works. Importing ttkbootstrap stays side-effect-free;
 the geometry patch only happens when you explicitly opt in.
+
+---
+
+## `TkLabel` blessed tk.Label + ColorChooser default-mode fix  *(New / Fix)*
+
+**What.** Added `ttk.TkLabel` — a blessed `AutoStyleMixin` subclass of
+`tkinter.Label` (mirroring the existing `TkFrame`), re-exported from
+`ttkbootstrap`. Like the other blessed tk widgets it accepts `autostyle=` and,
+with `autostyle=False`, opts out of theming entirely (keeps its explicit
+colors). Used it to fix a **ColorChooser** crash.
+
+**Why (the bug).** `ColorChooser` built its color swatches and preview panels
+from *native* `tkinter.Frame`/`tkinter.Label` passed `autostyle=False`. But
+`autostyle` is a ttkbootstrap concept — stock tkinter rejects `-autostyle`
+unless `enable_global_api()` has patched the tk constructors. Since 2.0 no
+longer monkey-patches at import (PR 3), opening the color chooser in the default
+configuration raised `TclError: unknown option "-autostyle"`. The swatches use
+`autostyle=False` deliberately (they must show literal colors the theme must not
+repaint), so the fix is to build them from the blessed `TkFrame`/`TkLabel`,
+which honor `autostyle=` in both modes. A second latent break in the same dialog
+was fixed too: `create_buttonbox` called `ToolTip(widget, text)` positionally,
+but `ToolTip` became keyword-only in the #1114 normalization.
+
+**Migration.** None. `ColorChooser`/`ColorChooserDialog` (and `Querybox.get_color`)
+now work without `enable_global_api()`. `ttk.TkLabel` is available for any tk
+label that must carry explicit, un-themed colors.

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -39,7 +39,7 @@ For more information, see: https://ttkbootstrap.readthedocs.io/
 """
 from tkinter import (
     Menu as _tkMenu, Text as _tkText, Canvas as _tkCanvas, Tk as _tkTk,
-    Frame as _tkFrame, LabelFrame as _tkLabelFrame,
+    Frame as _tkFrame, LabelFrame as _tkLabelFrame, Label as _tkLabel,
     Variable, StringVar, IntVar, BooleanVar, DoubleVar, PhotoImage
 )
 from tkinter.ttk import (
@@ -192,6 +192,15 @@ class TkFrame(AutoStyleMixin, _tkFrame):
     """
 
 
+class TkLabel(AutoStyleMixin, _tkLabel):
+    """tk Label with ttkbootstrap theming (accepts `autostyle=`).
+
+    Exported as ``TkLabel`` to avoid colliding with the ttk ``Label`` above.
+    Use it (with ``autostyle=False``) for a label that must show explicit
+    colors the theme should not repaint.
+    """
+
+
 class LabelFrame(AutoStyleMixin, _tkLabelFrame):
     """tk LabelFrame with ttkbootstrap theming (accepts `autostyle=`)."""
 
@@ -235,7 +244,7 @@ from ttkbootstrap.dialogs import (
 
 __all__ = [
     # Tk exports
-    "Tk", "Menu", "Text", "Canvas", "TkFrame", "LabelFrame", "Variable", "StringVar", "IntVar", "BooleanVar",
+    "Tk", "Menu", "Text", "Canvas", "TkFrame", "TkLabel", "LabelFrame", "Variable", "StringVar", "IntVar", "BooleanVar",
     "DoubleVar", "PhotoImage",
 
     # TTk exports

--- a/src/ttkbootstrap/dialogs/colorchooser.py
+++ b/src/ttkbootstrap/dialogs/colorchooser.py
@@ -51,7 +51,6 @@ Example:
 """
 import tkinter
 from collections import namedtuple
-from tkinter import Frame as tkFrame, Label as tkLabel
 from typing import Any, List, Optional, Tuple
 
 from PIL import ImageColor
@@ -238,7 +237,7 @@ class ColorChooser(ttk.Frame):
         for row in color_rows:
             rowframe = ttk.Frame(container)
             for j, color in enumerate(row):
-                swatch = tkFrame(
+                swatch = ttk.TkFrame(
                     master=rowframe,
                     bg=color,
                     width=boxwidth,
@@ -264,7 +263,7 @@ class ColorChooser(ttk.Frame):
         container = ttk.Frame(master)
 
         # the frame and label for the original color (current)
-        old = tkFrame(
+        old = ttk.TkFrame(
             master=container,
             relief=FLAT,
             bd=2,
@@ -278,7 +277,7 @@ class ColorChooser(ttk.Frame):
             color=self.initialcolor,
             model='hex',
         )
-        tkLabel(
+        ttk.TkLabel(
             master=old,
             text=MessageCatalog.translate('Current'),
             background=self.initialcolor,
@@ -288,7 +287,7 @@ class ColorChooser(ttk.Frame):
         ).pack(anchor=NW)
 
         # the frame and label for the new color
-        self.preview = tkFrame(
+        self.preview = ttk.TkFrame(
             master=container,
             relief=FLAT,
             bd=2,
@@ -298,7 +297,7 @@ class ColorChooser(ttk.Frame):
             autostyle=False
         )
         self.preview.pack(side=LEFT, fill=BOTH, expand=YES, padx=(2, 0))
-        self.preview_lbl = tkLabel(
+        self.preview_lbl = ttk.TkLabel(
             master=self.preview,
             text=MessageCatalog.translate('New'),
             background=self.initialcolor,
@@ -533,7 +532,7 @@ class ColorChooser(ttk.Frame):
 
     def on_press_swatch(self, event: tkinter.Event) -> None:
         """Update the widget colors when a color swatch is clicked."""
-        button: tkFrame = self.nametowidget(event.widget)
+        button: ttk.TkFrame = self.nametowidget(event.widget)
         color = button.cget('background')
         self.hex.set(color)
         self.sync_color_values(HEX)
@@ -649,7 +648,7 @@ class ColorChooserDialog(Dialog):
         # color dropper (not supported on Mac OS)
         if self._toplevel.winsys != 'aqua':
             dropper = ttk.Label(frame, text=PEN, font=('-size 16'))
-            ToolTip(dropper, MessageCatalog.translate('color dropper'))  # add tooltip
+            ToolTip(dropper, text=MessageCatalog.translate('color dropper'))  # add tooltip
             dropper.pack(side=RIGHT, padx=2)
             dropper.bind("<Button-1>", self.on_show_colordropper)
 

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -134,3 +134,32 @@ def test_datepicker_has_show_and_autoshow():
     assert "autoshow" in sig.parameters
     assert hasattr(DatePickerDialog, "show")
     assert isinstance(inspect.getattr_static(DatePickerDialog, "result"), property)
+
+
+# --- ColorChooser: builds under the 2.0 default (no global monkey-patch) ----
+# Regression: the swatch/preview widgets used native tk.Frame/tk.Label with
+# `autostyle=False`, which stock tkinter rejects unless enable_global_api() has
+# patched the tk constructors. They now use the blessed ttk.TkFrame/ttk.TkLabel
+# (AutoStyleMixin), which honor `autostyle=` in both modes.
+
+def test_blessed_tk_label_opts_out_of_theming(root):
+    lbl = ttk.TkLabel(root, text="x", background="#ff0000", autostyle=False)
+    from ttkbootstrap.style import AutoStyleMixin
+    assert isinstance(lbl, AutoStyleMixin)
+    assert getattr(lbl, "_tb_no_autostyle", False) is True
+    assert lbl.cget("background") == "#ff0000"   # theme did not repaint it
+
+
+def test_colorchooser_builds_without_global_api(root):
+    from ttkbootstrap.dialogs.colorchooser import ColorChooser
+    cc = ColorChooser(root, initialcolor="#3366cc")
+    assert isinstance(cc.preview, ttk.TkFrame)
+    assert isinstance(cc.preview_lbl, ttk.TkLabel)
+
+
+def test_colorchooserdialog_build_without_global_api(root):
+    from ttkbootstrap.dialogs.colorchooser import ColorChooserDialog
+    dlg = ColorChooserDialog(initialcolor="#3366cc")
+    dlg.build()   # full body + buttonbox (regressed on the ToolTip call)
+    assert dlg._toplevel is not None
+    dlg._toplevel.destroy()


### PR DESCRIPTION
## Summary

Fixes a **2.0 regression** that crashes `ColorChooser`/`ColorChooserDialog`
(and `Querybox.get_color`) in the default configuration, and adds the blessed
`ttk.TkLabel` needed for the fix.

## The bug

`ColorChooser` builds its color swatches and preview panels from *native*
`tkinter.Frame`/`tkinter.Label` passed `autostyle=False`. `autostyle` is a
ttkbootstrap concept — stock tkinter rejects `-autostyle` unless
`enable_global_api()` has patched the tk constructors. Since 2.0 stopped
monkey-patching tkinter at import (PR 3, #1075), opening the color chooser now
raises:

```
_tkinter.TclError: unknown option "-autostyle"
```

The swatches use `autostyle=False` *deliberately* — they must show literal
colors the theme must not repaint.

## The fix

- **Add `ttk.TkLabel`** — a blessed `AutoStyleMixin` subclass of `tkinter.Label`
  (mirroring the existing `TkFrame`), re-exported from `ttkbootstrap`. It honors
  `autostyle=` in both the default and global-API modes; with `autostyle=False`
  it opts out of theming and keeps its explicit colors.
- **Build the swatches/preview from `TkFrame`/`TkLabel`** instead of the native
  classes. (`colordropper.py` already used the blessed `ttk.Canvas` for the same
  reason — this brings the color chooser in line.)
- **Fix a second latent break in the same dialog:** `create_buttonbox` called
  `ToolTip(widget, text)` positionally, but `ToolTip` became keyword-only in the
  #1114 normalization.

## Tests

`tests/test_dialogs_api.py` (+3): `TkLabel(autostyle=False)` opts out and keeps
its bg; `ColorChooser` and `ColorChooserDialog.build()` both work **without**
`enable_global_api()`. Full suite green apart from the known pre-existing env
flakes (`test_msgcat`, `test_center_on_screen`, and an order-dependent
`test_color_helpers` case) — all confirmed failing identically on pristine `2.0`.

Found while smoke-testing the fluent-geometry PR (#1130). Logged in
`development/2_0_breaking_changes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
