### PR TITLE
Control-height parity + focus rings across the button family (incl. toggles)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -1102,9 +1102,10 @@ explicit.
   `Menubutton`, `Toolbutton`, `Entry`, `Combobox`, `Spinbox` — is the same
   height again, matching 1.x (where they were all ~29).
 - **Focus rings everywhere in the button family.** `Checkbutton`, `Radiobutton`,
-  and `Menubutton` had **no** keyboard-focus ring; `Button`/`Toolbutton` already
+  `Menubutton`, and the toggle/switch styles (`toggle`/`round-toggle`/
+  `square-toggle`) had **no** keyboard-focus ring; `Button`/`Toolbutton` already
   did. They now all draw the same 1px `focuscolor` ring on focus (the ring hugs
-  the label and does not change the indicator-driven check/radio height).
+  the label and does not change the indicator-driven check/radio/switch height).
 
 **Why.** The +2px on buttons was an unintended side effect of the 2.0 button
 restyle adding a `focusthickness=1` focus ring (which reserves 1px per side) on
@@ -1116,8 +1117,10 @@ whole family.
 
 **Scope.** `style/builders/{button,toolbutton,menubutton}.py` (padding
 `(…,5,…)` → `(…,4,…)`; menubutton `focusthickness` 0 → 1) and
-`style/builders/{checkbutton,radiobutton}.py` (add `focuscolor`/`focusthickness`
-+ a disabled `focuscolor` map). Inputs are unchanged (they signal focus with a
-border-color highlight, not a ring — see "Inputs: focus color on focus only").
+`style/builders/{checkbutton,radiobutton,toggle}.py` (add
+`focuscolor`/`focusthickness` + a disabled `focuscolor` map; the toggle layouts
+also gain a `Toolbutton.focus` wrapper around the label, which they lacked).
+Inputs are unchanged (they signal focus with a border-color highlight, not a
+ring — see "Inputs: focus color on focus only").
 
 **Migration.** None (appearance only).

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -39,6 +39,7 @@
 | **Scrollbar: no trough channel, darker light-mode thumb** | Visual | this doc, below |
 | **Inputs: focus color on focus only (not hover)** | Visual | this doc, below |
 | **`card` / `highlight` frames: hairline border (`RAISED`, no bevel)** | Visual | this doc, below |
+| **Control-height parity + check/radio/menubutton focus rings** | Visual | this doc, below |
 
 ---
 
@@ -1088,3 +1089,35 @@ explicit.
 
 **Migration.** None — purely additive. The `ttkbootstrap.utility` /
 `ttkbootstrap.colorutils` import paths remain valid.
+
+---
+
+## Control-height parity + check/radio/menubutton focus rings  *(Visual)*
+
+**What.** Two related visual fixes to the interactive controls:
+
+- **Height parity.** Buttons, toolbuttons, and menubuttons rendered 2px taller
+  than the text inputs (31 vs 29px at 100%). The button/toolbutton/menubutton
+  vertical padding is trimmed by 1px per side so every control — `Button`,
+  `Menubutton`, `Toolbutton`, `Entry`, `Combobox`, `Spinbox` — is the same
+  height again, matching 1.x (where they were all ~29).
+- **Focus rings everywhere in the button family.** `Checkbutton`, `Radiobutton`,
+  and `Menubutton` had **no** keyboard-focus ring; `Button`/`Toolbutton` already
+  did. They now all draw the same 1px `focuscolor` ring on focus (the ring hugs
+  the label and does not change the indicator-driven check/radio height).
+
+**Why.** The +2px on buttons was an unintended side effect of the 2.0 button
+restyle adding a `focusthickness=1` focus ring (which reserves 1px per side) on
+top of the existing padding; nothing compensated for it, so buttons grew. The
+fix keeps the accessibility win (a visible focus ring) and restores the height by
+absorbing the ring into the padding. Adding the missing rings to
+check/radio/menubutton makes keyboard focus visible and consistent across the
+whole family.
+
+**Scope.** `style/builders/{button,toolbutton,menubutton}.py` (padding
+`(…,5,…)` → `(…,4,…)`; menubutton `focusthickness` 0 → 1) and
+`style/builders/{checkbutton,radiobutton}.py` (add `focuscolor`/`focusthickness`
++ a disabled `focuscolor` map). Inputs are unchanged (they signal focus with a
+border-color highlight, not a ring — see "Inputs: focus color on focus only").
+
+**Migration.** None (appearance only).

