### PR TITLE
Clamp center_on_screen to the target monitor's bounds

### DIFF
--- a/src/ttkbootstrap/internal/positioning.py
+++ b/src/ttkbootstrap/internal/positioning.py
@@ -60,19 +60,28 @@ def center_on_screen(window: tkinter.Misc) -> Tuple[int, int]:
 
     With ``screeninfo`` installed, centers on the monitor under the mouse
     cursor (the display the user is most likely looking at); otherwise centers
-    on Tk's single reported screen. Call ``update_idletasks()`` first for an
-    accurate size — this method does so as well.
+    on Tk's single reported screen. The result is clamped so the window stays
+    fully within that monitor — on a multi-monitor layout the target display can
+    have a negative origin (e.g. a screen to the left of the primary), and a
+    window larger than the monitor is pinned to its top-left rather than
+    overflowing. Call ``update_idletasks()`` first for an accurate size — this
+    method does so as well.
     """
     window.update_idletasks()
     w_width, w_height = _window_size(window)
     monitor = _monitor_at_point(window.winfo_pointerx(), window.winfo_pointery())
     if monitor:
         mx, my, mw, mh = monitor
-        x = mx + (mw - w_width) // 2
-        y = my + (mh - w_height) // 2
     else:
-        x = (window.winfo_screenwidth() - w_width) // 2
-        y = (window.winfo_screenheight() - w_height) // 2
+        mx, my = 0, 0
+        mw, mh = window.winfo_screenwidth(), window.winfo_screenheight()
+    x = mx + (mw - w_width) // 2
+    y = my + (mh - w_height) // 2
+    # Keep the window inside the monitor: never let a large window overflow past
+    # the monitor's own origin (which may itself be negative on a secondary
+    # display), and never off its far edge.
+    x = max(mx, min(x, mx + mw - w_width))
+    y = max(my, min(y, my + mh - w_height))
     return int(x), int(y)
 
 

--- a/tests/test_window_api.py
+++ b/tests/test_window_api.py
@@ -97,10 +97,24 @@ def test_apply_geometry_nothing_is_a_noop():
 # --------------------------------------------------------------------------
 
 def test_center_on_screen_is_within_bounds(root):
+    # The window must land fully inside its target monitor. On a multi-monitor
+    # layout that monitor can have a negative origin (a display left of/above the
+    # primary), so asserting `x >= 0` is wrong — resolve the same monitor the
+    # function centers on and assert against its bounds.
     x, y = positioning.center_on_screen(root)
-    assert x >= 0 and y >= 0
-    assert x <= root.winfo_screenwidth()
-    assert y <= root.winfo_screenheight()
+    w_width, w_height = positioning._window_size(root)
+    monitor = positioning._monitor_at_point(
+        root.winfo_pointerx(), root.winfo_pointery()
+    )
+    if monitor:
+        mx, my, mw, mh = monitor
+    else:
+        mx, my = 0, 0
+        mw, mh = root.winfo_screenwidth(), root.winfo_screenheight()
+    # `max(0, ...)` keeps the bound valid even if the window is larger than the
+    # monitor, in which case the function pins it to the monitor's top-left.
+    assert mx <= x <= mx + max(0, mw - w_width)
+    assert my <= y <= my + max(0, mh - w_height)
 
 
 def test_center_on_parent_offsets_from_parent_origin(root):


### PR DESCRIPTION
## What

`internal/positioning.center_on_screen` (used by `Window`/`Toplevel.place_window_center`) centered on the monitor under the cursor but never clamped the result. On a multi-monitor layout where the target display has a **negative origin** (a screen positioned left of / above the primary), it could return coordinates that place the window outside that monitor.

- Clamp the centered position to the resolved monitor's bounds.
- Unify the no-`screeninfo` fallback onto the same `(origin, size)` path, so a window larger than the screen is pinned to the top-left instead of overflowing.
- Rewrite `test_center_on_screen_is_within_bounds` to assert the window lands within its **resolved monitor** (mirroring the function's monitor resolution) instead of the naive `x >= 0` — which was wrong for negative-origin displays and made the test order-dependent.

## Testing

- `tests/test_window_api.py` — 22 passed.
- Full headless suite green apart from the two known **pre-existing** non-blocking failures (the `nl.msg`/`test_msgcat` localization env flake, and the order-dependent `test_color_helpers` flake — both fail on clean `2.0` and pass in isolation).

Fixes the latent multi-monitor centering bug tracked since the PR B positioning port (#1103).

🤖 Generated with [Claude Code](https://claude.com/claude-code)