### PR TITLE
Auto-register legacy theme names on use (Slice 1)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -14,6 +14,7 @@
 | Area | Kind | Where |
 |---|---|---|
 | Theme model, `Theme`, default theme, ramp addressing | API | `development/2_0_theme_migration.md` |
+| **Legacy theme names auto-register on use (no hard-stop)** | Fix/Deprecated | this doc, below (Slice 1) |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -40,6 +41,32 @@
 | **Inputs: focus color on focus only (not hover)** | Visual | this doc, below |
 | **`card` / `highlight` frames: hairline border (`RAISED`, no bevel)** | Visual | this doc, below |
 | **Control-height parity + check/radio/menubutton focus rings** | Visual | this doc, below |
+
+---
+
+## Legacy (pre-2.0) theme names auto-register on use  *(Fix / Deprecated)*
+
+**What.** `ttk.Window(themename="darkly")` (and any `theme_use("<legacy>")`)
+works again. In 2.0 the curated semantic-anchor catalog replaced the pre-2.0
+theme names, and those old names were opt-in only via
+`ttk.install_legacy_themes()` — so `theme_use("darkly")` on a legacy name raised
+`TclError` with no ordering that fixed it from user code (the first line of
+~every existing app broke). Now, when a name is in `STANDARD_THEMES` but not yet
+registered, `theme_use` **lazily adapts + registers just that one theme**
+(`theme_from_legacy_dict` → `register_theme`), emits a one-time
+`DeprecationWarning`, and builds it normally. `darkly` still looks like darkly
+(only its buggy plumbing is regenerated). `install_legacy_themes()` stays as the
+explicit **bulk** register so `theme_names()`/ttkcreator can enumerate the full
+legacy set.
+
+**Why.** Prefer deprecation over a hard break. There is no 1:1 legacy→2.0 theme
+mapping (`darkly` ≠ `bootstrap-dark`, different palettes), so forcing migration
+would change every app's colors *and* its code. This intentionally reverses
+Workstream E's "opt-in only" decision — that decision is what created the wall —
+while keeping its deprecation nudge (a per-name `DeprecationWarning`).
+
+**Not changed.** The default theme: `ttk.Window()` with no name still renders
+`bootstrap-light` — a documented *visual* change, not a crash.
 
 ---
 

--- a/development/2_0_theme_migration.md
+++ b/development/2_0_theme_migration.md
@@ -17,7 +17,7 @@ changed and how to migrate.
 |---|---|
 | ~18 single-mode themes (`cosmo`, `darkly`, …) | 15 curated **families** → 30 `-light`/`-dark` themes |
 | Default `litera` | Default **`bootstrap-light`** |
-| `Window(themename="darkly")` just works | Curated names only; legacy names need `install_legacy_themes()` |
+| `Window(themename="darkly")` just works | Still works — a legacy name auto-registers on use (one-time `DeprecationWarning`) |
 | Author a 16-key `colors` dict | Author a `Theme(...)` (accent anchors + light/dark blocks) |
 | `style.colors.primary` (a string) | Still a string — **plus** `style.colors.primary[300]` ramp steps |
 
@@ -37,22 +37,32 @@ import ttkbootstrap as ttk
 app = ttk.Window(themename="bootstrap-dark")   # was e.g. "darkly"
 ```
 
-### Getting the old themes back
+### The old theme names still work
 
 The pre-2.0 names (`cosmo`, `flatly`, `litera`, `darkly`, `superhero`, `solar`,
-`cyborg`, `united`, `journal`, …) are available on demand:
+`cyborg`, `united`, `journal`, …) keep working with **no code change** — using
+one auto-registers that theme on demand and emits a one-time
+`DeprecationWarning`:
 
 ```python
 import ttkbootstrap as ttk