--- a/src/ttkbootstrap/style/builders/button.py
+++ b/src/ttkbootstrap/style/builders/button.py
@@ -70,7 +70,7 @@ def build_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),
         focuscolor=on_fill,
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 4)),
         anchor=tk.CENTER,
     )
     builder.style.map(
@@ -110,7 +110,7 @@ def _build_neutral_outline_button_style(builder: StyleBuilderTTK, ttk_class):
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),
         focuscolor=fg,
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 4)),
         anchor=tk.CENTER,
     )
     builder.style.map(
@@ -180,7 +180,7 @@ def build_outline_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),
         focuscolor=accent,
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 4)),
         anchor=tk.CENTER,
     )
     builder.style.map(
@@ -252,7 +252,7 @@ def build_link_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         focusthickness=builder.scale_size(1),
         focuscolor=on_surface,
         anchor=tk.CENTER,
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 4)),
     )
     builder.style.map(
         ttk_style,
@@ -322,7 +322,7 @@ def build_ghost_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         borderwidth=1,
         focusthickness=builder.scale_size(1),
         focuscolor=fg,
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 4)),
         anchor=tk.CENTER,
     )
     builder.style.map(

--- a/src/ttkbootstrap/style/builders/checkbutton.py
+++ b/src/ttkbootstrap/style/builders/checkbutton.py
@@ -27,8 +27,18 @@ def build_checkbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     accent = builder.colors.get(colorname or 'primary')
     on_accent = builder.on_color(accent)
 
-    builder.configure(sn.ttk_style, foreground=fg)
-    state_map(builder.style, sn.ttk_style, foreground={"disabled": disabled})
+    # A 1px keyboard-focus ring around the label (drawn by the `.focus` element
+    # in the layout below), matching the button family so focus is visible here
+    # too. It hugs the label and does not change the indicator-driven height.
+    builder.configure(
+        sn.ttk_style, foreground=fg,
+        focuscolor=fg, focusthickness=builder.scale_size(1),
+    )
+    state_map(
+        builder.style, sn.ttk_style,
+        foreground={"disabled": disabled},
+        focuscolor={"disabled": disabled},
+    )
 
     # Create style assets
     a = builder.assets

--- a/src/ttkbootstrap/style/builders/menubutton.py
+++ b/src/ttkbootstrap/style/builders/menubutton.py
@@ -64,15 +64,16 @@ def build_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         lightcolor=background,
         relief=tk.RAISED,
         borderwidth=1,  # 1px hairline; intentionally unscaled
-        focusthickness=0,
+        focusthickness=builder.scale_size(1),
         focuscolor=foreground,
         # (left, top, right, bottom): 10px label inset on the left, a tighter
         # 6px on the right so the caret sits closer to the edge than the label.
-        padding=builder.scale_size((10, 5, 6, 5)),
+        padding=builder.scale_size((10, 4, 6, 4)),
     )
     builder.style.map(
         ttk_style,
         foreground=[("disabled", disabled_fg)],
+        focuscolor=[("disabled", disabled_fg)],
         background=fill_states,
         bordercolor=border_states,
         darkcolor=fill_states,
@@ -147,13 +148,14 @@ def _build_neutral_outline_menubutton(builder: StyleBuilderTTK, ttk_class, disab
         lightcolor=surface,
         relief=tk.RAISED,
         borderwidth=1,  # 1px hairline; intentionally unscaled
-        focusthickness=0,
+        focusthickness=builder.scale_size(1),
         focuscolor=fg,
-        padding=builder.scale_size((10, 5, 6, 5)),
+        padding=builder.scale_size((10, 4, 6, 4)),
     )
     builder.style.map(
         ttk_style,
         foreground=[("disabled", disabled_fg)],
+        focuscolor=[("disabled", disabled_fg)],
         background=fill_states,
         bordercolor=border_states,
         darkcolor=fill_states,
@@ -204,9 +206,9 @@ def build_outline_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         lightcolor=builder.colors.bg,
         relief=tk.RAISED,
         borderwidth=1,  # 1px hairline; intentionally unscaled
-        focusthickness=0,
+        focusthickness=builder.scale_size(1),
         focuscolor=foreground,
-        padding=builder.scale_size((10, 5, 6, 5)),
+        padding=builder.scale_size((10, 4, 6, 4)),
     )
     builder.style.map(
         ttk_style,
@@ -215,6 +217,7 @@ def build_outline_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             ("pressed !disabled", foreground_pressed),
             ("hover !disabled", foreground_pressed),
         ],
+        focuscolor=[("disabled", disabled_fg)],
         background=[
             ("pressed !disabled", pressed),
             ("hover !disabled", hover),

--- a/src/ttkbootstrap/style/builders/radiobutton.py
+++ b/src/ttkbootstrap/style/builders/radiobutton.py
@@ -33,8 +33,18 @@ def build_radiobutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     else:
         accent = builder.colors.get(sn.colorname)
 
-    builder.configure(sn.ttk_style, foreground=fg)
-    state_map(builder.style, sn.ttk_style, foreground={"disabled": disabled})
+    # A 1px keyboard-focus ring around the label (drawn by the `.focus` element
+    # in the layout below), matching the button family so focus is visible here
+    # too. It hugs the label and does not change the indicator-driven height.
+    builder.configure(
+        sn.ttk_style, foreground=fg,
+        focuscolor=fg, focusthickness=builder.scale_size(1),
+    )
+    state_map(
+        builder.style, sn.ttk_style,
+        foreground={"disabled": disabled},
+        focuscolor={"disabled": disabled},
+    )
 
     a = builder.assets
     selected = a.recolor("radiobutton", white=accent, black=accent)

--- a/src/ttkbootstrap/style/builders/toggle.py
+++ b/src/ttkbootstrap/style/builders/toggle.py
@@ -72,10 +72,15 @@ def _build_round_toggle_style(builder: StyleBuilderTTK, colorname, ttk_class):
         padding=0,
         foreground=builder.colors.fg,
         background=builder.colors.bg,
+        # 1px keyboard-focus ring around the label (via the `Toolbutton.focus`
+        # element in the layout below), matching the rest of the button family.
+        focuscolor=builder.colors.fg,
+        focusthickness=builder.scale_size(1),
     )
     builder.style.map(
         ttk_style,
         foreground=[("disabled", disabled_fg)],
+        focuscolor=[("disabled", disabled_fg)],
         background=[("selected", builder.colors.bg)],
     )
     a = builder.assets
@@ -107,7 +112,8 @@ def _build_round_toggle_style(builder: StyleBuilderTTK, colorname, ttk_class):
             El("Toolbutton.padding", sticky=NSEW, children=[
                 El(f"{ttk_style}.indicator", side=LEFT),
                 El(spacer_name, side=LEFT),
-                El("Toolbutton.label", side=LEFT)])]))
+                El("Toolbutton.focus", side=LEFT, sticky="", children=[
+                    El("Toolbutton.label", side=LEFT)])])]))
     # register ttkstyle
     builder.register_ttkstyle(ttk_style)
 
