### PR TITLE
Use 2.0 kwarg spellings in the __main__ demo

### DIFF
--- a/src/ttkbootstrap/__main__.py
+++ b/src/ttkbootstrap/__main__.py
@@ -139,7 +139,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
     nb.add(ttk.Frame(nb), text="Tab 5")
 
     # text widget
-    txt = ScrolledText(master=lframe, height=5, width=50, autohide=True)
+    txt = ScrolledText(master=lframe, height=5, width=50, auto_hide=True)
     txt.insert(END, ZEN)
     txt.pack(side=LEFT, anchor=NW, pady=5, fill=BOTH, expand=YES)
     lframe_inner = ttk.Frame(lframe).pack(fill=BOTH, expand=YES, padx=10)
@@ -163,8 +163,8 @@ Namespaces are one honking great idea -- let's do more of those!"""
 
     m = ttk.Meter(
         master=lframe_inner,
-        metersize=150,
-        amountused=45,
+        meter_size=150,
+        amount_used=45,
         subtext="meter widget",
         bootstyle=INFO,
         interactive=True,


### PR DESCRIPTION
## Summary

Removes 3 self-inflicted `DeprecationWarning`s from the `python -m ttkbootstrap`
demo. It constructed `Meter` with the pre-2.0 `metersize`/`amountused` and
`ScrolledText` with `autohide` — all warn-and-normalized by `style/_compat.py`,
so the library's own demo warned on launch. Switched to the normalized
`meter_size`/`amount_used`/`auto_hide`. No behavior change.

## Context

Found during a sweep for **latent 2.0 regressions** (code still assuming the
removed import-time monkey-patch or the pre-normalization signatures). The audit
covered two crash classes:

- **Native tk/ttk widget given `bootstyle=`/`autostyle=`** — none remain (the
  only instance was ColorChooser, fixed in #1131).
- **Positional arg to a now-keyword-only API** — none remain in `src/` (the only
  instance was the `ToolTip` call in ColorChooser, also fixed in #1131).

This demo self-deprecation was the only other actionable finding, and it's
warnings-only (not a crash). Purely a first-party tidy-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
