### PR TITLE
Expose public utilities at the top level + windowing_system helper

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -1057,3 +1057,34 @@ but `ToolTip` became keyword-only in the #1114 normalization.
 **Migration.** None. `ColorChooser`/`ColorChooserDialog` (and `Querybox.get_color`)
 now work without `enable_global_api()`. `ttk.TkLabel` is available for any tk
 label that must carry explicit, un-themed colors.
+
+---
+
+## Public utilities re-exported at the top level + `windowing_system`  *(New)*
+
+**What.** The public utility helpers are now reachable directly on the package,
+the same way widgets and dialogs are (`ttk.<name>`), instead of only via their
+submodules:
+
+- from `ttkbootstrap.utility`: `enable_high_dpi_awareness`, `scale_size`, and a
+  **new** `windowing_system(widget)` helper (returns `'win32'`/`'aqua'`/`'x11'`).
+- from `ttkbootstrap.colorutils`: `color_to_rgb`, `color_to_hex`, `color_to_hsl`,
+  `update_hsl_value`, `contrast_color`, `conform_color_model`.
+
+`windowing_system(widget)` wraps `widget.tk.call('tk', 'windowingsystem')` and
+now backs the ~8 first-party sites that previously repeated that raw Tcl call
+(`window.py`, `dialogs/base.py`, `dialogs/datepicker.py`, `widgets/toast.py`,
+`widgets/tableview.py`, `widgets/scrolled.py`). `style/scaling.py` keeps its own
+leaf `windowing_system` property (it sits in the early style-init path, so it
+stays free of a cross-package import).
+
+**Why.** These are documented public helpers, but reaching them meant knowing the
+submodule path (`from ttkbootstrap.utility import scale_size`). Surfacing them on
+the top-level namespace matches how the rest of the public API is exposed and
+makes `ttk.scale_size(...)` / `ttk.contrast_color(...)` "just work". The
+`windowing_system` helper also gives platform checks one spelling instead of a
+scattered raw Tcl call. `colorutils` gained an `__all__` so its public surface is
+explicit.
+
+**Migration.** None — purely additive. The `ttkbootstrap.utility` /
+`ttkbootstrap.colorutils` import paths remain valid.

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -73,6 +73,24 @@ from ttkbootstrap.style import (
 # Opt-in migration path for the pre-2.0 theme names (Workstream E/F).
 from ttkbootstrap.themes.legacy import install_legacy_themes
 
+# Public utilities re-exported at the top level for convenience. The
+# `ttkbootstrap.utility` / `ttkbootstrap.colorutils` module paths remain valid;
+# these names just make `ttk.scale_size(...)` / `ttk.contrast_color(...)` work
+# the same way the widgets and dialogs are reachable as `ttk.<Name>`.
+from ttkbootstrap.utility import (
+    enable_high_dpi_awareness,
+    scale_size,
+    windowing_system,
+)
+from ttkbootstrap.colorutils import (
+    color_to_rgb,
+    color_to_hex,
+    color_to_hsl,
+    update_hsl_value,
+    contrast_color,
+    conform_color_model,
+)
+
 
 # --------------------------------------------------------------------------- #
 # Concrete ttk widget classes — the blessed `bootstyle` set.
@@ -279,6 +297,17 @@ __all__ = [
     "icon_element",
     "set_bootstyle_strict",
     "is_bootstyle_strict",
+
+    # Public utilities
+    "enable_high_dpi_awareness",
+    "scale_size",
+    "windowing_system",
+    "color_to_rgb",
+    "color_to_hex",
+    "color_to_hsl",
+    "update_hsl_value",
+    "contrast_color",
+    "conform_color_model",
 
     # Windows
     "Toplevel",

--- a/src/ttkbootstrap/colorutils.py
+++ b/src/ttkbootstrap/colorutils.py
@@ -33,6 +33,15 @@ Example:
 from PIL import ImageColor
 from colorsys import rgb_to_hls
 
+__all__ = [
+    "color_to_rgb",
+    "color_to_hex",
+    "color_to_hsl",
+    "update_hsl_value",
+    "contrast_color",
+    "conform_color_model",
+]
+
 RGB = 'rgb'
 HSL = 'hsl'
 HEX = 'hex'

--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, Tuple
 import ttkbootstrap as ttk
 from ttkbootstrap.internal.utility import center_on_parent
 from ttkbootstrap.internal.positioning import ensure_on_screen
+from ttkbootstrap.utility import windowing_system
 
 
 class Dialog(BaseWidget):
@@ -34,7 +35,7 @@ class Dialog(BaseWidget):
                 Ring the display's bell when the dialog is shown.
         """
         BaseWidget._setup(self, parent, {})
-        self._winsys = self.master.tk.call("tk", "windowingsystem")
+        self._winsys = windowing_system(self.master)
         self._parent = parent
         self._toplevel = None
         self._title = title or " "

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -13,6 +13,7 @@ from ttkbootstrap.internal.positioning import (
     center_on_screen,
     ensure_on_screen,
 )
+from ttkbootstrap.utility import windowing_system
 from ttkbootstrap.style._compat import normalize_datepicker_kwargs
 
 
@@ -305,7 +306,7 @@ class DatePickerDialog:
     def _setup_calendar(self) -> None:
         """Setup the calendar widget"""
         # create the widget containers
-        frm_style = "Card.TFrame" if self.root.tk.call('tk', 'windowingsystem') != 'aqua' else  "TFrame"
+        frm_style = "Card.TFrame" if windowing_system(self.root) != 'aqua' else "TFrame"
         self.frm_calendar = ttk.Frame(master=self.root, padding=2, style=frm_style).pack(fill=BOTH, expand=YES)
         self.frm_title = ttk.Frame(self.frm_calendar, padding=(3, 3)).pack(fill=X)
         self.frm_header = ttk.Frame(self.frm_calendar).pack(fill=X)

--- a/src/ttkbootstrap/utility.py
+++ b/src/ttkbootstrap/utility.py
@@ -6,6 +6,7 @@ ttkbootstrap applications.
 Functions:
     enable_high_dpi_awareness: Enable high-DPI scaling on Windows/Linux
     scale_size: Scale a size value for high-DPI displays
+    windowing_system: Detect the Tk windowing system ('win32'/'aqua'/'x11')
 
 Example:
     ```python
@@ -130,3 +131,23 @@ def scale_size(widget, size):
     from ttkbootstrap.style.scaling import Scaling
 
     return Scaling.for_widget(widget).logical(size)
+
+
+def windowing_system(widget):
+    """Return the Tk windowing system for `widget`'s display.
+
+    One of `'win32'` (Windows), `'aqua'` (macOS), or `'x11'` (Linux/Unix).
+    Wraps `widget.tk.call('tk', 'windowingsystem')` so platform checks read the
+    same everywhere instead of repeating the raw Tcl call.
+
+    Parameters:
+
+        widget (Misc):
+            Any widget (or the root) whose interpreter is queried.
+
+    Returns:
+
+        str:
+            The windowing system identifier.
+    """
+    return str(widget.tk.call('tk', 'windowingsystem'))

--- a/src/ttkbootstrap/widgets/scrolled.py
+++ b/src/ttkbootstrap/widgets/scrolled.py
@@ -43,6 +43,7 @@ import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
 from ttkbootstrap.internal.configure_delegation import ConfigureDelegationMixin
 from ttkbootstrap.style._compat import normalize_scrolled_kwargs, warn_deprecated
+from ttkbootstrap.utility import windowing_system
 
 # Small pad at both long-axis ends of a scrollbar so it isn't flush against the
 # container edge -- applied on both ends because either can sit at the border
@@ -420,7 +421,7 @@ class ScrolledFrame(ttk.Frame):
             width=width,
             height=height,
         )
-        self.winsys: str = self.container.tk.call("tk", "windowingsystem")
+        self.winsys: str = windowing_system(self.container)
         self.container.propagate(False)
         self.container.grid_rowconfigure(0, weight=1)
         self.container.grid_columnconfigure(0, weight=1)

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -2562,7 +2562,7 @@ class Tableview(ttk.Frame):
         self.view.bind("<Button-1>", self._header_leftclick)
 
         if not self.disable_right_click:
-            if self.tk.call("tk", "windowingsystem") == "aqua":
+            if utility.windowing_system(self) == "aqua":
                 sequence = "<Button-2>"
             else:
                 sequence = "<Button-3>"

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -242,7 +242,7 @@ class ToastNotification:
         # with the tooltip); set it at construction, so probe the windowing
         # system from the existing root before creating the Toplevel.
         if _default_root is not None and "window_type" not in self.kwargs:
-            if _default_root.tk.call("tk", "windowingsystem") == "aqua":
+            if utility.windowing_system(_default_root) == "aqua":
                 self.kwargs["window_type"] = "tooltip"
 
         self.toplevel = Toplevel(**self.kwargs)
@@ -359,7 +359,7 @@ class ToastNotification:
     def _setup(self, window) -> None:
         from ttkbootstrap import utility
 
-        winsys = window.tk.call("tk", "windowingsystem")
+        winsys = utility.windowing_system(window)
         self.toplevel.configure(relief=RAISED)
 
         if "minsize" not in self.kwargs:

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -526,7 +526,7 @@ class Window(_BaseWindow, tkinter.Tk):
         self._set_app_user_model_id()
 
         super().__init__(**kwargs)
-        self.winsys: str = self.tk.call('tk', 'windowingsystem')
+        self.winsys: str = utility.windowing_system(self)
 
         if scaling is not None:
             utility.enable_high_dpi_awareness(self, scaling)
@@ -699,7 +699,7 @@ class Toplevel(_BaseWindow, tkinter.Toplevel):
         tool_window = aliases.get("tool_window", tool_window)
 
         super().__init__(**kwargs)
-        self.winsys: str = self.tk.call('tk', 'windowingsystem')
+        self.winsys: str = utility.windowing_system(self)
 
         # On aqua, give a borderless popup type (tooltip/splash/...) a native
         # macOS window class instead of the default chrome, so it isn't drawn

--- a/tests/test_utility_api.py
+++ b/tests/test_utility_api.py
@@ -1,0 +1,58 @@
+"""Headless tests for the 2.0 public-utility surface.
+
+Covers that the utility/colorutils helpers are reachable at the top level
+(`ttk.<name>`) and that the new `windowing_system` helper matches the raw Tcl
+call it consolidates.
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap import colorutils, utility
+
+
+# --------------------------------------------------------------------------
+# top-level exposure
+# --------------------------------------------------------------------------
+
+_UTILITY_NAMES = ("enable_high_dpi_awareness", "scale_size", "windowing_system")
+_COLOR_NAMES = (
+    "color_to_rgb", "color_to_hex", "color_to_hsl",
+    "update_hsl_value", "contrast_color", "conform_color_model",
+)
+
+
+def test_public_utilities_are_top_level_and_in_all():
+    for name in _UTILITY_NAMES + _COLOR_NAMES:
+        assert hasattr(ttk, name), f"ttk.{name} is not exported"
+        assert name in ttk.__all__, f"{name} missing from ttk.__all__"
+
+
+def test_top_level_names_are_the_module_objects():
+    # the re-exports must be the real functions, not shadowing copies
+    assert ttk.scale_size is utility.scale_size
+    assert ttk.windowing_system is utility.windowing_system
+    assert ttk.contrast_color is colorutils.contrast_color
+
+
+# --------------------------------------------------------------------------
+# windowing_system
+# --------------------------------------------------------------------------
+
+def test_windowing_system_matches_raw_call(root):
+    assert ttk.windowing_system(root) == root.tk.call("tk", "windowingsystem")
+
+
+def test_windowing_system_returns_known_value(root):
+    assert ttk.windowing_system(root) in ("win32", "aqua", "x11")
+
+
+# --------------------------------------------------------------------------
+# scale_size + colorutils behave through the top-level names
+# --------------------------------------------------------------------------
+
+def test_scale_size_scales_a_pair(root):
+    scaled = ttk.scale_size(root, (10, 20))
+    assert isinstance(scaled, list) and len(scaled) == 2
+
+
+def test_colorutils_round_trip():
+    assert ttk.color_to_rgb("#ff5733", model=colorutils.HEX) == (255, 87, 51)
+    assert ttk.color_to_hex((255, 87, 51), model=colorutils.RGB) == "#ff5733"


### PR DESCRIPTION
## What

Surfaces the documented public utility/colorutils helpers on the top-level `ttkbootstrap` namespace (`ttk.<name>`), the same way widgets and dialogs are reachable — plus a new `windowing_system(widget)` helper that consolidates a repeated raw Tcl call.

**Re-exported at top level** (submodule paths remain valid):
- `ttkbootstrap.utility`: `enable_high_dpi_awareness`, `scale_size`, and the **new** `windowing_system(widget)` → `'win32'`/`'aqua'`/`'x11'`
- `ttkbootstrap.colorutils`: `color_to_rgb`, `color_to_hex`, `color_to_hsl`, `update_hsl_value`, `contrast_color`, `conform_color_model` (module gained an `__all__`)

**Consolidation:** `windowing_system` now backs the ~8 first-party sites that repeated `widget.tk.call('tk', 'windowingsystem')` (`window.py`, `dialogs/base.py`, `dialogs/datepicker.py`, `widgets/toast.py`, `widgets/tableview.py`, `widgets/scrolled.py`). `style/scaling.py` keeps its own leaf property to avoid a cross-package import in the early style-init path.

## Testing

- New `tests/test_utility_api.py` (+6): top-level exposure + `__all__` membership, identity with the module objects, `windowing_system` matches the raw call, `scale_size` / colorutils round-trip.
- Full headless suite green (495 passed) apart from the known pre-existing non-blocking failures: the `nl.msg`/`test_msgcat` localization env flake, the order-dependent `test_color_helpers` flake, and `test_center_on_screen_is_within_bounds` (the multi-monitor bug fixed separately in #1134 — not in this branch's base).
- Import is warning-free (`warnings.simplefilter("error")`).

Purely additive — no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)