@@ -143,10 +149,16 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     else:
         accent = builder.colors.get(colorname)
 
-    builder.configure(ttk_style, relief=tk.FLAT, borderwidth=0, foreground=builder.colors.fg)
+    builder.configure(
+        ttk_style, relief=tk.FLAT, borderwidth=0, foreground=builder.colors.fg,
+        # 1px keyboard-focus ring around the label (via the `Toolbutton.focus`
+        # element in the layout below), matching the rest of the button family.
+        focuscolor=builder.colors.fg, focusthickness=builder.scale_size(1),
+    )
     builder.style.map(
         ttk_style,
         foreground=[("disabled", disabled_fg)],
+        focuscolor=[("disabled", disabled_fg)],
         background=[
             ("selected", builder.colors.bg),
             ("!selected", builder.colors.bg),
@@ -174,7 +186,8 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             El("Toolbutton.padding", sticky=NSEW, children=[
                 El(f"{ttk_style}.indicator", side=LEFT),
                 El(spacer_name, side=LEFT),
-                El("Toolbutton.label", side=LEFT)])]))
+                El("Toolbutton.focus", side=LEFT, sticky="", children=[
+                    El("Toolbutton.label", side=LEFT)])])]))
 
     # register ttk style
     builder.register_ttkstyle(ttk_style)

