### PR TITLE
Review and standardize docstrings across the package for 2.0

### DIFF
--- a/development/2_0_docstring_conventions.md
+++ b/development/2_0_docstring_conventions.md
@@ -1,0 +1,62 @@
+# 2.0 docstring conventions
+
+Frozen rules for the 2.0 docstring review/update pass. Every module, class,
+method, and function docstring in `src/` is brought in line with this. The pass
+is **accuracy-first**: the main work is verifying each docstring against the
+current (2.0) signature and behavior, not prose polish.
+
+## Format
+
+- **Google style** — that's what the docs site renders (`mkdocstrings`, Python
+  handler, default config in `mkdocs.yml`). The API reference pages *are* these
+  docstrings, so they must render cleanly there.
+- Section headers, one spelling each: `Parameters:`, `Returns:`, `Raises:`,
+  `Examples:`. (`Parameters:` — not `Args:` — is already dominant; keep it.)
+- Triple-double-quote; summary line in the imperative, then a blank line, then
+  the body.
+
+## Voice / altitude
+
+- Say what the thing **does**, terse and functional. No design rationale, no
+  "canonical" / "the new 2.0 way" narration — that lives in `development/`
+  design docs, not docstrings.
+- Document behavior a caller needs: what it returns, what it raises, side
+  effects, keyword-only-ness where it matters.
+
+## Accuracy (the core work)
+
+- Every documented parameter must exist in the **current** signature with the
+  right type and default. 2.0 churned these hard — `snake_case` renames,
+  keyword-only constructors, unified dialog returns, `get_date`→None on cancel.
+  Assume pre-2.0 docstrings are stale until verified against the code.
+- Kill references to removed modules/shims and pre-2.0 names.
+- Deprecated aliases: mention only where it helps a user migrate; don't
+  exhaustively catalog every legacy spelling in the prose (the `_compat` warnings
+  already do that).
+
+## Images
+
+- **Remove all `![](...png/gif)` image links from docstrings.** They're noise
+  (often broken) in IDE hover and `help()`. Just delete them — do **not**
+  relocate them anywhere. The prose docs pages are being fully rewritten later
+  and will re-add visuals themselves.
+
+## Examples
+
+- Keep runnable `Examples:` blocks on the major public widgets/dialogs; **verify
+  they use current 2.0 API** and trim duplicates / overlong ones.
+- Don't add example blocks to internal helpers or style builders.
+
+## Coverage bar
+
+- **Every module** gets a module docstring (one-paragraph purpose).
+- **Every public class** + its `__init__` and public methods get a docstring.
+- **`internal/` plumbing and per-widget style builders**: a one-line summary is
+  enough; only expand where behavior is non-obvious.
+
+## Validation
+
+- `python -m pytest -q` after each area (should stay green — these aren't
+  doctests).
+- `mkdocs build` to catch broken cross-references and any docs page relying on a
+  removed image path.

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -10,13 +10,13 @@ This package provides:
     - Window and Toplevel classes with enhanced functionality
     - Cross-platform compatibility
 
-Example:
+Examples:
     ```python
     import ttkbootstrap as ttk
     from ttkbootstrap.constants import *
 
     # Create a themed window
-    root = ttk.Window(themename="darkly")
+    root = ttk.Window(themename="bootstrap-dark")
 
     # Create styled widgets
     btn = ttk.Button(root, text="Click Me", bootstyle="success")

--- a/src/ttkbootstrap/__main__.py
+++ b/src/ttkbootstrap/__main__.py
@@ -1,8 +1,6 @@
-"""
-    ttkbootstrap demo
+"""Interactive demo app showcasing ttkbootstrap widgets and themes.
 
-    ISSUES:
-        - the legacy tk widgets do not update after DateDialog is used.
+Known issue: legacy tk widgets do not update after DateDialog is used.
 """
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
@@ -11,6 +9,7 @@ from ttkbootstrap.widgets.scrolled import ScrolledText
 
 
 def setup_demo(master):
+    """Build and return a Frame showcasing themed widgets and a theme selector."""
     ZEN = """Beautiful is better than ugly. 
 Explicit is better than implicit. 
 Simple is better than complex. 

--- a/src/ttkbootstrap/assets/__init__.py
+++ b/src/ttkbootstrap/assets/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored static assets (icon font, images, theme data) bundled with ttkbootstrap."""

--- a/src/ttkbootstrap/assets/elements/__init__.py
+++ b/src/ttkbootstrap/assets/elements/__init__.py
@@ -1,0 +1,1 @@
+"""Marker package for the bundled widget-element image assets (PNGs + manifest)."""

--- a/src/ttkbootstrap/colorutils.py
+++ b/src/ttkbootstrap/colorutils.py
@@ -1,34 +1,7 @@
 """Color utility functions for ttkbootstrap.
 
-This module provides utilities for converting between different color models
-and manipulating colors (adjusting hue, saturation, luminance).
-
-Supported color models:
-    - RGB: Red, Green, Blue tuple (0-255)
-    - HSL: Hue (0-360), Saturation (0-100), Luminance (0-100)
-    - HEX: Hexadecimal color string (#RRGGBB)
-    - NAME: Named colors (e.g., 'red', 'blue')
-
-Functions:
-    color_to_rgb: Convert any color model to RGB
-    color_to_hex: Convert any color model to HEX
-    color_to_hsl: Convert any color model to HSL
-    update_color: Modify HSL values of a color
-    contrast_color: Get contrasting foreground color for readability
-
-Example:
-    ```python
-    from ttkbootstrap.colorutils import *
-
-    # Convert hex to RGB
-    rgb = color_to_rgb('#FF5733', model=HEX)  # (255, 87, 51)
-
-    # Adjust color lightness
-    lighter = update_color('#FF5733', lum=80, inmodel=HEX, outmodel=HEX)
-
-    # Get contrasting text color
-    fg_color = contrast_color('#FF5733')  # Returns 'white' or 'black'
-    ```
+Convert between color models (RGB, HSL, HEX, and named colors) and manipulate
+colors by adjusting hue, saturation, and luminance.
 """
 from PIL import ImageColor
 from colorsys import rgb_to_hls
@@ -227,7 +200,7 @@ def conform_color_model(color, model):
             The color value to conform.
 
         model (str):
-            One of 'HSL', 'RGB', or 'HEX'
+            One of 'hsl', 'rgb', 'hex', or 'name'.
 
     Returns:
 

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -1,42 +1,10 @@
 """Constants and type aliases for ttkbootstrap.
 
-This module defines constants and type aliases used throughout ttkbootstrap,
-including tkinter/ttk configuration values and ttkbootstrap-specific enums.
-
-The module provides:
-    - Type aliases using Literal for better type checking
-    - Standard tkinter constants (anchor, fill, relief, etc.)
-    - TTkbootstrap-specific constants (bootstyle colors and types)
-    - Final-typed constants for IDE autocomplete
-
-All constants are exported in __all__ for easy wildcard import:
-    ```python
-    from ttkbootstrap.constants import *
-    ```
-
-Type Aliases:
-    Anchor: Widget anchor positions (n, s, e, w, nw, ne, sw, se, center)
-    Fill: Fill modes for pack geometry manager (none, x, y, both)
-    Side: Widget placement side (left, top, right, bottom)
-    Relief: Border relief style (raised, sunken, flat, ridge, groove, solid)
-    Orient: Widget orientation (horizontal, vertical)
-    State: Widget state (normal, disabled, active, hidden, readonly)
-    BootColor: Bootstyle color names (primary, secondary, success, etc.)
-    BootType: Bootstyle type modifiers (outline, link, toggle, etc.)
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-    from ttkbootstrap.constants import *
-
-    root = ttk.Window()
-
-    # Use constants for cleaner code
-    btn = ttk.Button(root, text="OK", bootstyle=SUCCESS)
-    btn.pack(side=LEFT, fill=X, padx=10)
-
-    root.mainloop()
-    ```
+Re-exports the standard tkinter/ttk configuration values (anchors, fills,
+reliefs, orientations, states) and defines the ttkbootstrap bootstyle
+vocabulary: the `BootColor`/`BootType`/`BootBase` `Literal` aliases and the
+color/keyword constants. All names are exported via `__all__` for
+`from ttkbootstrap.constants import *`.
 """
 from __future__ import annotations
 

--- a/src/ttkbootstrap/dialogs/__init__.py
+++ b/src/ttkbootstrap/dialogs/__init__.py
@@ -1,35 +1,4 @@
-"""Dialog widgets for ttkbootstrap applications.
-
-This module provides Bootstrap-styled dialog windows for common user interactions
-like messages, questions, file selection, and color picking.
-
-Dialogs:
-    - Messagebox: Display informational messages (info, warning, error, question)
-    - Querybox: Get user input (text, integer, float, selection)
-    - Colorchooser: Select colors using various methods
-    - FontDialog: Select and configure fonts
-
-All dialogs support Bootstrap styling and theming.
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-    from ttkbootstrap.dialogs import Messagebox, Querybox
-
-    root = ttk.Window()
-
-    # Show message
-    Messagebox.ok("Operation completed successfully!")
-
-    # Ask question
-    result = Messagebox.yesno("Do you want to continue?")
-
-    # Get user input
-    name = Querybox.get_string("Enter your name:")
-
-    root.mainloop()
-    ```
-"""
+"""Dialog widgets for ttkbootstrap: message boxes, input queries, date picking, color selection, and font selection."""
 from .colorchooser import (
     ColorChooser,
     ColorChooserDialog,

--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -22,11 +22,11 @@ class Dialog(BaseWidget):
         Parameters:
 
             parent (Widget):
-                Makes the window the logical parent of the message box.
-                The messagebox is displayed on top of its parent window.
+                Makes the window the logical parent of the dialog.
+                The dialog is displayed on top of its parent window.
 
             title (str):
-                The string displayed as the title of the message box.
+                The string displayed as the title of the dialog.
                 This option is ignored on Mac OS X, where platform
                 guidelines forbid the use of a title on this kind of
                 dialog.
@@ -48,13 +48,16 @@ class Dialog(BaseWidget):
         center_on_parent(toplevel, self._parent)
 
     def show(self, position: Optional[Tuple[int, int]] = None, wait_for_result: bool = True) -> None:
-        """Show the popup dialog
+        """Show the popup dialog.
+
         Parameters:
 
-            wait_for_result:
-            position: tuple[int, int]
-                The x and y coordinates used to position the dialog. If no parent
-                then the dialog will anchor to the center of the parent window.
+            position (tuple[int, int], optional):
+                The x and y coordinates used to position the dialog. If not
+                given, the dialog is centered on the parent window.
+
+            wait_for_result (bool):
+                Grab input focus and block until the dialog is closed.
         """
         self.update_idletasks()
         self._result = None
@@ -102,7 +105,7 @@ class Dialog(BaseWidget):
 
         This method should be overridden and is called by the `build`
         method. Set the `self._initial_focus` for the button that
-        should receive the intial focus.
+        should receive the initial focus.
 
         Parameters:
 
@@ -158,9 +161,7 @@ class Dialog(BaseWidget):
         Safe to read whether the toplevel is already destroyed (e.g.
         ``QueryDialog`` destroys it synchronously on submit) or only queued for
         destruction (``MessageDialog`` uses ``after_idle``); the grab is released
-        only if the window still exists. This is the single result accessor for
-        every ``Dialog`` subclass -- facades must read ``.result``, not the
-        private ``._result`` (2.0 result-convention unification).
+        only if the window still exists.
         """
         toplevel = self._toplevel
         if toplevel is not None:

--- a/src/ttkbootstrap/dialogs/colorchooser.py
+++ b/src/ttkbootstrap/dialogs/colorchooser.py
@@ -1,53 +1,8 @@
-"""Color chooser widget for ttkbootstrap dialogs.
+"""Color chooser widget and dialog for ttkbootstrap.
 
-This module provides a comprehensive color selection widget with multiple
-selection methods including RGB sliders, HSL controls, standard color palette,
-hex input, and screen color picker (color dropper).
-
-Classes:
-    ColorChooser: Main color chooser widget with tabbed interface
-    ColorValues: Named tuple for color value storage
-    ColorChoice: Named tuple for final color selection result
-
-Features:
-    - Multiple color selection methods via tabbed interface
-    - RGB color model with R, G, B sliders (0-255 range)
-    - HSL color model with H (0-360), S, L (0-100) sliders
-    - Standard color palette with common colors and shades
-    - Hex color input with validation
-    - Color dropper for selecting colors from screen
-    - Live color preview
-    - Integration with Querybox for dialog usage
-
-Color Models:
-    - RGB: Red, Green, Blue (0-255 each)
-    - HSL: Hue (0-360), Saturation (0-100), Luminance (0-100)
-    - HEX: Hexadecimal color string (#RRGGBB)
-
-Example:
-    Using ColorChooser in a dialog:
-    ```python
-    from ttkbootstrap.dialogs import Querybox
-
-    # Get color from user
-    color = Querybox.get_color(initialcolor="#FF0000")
-    if color:
-        print(f"Selected color: {color.hex}")
-        print(f"RGB: {color.rgb}")
-        print(f"HSL: {color.hsl}")
-    ```
-
-    Using ColorChooser widget directly:
-    ```python
-    import ttkbootstrap as ttk
-    from ttkbootstrap.dialogs.colorchooser import ColorChooser
-
-    root = ttk.Window()
-    chooser = ColorChooser(root, initialcolor="#00FF00")
-    chooser.pack(padx=10, pady=10)
-
-    root.mainloop()
-    ```
+A tabbed color-selection widget (spectrum, themed swatches, standard palette)
+with RGB/HSL/hex inputs and live preview, plus the `ColorChooserDialog` wrapper
+used by `Querybox.get_color`.
 """
 import tkinter
 from collections import namedtuple
@@ -87,10 +42,7 @@ def validate_color(event: Any) -> bool:
 
 
 class ColorChooser(ttk.Frame):
-    """A class which creates a color chooser widget
-
-    ![](../../assets/dialogs/querybox-get-color.png)
-    """
+    """A class which creates a color chooser widget."""
 
     def __init__(
             self, master: Optional[tkinter.Misc], initialcolor: Optional[str] = None,
@@ -103,9 +55,9 @@ class ColorChooser(ttk.Frame):
         - Themed: Swatches of theme colors and their shades
         - Standard: Common standard colors and their shades
 
-        The widget includes RGB/HSL/Hex value inputs, live preview, and optional
-        color dropper (platform-dependent). Color values are accessible through
-        widget variables (hue, sat, lum, red, grn, blu, hex).
+        The widget includes RGB/HSL/Hex value inputs and a live preview. Color
+        values are accessible through widget variables (hue, sat, lum, red,
+        grn, blu, hex).
 
         Parameters:
 
@@ -568,8 +520,6 @@ class ColorChooserDialog(Dialog):
     hex. These values can be accessed by indexing the tuple or by using
     the named fields.
 
-    ![](../../assets/dialogs/querybox-get-color.png)
-
     Examples:
 
         ```python