-ttk.install_legacy_themes()          # registers the pre-2.0 names
-app = ttk.Window(themename="darkly")
+app = ttk.Window(themename="darkly")   # works; warns once that "darkly" is legacy
 ```
 
 Legacy themes keep their authored accent and background/foreground colors; only
 their inconsistent plumbing (borders, input backgrounds) is regenerated, so they
-look the same but cleaner. Using a legacy name **without** calling
-`install_legacy_themes()` raises a clear error telling you what to do. These
-names are a migration convenience and are planned for removal in 3.0.
+look the same but cleaner.
+
+If you need the **whole** pre-2.0 catalog registered up front — e.g. to
+enumerate it via `Style.theme_names()` or to offer every legacy name in a theme
+picker — call `install_legacy_themes()` once after creating the app:
+
+```python
+ttk.install_legacy_themes()          # bulk-registers all pre-2.0 names
+```
+
+Either way, these names are a migration convenience and are planned for removal
+in 3.0.
 
 ## Authoring your own theme
 

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -5,6 +5,7 @@ theme definitions, the active theme, the version-stamped theme walk, and the
 content-addressed image cache. Split out of the monolithic `style.py` in 2.0.
 """
 import json
+import warnings
 from tkinter import TclError, ttk
 from typing import Any
 
@@ -231,12 +232,28 @@ class Style(ttk.Style):
             # new theme and builds its default (".") styles.
             self._theme_objects[themename] = StyleBuilderTTK()
         elif themename in STANDARD_THEMES:
-            raise TclError(
-                f"{themename!r} is a legacy (pre-2.0) theme name. Call "
-                f"ttkbootstrap.install_legacy_themes() to enable the legacy "
-                f"catalog, or use a 2.0 theme such as 'bootstrap-dark' "
-                f"(see Style.theme_names())."
+            # Legacy (pre-2.0) name: lazily adapt+register just this one theme
+            # so the first line of ~every existing app
+            # (Window(themename="darkly")) keeps working, warn once, then fall
+            # through to the normal build path below. The full legacy catalog
+            # stays opt-in via install_legacy_themes() (bulk register, so
+            # theme_names()/ttkcreator can enumerate it).
+            from ttkbootstrap.themes.legacy import theme_from_legacy_dict
+
+            warnings.warn(
+                f"{themename!r} is a legacy (pre-2.0) theme name, kept as a "
+                f"migration convenience and planned for removal in 3.0; prefer "
+                f"a 2.0 theme (see Style.theme_names()).",
+                DeprecationWarning,
+                stacklevel=2,
             )
+            self.register_theme(
+                theme_from_legacy_dict(themename, STANDARD_THEMES[themename])
+            )
+            self.theme = self._theme_definitions.get(themename)
+            # Creating the builder also runs theme_create + theme_use for the
+            # new theme and builds its default (".") styles.
+            self._theme_objects[themename] = StyleBuilderTTK()
         else:
             raise TclError(themename, "is not a valid theme.")
 

--- a/tests/widget_styles/test_theme_anchor.py
+++ b/tests/widget_styles/test_theme_anchor.py
@@ -6,7 +6,6 @@ Covers the schema->16-key derivation, the curated built-in catalog, the legacy
 Workstream E was chartered to land (a themed dark field must not desaturate).
 """
 import warnings
-from tkinter import TclError
 
 import pytest
 
@@ -209,17 +208,25 @@ def test_from_existing_overrides_and_rejects_unknown_tokens():
         Theme.from_existing(BOOTSTRAP, name="acme", bogus="x")
 
 
-def test_install_legacy_themes_error_then_opt_in(root):
+def test_legacy_theme_use_lazy_registers_then_bulk_opt_in(root):
+    """Slice 1: theme_use on a legacy name lazily registers just that theme
+    (warns once) instead of hard-stopping; install_legacy_themes() bulk-registers
+    the rest."""
     style = root.style
     before = set(style._theme_names)
     assert "darkly" not in before
-    # helpful error before opt-in
-    with pytest.raises(TclError, match="install_legacy_themes"):
-        style.theme_use("darkly")
     try:
+        # Slice 1: a legacy name via theme_use no longer hard-stops -- it
+        # lazily adapts+registers that ONE theme and switches to it.
+        with pytest.warns(DeprecationWarning, match="legacy"):
+            style.theme_use("darkly")
+        assert style.theme.name == "darkly"
+        assert "darkly" in style._theme_names
+        # only that one name was registered, not the whole legacy catalog
+        assert "superhero" not in style._theme_names
+        # bulk opt-in registers the rest
         with pytest.warns(DeprecationWarning):
             ttk.install_legacy_themes()
-        assert "darkly" in style._theme_names
         # idempotent: a second call adds nothing new
         count = len(style._theme_names)
         with warnings.catch_warnings():
@@ -228,8 +235,8 @@ def test_install_legacy_themes_error_then_opt_in(root):
         assert len(style._theme_names) == count
         # every legacy name is now registered and usable
         assert set(STANDARD_THEMES) <= style._theme_names
-        style.theme_use("darkly")
-        assert style.theme.name == "darkly"
+        style.theme_use("superhero")
+        assert style.theme.name == "superhero"
     finally:
         # restore the shared session registry for later tests
         for name in list(style._theme_names):


### PR DESCRIPTION
## Slice 1 — Theme compat: kill the `install_legacy_themes()` hard-stop

First of the compat & utilities slices (`development/2_0_compat_and_utilities_design.md`).

### Problem
`ttk.Window(themename="darkly")` — the first line of ~every existing app — raised `TclError` in 2.0. Legacy names live in `STANDARD_THEMES` but were registered only by the opt-in `install_legacy_themes()`, which needs a live `Style`, which needs a root — so no ordering fixed it from user code (`style/engine.py`, the `elif themename in STANDARD_THEMES: raise TclError`).

### Fix
In `Style.theme_use`, when a name is in `STANDARD_THEMES` but not yet registered, **lazily adapt + register just that one theme** (`theme_from_legacy_dict` → `register_theme`), emit a **one-time per-name `DeprecationWarning`**, and fall through to the normal build path. `themename="darkly"` works again and still looks like darkly (only its buggy plumbing is regenerated).

- `install_legacy_themes()` stays as the explicit **bulk** register so `theme_names()` / ttkcreator can enumerate the full legacy set.
- Warns once per legacy name (Python's warning dedup handles repeats; the name is in the message).

### Rationale
Prefer deprecation over a hard break. No 1:1 legacy→2.0 mapping exists (`darkly` ≠ `bootstrap-dark`, different palettes), so forcing migration would change every app's colors *and* its code. This intentionally reverses Workstream E's "opt-in only" decision — the thing that created the wall — while keeping its deprecation nudge.

**Not changed:** the default theme. `ttk.Window()` with no name still renders `bootstrap-light` (a documented visual change, not a crash).

### Docs / notes
- `development/2_0_breaking_changes.md` — new index row + section (Fix/Deprecated).
- `development/2_0_theme_migration.md` — TL;DR row + "the old theme names still work" section rewritten (auto-register on use; `install_legacy_themes()` reframed as the bulk/enumeration path).

### Tests
- Reworked `test_theme_anchor.py`'s legacy test: asserts the lazy path (warns once, registers only that one theme, switches to it) **and** the still-working bulk opt-in. Dropped the now-unused `TclError` import.
- End-to-end smoke: `Window(themename="darkly")` renders darkly and warns exactly once.
- Full headless suite: **497 passed**. The single `test_color_helpers` failure is **pre-existing and order-dependent** (verified failing identically on the `2.0` baseline without this change), alongside the known `nl.msg` localization flake. No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