--- a/src/ttkbootstrap/style/builders/toolbutton.py
+++ b/src/ttkbootstrap/style/builders/toolbutton.py
@@ -68,7 +68,7 @@ def build_toolbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),
         focuscolor=on_unselected,
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 4)),
         anchor=tk.CENTER,
     )
     builder.style.map(
@@ -126,7 +126,7 @@ def _build_neutral_outline_toolbutton(builder: StyleBuilderTTK, ttk_class):
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),  # match solid toolbutton height
         focuscolor=on_unselected,
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 4)),
         anchor=tk.CENTER,
     )
     builder.style.map(
@@ -187,7 +187,7 @@ def build_outline_toolbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),  # match solid toolbutton height
         focuscolor=accent,  # focus ring matches the text color (accent at rest)
-        padding=builder.scale_size((10, 5)),
+        padding=builder.scale_size((10, 4)),
         anchor=tk.CENTER,
     )
     # A toolbutton is a toggle: only ON (selected) vs OFF (unselected) -- no

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -275,7 +275,7 @@ def test_representative_builder_geometry_scales_once(root):
         for recipe in recipes:
             recipe(builder, "danger")
 
-        assert style.configure("danger.TButton", "padding") == "15 8"
+        assert style.configure("danger.TButton", "padding") == "15 6"
         assert int(style.configure("danger.TButton", "focusthickness")) == 2
         assert int(style.configure("danger.TEntry", "padding")) == 8
         assert int(style.configure("Sash", "sashthickness")) == 3


### PR DESCRIPTION
## What

Two related visual fixes to the interactive controls (visually approved, light + dark).

**1. Control-height parity.** Buttons, toolbuttons, and menubuttons rendered 2px taller than the text inputs (31 vs 29px at 100%; 1.x had them all ~29). The +2px was an unintended side effect of the 2.0 button restyle adding a `focusthickness=1` focus ring (which reserves 1px per side) without compensating the padding. Trim the vertical padding by 1px per side on the button/toolbutton/menubutton recipes so every control — `Button`, `Menubutton`, `Toolbutton`, `Entry`, `Combobox`, `Spinbox` — lines up at 29 again, **keeping** the focus ring.

**2. Focus rings across the whole button family.** `Checkbutton`, `Radiobutton`, and `Menubutton` had **no** keyboard-focus ring (`Button`/`Toolbutton` already did). They now draw the same 1px `focuscolor` ring on focus. The check/radio ring hugs the label and leaves their indicator-driven height unchanged; menubutton gets the ring plus the matching padding trim so it stays 29.

Inputs are unchanged — they signal focus with a border-color highlight (not a ring), which is the right convention for text fields.

## Scope

- `style/builders/{button,toolbutton,menubutton}.py` — padding `(…,5,…)` → `(…,4,…)`; menubutton `focusthickness` 0 → 1 (+ disabled `focuscolor` map).
- `style/builders/{checkbutton,radiobutton}.py` — add `focuscolor`/`focusthickness` + disabled `focuscolor` map.
- `tests/test_scaling.py` — the one test that pinned the old button padding (`"15 8"` → `"15 6"` at 1.5×).
- `development/2_0_breaking_changes.md` — entry added.

## Testing

- Headless: every control measures 29px in both `bootstrap-light`/`bootstrap-dark`; check/radio stay 18px; menubutton rings wired. **487 passed** apart from the known pre-existing non-blocking flakes (the `nl.msg`/`zh_cn.msg` localization env flake, the order-dependent `test_color_helpers` flake, and the multi-monitor `test_center_on_screen` fixed separately in #1134).
- Visual gate: approved by the author in light + dark (height parity + rings on Tab across buttons/toolbutton/menubutton/checks/radios).

🤖 Generated with [Claude Code](https://claude.com/claude-code)