@@ -579,7 +529,7 @@ class ColorChooserDialog(Dialog):
         >>> colors.hex
         '#5fb04f'
         >>> colors[2]
-        '#5fb04f
+        '#5fb04f'
         >>> colors.rgb
         (95, 176, 79)
         >>> colors[0]
@@ -627,10 +577,12 @@ class ColorChooserDialog(Dialog):
         self.dropper.result.trace_add('write', self.trace_dropper_color)
 
     def create_body(self, master: tkinter.Misc) -> None:
+        """Overrides the parent method; adds the ColorChooser widget."""
         self.colorchooser = ColorChooser(master, self.initialcolor)
         self.colorchooser.pack(fill=BOTH, expand=YES)
 
     def create_buttonbox(self, master: tkinter.Misc) -> None:
+        """Overrides the parent method; adds the OK/Cancel/color-dropper buttonbox."""
         frame = ttk.Frame(master, padding=(5, 5))
 
         # OK button
@@ -655,14 +607,17 @@ class ColorChooserDialog(Dialog):
         frame.pack(side=BOTTOM, fill=X, anchor=S)
 
     def on_show_colordropper(self, event: tkinter.Event) -> None:
+        """Show the color dropper dialog."""
         self.dropper.show()
 
     def trace_dropper_color(self, *_: Any) -> None:
+        """Sync the color chooser to the hex value picked by the dropper."""
         values = self.dropper.result.get()
         self.colorchooser.hex.set(values[2])
         self.colorchooser.sync_color_values('hex')
 
     def on_button_press(self, button: ttk.Button) -> None:
+        """Set the result on OK and close the dialog; just close on Cancel."""
         if button.cget('text') == MessageCatalog.translate('OK'):
             values = self.colorchooser.get_variables()
             self._result = ColorChoice(

--- a/src/ttkbootstrap/dialogs/colordropper.py
+++ b/src/ttkbootstrap/dialogs/colordropper.py
@@ -1,45 +1,7 @@
 """Screen color picker (dropper) dialog for ttkbootstrap.
 
-This module provides a color dropper tool that allows users to select colors
-directly from anywhere on the screen. It captures a screenshot and displays
-a magnified view to help with precise color selection.
-
-Classes:
-    ColorDropperDialog: Interactive screen color picker widget
-    ColorChoice: Named tuple containing selected color in multiple formats
-
-Features:
-    - Click anywhere on screen to select color
-    - Magnified zoom window for precise selection
-    - Mouse wheel zoom in/out control
-    - Returns color in RGB, HSL, and HEX formats
-    - Cross-platform support (Windows and Linux only)
-
-Platform Support:
-    - Windows: Fully supported
-    - Linux: Fully supported
-    - macOS: NOT SUPPORTED (ImageGrab limitation)
-
-Known Issues:
-    High-DPI displays may require application to run in high-DPI mode for
-    accurate color selection. On Windows, this is handled automatically.
-    See: https://stackoverflow.com/questions/25467288
-
-Example:
-    ```python
-    from ttkbootstrap.dialogs.colordropper import ColorDropperDialog
-
-    # Create color dropper
-    dropper = ColorDropperDialog()
-    dropper.show()
-
-    # Get selected color
-    color = dropper.result.get()
-    if color:
-        print(f"Selected: {color.hex}")
-        print(f"RGB: {color.rgb}")
-        print(f"HSL: {color.hsl}")
-    ```
+Captures a screenshot and shows a magnified view so the user can click anywhere
+on screen to pick a color, returned as RGB/HSL/HEX. Windows and Linux only.
 """
 import tkinter as tk
 from collections import namedtuple
@@ -67,8 +29,6 @@ class ColorDropperDialog:
 
     This widget is implemented for **Windows** and **Linux** only.
 
-    ![](../../assets/dialogs/color-dropper.png)       
-
     !!! warning "high resolution displays"
         This widget may not function properly on high resolution
         displays if you are not using the application in high
@@ -76,6 +36,7 @@ class ColorDropperDialog:
     """
 
     def __init__(self) -> None:
+        """Initialize the dropper with no active toplevel and an empty result."""
         self.toplevel: Optional[ttk.Toplevel] = None
         self.result: ttk.Variable = ttk.Variable()
 

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -479,28 +479,33 @@ class DatePickerDialog:
 
     @_selection_callback
     def on_next_month(self) -> None:
+        """Advance the displayed calendar to the next month."""
         year, month = self._nextmonth(self.date.year, self.date.month)
         self.date = datetime(year=year, month=month, day=1).date()
 
     @_selection_callback
     def on_next_year(self, *_: Any) -> None:
+        """Advance the displayed calendar to the next year."""
         year = self.date.year + 1
         month = self.date.month
         self.date = datetime(year=year, month=month, day=1).date()
 
     @_selection_callback
     def on_prev_month(self) -> None:
+        """Move the displayed calendar back to the previous month."""
         year, month = self._prevmonth(self.date.year, self.date.month)
         self.date = datetime(year=year, month=month, day=1).date()
 
     @_selection_callback
     def on_prev_year(self, *_: Any) -> None:
+        """Move the displayed calendar back to the previous year."""
         year = self.date.year - 1
         month = self.date.month
         self.date = datetime(year=year, month=month, day=1).date()
 
     @_selection_callback
     def on_reset_date(self, *_: Any) -> None:
+        """Reset the displayed calendar to the start date."""
         self.date = self.start_date
 
     def _set_window_position(self, position: Optional[Tuple[int, int]] = None) -> None:

--- a/src/ttkbootstrap/dialogs/message.py
+++ b/src/ttkbootstrap/dialogs/message.py
@@ -75,8 +75,8 @@ class MessageDialog(Dialog):
             command (Callable):
                 Optional zero-argument callback to run when a button is
                 pressed. The legacy ``(callable, label)`` tuple form is
-                deprecated (the label was never used) and will be removed in
-                3.0; pass the callable directly.
+                deprecated and will be removed in 3.0; pass the callable
+                directly.
 
             width (int):
                 Maximum width in characters for text wrapping (default=50).
@@ -246,13 +246,8 @@ class Messagebox:
     and alert options, and return the label of the button the user pressed
     (or ``None`` if the dialog was dismissed via Escape / the window close).
 
-    2.0 signature normalization: every method takes ``(message, title, *,
-    parent, alert, position, buttons, icon, localize)``. ``parent``/``alert``
-    are now **keyword-only** and in a uniform order (previously some methods
-    ordered them ``parent, alert`` and others ``alert, parent`` positionally,
-    so a positional third argument was ambiguous). The formerly hidden
-    ``**kwargs`` options -- ``position``, ``buttons``, ``icon``, ``localize`` --
-    are now discoverable named parameters.
+    Every method takes ``(message, title, *, parent, alert, position,
+    buttons, icon, localize)``; ``parent`` and ``alert`` are keyword-only.
     """
 
     @staticmethod

--- a/src/ttkbootstrap/dialogs/query.py
+++ b/src/ttkbootstrap/dialogs/query.py
@@ -87,6 +87,7 @@ class QueryDialog(Dialog):
         self._result = None
 
     def create_body(self, master: tkinter.Misc) -> None:
+        """Build the prompt label and input widget (Entry or Combobox)."""
         frame = ttk.Frame(master, padding=self._padding)
         if self._prompt:
             for p in self._prompt.split("\n"):
@@ -106,6 +107,7 @@ class QueryDialog(Dialog):
         self._initial_focus = entry
 
     def create_buttonbox(self, master: tkinter.Misc) -> None:
+        """Build the Submit/Cancel button row."""
         frame = ttk.Frame(master, padding=(5, 10))
 
         submit = ttk.Button(
@@ -130,6 +132,7 @@ class QueryDialog(Dialog):
         frame.pack(side=BOTTOM, fill=X, anchor=S)
 
     def on_submit(self, *_: Any) -> None:
+        """Capture the input value, validate it, and close the dialog if valid."""
         self._result = self._initial_focus.get()
         valid_result = self.validate()
         if not valid_result:
@@ -138,10 +141,12 @@ class QueryDialog(Dialog):
         self.apply()
 
     def on_cancel(self, *_: Any) -> None:
+        """Close the dialog without setting a result."""
         self._toplevel.destroy()
         return
 
     def on_filter_list(self, event: tkinter.Event) -> None:
+        """Filter the Combobox values to those matching the typed text."""
         value = event.widget.get().lower()
         if not value:
             event.widget["values"] = self._items

--- a/src/ttkbootstrap/internal/configure_delegation.py
+++ b/src/ttkbootstrap/internal/configure_delegation.py
@@ -1,13 +1,7 @@
-"""Configure/cget delegation for ttkbootstrap's custom widgets.
+"""Configure/cget delegation mixin for ttkbootstrap's custom widgets.
 
 Custom widgets (Meter, Floodgauge, DateEntry, ...) add their own options on top
-of a real ttk/tk widget. Historically each hand-maintained two parallel `if/else`
-ladders — one in a `configure` override to *set*, one to *get* — and often forgot
-a `cget` override entirely, so an option could be set but never read back (or a
-construction-only option had no `configure` branch at all). Those ladders are
-where the round-trip bugs live.
-
-This mixin replaces them. A widget marks one method per option with
+of a real ttk/tk widget. A widget marks one method per option with
 `@configure_delegate("name")`; `__init_subclass__` collects every such method in
 the MRO into a `key -> handler` map at class-creation time; and `configure`,
 `config`, `cget`, `keys`, `__getitem__`, and `__setitem__` all route delegated
@@ -24,15 +18,14 @@ class Meter(ConfigureDelegationMixin, Frame):
 ```
 
 `cget("amountused")`, `configure("amountused")`, `meter["amountused"]`,
-`configure(amountused=…)`, and `meter["amountused"] = …` now all work and stay in
-sync, with no ladder to keep aligned.
+`configure(amountused=…)`, and `meter["amountused"] = …` all route through this
+handler.
 
-**Inner-widget fallthrough** (the piece bootstack's original lacks): a composite
-that proxies to an inner widget — e.g. `ScrolledText` wrapping a `Text` — can
-override `_configure_delegate_target()` to return that inner widget. Non-delegated
-options then route to it instead of the outer frame, so `st.configure(font=…)` /
-`st.cget("wrap")` reach the `Text`. The default returns `None` (use the widget
-itself), which is what the non-composite widgets want.
+Inner-widget fallthrough: a composite that proxies to an inner widget — e.g.
+`ScrolledText` wrapping a `Text` — can override `_configure_delegate_target()`
+to return that inner widget. Non-delegated options then route to it instead of
+the outer frame, so `st.configure(font=…)` / `st.cget("wrap")` reach the `Text`.
+The default returns `None` (use the widget itself).
 
 This module is internal (`ttkbootstrap.internal`): no back-compat guarantee.
 """

--- a/src/ttkbootstrap/internal/publisher.py
+++ b/src/ttkbootstrap/internal/publisher.py
@@ -1,32 +1,11 @@
-"""Publisher-Subscriber pattern implementation for ttkbootstrap.
+"""A channel-based publisher-subscriber registry.
 
-This module implements a simple publisher-subscriber (pub-sub) pattern used
-for theme change notifications and widget updates throughout ttkbootstrap.
-
-The Publisher class manages subscribers on different channels and broadcasts
-messages to all subscribers when events occur (like theme changes).
-
-Classes:
-    Channel: Enum defining subscriber channels (STD for tk, TTK for ttk)
-    Subscriber: Data class storing subscriber information
-    Publisher: Manages subscriptions and publishes messages to subscribers
-
-Example:
-    ```python
-    from ttkbootstrap.internal.publisher import Publisher, Channel
-
-    # Subscribe a function to theme changes
-    def on_theme_change():
-        print("Theme changed!")
-
-    Publisher.subscribe(
-        func=on_theme_change,
-        channel=Channel.TTK
-    )
-
-    # Publish a message to all TTK subscribers
-    Publisher.publish(Channel.TTK)
-    ```
+Subscribers register a callback under a `Channel` (`STD` for legacy tk
+widgets, `TTK` for themed widgets); `Publisher.publish_message` invokes every
+callback registered on a given channel. The engine's theme walk repaints
+mounted widgets directly rather than through this registry, so nothing in
+ttkbootstrap currently subscribes here; the module is kept as internal
+plumbing behind the `ttkbootstrap.publisher` backward-compatibility shim.
 """
 from enum import Enum
 from typing import List
@@ -79,6 +58,7 @@ class Publisher:
 
     @staticmethod
     def subscriber_count():
+        """Return the total number of registered subscribers."""
         return len(Publisher.__subscribers)
 
     @staticmethod
@@ -115,12 +95,17 @@ class Publisher:
             pass
 
     def get_subscribers(channel):
-        """Return a list of subscribers.
+        """Return the subscribers registered on a channel.
+
+        Parameters:
+
+            channel (Channel):
+                The channel to filter subscribers by.
 
         Returns:
 
             List:
-                List of key-value tuples
+                List of `Subscriber` instances registered on the channel.
         """
         subs = Publisher.__subscribers.values()
         channel_subs = [s for s in subs if s.channel == channel]
@@ -132,10 +117,11 @@ class Publisher:
         Parameters:
 
             channel (Channel):
-                The name of the channel to subscribe.
+                The channel to publish to.
 
-            **args:
-                optional arguments to pass to the subscribers.
+            *args:
+                Optional positional arguments to pass to each subscriber's
+                callback.
         """
         subs: list[Subscriber] = Publisher.get_subscribers(channel)
         for sub in subs:

--- a/src/ttkbootstrap/localization/__init__.py
+++ b/src/ttkbootstrap/localization/__init__.py
@@ -1,15 +1,4 @@
-"""
-    A partial wrapper on the tcl/tk msgcat (Tcl message catalog)
-
-    The MessageCatalog provides a set of functions that can be used to 
-    manage multi-lingual user interfaces. Text strings are defined in a 
-    “message catalog” which is independent from the application, and 
-    which can be edited or localized without modifying the application 
-    source code. New languages or locales may be provided by adding a 
-    new file to the message catalog.
-
-    https://www.tcl.tk/man/tcl/TclCmd/msgcat.html    
-"""
+"""Localization package: msgcat-based message catalog and built-in locale data."""
 from ttkbootstrap.localization.msgs import initialize_localities
 from ttkbootstrap.localization.msgcat import MessageCatalog
 

--- a/src/ttkbootstrap/localization/msgcat.py
+++ b/src/ttkbootstrap/localization/msgcat.py
@@ -1,36 +1,8 @@
 """Message catalog wrapper for ttkbootstrap localization.
 
-This module provides a Python interface to the Tcl/Tk msgcat (message catalog)
-system for managing multi-lingual user interfaces. It enables applications to
-translate UI text based on the user's locale.
-
-Classes:
-    MessageCatalog: Static wrapper for Tcl/Tk msgcat commands
-
-The MessageCatalog allows applications to:
-    - Translate strings based on current locale
-    - Set locale preferences
-    - Define message translations for multiple languages
-    - Format translated messages with arguments
-
-See also:
-    https://www.tcl.tk/man/tcl/TclCmd/msgcat.html
-
-Example:
-    ```python
-    from ttkbootstrap.localization import MessageCatalog
-
-    # Set locale
-    MessageCatalog.locale('de')
-
-    # Define German translations
-    MessageCatalog.set('de', 'Hello', 'Hallo')
-    MessageCatalog.set('de', 'Goodbye', 'Auf Wiedersehen')
-
-    # Translate
-    greeting = MessageCatalog.translate('Hello')  # Returns 'Hallo'
-    farewell = MessageCatalog.translate('Goodbye')  # Returns 'Auf Wiedersehen'
-    ```
+A Python interface to the Tcl/Tk msgcat system: translate UI text by the user's
+locale, set locale preferences, register per-language translations, and format
+translated messages. See https://www.tcl.tk/man/tcl/TclCmd/msgcat.html.
 """
 from os import PathLike
 from typing import Any, Optional, Union
@@ -39,6 +11,8 @@ from ttkbootstrap.window import get_default_root
 
 
 class MessageCatalog:
+    """Static wrapper for the Tcl/Tk `::msgcat` message catalog commands."""
+
     @staticmethod
     def __join(*args: Any) -> str:
         """Join multiple format arguments into a joined argument string."""
@@ -69,7 +43,7 @@ class MessageCatalog:
             src (str):
                 The string to be translated.
 
-            *fmtargs (tuple, optional):
+            *fmtargs (Any, optional):
                 Extra arguments passed internally to the
                 [format](https://www.tcl-lang.org/man/tcl/TclCmd/format.html) package.
 
@@ -87,16 +61,16 @@ class MessageCatalog:
 
     @staticmethod
     def locale(newlocale: Optional[str] = None) -> str:
-        """ "This function sets the locale to newlocale. If newlocale is
+        """Sets the locale to newlocale. If newlocale is
         omitted, the current locale is returned, otherwise the current
         locale is set to newlocale. The initial locale defaults to the
         locale specified in the user's environment.
 
         Parameters:
 
-            newlocale (str):
+            newlocale (str, optional):
                 The new locale code used to define the language for the
-                application.
+                application. Default is None.
 
         Returns:
 
@@ -117,7 +91,7 @@ class MessageCatalog:
 
         Returns:
 
-            list[str, ...]:
+            list[str]:
                 Locales preferred by the user.
         """
         root = get_default_root()
@@ -166,8 +140,9 @@ class MessageCatalog:
             src (str):
                 The original language string.
 
-            translated (str):
-                The translated string.
+            translated (str, optional):
+                The translated string. Default is None, in which case
+                src is used.
         """
         root = get_default_root()
         command = "::msgcat::mcset"

--- a/src/ttkbootstrap/localization/msgs.py
+++ b/src/ttkbootstrap/localization/msgs.py
@@ -1,53 +1,8 @@
 """Pre-defined message translations for ttkbootstrap localization.
 
-This module contains built-in translations for common UI strings used throughout
-ttkbootstrap widgets and dialogs. Translations are provided for multiple languages
-and automatically loaded when the localization system initializes.
-
-Classes:
-    LocaleMsgs: Helper class for loading locale-specific message translations
-
-Functions:
-    initialize_localities: Load all custom message files into MessageCatalog
-
-Supported Languages:
-    - Czech (cs)
-    - German (de)
-    - Spanish (es)
-    - French (fr)
-    - Italian (it)
-    - Japanese (ja)
-    - Korean (ko)
-    - Dutch (nl)
-    - Polish (pl)
-    - Portuguese (pt)
-    - Russian (ru)
-    - Turkish (tr)
-    - Chinese Simplified (zh_cn)
-    - Chinese Traditional (zh_tw)
-    - And more...
-
-Common Translated Strings:
-    - Dialog buttons: OK, Cancel, Yes, No, Close, etc.
-    - Actions: Submit, Delete, Add, Remove, etc.
-    - Navigation: Next, Previous, Continue, etc.
-    - Font dialog: Family, Weight, Slant, Size, etc.
-    - Months and days of the week
-    - Common verbs and UI labels
-
-Example:
-    Translations are used automatically by ttkbootstrap dialogs:
-    ```python
-    from ttkbootstrap.dialogs import Messagebox
-    from ttkbootstrap.localization import MessageCatalog
-
-    # Set locale to German
-    MessageCatalog.locale('de')
-
-    # Dialog buttons automatically display in German
-    Messagebox.ok("Dies ist eine Nachricht")  # "OK" button shows as "OK"
-    Messagebox.yesno("Fortfahren?")  # "Yes"/"No" show as "Ja"/"Nein"
-    ```
+Built-in translations for common UI strings (dialog buttons, actions, months and
+weekdays, font-dialog labels) across the supported locales, loaded into the
+`MessageCatalog` when the localization system initializes.
 """
 from ttkbootstrap.localization.msgcat import MessageCatalog
 

--- a/src/ttkbootstrap/style/_compat.py
+++ b/src/ttkbootstrap/style/_compat.py
@@ -258,9 +258,12 @@ def normalize_bootstyle(value, *, warn: bool = False) -> str:
     a plain string, and returns a single dash-joined string the tokenizer can
     split. Slot re-ordering is handled downstream by the tokenizer, not here.
 
-    In 2.0 D1 this is called with ``warn=False`` so the internal tuple callers
-    (Meter/DateEntry/...) stay quiet until they are migrated in D2; D2 flips the
-    default caller to ``warn=True`` so genuine external tuple use is flagged.
+    Parameters:
+        value: legacy bootstyle value -- a tuple/list, a plain string, or ``None``.
+        warn: emit a deprecation warning when a non-empty tuple/list is passed.
+
+    Returns:
+        The canonical dash-joined string (``""`` for ``None``).
     """
     if value is None:
         return ""

--- a/src/ttkbootstrap/style/assets.py
+++ b/src/ttkbootstrap/style/assets.py
@@ -1,11 +1,10 @@
-"""Public image-construction toolkit for ttkbootstrap styles.
+"""Image-construction toolkit for ttkbootstrap styles.
 
-`Assets(style)` is the ergonomic, key-safe front door to the engine's
-content-addressed image cache (`Style._get_or_create_image`). The shape recipes
-(`circle`/`rect`/`rounded_rect`) and the general `image()` escape hatch each
-render an asset *and* derive its cache key from the same inputs, so a key can
-never drift from the pixels it names -- the purity hazard PR 2's whole audit
-existed to manage.
+`Assets(style)` wraps the engine's content-addressed image cache
+(`Style._get_or_create_image`). The shape recipes (`circle`/`rect`/
+`rounded_rect`), the icon and recolor renderers, and the general `image()`
+escape hatch each render an asset *and* derive its cache key from the same
+inputs, so a key cannot drift from the pixels it names.
 
 The renderer uses adaptive supersampling, LANCZOS downscaling, and sharpening
 while preserving exact root-scaled output dimensions. Callers pass logical UI
@@ -17,7 +16,7 @@ from PIL.Image import Resampling
 from ttkbootstrap.style.elements import RecolorRenderer, RecolorResult
 
 def _oversample(w, h):
-    """Adaptive supersample factor by the larger dimension (bootstack: 3/2/1)."""
+    """Adaptive supersample factor by the larger dimension: 3x below 32px, 2x below 64px, else 1x."""
     longest = max(w, h)
     if longest < 32:
         return 3
@@ -47,13 +46,12 @@ def _render(size, draw_fn):
 
 
 class Assets:
-    """Key-safe image construction over the engine's content-addressed cache.
+    """Image construction over the engine's content-addressed cache.
 
     `Assets(style)` wraps `Style._get_or_create_image`: each method renders an
     asset *and* derives its cache key from the same render inputs, so the key
-    cannot drift from the pixels (the purity hazard PR 2's audit existed to
-    manage). Builders reach a shared instance via `self.assets`; public users
-    construct `Assets(Style.get_instance())`.
+    cannot drift from the pixels. Builders reach a shared instance via
+    `self.assets`; public users construct `Assets(Style.get_instance())`.
 
     Sizes are logical UI units converted once by the root-bound scaling service;
     final image dimensions are exact and may be odd. Every
@@ -129,8 +127,9 @@ class Assets:
 
         `white`, `black`, and optional `magenta` are resolved color strings for
         the source template's semantic channels. Source alpha is preserved.
-        `transform` may flip the image horizontally or rotate it by a quarter
-        turn; dimensions and border/padding metadata transform with the pixels.
+        `transform` may flip the image horizontally (`"flip-x"`) or rotate it
+        by 90/180/270 degrees (`"rotate-90"`/`"rotate-180"`/`"rotate-270"`);
+        dimensions and border/padding metadata transform with the pixels.
 
         Returns a `RecolorResult` containing the Tcl image name and scaled
         logical manifest metadata. Source-image dimensions only validate the

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -3,8 +3,7 @@
 `Bootstyle` maps a `bootstyle`/`style` string to a built ttk style (reading the
 `Keywords` grammar). `BootMixin`/`AutoStyleMixin` are the concrete-subclass
 delivery path; `bootify`/`apply_bootstyle`/`enable_global_api` are the dynamic
-and opt-in-global delivery primitives. Top layer of the `style` package. Split
-out of the monolithic `style.py` in 2.0.
+and opt-in-global delivery primitives. Top layer of the `style` package.
 """
 import difflib
 import re
@@ -39,12 +38,12 @@ class Keywords:
     This class is internal to the styling system and not intended to be
     instantiated.
 
-    As of 2.0 (Workstream D) the token lists are sourced from the single
-    vocabulary in `ttkbootstrap.constants` -- this class no longer keeps a
-    second copy. The "type" slot spans both public modifiers (`outline`,
-    `round`, ...) and the internal composite modifiers (`meter`, `date`, ...).
-    The compiled patterns are retained for the orientation lookup and any
-    back-compat callers; the primary parse path is the token classifier below.
+    The token lists are sourced from the single vocabulary in
+    `ttkbootstrap.constants`. The "type" slot spans both public modifiers
+    (`outline`, `round`, ...) and the internal composite modifiers (`meter`,
+    `date`, ...). The compiled patterns are retained for the orientation
+    lookup and any back-compat callers; the primary parse path is the token
+    classifier below.
     """
 
     COLORS = list(BOOTSTYLE_COLORS)
@@ -565,7 +564,7 @@ class Bootstyle:
                 The widget instance being updated.
 
             style_string (str):
-                The style string to evalulate. May be the `style`, `ttkstyle`
+                The style string to evaluate. May be the `style`, `ttkstyle`
                 or `bootstyle` argument depending on the context and scenario.
 
             **kwargs:
@@ -645,8 +644,8 @@ class Bootstyle:
         """Monkey-patch the stock tkinter/ttk widget classes with the
         bootstyle/autostyle api.
 
-        As of 2.0 this is the legacy *global* path and is no longer run at
-        import time; the default api is delivered through concrete subclasses
+        This is the legacy *global* path and is not run at import time; the
+        default api is delivered through concrete subclasses
         (`BootMixin`/`AutoStyleMixin`). Call `enable_global_api` to opt back
         into patching the stock classes (e.g. for code that creates vanilla
         ``tkinter.ttk`` widgets)."""
@@ -755,13 +754,13 @@ class Bootstyle:
 
     @staticmethod
     def update_tk_widget_style(widget):
-        """Lookup the widget name and call the appropriate update
-        method
+        """Look up and call the appropriate style-update method for a
+        legacy tk widget.
 
         Parameters:
 
-            widget (object):
-                The tcl/tk name given by `tkinter.Widget.winfo_name()`
+            widget (tkinter.Widget):
+                The tk widget instance to style.
         """
         try:
             style = Style.get_instance()
@@ -836,14 +835,17 @@ class FluentGeometryMixin:
     """
 
     def pack_configure(self, cnf={}, **kwargs):
+        """Pack the widget, then return it for chaining."""
         super().pack_configure(cnf, **kwargs)
         return self
 
     def grid_configure(self, cnf={}, **kwargs):
+        """Grid the widget, then return it for chaining."""
         super().grid_configure(cnf, **kwargs)
         return self
 
     def place_configure(self, cnf={}, **kwargs):
+        """Place the widget, then return it for chaining."""
         super().place_configure(cnf, **kwargs)
         return self
 
@@ -855,11 +857,9 @@ class FluentGeometryMixin:
 class BootMixin(FluentGeometryMixin):
     """Mixin that adds the ``bootstyle`` API to a ttk widget class.
 
-    This is the 2.0 delivery vehicle for the styling API. Instead of
-    monkey-patching ttk widget classes at import time, ttkbootstrap ships
-    concrete subclasses such as ``class Button(BootMixin, ttk.Button)`` and
-    re-exports them. Mixing this in front of any ttk-derived class gives that
-    class:
+    Concrete subclasses such as ``class Button(BootMixin, ttk.Button)`` are
+    shipped and re-exported. Mixing this in front of any ttk-derived class
+    gives that class:
 
     - a ``bootstyle=`` (and bare ``style=``) keyword on the constructor,
     - an ``icon=``/``icon_size=`` keyword for a theme-aware glyph (see
@@ -867,14 +867,25 @@ class BootMixin(FluentGeometryMixin):
     - ``configure``/``config`` that accept and report ``bootstyle``,
     - ``widget["bootstyle"]`` / ``widget["bootstyle"] = ...`` access.
 
-    All resolution flows through the unchanged `Bootstyle.update_ttk_widget_style`
-    engine, so the mixin only changes *delivery* — not how a style string maps
-    to a ttk style. Because the accessors are real methods that use ``super()``
-    (not closures captured in a loop), the late-binding bug of the old
-    monkey-patch is gone.
+    All resolution flows through `Bootstyle.update_ttk_widget_style`, so the
+    mixin only changes *delivery* — not how a style string maps to a ttk
+    style.
     """
 
     def __init__(self, *args, **kwargs):
+        """Construct the widget, then resolve and apply its style and icon.
+
+        Parameters:
+
+            *args:
+                Positional arguments forwarded to the wrapped ttk widget's
+                constructor.
+
+            **kwargs:
+                Keyword arguments forwarded to the wrapped ttk widget's
+                constructor. ``bootstyle``, ``style``, ``icon``, and
+                ``icon_size`` are consumed here rather than forwarded.
+        """
         # capture bootstyle, style, and icon arguments
         bootstyle = kwargs.pop("bootstyle", "")
         style = kwargs.pop("style", "") or ""
@@ -920,6 +931,19 @@ class BootMixin(FluentGeometryMixin):
             pass
 
     def configure(self, cnf=None, **kwargs):
+        """Get or set widget options, resolving ``bootstyle``/``style``/
+        ``icon`` changes along the way.
+
+        Parameters:
+
+            cnf (str | dict | None):
+                An option name to query, a dict of options to set, or
+                ``None`` to set from ``**kwargs``.
+
+            **kwargs:
+                Options to set, including ``bootstyle``, ``style``, ``icon``,
+                and ``icon_size``.
+        """
         # query a single option
         if cnf in ("bootstyle", "style"):
             return self.cget("style")
@@ -989,11 +1013,24 @@ class AutoStyleMixin(FluentGeometryMixin):
 
     Passing ``autostyle=False`` opts the widget out of theming entirely: it
     keeps its native tk look and the theme walk skips it on switch (the
-    ``_tb_no_autostyle`` flag), matching the pre-2.0 behavior where an
-    unstyled widget never subscribed for repaints.
+    ``_tb_no_autostyle`` flag).
     """
 
     def __init__(self, *args, **kwargs):
+        """Construct the widget, then apply the active theme unless
+        ``autostyle=False`` is passed.
+
+        Parameters:
+
+            *args:
+                Positional arguments forwarded to the wrapped tk widget's
+                constructor.
+
+            **kwargs:
+                Keyword arguments forwarded to the wrapped tk widget's
+                constructor. ``autostyle`` (default ``True``) is consumed
+                here rather than forwarded.
+        """
         autostyle = kwargs.pop("autostyle", True)
         super().__init__(*args, **kwargs)
         if autostyle:
@@ -1048,8 +1085,8 @@ _global_api_installed = False
 def enable_global_api():
     """Re-apply the legacy global monkey-patch (opt-in).
 
-    In 2.0 the default styling API is delivered through concrete subclasses
-    (`BootMixin`/`AutoStyleMixin`), so importing ttkbootstrap no longer mutates
+    By default the styling API is delivered through concrete subclasses
+    (`BootMixin`/`AutoStyleMixin`), so importing ttkbootstrap does not mutate
     the stock ``tkinter``/``tkinter.ttk`` classes. Call this once if you have
     code that creates *vanilla* ttk/tk widgets (e.g. ``from tkinter import
     ttk; ttk.Button(..., bootstyle=...)``) and want the ``bootstyle``/

--- a/src/ttkbootstrap/style/builders/calendar.py
+++ b/src/ttkbootstrap/style/builders/calendar.py
@@ -10,15 +10,12 @@ from ttkbootstrap.style.builders.registry import register_builder
 
 @register_builder("default", "calendar")
 def build_calendar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
-    """Create a style for the
-    ttkbootstrap.dialogs.DatePickerPopup widget.
+    """Create a style for the calendar day buttons used by
+    `ttkbootstrap.dialogs.DatePickerDialog`.
 
     Parameters:
-
-        builder (StyleBuilderTTK):
-            The style builder
-        colorname (str):
-            The color label used to style the widget.
+        builder (StyleBuilderTTK): The style builder.
+        colorname (str): The color label used to style the widget.
     """
 
     ttk_class = "TCalendar"

--- a/src/ttkbootstrap/style/builders/floodgauge.py
+++ b/src/ttkbootstrap/style/builders/floodgauge.py
@@ -10,9 +10,8 @@ from ttkbootstrap.style.builders.registry import register_builder
 
 @register_builder("default", "floodgauge")
 def build_floodgauge_style(builder: StyleBuilderTTK, colorname=DEFAULT):
-    """Create a ttk style for the ttkbootstrap.widgets.Floodgauge
-    widget. This is a custom widget style that uses components of
-    the progressbar and label.
+    """Create a ttk style for the ttkbootstrap Floodgauge widget, combining
+    progressbar and label components.
 
     Parameters:
 

--- a/src/ttkbootstrap/style/builders/menubutton.py
+++ b/src/ttkbootstrap/style/builders/menubutton.py
@@ -167,7 +167,7 @@ def _build_neutral_outline_menubutton(builder: StyleBuilderTTK, ttk_class, disab
 
 @register_builder("outline", "menubutton")
 def build_outline_menubutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
-    """Create an outline button style for the ttk.Menubutton widget
+    """Create an outline button style for the ttk.Menubutton widget.
 
     Parameters:
 

--- a/src/ttkbootstrap/style/builders/progressbar.py
+++ b/src/ttkbootstrap/style/builders/progressbar.py
@@ -9,18 +9,19 @@ from ttkbootstrap.style.builders.registry import register_builder
 
 
 def _create_striped_progressbar_assets(builder, colorname=DEFAULT):
-    """Create the striped progressbar image and return as a
-    `PhotoImage`
+    """Create the horizontal and vertical striped progressbar images.
 
     Parameters:
 
+        builder (StyleBuilderTTK):
+            The style builder.
         colorname (str):
             The color label used to style the widget.
 
     Returns:
 
-        tuple[str]:
-            A list of photoimage names.
+        tuple[str, str]:
+            The horizontal and vertical photoimage names.
     """
     if any([colorname == DEFAULT, colorname == ""]):
         bar_color = builder.colors.primary

--- a/src/ttkbootstrap/style/builders/utils.py
+++ b/src/ttkbootstrap/style/builders/utils.py
@@ -4,12 +4,11 @@ from ttkbootstrap.constants import NEUTRAL
 
 
 def default_button_fill(builder):
-    """The fill for a bare (no-color) button/menubutton.
+    """Return the fill for a bare (no-color) button/menubutton.
 
-    Honors the Style's `default_button` setting (default `"neutral"`): the quiet
-    neutral raise, or the resolved accent for any other color (e.g. `"primary"`
-    to restore the pre-2.0 accented default). This is what makes a plain
-    `ttk.Button()` render neutral by default.
+    Reads the Style's `default_button` setting (default `"neutral"`): returns
+    the neutral elevation fill for `"neutral"`, or the resolved accent color
+    for any other color name.
     """
     color = getattr(builder.style, "default_button", NEUTRAL)
     if color == NEUTRAL:
@@ -18,14 +17,12 @@ def default_button_fill(builder):
 
 
 def neutral_fill(builder, level=1):
-    """A mode-aware elevation of the theme surface (bootstack's `elevate`).
+    """Return a mode-aware elevation of the theme surface color.
 
-    Darkens the surface a touch in a light theme, lightens it in a dark theme, so
-    an unaccented control reads as a subtly raised surface in either mode (a fixed
-    `colors.light` would only be right in light themes). `level` 1 (~6%) is the
-    quiet neutral fill; `level` 2 (~12%) is a stronger raise used to distinguish
-    an "on"/selected neutral state from the "off" fill without an accent color.
-    Shared by the button-family neutral recipes.
+    Darkens the surface in a light theme, lightens it in a dark theme, so an
+    unaccented control reads as a subtly raised surface in either mode. `level`
+    1 (~6%) is the quiet neutral fill; `level` 2 (~12%) is a stronger raise used
+    to distinguish an "on"/selected neutral state from the "off" fill.
     """
     weight = level * 0.06
     surface = builder.colors.bg
@@ -47,18 +44,15 @@ def indicator_spacer(builder):
 def simple_arrow_assets(builder, arrowcolor: str, disabledcolor: str, activecolor: str, y_offset: int = 0):
     """Create caret arrow assets using Bootstrap Icons glyphs.
 
-    Used for Combobox and Spinbox indicators. Uses the solid `caret-*-fill`
-    triangles so the indicators read consistently with the filled-triangle
-    arrows elsewhere in the app (menubutton, datepicker header).
+    Used for Combobox and Spinbox indicators. Renders the solid `caret-*-fill`
+    triangles for up/down/left/right in each of the given colors.
 
-    The `y_offset` parameter is accepted for API compatibility but is no
-    longer used (it was specific to the old hand-drawn triangle approach).
-
-    Args:
+    Parameters:
         arrowcolor: The color value to use as the arrow fill color.
         disabledcolor: A second color value to use when the arrow is disabled.
         activecolor: A third color value to use when the arrow has focus.
         y_offset: Accepted for API compatibility; ignored.
+
     Returns:
         A nested tuple (normal, disabled, active), each a 4-tuple of Tcl
         image names in the order (up, down, left, right).

--- a/src/ttkbootstrap/style/builders_tk.py
+++ b/src/ttkbootstrap/style/builders_tk.py
@@ -10,21 +10,15 @@ from ttkbootstrap.style.theme import Colors, ThemeDefinition, _accent_on_color
 
 
 class StyleBuilderTK:
-    """A class for styling legacy tkinter widgets (not ttk).
+    """Styles legacy tkinter widgets (not ttk) to match the active theme.
 
-    The methods in this classed are used internally to update tk widget
-    style configurations and are not intended to be called by the end
-    user.
+    The methods here update tk widget style configurations internally and
+    are not intended to be called by the end user. All legacy tkinter
+    widgets are restyled via a callback whenever the theme changes.
 
-    All legacy tkinter widgets are updated with a callback whenever the
-    theme is changed. The color configuration of the widget is updated
-    to match the current theme. Legacy ttk widgets are not the primary
-    focus of this library, however, an attempt was made to make sure they
-    did not stick out amongst ttk widgets if used.
-
-    Some ttk widgets contain legacy components that must be updated
-    such as the Combobox popdown, so this ensures they are styled
-    completely to match the current theme.
+    Some ttk widgets contain legacy components that must be updated too,
+    such as the Combobox popdown, so this ensures they stay in sync with
+    the current theme.
     """
 
     def __init__(self):
@@ -190,7 +184,7 @@ class StyleBuilderTK:
 
         Parameters:
 
-            widget (tkinter.scale):
+            widget (tkinter.Scale):
                 The scale object to update.
         """
         bordercolor = self.colors.border
@@ -214,7 +208,7 @@ class StyleBuilderTK:
         Parameters:
 
             widget (tkinter.Spinbox):
-                THe spinbox object to update.
+                The spinbox object to update.
         """
         bordercolor = self.colors.border
 

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -38,6 +38,7 @@ class StyleBuilderTTK:
     """
 
     def __init__(self, build: bool = True):
+        """Bind to the active `Style` instance and build the theme unless `build` is False."""
         # local import breaks the builders<-engine cycle (engine imports builders)
         from ttkbootstrap.style.engine import Style
 
@@ -114,8 +115,7 @@ class StyleBuilderTTK:
     def shade(self, color: str, weight: float = _TROUGH_SHADE) -> str:
         """Return `color` darkened by mixing `weight` of black into it.
 
-        The recessed dark-theme track/trough recipes use the default weight;
-        this replaces their `Colors.update_hsv(..., vd=-0.2)` darken.
+        The default weight matches the recessed dark-theme track/trough recipes.
         """
         return _shade(color, weight)
 
@@ -131,12 +131,7 @@ class StyleBuilderTTK:
         self, color: str, surface: str | None = None,
         amount: float = _MUTE_AMOUNT,
     ) -> str:
-        """Return `color` alpha-blended onto a surface to mute an indicator.
-
-        Replaces `Colors.make_transparent(amount, color, surface)`; visually
-        identical (that helper truncated, `_mix_colors` rounds — at most 1/255
-        per channel).
-        """
+        """Return `color` alpha-blended onto a surface to mute an indicator."""
         return _mix_colors(color, surface or self.colors.bg, amount)
 
     def on_color(self, color: str) -> str:
@@ -176,9 +171,7 @@ class StyleBuilderTTK:
         return True
 
     def register_ttkstyle(self, style_name: str):
-        """Register that a ttk style name. This ensures that the builder will not attempt to build a style
-        that has already been created.
-        """
+        """Mark `style_name` as built so the builder will not recreate it."""
         return self.style._register_ttkstyle(style_name)
 
     def create_theme(self):

--- a/src/ttkbootstrap/style/elements.py
+++ b/src/ttkbootstrap/style/elements.py
@@ -55,6 +55,7 @@ class RecolorRenderer:
 
     @classmethod
     def info(cls, name):
+        """Return the manifest entry for element `name`."""
         images = cls._load_manifest().get("images", {})
         try:
             return images[name]
@@ -65,6 +66,7 @@ class RecolorRenderer:
 
     @classmethod
     def source_dpi(cls):
+        """Return the manifest's default source scale (template DPI multiplier)."""
         return float(cls._load_manifest().get("default_source_scale", 2.0))
 
     @classmethod
@@ -122,6 +124,7 @@ class RecolorRenderer:
 
     @classmethod
     def metadata(cls, name, scaling, transform=None):
+        """Return `ElementMeta` for `name`, scaled and adjusted for `transform`."""
         cls._validate_transform(transform)
         info = cls.info(name)
         width, height = info["size"]

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -44,7 +44,7 @@ class Style(ttk.Style):
         style = Style()
 
         # instantiate the style with another theme
-        style = Style(theme='superhero')
+        style = Style(theme='bootstrap-dark')
 
         # check all available themes
         for theme in style.theme_names():
@@ -132,6 +132,21 @@ class Style(ttk.Style):
             return []  # TODO refactor this
 
     def configure(self, style, query_opt: Any = None, **kw):
+        """Configure a ttk style, resolving `style` through the bootstyle
+        parser if it is not already a registered ttk style name.
+
+        Parameters:
+
+            style (str):
+                A ttk style name or a `bootstyle` string to resolve first.
+
+            query_opt (Any):
+                If given, query this single style option instead of setting
+                options; forwarded to `ttk.Style.configure`.
+
+            **kw:
+                Style options to configure (forwarded to `ttk.Style.configure`).
+        """
         if query_opt:
             return super().configure(style, query_opt=query_opt, **kw)
 
@@ -336,7 +351,7 @@ class Style(ttk.Style):
 
     @staticmethod
     def get_instance():
-        """Returns and instance of the style class"""
+        """Returns the singleton `Style` instance (or `None` if not yet created)."""
         return Style.instance
 
     @staticmethod
@@ -346,7 +361,7 @@ class Style(ttk.Style):
 
         Returns:
 
-            ThemeBuilderTTK:
+            StyleBuilderTTK:
                 The theme builder object that builds the ttk styles for
                 the current theme.
         """
@@ -361,7 +376,7 @@ class Style(ttk.Style):
 
         Returns:
 
-            ThemeBuilderTK:
+            StyleBuilderTK:
                 The theme builder object that builds the ttk styles for
                 the current theme.
         """

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -2,10 +2,9 @@
 
 `IconRenderer` rasterizes a single named glyph from the vendored Bootstrap Icons
 font (`assets/icons/`) to a PIL image, using a precomputed per-glyph ink box to
-fit-and-center it accurately -- the alignment fix ported from the sibling
-bootstack project. Pillow's `font.getbbox()` under-reports the ink of full-bleed
-icon glyphs, which skews sizing/centering; `icon_metrics.json` instead carries
-each glyph's true inked bounds (in em-fractions) measured offline, so the
+fit-and-center it accurately. Pillow's `font.getbbox()` under-reports the ink of
+full-bleed icon glyphs, which skews sizing/centering; `icon_metrics.json` instead
+carries each glyph's true inked bounds (in em-fractions) measured offline, so the
 renderer fits the real ink to the frame with no per-glyph fudge.
 
 The public surface layered on top:
@@ -17,11 +16,8 @@ The public surface layered on top:
     ttk widget state and bakes a validated image element (the `Style.map`-aligned
     analog of `image_element`, with the icon as the asset source).
 
-Layering: this module's top-level imports are PIL + stdlib + the two leaf toolkit
-modules (`assets`, `layout`); it carries **no module-level engine edge** (the
-`Style` singleton is reached function-locally inside `Icon`), so it stays a leaf
-and imports standalone. Asset loading is lazy: `import ttkbootstrap` does not read
-the font -- `IconRenderer` loads it on first `render`.
+Asset loading is lazy: `import ttkbootstrap` does not read the font --
+`IconRenderer` loads it on first `render`.
 """
 import hashlib
 import io
@@ -64,11 +60,9 @@ def _icon_oversample(w, h):
 
     Glyph outlines (circle/chevron) carry thin curved strokes; the smoothness of
     those curves is set by the *supersample*, not the sharpen -- a hard sharpen
-    just stair-steps them. So push samples high (6x) for the small indicator tier
-    and pair it with a gentle UnsharpMask (see `render`): the curves stay smooth
-    and the straight strokes stay defined. bootstack stops at 3x + a gentle
-    sharpen (soft but smooth); the richer supersample here is what lets the edges
-    read crisp without pixelating the rings.
+    just stair-steps them. Samples are pushed high (6x) for the small indicator
+    tier and paired with a gentle UnsharpMask (see `render`), keeping curves
+    smooth and straight strokes defined without pixelating the rings.
     """
     longest = max(w, h)
     if longest < 32:
@@ -142,7 +136,7 @@ class IconRenderer:
         a literal color string (already resolved). The glyph is drawn onto an
         adaptively oversampled canvas, fit-and-centered via its precomputed ink
         box, then LANCZOS-downscaled with an `UnsharpMask` to restore edge
-        crispness (bootstack's pipeline, shared with `assets._render`).
+        crispness (shared with `assets._render`).
 
         Raises `ValueError` for a name absent from the Bootstrap Icons glyphmap
         (a typo fails loudly rather than rendering a blank image).
@@ -254,10 +248,10 @@ def Icon(name, size=16, color=None):
             The logical UI size. It is converted once by the root-bound service;
             final dimensions may be odd.
 
-        color (str):
+        color (str | None):
             A bootstyle keyword ("primary", "success", "fg", ...) resolved against
-            the active theme, or a hex string passed through. Defaults to the
-            theme foreground.
+            the active theme, or a hex string passed through. `None` (the
+            default) resolves to the theme foreground.
     """
     from ttkbootstrap.style.engine import Style  # back-edge; keeps this a leaf
 
@@ -297,8 +291,7 @@ def icon_element(style, name, *, size, default, states=None, **options):
 
     The `Style.map`-aligned analog of `image_element`, with the icon as the asset
     source: each per-state spec is rendered via `Icon`/`Assets.icon` and assembled
-    into one validated, first-match-wins image element. One declarative call
-    replaces a `create_*_assets` method plus its `image_element` wiring.
+    into one validated, first-match-wins image element.
 
     `name` is the element name and must be `"<ttkstyle>.<element>"` (e.g.
     `"Favorite.TCheckbutton.indicator"`); the foreground a color-less spec follows
@@ -496,7 +489,7 @@ def apply_icon(widget, name, *, size=14, states=None, compound=None):
     so it inverts on ``outline``/``toggle`` buttons, mutes when disabled, and
     re-colors on a theme switch. It does so by giving the widget a derived,
     content-hashed style that augments (inherits) its current ``style``/
-    ``bootstyle`` -- see the design doc's "What this does to your widget's style".
+    ``bootstyle``.
 
     Parameters:
 

--- a/src/ttkbootstrap/style/layout.py
+++ b/src/ttkbootstrap/style/layout.py
@@ -31,10 +31,11 @@ def statespec(spec):
     Tokens are space-separated; each may be negated with a leading `!`
     ("!selected"). An unknown token raises `ValueError`.
 
-    ```python
-    statespec("disabled selected")  # -> ("disabled", "selected")
-    statespec("!selected")          # -> ("!selected",)
-    ```
+    Examples:
+        ```python
+        statespec("disabled selected")  # -> ("disabled", "selected")
+        statespec("!selected")          # -> ("!selected",)
+        ```
     """
     tokens = tuple(spec.split())
     for token in tokens:
@@ -55,12 +56,13 @@ class El:
     constructor `children=[...]` kwarg (unambiguous; reads as the tree it builds)
     rather than fluent positional parenting.
 
-    ```python
-    El("Radiobutton.padding", sticky=NSEW, children=[
-        El(f"{ttk_style}.indicator", side=LEFT),
-        El("Radiobutton.focus", side=LEFT, children=[
-            El("Radiobutton.label", sticky=NSEW)])])
-    ```
+    Examples:
+        ```python
+        El("Radiobutton.padding", sticky=NSEW, children=[
+            El(f"{ttk_style}.indicator", side=LEFT),
+            El("Radiobutton.focus", side=LEFT, children=[
+                El("Radiobutton.label", sticky=NSEW)])])
+        ```
     """
 
     __slots__ = ("name", "options", "children")
@@ -98,10 +100,11 @@ def register_style(style, ttk_style):
     `map`) does not register it on its own; call this (or `layout()`, which calls
     it for you) so `style="<ttk_style>"` resolves to what you built.
 
-    ```python
-    state_map(style, "My.TButton", background={"pressed": "#333"})
-    register_style(style, "My.TButton")   # now style="My.TButton" resolves
-    ```
+    Examples:
+        ```python
+        state_map(style, "My.TButton", background={"pressed": "#333"})
+        register_style(style, "My.TButton")   # now style="My.TButton" resolves
+        ```
 
     Registration is per *active* theme (it mirrors the built-in builders). A
     hand-built style is not auto-rebuilt on a theme switch, so re-build + re
@@ -112,13 +115,13 @@ def register_style(style, ttk_style):
 
 
 def layout(style, ttk_style, root):
-    """Apply an `El` (or list of `El`s) as the layout for `ttkstyle`.
+    """Apply an `El` (or list of `El`s) as the layout for `ttk_style`.
 
     Structural sugar over `style.layout(ttk_style, [...])`. Defining a layout is
     what gives a style its identity, so this also **registers** `ttk_style` with
     the engine (via `register_style`) -- a hand-built style whose terminal step is
     `layout()` resolves through `style="<ttk_style>"` with no extra step. (Built-in
-    builders that also call `_register_ttk_style` explicitly are unaffected --
+    builders that also call `_register_ttkstyle` explicitly are unaffected --
     registration is an idempotent set add.)
     """
     roots = [root] if isinstance(root, El) else list(root)
@@ -136,12 +139,13 @@ def image_element(style, name, *, default, states=None, **options):
     instead of silently never matching). `options` (width, border, sticky, ...)
     pass through to `element_create`.
 
-    ```python
-    image_element(style, f"{ttk_style}.indicator", default=on,
-        states={"disabled selected": on_disabled, "disabled": disabled,
-                "!selected": off},
-        width=20, border=4, sticky=W)
-    ```
+    Examples:
+        ```python
+        image_element(style, f"{ttk_style}.indicator", default=on,
+            states={"disabled selected": on_disabled, "disabled": disabled,
+                    "!selected": off},
+            width=20, border=4, sticky=W)
+        ```
     """
     args = [default]
     if states:
@@ -158,9 +162,10 @@ def state_map(style, ttk_style, **options):
     pairs). State strings are validated by `statespec`. Replaces bare
     `foreground=[("disabled", fg)]` lists.
 
-    ```python
-    state_map(style, ttk_style, foreground={"disabled": disabled_fg})
-    ```
+    Examples:
+        ```python
+        state_map(style, ttk_style, foreground={"disabled": disabled_fg})
+        ```
     """
     mapping = {}
     for option, spec in options.items():
@@ -185,12 +190,13 @@ class StyleName:
                   dropped ("info.Horizontal.TScale" -> "info.Horizontal.Scale"),
                   matching the old `h_ttkstyle.replace(".TS", ".S")` dance.
 
-    ```python
-    sn = StyleName("TScale", colorname, orient="Horizontal")
-    sn.colorname    # PRIMARY when colorname was DEFAULT/"", else as given
-    sn.ttk_style     # "Horizontal.TScale" or "primary.Horizontal.TScale"
-    sn.element      # "Horizontal.Scale"
-    ```
+    Examples:
+        ```python
+        sn = StyleName("TScale", colorname, orient="Horizontal")
+        sn.colorname    # PRIMARY when colorname was DEFAULT/"", else as given
+        sn.ttk_style     # "Horizontal.TScale" or "primary.Horizontal.TScale"
+        sn.element      # "Horizontal.Scale"
+        ```
     """
 
     __slots__ = ("colorname", "ttk_style", "element")
@@ -210,5 +216,5 @@ class StyleName:
 
     @property
     def ttkstyle(self):
-        '''Backward-compatible spelling of ``ttk_style``.'''
+        """Backward-compatible spelling of `ttk_style`."""
         return self.ttk_style

--- a/src/ttkbootstrap/style/scaling.py
+++ b/src/ttkbootstrap/style/scaling.py
@@ -21,6 +21,7 @@ class Scaling:
     """Convert logical UI units for one Tk root/interpreter."""
 
     def __init__(self, root):
+        """Bind the service to `root`'s Tk interpreter."""
         self.root = root
 
     @classmethod
@@ -36,14 +37,17 @@ class Scaling:
 
     @property
     def windowing_system(self) -> str:
+        """Name of the underlying Tk windowing system (`x11`, `win32`, or `aqua`)."""
         return str(self.root.tk.call("tk", "windowingsystem"))
 
     @property
     def baseline(self) -> float:
+        """Tk scaling value that corresponds to a 1.0 (unscaled) UI factor."""
         return 1.0 if self.windowing_system == "aqua" else 4 / 3
 
     @property
     def tk_scaling(self) -> float:
+        """Current Tk scaling factor, falling back to a fpixels-based estimate."""
         try:
             return float(self.root.tk.call("tk", "scaling"))
         except Exception:
@@ -51,6 +55,7 @@ class Scaling:
 
     @property
     def factor(self) -> float:
+        """Scaling factor relative to `baseline`, snapped to the nearest quarter step when close."""
         raw = self.tk_scaling / self.baseline
         quarter = round(raw * 4) / 4
         if abs(raw - quarter) <= _QUARTER_STEP_TOLERANCE:

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -1,9 +1,9 @@
-"""Color model and theme definition for ttkbootstrap.
+"""Color model and theme definitions for ttkbootstrap.
 
-Holds `Colors` (the color scheme plus color math) and `ThemeDefinition` (the
-name/colors/light-or-dark container the style engine consumes). Lowest layer of
-the `style` package; the semantic-anchor `Theme` model (Workstream E) will grow
-here. Split out of the monolithic `style.py` in 2.0.
+Holds `Colors` (the color scheme plus color math), `ThemeDefinition` (the
+name/colors/light-or-dark container the style engine consumes), and `Theme`
+(a semantic-anchor theme family that generates light/dark `ThemeDefinition`s
+from a handful of accent colors). Lowest layer of the `style` package.
 """
 import colorsys
 from collections.abc import Mapping
@@ -254,7 +254,7 @@ class Colors:
 
         This class is an iterator, so you can iterate over the main
         style color labels (primary, secondary, success, info, warning,
-        danger):
+        danger, light, dark):
 
         ```python
         for color_label in style.colors:
@@ -268,7 +268,7 @@ class Colors:
 
         ```python
         for color_label in style.colors.label_iter():
-            color = Colors.get(color_label)
+            color = style.colors.get(color_label)
             print(color_label, color)
         ```
 
@@ -504,7 +504,7 @@ class Colors:
         Parameters:
 
             color_label (str):
-                A color label corresponding to a class propery
+                A color label corresponding to a class property
 
         Returns:
 
@@ -606,8 +606,8 @@ class Colors:
 
         Returns:
 
-            tuple[int, int, int]:
-                An rgb color value.
+            tuple[float, float, float]:
+                The rgb color value, each channel normalized to 0-1.
         """
         r, g, b = colorutils.color_to_rgb(color)
         return r / 255, g / 255, b / 255
@@ -933,9 +933,13 @@ class Theme:
         """Derive a new family from an existing `Theme`, overriding some tokens.
 
         Every token not overridden is inherited from `base`, so a built-in can
-        be re-branded by changing just its `primary` (and anything else):
+        be re-branded by changing just its `primary` (and anything else).
 
+        Examples:
+
+            ```python
             Theme.from_existing(BOOTSTRAP, name="acme", primary="#ff5722")
+            ```
         """
         unknown = set(overrides) - {f.name for f in fields(cls)}
         if unknown:

--- a/src/ttkbootstrap/themes/legacy.py
+++ b/src/ttkbootstrap/themes/legacy.py
@@ -34,6 +34,13 @@ def theme_from_legacy_dict(name, spec) -> ThemeDefinition:
     Authored accents, `bg`/`fg`, `selectbg`/`selectfg`, and the `light`/`dark`
     accents are preserved; `border`, `inputbg`, and `active` are regenerated
     from `bg` with the mode-aware, hue-preserving surface derivation.
+
+    Parameters:
+        name: Theme name to assign.
+        spec: Legacy spec, `{'type': 'light'|'dark', 'colors': {16 keys}}`.
+
+    Returns:
+        ThemeDefinition: The resolved theme definition.
     """
     c = spec["colors"]
     mode = spec["type"]

--- a/src/ttkbootstrap/themes/standard.py
+++ b/src/ttkbootstrap/themes/standard.py
@@ -1,36 +1,9 @@
-"""Standard built-in theme definitions for ttkbootstrap.
+"""Legacy (pre-2.0) theme definitions for ttkbootstrap.
 
-This module contains over 40 pre-defined Bootstrap-inspired themes that can
-be used in ttkbootstrap applications. Each theme includes a complete color
-scheme with primary, secondary, success, info, warning, danger, light, and
-dark colors, plus additional UI colors for backgrounds, foregrounds, borders, etc.
-
-Themes are categorized as:
-    - Light themes: bright backgrounds with dark text
-    - Dark themes: dark backgrounds with light text
-
-Available themes include:
-    Light: cosmo, flatly, litera, minty, lumen, pulse, sandstone, united,
-           yeti, morph, journal, simplex, cerulean, solar, superhero, darkly,
-           cyborg, vapor
-
-    Dark: darkly, solar, superhero, cyborg, vapor
-
-Each theme dictionary contains:
-    - type: "light" or "dark"
-    - colors: dict with primary, secondary, success, info, warning, danger,
-              light, dark, bg, fg, selectbg, selectfg, border, inputfg,
-              inputbg, and active color definitions
-
-Example:
-    Themes are automatically loaded by the Style class:
-    ```python
-    import ttkbootstrap as ttk
-
-    # Use a standard theme
-    root = ttk.Window(themename="darkly")
-    root.mainloop()
-    ```
+`STANDARD_THEMES` maps each pre-2.0 theme name (e.g. "cosmo", "darkly") to its
+color definition. These are retained for backward compatibility and installed
+onto the 2.0 semantic-anchor model by `themes.legacy.install_legacy_themes()`.
+The curated 2.0 theme catalog lives in `themes.builtin` (`CURATED_THEMES`).
 """
 
 STANDARD_THEMES = {

--- a/src/ttkbootstrap/utility.py
+++ b/src/ttkbootstrap/utility.py
@@ -1,24 +1,6 @@
 """Public utility functions for ttkbootstrap.
 
-This module provides high-DPI support and size scaling helpers for
-ttkbootstrap applications.
-
-Functions:
-    enable_high_dpi_awareness: Enable high-DPI scaling on Windows/Linux
-    scale_size: Scale a size value for high-DPI displays
-    windowing_system: Detect the Tk windowing system ('win32'/'aqua'/'x11')
-
-Example:
-    ```python
-    from ttkbootstrap.utility import enable_high_dpi_awareness
-    import ttkbootstrap as ttk
-
-    # Enable high-DPI before creating window
-    enable_high_dpi_awareness()
-
-    root = ttk.Window()
-    root.mainloop()
-    ```
+High-DPI awareness and size-scaling helpers for ttkbootstrap applications.
 """
 import warnings
 

--- a/src/ttkbootstrap/validation.py
+++ b/src/ttkbootstrap/validation.py
@@ -1,65 +1,10 @@
 r"""Validation framework for ttkbootstrap entry widgets.
 
-This module provides classes and functions for adding validation to Entry,
-Spinbox, and Combobox widgets. When validation fails, a 'danger' colored
-border is applied to the widget, which disappears when the contents become valid.
-
-The module includes:
-    - Predefined validation functions (text, numeric, phone number, regex, etc.)
-    - Custom validation decorator (@validator)
-    - Helper functions starting with "add_" prefix for quick validation setup
-
-Classes:
-    ValidationEvent: Contains attributes of a validation event from tkinter
-
-Functions:
-    add_validation: Core function to add validation to any compatible widget
-    add_text_validation: Validate that contents is alphabetic text
-    add_numeric_validation: Validate that contents is numeric
-    add_phonenumber_validation: Validate phone number format
-    add_regex_validation: Validate against custom regex pattern
-    add_range_validation: Validate numeric value is within range
-    add_option_validation: Validate value is in list of options
-
-Example:
-    Using predefined validation:
-    ```python
-    import ttkbootstrap as ttk
-    from ttkbootstrap.validation import *
-
-    app = ttk.Window()
-    entry = ttk.Entry()
-    entry.pack(padx=10, pady=10)
-
-    # Check if contents is text
-    add_text_validation(entry)
-
-    # Prevent any entry except text
-    add_text_validation(entry, when='key')
-
-    # Check for specific list of options
-    add_option_validation(entry, ['red', 'blue', 'green'])
-
-    # Validate against regex expression
-    add_regex_validation(entry, r'\d{4}-\d{2}-\d{2}')
-
-    app.mainloop()
-    ```
-
-    Creating custom validation:
-    ```python
-    from ttkbootstrap.validation import validator, add_validation
-
-    @validator
-    def validate_long_text(event):
-        if len(event.postchangetext) > 20:
-            return True
-        else:
-            return False
-
-    # Apply custom validation
-    add_validation(entry, validate_long_text)
-    ```
+Adds input validation to Entry, Spinbox, and Combobox widgets: a failing value
+flags the widget with a 'danger'-colored border that clears once the contents
+become valid. Provides the `@validator` decorator, the core `add_validation`,
+and a family of `add_*` helpers for common cases (text, numeric, phone number,
+regex, range, options).
 """
 import re
 from tkinter import Misc
@@ -299,6 +244,12 @@ def add_range_validation(
         widget (Widget):
             The widget on which to add validation.
 
+        startrange (Union[int, float]):
+            The lower bound of the accepted range, inclusive.
+
+        endrange (Union[int, float]):
+            The upper bound of the accepted range, inclusive.
+
         when (str):
             Specifies when to apply validation. See the `add_validation`
             method docstring for a full list of options.
@@ -315,11 +266,13 @@ def add_range_validation(
 def add_option_validation(widget: Misc, options: list[Any], when: str = "focusout") -> None:
     """Check if the widget contents is in a list of options.
 
-
     Parameters:
 
         widget (Widget):
             The widget on which to add validation.
+
+        options (list):
+            The list of acceptable values.
 
         when (str):
             Specifies when to apply validation. See the `add_validation`

--- a/src/ttkbootstrap/widgets/__init__.py
+++ b/src/ttkbootstrap/widgets/__init__.py
@@ -1,47 +1,8 @@
-"""Widgets module for ttkbootstrap.
+"""Custom widgets for ttkbootstrap.
 
-This module provides custom widgets for ttkbootstrap, extending the standard
-tkinter and ttk widget set with enhanced functionality and styling options.
-
-Available Widgets:
-    DateEntry: Date picker widget with calendar popup
-    Floodgauge: Progress bar with customizable text overlay
-    FloodgaugeLegacy: Legacy ttk-based progress bar
-    Meter: Radial progress indicator with various display styles
-    LabeledScale: Scale widget with automatic value label
-
-Module Constants:
-    M (int): Meter image scale factor (3)
-    TTK_WIDGETS: Tuple of standard ttk widget classes
-    TK_WIDGETS: Tuple of standard tk widget classes
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-    from datetime import datetime
-
-    root = ttk.Window()
-
-    # Create various custom widgets
-    date_entry = ttk.DateEntry(root, first_weekday=0)
-    date_entry.pack(padx=10, pady=5)
-
-    floodgauge = ttk.Floodgauge(root, maximum=100, mask="{}% Complete")
-    floodgauge.pack(fill='x', padx=10, pady=5)
-
-    meter = ttk.Meter(root, amount_used=75, meter_type="semi")
-    meter.pack(padx=10, pady=5)
-
-    scale = ttk.LabeledScale(root, from_=0, to=100)
-    scale.pack(fill='x', padx=10, pady=5)
-
-    root.mainloop()
-    ```
-
-Note:
-    All widgets in this module maintain backwards compatibility with the
-    previous monolithic widgets.py file. Imports from ttkbootstrap.widgets
-    will work identically to before the module refactoring.
+The shipped widgets that extend the standard tkinter/ttk set — date entry,
+meter, floodgauge, labeled scale, scrolled containers, table view, toast, and
+tooltip.
 """
 import tkinter as tk
 from tkinter import ttk

--- a/src/ttkbootstrap/widgets/dateentry.py
+++ b/src/ttkbootstrap/widgets/dateentry.py
@@ -1,30 +1,7 @@
 """DateEntry widget for ttkbootstrap.
 
-This module provides the DateEntry widget, which combines an Entry field
-with a calendar button to allow users to select dates from a popup calendar.
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-    from datetime import datetime
-
-    root = ttk.Window()
-
-    # Create a date entry widget
-    date_entry = ttk.DateEntry(root, first_weekday=0, start_date=datetime.now())
-    date_entry.pack(padx=10, pady=10)
-
-    # Get the selected date (reads the live entry text)
-    selected_date = date_entry.get_date()
-
-    # Handle date selection events
-    def on_date_selected(event):
-        print(f"Selected date: {date_entry.get_date()}")
-
-    date_entry.bind("<<DateEntrySelected>>", on_date_selected)
-
-    root.mainloop()
-    ```
+An Entry field paired with a button that opens a popup calendar for date
+selection; the chosen date is written back into the entry.
 """
 from datetime import date, datetime
 from tkinter import Misc
@@ -73,8 +50,6 @@ class DateEntry(ConfigureDelegationMixin, Frame):
     Widget Attributes:
         entry (ttk.Entry): The entry field displaying the selected date
         button (ttk.Button): The button that opens the calendar popup
-
-    ![](../../assets/widgets/date-entry.png)
     """
 
     # Common fallback formats tried (after the widget's own `date_format`) when

--- a/src/ttkbootstrap/widgets/floodgauge.py
+++ b/src/ttkbootstrap/widgets/floodgauge.py
@@ -1,35 +1,7 @@
-"""Floodgauge widgets for ttkbootstrap.
+"""Floodgauge widget for ttkbootstrap.
 
-This module provides Floodgauge widgets that display progress with optional
-text labels. Floodgauge is a canvas-based alternative to the ttk Progressbar
-with enhanced styling and animation capabilities.
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-
-    root = ttk.Window()
-
-    # Create a floodgauge with a mask for percentage display
-    fg = ttk.Floodgauge(
-        root,
-        maximum=100,
-        value=0,
-        bootstyle="success",
-        mask="{}% Complete"
-    )
-    fg.pack(fill='x', padx=10, pady=10)
-
-    # Start animation or update value
-    fg.configure(value=50)
-
-    # For indeterminate mode
-    fg_indet = ttk.Floodgauge(root, mode='indeterminate', bootstyle='info')
-    fg_indet.pack(fill='x', padx=10, pady=10)
-    fg_indet.start()
-
-    root.mainloop()
-    ```
+A canvas-based progress indicator (a styled alternative to `ttk.Progressbar`)
+with determinate and indeterminate modes and an optional text/percentage label.
 """
 import warnings
 from tkinter import Event, Misc, TclError

--- a/src/ttkbootstrap/widgets/labeledscale.py
+++ b/src/ttkbootstrap/widgets/labeledscale.py
@@ -1,23 +1,7 @@
 """LabeledScale widget for ttkbootstrap.
 
-This module provides the LabeledScale widget, which combines a Scale
-widget with a Label that automatically displays the current value.
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-
-    root = ttk.Window()
-
-    # Create a labeled scale
-    scale = ttk.LabeledScale(root, from_=0, to=100)
-    scale.pack(padx=10, pady=10)
-
-    # Access the current value
-    print(scale.value)
-
-    root.mainloop()
-    ```
+A `ttk.Scale` paired with a `ttk.Label` that tracks and displays the current
+value above or below the scale.
 """
 from tkinter import Misc, TclError, Variable
 from typing import Any, Optional, Union

--- a/src/ttkbootstrap/widgets/meter.py
+++ b/src/ttkbootstrap/widgets/meter.py
@@ -1,41 +1,8 @@
 """Meter widget for ttkbootstrap.
 
-This module provides the Meter widget, a radial progress indicator that can
-display progress in various styles (full circle, semi-circle, solid, striped).
-The meter can be interactive, allowing users to adjust values with mouse input.
-
-Module Constants:
-    M (int): Meter image scale factor (3). Higher values increase resolution
-             of the rendered meter image.
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-    from ttkbootstrap.constants import *
-
-    root = ttk.Window()
-
-    # Create a meter
-    meter = ttk.Meter(
-        root,
-        meter_size=200,
-        amount_used=65,
-        amount_total=100,
-        meter_type="semi",
-        subtext="CPU Usage",
-        interactive=True,
-        bootstyle="success"
-    )
-    meter.pack(padx=10, pady=10)
-
-    # Update the value
-    meter.configure(amount_used=75)
-
-    # Access the value
-    print(meter.value)
-
-    root.mainloop()
-    ```
+A radial progress indicator that shows progress as a full or semi circle, with
+solid or striped fill and optional center/side text. Can be made interactive so
+the user drags to set the value.
 """
 import math
 from tkinter import Event, Misc, TclError
@@ -86,8 +53,6 @@ class Meter(ConfigureDelegationMixin, Frame):
     The current value is available through the `value` property (and
     the `amount_used_var` variable); the value can also be retrieved
     or set via the `configure`/`cget` methods.
-
-    ![](../../assets/widgets/meter.gif)
 
     Examples:
 

--- a/src/ttkbootstrap/widgets/scrolled.py
+++ b/src/ttkbootstrap/widgets/scrolled.py
@@ -1,39 +1,8 @@
-"""Scrolling widgets with optional autohide scrollbars for ttkbootstrap.
+"""Scrolling containers for ttkbootstrap.
 
-This module provides enhanced scrolling widgets that wrap standard tkinter
-and ttk widgets with automatic scrollbar management. The scrollbars can be
-configured to auto-hide when the mouse is not over the widget.
-
-Classes:
-    ScrolledText: Text widget with vertical/horizontal scrollbars
-    ScrolledFrame: Frame container with a vertical scrollbar (Canvas viewport)
-
-Features:
-    - Optional auto-hide scrollbars (hide when the mouse leaves the widget)
-    - Configurable vertical and horizontal scrollbars
-    - Seamless delegation of widget methods
-    - Bootstrap styling support via the bootstyle parameter
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-    from ttkbootstrap.constants import *
-
-    app = ttk.Window()
-
-    # Scrolled text with an auto-hide scrollbar
-    st = ttk.ScrolledText(app, padding=5, height=10, auto_hide=True)
-    st.pack(fill=BOTH, expand=YES)
-    st.insert(END, 'Insert your text here.')
-
-    # Scrolled frame for multiple widgets
-    sf = ttk.ScrolledFrame(app, auto_hide=True)
-    sf.pack(fill=BOTH, expand=YES, padx=10, pady=10)
-    for x in range(20):
-        ttk.Checkbutton(sf, text=f"Checkbutton {x}").pack(anchor=W)
-
-    app.mainloop()
-    ```
+`ScrolledText` and `ScrolledFrame` wrap a Text widget / Frame with managed
+vertical and horizontal scrollbars that can optionally auto-hide when the mouse
+leaves the widget.
 """
 import tkinter
 from tkinter import Grid, Pack, Place
@@ -62,8 +31,6 @@ class ScrolledText(ConfigureDelegationMixin, ttk.Frame):
     This widget is identical in configuration to the `Text` widget other
     than the scrolling frame; `configure`/`cget` and unknown method access
     are delegated to the internal `Text`. https://tcl.tk/man/tcl8.6/TkCmd/text.htm
-
-    ![scrolled text](../../../assets/scrolled/scrolledtext.gif)
 
     Examples:
 

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -1,58 +1,7 @@
-"""Table view widget with sorting, searching, and pagination for ttkbootstrap.
+"""Table view widget for ttkbootstrap.
 
-This module provides a powerful table widget built on top of ttk.Treeview with
-enhanced features like column sorting, row striping, pagination, searching,
-and data loading from various sources.
-
-Classes:
-    TableColumn: Represents a column in the Tableview
-    Tableview: Enhanced treeview widget for displaying tabular data
-
-Features:
-    - Automatic column sorting with visual indicators
-    - Row striping for better readability
-    - Pagination with configurable page size
-    - Column-specific searching
-    - Loading data from lists, dicts, CSV files
-    - Row selection with callback events
-    - Autofit columns and autoalign numeric data
-    - Localization support for date formatting
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-    from ttkbootstrap.widgets.tableview import Tableview
-
-    app = ttk.Window()
-
-    # Define column structure
-    coldata = [
-        {"text": "Name", "stretch": False},
-        {"text": "Age", "stretch": False},
-        {"text": "Email", "stretch": True}
-    ]
-
-    # Define row data
-    rowdata = [
-        ["John Doe", 28, "john@example.com"],
-        ["Jane Smith", 35, "jane@example.com"],
-        ["Bob Wilson", 42, "bob@example.com"],
-    ]
-
-    # Create tableview
-    tv = Tableview(
-        master=app,
-        coldata=coldata,
-        rowdata=rowdata,
-        paginated=True,
-        searchable=True,
-        bootstyle="primary",
-        stripecolor=(None, None),
-    )
-    tv.pack(fill="both", expand=True, padx=10, pady=10)
-
-    app.mainloop()
-    ```
+A `ttk.Treeview`-based table with column sorting, row striping, pagination,
+searching, and data loading from lists, dicts, or CSV files.
 """
 import tkinter as tk
 from datetime import datetime
@@ -93,7 +42,7 @@ class TableColumn:
             tableview (Tableview):
                 The parent tableview object.
 
-            cid (str):
+            cid (int):
                 The column id.
 
             text (str):
@@ -473,15 +422,11 @@ class Tableview(ttk.Frame):
     The object has a right-click menu on the header and the cells that
     allow you to configure various settings.
 
-    ![](../../assets/widgets/tableview-1.png)
-    ![](../../assets/widgets/tableview-2.png)
-
     Examples:
 
         Adding data with the constructor
         ```python
         import ttkbootstrap as ttk
-        from ttkbootstrap.widgets.tableview import Tableview
         from ttkbootstrap.constants import *
 
         app = ttk.Window()
@@ -499,7 +444,7 @@ class Tableview(ttk.Frame):
             ('A158', 'Farmadding Co.', 36)
         ]
 
-        dt = Tableview(
+        dt = ttk.Tableview(
             master=app,
             coldata=coldata,
             rowdata=rowdata,
@@ -545,10 +490,10 @@ class Tableview(ttk.Frame):
                 The parent widget.
 
             bootstyle (str):
-                A style keyword used to set the focus color of the entry
-                and the background color of the date button. Available
-                options include -> primary, secondary, success, info,
-                warning, danger, dark, light.
+                A color keyword used to set the color of the table headers,
+                selection, and other accents. Available options include ->
+                primary, secondary, success, info, warning, danger, dark,
+                light.
 
             coldata (list[str | dict]):
                 An iterable containing either the heading name or a

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -1,40 +1,8 @@
-"""Toast notification popup widgets for ttkbootstrap.
+"""Toast notification popup for ttkbootstrap.
 
-This module provides a semi-transparent toast notification system for displaying
-temporary alerts or messages. Toasts appear as popup windows that can be
-configured to automatically close after a duration or require user interaction
-to dismiss. Concurrent toasts anchored to the same screen corner are stacked so
-they do not overlap, and the stack reflows when one is dismissed.
-
-Classes:
-    ToastNotification: Semi-transparent popup for alerts and messages
-
-Features:
-    - Configurable display duration or click-to-close behavior
-    - Bootstrap styling support (primary, secondary, success, danger, etc.)
-    - A theme-aware icon rendered from the built-in Bootstrap-Icons font
-    - Flexible positioning (anchored to screen corners) with non-overlapping
-      stacking of concurrent toasts
-    - Optional audible alert bell
-    - Smooth (cancellable) fade-out animation on close
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-
-    app = ttk.Window()
-
-    # Toast with auto-close after 3 seconds
-    toast = ttk.ToastNotification(
-        title="ttkbootstrap toast message",
-        message="This is a toast message",
-        duration=3000,
-        bootstyle="info",
-    )
-    toast.show_toast()
-
-    app.mainloop()
-    ```
+A semi-transparent popup window for temporary alerts, anchored to a screen
+corner with non-overlapping stacking of concurrent toasts, an optional
+auto-close duration, a theme-aware icon, and a fade-out animation.
 """
 import tkinter
 from tkinter import font
@@ -103,8 +71,6 @@ class ToastNotification:
     Concurrent toasts anchored to the same corner stack without overlapping and
     reflow when one is dismissed. ``show_toast()`` returns the toast so it can be
     dismissed programmatically with :meth:`hide`.
-
-    ![toast notification](../assets/toast/toast.png)
 
     Examples:
 

--- a/src/ttkbootstrap/widgets/tooltip.py
+++ b/src/ttkbootstrap/widgets/tooltip.py
@@ -1,47 +1,8 @@
-"""Tooltip popup widgets for ttkbootstrap.
+"""Tooltip popup for ttkbootstrap.
 
-This module provides a semi-transparent tooltip system that displays helpful
-text when hovering over widgets. Tooltips automatically appear on mouse hover
-and disappear when the mouse leaves the widget or on click.
-
-Classes:
-    ToolTip: Semi-transparent popup that shows text on hover
-
-Features:
-    - Automatic show/hide on mouse enter/leave events
-    - Configurable delay before the tooltip appears
-    - Bootstrap styling support
-    - Flexible positioning (follows the mouse or anchored to the widget)
-    - Text wrapping and justification options
-    - Optional image display with the text
-    - `configure`/`cget` for live reconfiguration; self-releasing lifecycle
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-    from ttkbootstrap.constants import *
-
-    app = ttk.Window()
-
-    b1 = ttk.Button(app, text="default tooltip")
-    b1.pack(side=LEFT, padx=20, pady=20)
-
-    b2 = ttk.Button(app, text="styled tooltip")
-    b2.pack(side=LEFT, padx=20, pady=20)
-
-    # Default tooltip (follows the mouse)
-    ttk.ToolTip(b1, text="This is the default style")
-
-    # Styled tooltip anchored to the widget
-    ttk.ToolTip(
-        b2,
-        text="This is dangerous",
-        bootstyle="danger-inverse",
-        position="top right",
-    )
-
-    app.mainloop()
-    ```
+A semi-transparent tooltip that shows text on hover and hides on leave or click.
+Supports a configurable delay, mouse-following or widget-anchored positioning,
+text wrapping/justification, an optional image, and live reconfiguration.
 """
 import tkinter
 from tkinter import Event, Misc
@@ -65,8 +26,6 @@ class ToolTip:
     destroyed; call :meth:`destroy` to remove it explicitly. Its options can be
     changed after construction with :meth:`configure` / :meth:`cget` (or item
     access), and a currently-visible popup is reconfigured in place.
-
-    ![](../assets/tooltip/tooltip.gif)
 
     Examples:
 

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -1,47 +1,8 @@
 """Window and Toplevel classes for ttkbootstrap applications.
 
-This module provides enhanced Window and Toplevel classes that wrap tkinter.Tk
-and tkinter.Toplevel with integrated ttkbootstrap Style support, providing a
-consolidated API for application initialization and window creation.
-
-Classes:
-    Window: Main application window (wraps tk.Tk with Style)
-    Toplevel: Top-level popup window (wraps tk.Toplevel with Style)
-
-Features:
-    - Integrated ttkbootstrap theme support
-    - Simplified window configuration (size, position, title, etc.)
-    - High-DPI awareness configuration
-    - Window positioning utilities (center, place)
-    - Alpha transparency support
-    - Icon management (PhotoImage or file path)
-    - Resizable window control
-    - Theme-aware styling
-
-Example:
-    ```python
-    import ttkbootstrap as ttk
-    from ttkbootstrap.constants import *
-
-    # Create main window with theme
-    root = ttk.Window(
-        title="My Application",
-        themename="bootstrap-dark",
-        size=(800, 600),
-        position=(100, 100),
-        resizable=(True, True)
-    )
-
-    # Add widgets
-    ttk.Label(root, text="Hello, World!").pack(padx=20, pady=20)
-    ttk.Button(root, text="Click Me", bootstyle="success").pack()
-
-    # Create toplevel popup
-    popup = ttk.Toplevel(title="Popup Window")
-    popup.geometry("400x300")
-
-    root.mainloop()
-    ```
+`Window` and `Toplevel` wrap `tkinter.Tk`/`tkinter.Toplevel` with integrated
+ttkbootstrap `Style` support and a consolidated construction API — theme, title,
+size/position/geometry, resizability, high-DPI, alpha, and icon handling.
 """
 import sys
 import tkinter
@@ -226,9 +187,7 @@ class _BaseWindow:
 
     Used as a mixin alongside `tkinter.Tk`/`tkinter.Toplevel`, so both classes
     stop duplicating -- and drifting on -- their icon, geometry, alpha, and
-    positioning handling. Mirrors bootstack's `BaseWindow`
-    (`bootstack/src/bootstack/_runtime/base_window.py`); ttkbootstrap borrows
-    the mechanisms only, keeping its own `Window`/`Toplevel` split.
+    positioning handling.
     """
 
     winsys: str
@@ -249,8 +208,8 @@ class _BaseWindow:
                      otherwise inherit the application default (`Toplevel`).
             path  -> load the image, falling back to `default_data` on failure.
 
-        A `.ico` path is applied through `wm_iconbitmap` on Windows (mirrors
-        bootstack's platform branch); other formats go through `iconphoto`.
+        A `.ico` path is applied through `wm_iconbitmap` on Windows; other
+        formats go through `iconphoto`.
         """
         if iconphoto is None:
             return
@@ -276,7 +235,7 @@ class _BaseWindow:
                 self._apply_default_icon(default_data)
 
     def _apply_default_icon(self, default_data: str) -> None:
-        """Apply the brand app icon per-platform (mirrors bootstack).
+        """Apply the brand app icon per platform.
 
         Windows gets the multi-resolution ``.ico`` via ``wm_iconbitmap`` (built
         by ``tools/make_app_ico.py``); macOS/Linux get a PNG via ``iconphoto``.
@@ -323,6 +282,7 @@ class _BaseWindow:
             maxsize: Optional[Tuple[int, int]],
             resizable: Optional[Tuple[bool, bool]],
     ) -> None:
+        """Apply `minsize`/`maxsize`/`resizable`, skipping any left as `None`."""
         if minsize is not None:
             self.minsize(minsize[0], minsize[1])
         if maxsize is not None:
@@ -334,8 +294,7 @@ class _BaseWindow:
         """Set window transparency, platform-aware.
 
         On X11 alpha must be applied after the window is visible, so it is
-        deferred to the `<Visibility>` event (mirrors bootstack's
-        `on_visibility_alpha`); Windows/aqua set it immediately.
+        deferred to the `<Visibility>` event; Windows/aqua set it immediately.
         """
         if alpha is None:
             return
@@ -349,8 +308,7 @@ class _BaseWindow:
         """Get/set override-redirect, guarding the macOS no-op.
 
         On aqua, enabling override-redirect breaks click handling and can crash
-        Tk/Cocoa, so a truthy request is silently ignored there (bootstack
-        `base_window.py:619-639`).
+        Tk/Cocoa, so a truthy request is silently ignored there.
         """
         if boolean and getattr(self, 'winsys', None) == 'aqua':
             return None
@@ -394,8 +352,6 @@ class Window(_BaseWindow, tkinter.Tk):
     information on how to use the inherited `Tk` methods, see the
     [tcl/tk documentation](https://tcl.tk/man/tcl8.6/TkCmd/wm.htm)
     and the [Python documentation](https://docs.python.org/3/library/tkinter.html#tkinter.Tk).
-
-    ![](../../assets/window/window-toplevel.png)
 
     Examples:
 
@@ -500,9 +456,10 @@ class Window(_BaseWindow, tkinter.Tk):
                 `overrideredirect` in 2.0.)
 
             alpha (float):
-                On Windows, specifies the alpha transparency level of the
-                toplevel. Where not supported, alpha remains at 1.0. Internally,
-                this is processed as `Toplevel.attributes('-alpha', alpha)`.
+                Sets the window's alpha transparency level (1.0 is opaque).
+                Applied immediately via `Window.attributes('-alpha', alpha)`,
+                except on X11 where it is deferred until the window becomes
+                visible.
 
             **kwargs:
                 Any other keyword arguments that are passed through to tkinter.Tk() constructor
@@ -575,8 +532,6 @@ class Toplevel(_BaseWindow, tkinter.Toplevel):
     For more information on how to use the inherited `Toplevel`
     methods, see the [tcl/tk documentation](https://tcl.tk/man/tcl8.6/TkCmd/toplevel.htm)
     and the [Python documentation](https://docs.python.org/3/library/tkinter.html#tkinter.Toplevel).
-
-    ![](../../assets/window/window-toplevel.png)
 
     Examples:
 
@@ -685,9 +640,10 @@ class Toplevel(_BaseWindow, tkinter.Toplevel):
                 this calls `Toplevel.iconify`.
 
             alpha (float):
-                On Windows, specifies the alpha transparency level of the
-                toplevel. Where not supported, alpha remains at 1.0. Internally,
-                this is processed as `Toplevel.attributes('-alpha', alpha)`.
+                Sets the window's alpha transparency level (1.0 is opaque).
+                Applied immediately via `Toplevel.attributes('-alpha', alpha)`,
+                except on X11 where it is deferred until the window becomes
+                visible.
 
             **kwargs (Dict):
                 Other optional keyword arguments.

--- a/src/ttkcreator/__main__.py
+++ b/src/ttkcreator/__main__.py
@@ -1,3 +1,8 @@
+"""Standalone Tk app for authoring `Theme` definitions: edit accent/neutral
+colors and light/dark background/foreground, preview the result live, and
+export or save the theme.
+"""
+
 import sys
 import shutil
 import json
@@ -45,6 +50,7 @@ class ThemeCreator(ttk.Window):
     """
 
     def __init__(self):
+        """Build the main window: menu, configuration panel, and live preview."""
         super().__init__("TTK Creator")
         self._families = {t.name: t for t in CURATED_THEMES}
         self.rows = {}
@@ -57,6 +63,7 @@ class ThemeCreator(ttk.Window):
         self.demo_widgets.pack(fill=BOTH, expand=YES)
 
     def setup_theme_creator(self):
+        """Build the file menu and the accent/light/dark color-row sections."""
         # application menu
         self.menu = ttk.Menu()
         commands = [
@@ -329,6 +336,7 @@ class ColorRow(ttk.Frame):
     (e.g. an omitted `secondary`)."""
 
     def __init__(self, master, key, label):
+        """Build the label, color patch, hex entry, and picker button for `key`."""
         super().__init__(master, padding=(5, 2))
         self.key = key
         self.color_value = ""
@@ -357,6 +365,7 @@ class ColorRow(ttk.Frame):
         self.update_patch_color()
 
     def pick_color(self):
+        """Open the OS color picker and apply the chosen color."""
         color = askcolor(color=self.color_value or None)
         if color[1]:
             self.color_value = color[1].lower()
@@ -364,11 +373,13 @@ class ColorRow(ttk.Frame):
             self.event_generate("<<ColorSelected>>")
 
     def enter_color(self, *_):
+        """Apply the hex value typed into the entry."""
         self.color_value = self.entry.get().strip().lower()
         self.update_patch_color()
         self.event_generate("<<ColorSelected>>")
 
     def update_patch_color(self):
+        """Sync the entry text and swatch color to `color_value`."""
         self.entry.delete(0, END)
         self.entry.insert(END, self.color_value)
         if self.color_value:
@@ -404,6 +415,7 @@ class DemoWidgets(ttk.Frame):
     Namespaces are one honking great idea -- let's do more of those!"""
 
     def __init__(self, master, style):
+        """Build the left and right preview panels."""
         super().__init__(master)
 
         self.style: ttk.Style = style
@@ -411,6 +423,7 @@ class DemoWidgets(ttk.Frame):
         self.create_right_frame()
 
     def create_right_frame(self):
+        """Create the button and input-widget preview column."""
         container = ttk.Frame(self)
         container.pack(side=RIGHT, fill=BOTH, expand=YES, padx=5)
 


### PR DESCRIPTION
## Summary

Full accuracy-and-consistency pass over module, class, method, and function docstrings across `src/`, ahead of the Workstream H docs rewrite. Docstring text only — **no behavior change**.

## What changed
- **Removed** embedded `![](...png/gif)` image links from docstrings (noise in IDE hover / `help()`; the prose docs get rewritten separately).
- **Fixed ~38 accuracy bugs** surfaced by verifying every docstring against the real 2.0 signatures:
  - Wrong return types (e.g. `Colors.hex_to_rgb` → normalized `float`, not `int`).
  - Copy-paste drift (`Tableview.bootstyle` was DateEntry's text; `Window`/`Toplevel` `alpha` referenced `Toplevel.attributes` + a false "On Windows" scope).
  - Nonexistent names (`ThemeBuilderTTK`→`StyleBuilderTTK`, `update_color`→`update_hsl_value`, `_register_ttk_style`→`_register_ttkstyle`, `DatePickerPopup`→`DatePickerDialog`, `Publisher.publish`→`publish_message`).
  - Broken/stale examples (unbound `Colors.get(...)`, `themename="darkly"`→`"bootstrap-dark"`, wildcard-import `NameError`s).
  - Missing required parameters (`add_range_validation`/`add_option_validation`, etc.).
- **Trimmed** design-rationale / "Workstream" / bootstack-provenance narration to terse, functional voice.
- **Condensed** module docstrings to a one-paragraph purpose (dropped leftover `Classes:`/`Features:`/`Functions:` enumerations that duplicate the generated API listings).
- **Normalized** the `Examples:` section-header spelling and filled docstring coverage gaps on previously-undocumented public symbols.

Conventions captured in `development/2_0_docstring_conventions.md`.

## How it was done
`widgets/` reviewed inline; the remaining ~55 files swept by a multi-agent workflow (one agent per module against the frozen conventions), then reviewed. `gallery/stopwatch.py` (unrelated auto-format whitespace) deliberately excluded.

## Verification
- All changed files byte-compile; imports clean.
- Suite green: **~497 passed**. The 1–2 failing tests (`test_msgcat`, one `color_helpers` param) are **pre-existing order-dependent flakes** from the `Style` singleton / shared root — confirmed identical on the clean tree, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)