### PR TITLE
Add App/Window and theme/themename naming aliases (Slice 2)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -15,6 +15,7 @@
 |---|---|---|
 | Theme model, `Theme`, default theme, ramp addressing | API | `development/2_0_theme_migration.md` |
 | **Legacy theme names auto-register on use (no hard-stop)** | Fix/Deprecated | this doc, below (Slice 1) |
+| **`App` (canonical) / `Window` alias; `theme` / `themename` alias** | New | this doc, below (Slice 2) |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -67,6 +68,42 @@ while keeping its deprecation nudge (a per-name `DeprecationWarning`).
 
 **Not changed.** The default theme: `ttk.Window()` with no name still renders
 `bootstrap-light` — a documented *visual* change, not a crash.
+
+---
+
+## `App`/`Window` and `theme`/`themename` naming aliases  *(New — no break)*
+
+**What.** Two disambiguating renames, both delivered as **additive permanent
+aliases** — nothing existing breaks, and **no deprecation warnings** (these are
+the most-typed identifiers in every app).
+
+- **`App` is now the canonical application-root class; `Window` is a permanent,
+  fully-supported alias** (`Window = App`, the same class object). So
+  `type(app).__name__`, `repr`, and tracebacks read `App`, while `ttk.Window(...)`,
+  `isinstance(x, Window)`, and existing `class MyApp(ttk.Window)` subclasses keep
+  working unchanged. `Toplevel` is untouched (already unambiguous).
+- **`theme` is now the canonical constructor argument on `App`/`Window`/`Style`;
+  `themename` is a permanent, non-deprecated alias.** `Style` already used
+  `theme`; only the window classes were out of step. `theme` is the second
+  positional on `App`/`Window` (so `App("Title", "darkly")` still means theme),
+  and both `theme=` and `themename=` are accepted (canonical `theme` wins if both
+  are given).
+
+**Unchanged (deliberately).** `Style.theme_use(themename)` and
+`Style.theme_create(themename)` **keep the `themename` parameter** — they override
+`ttk.Style` methods whose tkinter parameter is literally `themename`, so they keep
+Tk's spelling for drop-in compatibility (and are almost always called
+positionally). This sharpens the 2.0 naming convention rather than breaking it:
+`theme` on the authored constructors, Tk spelling on the ttk.Style method
+overrides.
+
+**Why.** `Window` is ambiguous — a `Toplevel` is also a window. `App` (the one
+root, paired with the singleton `Style`) vs `Toplevel` (many) is the clearer
+split and mirrors tkinter's `Tk`/`Toplevel`. And `Style` already spelled it
+`theme`, so accepting `theme` on the window constructors removes a needless
+inconsistency. Both are aliases (not deprecations) because a warning on `Window`
+or `themename` would fire in ~100% of existing apps for a pure naming preference.
+Docs lead with `App`/`theme`; `Window`/`themename` are documented as the aliases.
 
 ---
 

--- a/development/2_0_theme_migration.md
+++ b/development/2_0_theme_migration.md
@@ -34,7 +34,7 @@ tokyo-night  one  everforest  vapor  minty  pulse  united  sandstone
 
 ```python
 import ttkbootstrap as ttk
-app = ttk.Window(themename="bootstrap-dark")   # was e.g. "darkly"
+app = ttk.App(theme="bootstrap-dark")   # was e.g. ttk.Window(themename="darkly")
 ```
 
 ### The old theme names still work
@@ -46,7 +46,7 @@ one auto-registers that theme on demand and emits a one-time
 
 ```python
 import ttkbootstrap as ttk
-app = ttk.Window(themename="darkly")   # works; warns once that "darkly" is legacy
+app = ttk.App(theme="darkly")   # works; warns once that "darkly" is legacy
 ```
 
 Legacy themes keep their authored accent and background/foreground colors; only
@@ -83,7 +83,7 @@ ttk.Theme(
     dark=dict(background="#222222",  foreground="#f8f9fa"),
 ).register()                      # registers acme-light + acme-dark
 
-app = ttk.Window(themename="acme-light")
+app = ttk.App(theme="acme-light")
 ```
 
 - Declare **one or both** of `light`/`dark`; each defined block yields a variant.

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -7,7 +7,7 @@ This package provides:
     - A comprehensive collection of modern, flat-style themes
     - Custom widgets extending tkinter/ttk functionality
     - Easy-to-use styling API with color keywords
-    - Window and Toplevel classes with enhanced functionality
+    - App (application root) and Toplevel classes with enhanced functionality
     - Cross-platform compatibility
 
 Examples:
@@ -15,8 +15,8 @@ Examples:
     import ttkbootstrap as ttk
     from ttkbootstrap.constants import *
 
-    # Create a themed window
-    root = ttk.Window(themename="bootstrap-dark")
+    # Create a themed application root
+    root = ttk.App(theme="bootstrap-dark")
 
     # Create styled widgets
     btn = ttk.Button(root, text="Click Me", bootstyle="success")
@@ -241,7 +241,7 @@ from ttkbootstrap.widgets import (
     ToastNotification,
     ToolTip,
 )
-from ttkbootstrap.window import Toplevel, Window
+from ttkbootstrap.window import App, Toplevel, Window
 
 # Dialogs re-exported at top level so the common front doors are reachable as
 # ttk.Messagebox / ttk.Querybox, matching how widgets are exposed (2.0). The
@@ -309,7 +309,8 @@ __all__ = [
     "contrast_color",
     "conform_color_model",
 
-    # Windows
+    # Application root + windows
+    "App",
     "Toplevel",
     "Window",
 

--- a/src/ttkbootstrap/__main__.py
+++ b/src/ttkbootstrap/__main__.py
@@ -279,7 +279,7 @@ Namespaces are one honking great idea -- let's do more of those!"""
 
 
 if __name__ == "__main__":
-    app = ttk.Window("ttkbootstrap widget demo")
+    app = ttk.App("ttkbootstrap widget demo")
 
     bagel = setup_demo(app)
     bagel.pack(fill=BOTH, expand=YES)

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -58,25 +58,33 @@ class Style(ttk.Style):
 
     instance = None
 
-    def __new__(cls, theme=None, default_button="neutral"):
+    def __new__(cls, *args, **kwargs):
         if Style.instance is None:
             return object.__new__(cls)
         else:
             return Style.instance
 
-    def __init__(self, theme=DEFAULT_THEME, default_button="neutral"):
+    def __init__(self, theme=None, default_button="neutral", *, themename=None):
         """
         Parameters:
 
             theme (str):
                 The name of the theme to use when styling the widget.
+                `themename` is a permanent, non-deprecated alias accepted for
+                the same purpose (pre-2.0 spelling); pass either.
 
             default_button (str):
                 The color a bare `Button`/`Menubutton` (no `bootstyle`) uses.
                 Defaults to `"neutral"`; pass `"primary"` for the pre-2.0
                 accented default. Read once when the base styles build, so set it
-                on the first `Style`/`Window`; ignored on the existing singleton.
+                on the first `Style`/`App`; ignored on the existing singleton.
         """
+        # `theme` is canonical; `themename` is a permanent, non-deprecated alias
+        # (the pre-2.0 spelling). Prefer `theme` when both are given.
+        theme = theme if theme is not None else themename
+        if theme is None:
+            theme = DEFAULT_THEME
+
         if Style.instance is not None:
             if theme != DEFAULT_THEME:
                 Style.instance.theme_use(theme)

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -916,7 +916,7 @@ class Theme:
         style = Style.get_instance()
         if style is None:
             raise RuntimeError(
-                "No Style instance yet; create a Window/Style before registering "
+                "No Style instance yet; create an App/Style before registering "
                 "a Theme, or add it to the built-in catalog."
             )
         definitions = self.to_definitions()

--- a/src/ttkbootstrap/themes/legacy.py
+++ b/src/ttkbootstrap/themes/legacy.py
@@ -92,7 +92,7 @@ def install_legacy_themes(style=None) -> None:
         style = Style.get_instance()
         if style is None:
             raise RuntimeError(
-                "No Style instance yet; create a Window/Style before calling "
+                "No Style instance yet; create an App/Style before calling "
                 "install_legacy_themes()."
             )
     warnings.warn(

--- a/src/ttkbootstrap/themes/user.py
+++ b/src/ttkbootstrap/themes/user.py
@@ -25,7 +25,7 @@ Example (2.0 spec):
     }
     ```
 
-    Then ``ttk.Window(themename="mytheme-light")`` (or ``-dark``).
+    Then ``ttk.App(theme="mytheme-light")`` (or ``-dark``).
 
 Prefer authoring in your own code with the public ``Theme`` API directly:
     ```python

--- a/src/ttkbootstrap/validation.py
+++ b/src/ttkbootstrap/validation.py
@@ -282,7 +282,7 @@ def add_option_validation(widget: Misc, options: list[Any], when: str = "focusou
 
 
 if __name__ == "__main__":
-    app = ttk.Window()
+    app = ttk.App()
 
 
     @validator

--- a/src/ttkbootstrap/widgets/meter.py
+++ b/src/ttkbootstrap/widgets/meter.py
@@ -60,7 +60,7 @@ class Meter(ConfigureDelegationMixin, Frame):
         import ttkbootstrap as ttk
         from ttkbootstrap.constants import *
 
-        app = ttk.Window()
+        app = ttk.App()
 
         meter = ttk.Meter(
             meter_size=180,

--- a/src/ttkbootstrap/widgets/scrolled.py
+++ b/src/ttkbootstrap/widgets/scrolled.py
@@ -38,7 +38,7 @@ class ScrolledText(ConfigureDelegationMixin, ttk.Frame):
         import ttkbootstrap as ttk
         from ttkbootstrap.constants import *
 
-        app = ttk.Window()
+        app = ttk.App()
 
         # scrolled text with an auto-hide vertical scrollbar
         st = ttk.ScrolledText(app, padding=5, height=10, auto_hide=True)
@@ -315,7 +315,7 @@ class ScrolledFrame(ttk.Frame):
         import ttkbootstrap as ttk
         from ttkbootstrap.constants import *
 
-        app = ttk.Window()
+        app = ttk.App()
 
         sf = ttk.ScrolledFrame(app, auto_hide=True)
         sf.pack(fill=BOTH, expand=YES, padx=10, pady=10)

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -429,7 +429,7 @@ class Tableview(ttk.Frame):
         import ttkbootstrap as ttk
         from ttkbootstrap.constants import *
 
-        app = ttk.Window()
+        app = ttk.App()
         colors = app.style.colors
 
         coldata = [

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -77,7 +77,7 @@ class ToastNotification:
         ```python
         import ttkbootstrap as ttk
 
-        app = ttk.Window()
+        app = ttk.App()
 
         toast = ttk.ToastNotification(
             title="ttkbootstrap toast message",

--- a/src/ttkbootstrap/widgets/tooltip.py
+++ b/src/ttkbootstrap/widgets/tooltip.py
@@ -33,7 +33,7 @@ class ToolTip:
         import ttkbootstrap as ttk
         from ttkbootstrap.constants import *
 
-        app = ttk.Window()
+        app = ttk.App()
         b1 = ttk.Button(app, text="default tooltip")
         b1.pack()
 

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -1,8 +1,11 @@
-"""Window and Toplevel classes for ttkbootstrap applications.
+"""App (root) and Toplevel classes for ttkbootstrap applications.
 
-`Window` and `Toplevel` wrap `tkinter.Tk`/`tkinter.Toplevel` with integrated
+`App` and `Toplevel` wrap `tkinter.Tk`/`tkinter.Toplevel` with integrated
 ttkbootstrap `Style` support and a consolidated construction API — theme, title,
 size/position/geometry, resizability, high-DPI, alpha, and icon handling.
+
+`App` is the application root (one per process, paired with the singleton
+`Style`); `Window` is a permanent, fully-supported alias for `App`.
 """
 import sys
 import tkinter
@@ -83,7 +86,7 @@ def _require_single_root(new_root: tkinter.Misc) -> None:
         raise RuntimeError(
             "ttkbootstrap supports a single application root window. A Style "
             "is already bound to an existing live root; create one "
-            "Window/Tk per process and reuse it (or destroy the existing "
+            "App/Tk per process and reuse it (or destroy the existing "
             "root before creating a new one). Multi-root support is out of "
             "scope."
         )
@@ -129,7 +132,7 @@ def apply_all_bindings(window: tkinter.Widget) -> None:
 def on_visibility(event: tkinter.Event) -> None:
     """Set Window or Toplevel alpha value on Visibility (X11)"""
     widget = event.widget
-    if isinstance(widget, (Window, Toplevel)) and widget.alpha_bind:
+    if isinstance(widget, (App, Toplevel)) and widget.alpha_bind:
         widget.unbind(widget.alpha_bind)
         widget.attributes("-alpha", widget.alpha)
 
@@ -183,7 +186,7 @@ def on_select_all(event: tkinter.Event) -> None:
 
 
 class _BaseWindow:
-    """Window logic shared by `Window` (root) and `Toplevel` (secondary).
+    """Window logic shared by `App` (root) and `Toplevel` (secondary).
 
     Used as a mixin alongside `tkinter.Tk`/`tkinter.Toplevel`, so both classes
     stop duplicating -- and drifting on -- their icon, geometry, alpha, and
@@ -204,7 +207,7 @@ class _BaseWindow:
 
         Semantics (identical for `Window` and `Toplevel`):
             None  -> leave the icon untouched (skip).
-            ''    -> use `default_data` if given (the brand icon on `Window`),
+            ''    -> use `default_data` if given (the brand icon on `App`),
                      otherwise inherit the application default (`Toplevel`).
             path  -> load the image, falling back to `default_data` on failure.
 
@@ -346,17 +349,21 @@ class _BaseWindow:
     position_center = place_window_center  # alias
 
 
-class Window(_BaseWindow, tkinter.Tk):
-    """A class that wraps the tkinter.Tk class in order to provide a
-    more convenient api with additional bells and whistles. For more
-    information on how to use the inherited `Tk` methods, see the
-    [tcl/tk documentation](https://tcl.tk/man/tcl8.6/TkCmd/wm.htm)
+class App(_BaseWindow, tkinter.Tk):
+    """The ttkbootstrap application root: a class that wraps the tkinter.Tk
+    class in order to provide a more convenient api with additional bells and
+    whistles. For more information on how to use the inherited `Tk` methods, see
+    the [tcl/tk documentation](https://tcl.tk/man/tcl8.6/TkCmd/wm.htm)
     and the [Python documentation](https://docs.python.org/3/library/tkinter.html#tkinter.Tk).
+
+    `Window` is a permanent, fully-supported alias for `App`; the two are the
+    same class, so `Window(...)`, `isinstance(x, Window)`, and subclasses keep
+    working. Docs and new code should prefer `App`.
 
     Examples:
 
         ```python
-        app = Window(title="My Application", themename="bootstrap-dark")
+        app = App(title="My Application", theme="bootstrap-dark")
         app.mainloop()
         ```
     """
@@ -364,8 +371,9 @@ class Window(_BaseWindow, tkinter.Tk):
     def __init__(
             self,
             title: str = "ttkbootstrap",
-            themename: str = "bootstrap-light",
+            theme: Optional[str] = None,
             *,
+            themename: Optional[str] = None,
             default_button: str = "neutral",
             iconphoto: Optional[str] = '',
             size: Optional[Tuple[int, int]] = None,
@@ -386,9 +394,10 @@ class Window(_BaseWindow, tkinter.Tk):
             title (str):
                 The title that appears on the application titlebar.
 
-            themename (str):
+            theme (str):
                 The name of the ttkbootstrap theme to apply to the
-                application.
+                application. `themename` is a permanent, non-deprecated alias
+                accepted for the same purpose (pre-2.0 spelling); pass either.
 
             default_button (str):
                 The color a bare `Button`/`Menubutton` (no `bootstyle`) uses.
@@ -406,31 +415,31 @@ class Window(_BaseWindow, tkinter.Tk):
             size (tuple[int, int]):
                 The width and height of the application window.
                 Internally, this argument is passed to the
-                `Window.geometry` method.
+                `App.geometry` method.
 
             position (tuple[int, int]):
                 The horizontal and vertical position of the window on
                 the screen relative to the top-left coordinate. Negative
                 values are edge-relative (e.g. `(-10, -10)` places the
                 window near the bottom-right). Internally this is passed
-                to the `Window.geometry` method.
+                to the `App.geometry` method.
 
             minsize (tuple[int, int]):
                 Specifies the minimum permissible dimensions for the
                 window. Internally, this argument is passed to the
-                `Window.minsize` method.
+                `App.minsize` method.
 
             maxsize (tuple[int, int]):
                 Specifies the maximum permissible dimensions for the
                 window. Internally, this argument is passed to the
-                `Window.maxsize` method.
+                `App.maxsize` method.
 
             resizable (tuple[bool, bool]):
                 Specifies whether the user may interactively resize the
                 toplevel window. Must pass in two arguments that specify
                 this flag for _horizontal_ and _vertical_ dimensions.
                 This can be adjusted after the window is created by using
-                the `Window.resizable` method.
+                the `App.resizable` method.
 
             high_dpi (bool):
                 Enable high-dpi support for Windows OS. This option is
@@ -446,18 +455,18 @@ class Window(_BaseWindow, tkinter.Tk):
             transient (Union[Tk, Widget]):
                 Instructs the window manager that this widget is
                 transient with regard to the widget master. Internally
-                this is passed to the `Window.transient` method.
+                this is passed to the `App.transient` method.
 
             override_redirect (bool):
                 Instructs the window manager to ignore this widget if
                 True. Internally, this argument is passed to the
-                `Window.overrideredirect(1)` method. Ignored on macOS
+                `App.overrideredirect(1)` method. Ignored on macOS
                 (aqua), where it destabilizes Tk. (Renamed from
                 `overrideredirect` in 2.0.)
 
             alpha (float):
                 Sets the window's alpha transparency level (1.0 is opaque).
-                Applied immediately via `Window.attributes('-alpha', alpha)`,
+                Applied immediately via `App.attributes('-alpha', alpha)`,
                 except on X11 where it is deferred until the window becomes
                 visible.
 
@@ -465,6 +474,13 @@ class Window(_BaseWindow, tkinter.Tk):
                 Any other keyword arguments that are passed through to tkinter.Tk() constructor
                 List of available keywords available at: https://docs.python.org/3/library/tkinter.html#tkinter.Tk
         """
+        # `theme` is canonical; `themename` is a permanent, non-deprecated alias
+        # (the pre-2.0 spelling). Prefer `theme` when both are given; fall back
+        # to the theme engine's default when neither is.
+        theme = theme if theme is not None else themename
+        if theme is None:
+            theme = DEFAULT_THEME
+
         # Accept the pre-2.0 raw-Tk kwarg spellings with a deprecation warning.
         aliases = normalize_window_kwargs(kwargs)
         high_dpi = aliases.get("high_dpi", high_dpi)
@@ -503,7 +519,7 @@ class Window(_BaseWindow, tkinter.Tk):
 
         apply_class_bindings(self)
         apply_all_bindings(self)
-        self._style = Style(themename, default_button=default_button)
+        self._style = Style(theme, default_button=default_button)
 
     @staticmethod
     def _set_app_user_model_id() -> None:
@@ -699,8 +715,16 @@ class Toplevel(_BaseWindow, tkinter.Toplevel):
         self._setup_alpha(alpha)
 
 
+#: Permanent, fully-supported alias for `App`. `App` is the canonical name (one
+#: application root, paired with the singleton `Style`, mirroring tkinter's
+#: `Tk`/`Toplevel` split); `Window` predates it and is kept working forever --
+#: `Window(...)`, `isinstance(x, Window)`, and existing subclasses are unchanged.
+#: Not deprecated: a warning here would fire in ~every existing app.
+Window = App
+
+
 if __name__ == "__main__":
-    root = Window(themename="bootstrap-dark", alpha=0.5, size=(1000, 1000))
+    root = App(theme="bootstrap-dark", alpha=0.5, size=(1000, 1000))
     # root.withdraw()
     root.place_window_center()
     # root.deiconify()

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -131,13 +131,13 @@ def test_style_builder_utility_and_assets_share_root_service(root):
 def test_window_and_style_initialize_scaling_before_style_builds():
     package = Path(__file__).parents[1] / "src" / "ttkbootstrap"
     window_source = (package / "window.py").read_text(encoding="utf-8")
-    init_source = window_source[window_source.index("class Window"):]
+    init_source = window_source[window_source.index("class App"):]
     assert init_source.index("utility.enable_high_dpi_awareness()") < init_source.index(
         "super().__init__(**kwargs)"
     )
     assert init_source.index("super().__init__(**kwargs)") < init_source.index(
         "utility.enable_high_dpi_awareness(self, scaling)"
-    ) < init_source.index("self._style = Style(themename")
+    ) < init_source.index("self._style = Style(theme")
 
     engine_source = (package / "style" / "engine.py").read_text(encoding="utf-8")
     style_init = engine_source[engine_source.index("class Style"):]

--- a/tests/test_window_api.py
+++ b/tests/test_window_api.py
@@ -16,7 +16,7 @@ import ttkbootstrap as ttk
 from ttkbootstrap.internal import positioning
 from ttkbootstrap.style import Style
 from ttkbootstrap.style._compat import normalize_window_kwargs
-from ttkbootstrap.window import Toplevel, Window, _BaseWindow
+from ttkbootstrap.window import App, Toplevel, Window, _BaseWindow
 
 
 # --------------------------------------------------------------------------
@@ -287,3 +287,49 @@ def test_default_icon_falls_back_when_asset_missing(root, monkeypatch):
     top._apply_default_icon(win._DEFAULT_ICON_DATA)
     assert top._icon is not None  # base64 fallback produced a PhotoImage
     top.destroy()
+
+
+# --------------------------------------------------------------------------
+# Slice 2: App/Window and theme/themename naming aliases
+# --------------------------------------------------------------------------
+
+def test_app_is_canonical_and_window_is_a_permanent_alias():
+    # App is the real class; Window is the same object, not a subclass -- so
+    # repr/type().__name__/tracebacks read "App" while Window(...) keeps working.
+    assert App is Window
+    assert App.__name__ == "App"
+    assert ttk.App is App and ttk.Window is App
+
+
+def test_window_alias_isinstance_and_type_name(root):
+    # The shared session root is created as ttk.Window(); it must be an App and
+    # report App as its type name (the disambiguation payoff).
+    assert isinstance(root, App)
+    assert isinstance(root, Window)
+    assert type(root).__name__ == "App"
+
+
+def test_style_accepts_theme_and_themename_alias(root):
+    # Both spellings reach the singleton and switch the theme; the fixture
+    # restores the active theme on teardown.
+    ttk.Style(themename="pydata-light")
+    assert root.style.theme.name == "pydata-light"
+    ttk.Style(theme="pydata-dark")
+    assert root.style.theme.name == "pydata-dark"
+
+
+def test_style_prefers_theme_when_both_given(root):
+    # theme is canonical, so it wins when both are passed.
+    ttk.Style(theme="pydata-dark", themename="pydata-light")
+    assert root.style.theme.name == "pydata-dark"
+
+
+def test_window_kwargs_are_warning_free_for_new_names():
+    # theme/themename are permanent aliases -- neither may emit a warning. Verify
+    # at the signature level (a second live root can't be constructed here).
+    import inspect
+    params = inspect.signature(App.__init__).parameters
+    assert "theme" in params and "themename" in params
+    # theme is the second positional; themename is keyword-only.
+    assert params["theme"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert params["themename"].kind is inspect.Parameter.KEYWORD_ONLY


### PR DESCRIPTION
## Slice 2 — Naming: `App`/`Window` and `theme`/`themename`

Second of the compat & utilities slices (`development/2_0_compat_and_utilities_design.md`). Disambiguation delivered as **additive permanent aliases** — nothing existing breaks, and **no deprecation warnings** (these are the most-typed identifiers in every app).

### `App` canonical, `Window` permanent alias
`Window` is ambiguous — a `Toplevel` is also a window. `App` (the one root, paired with the singleton `Style`) vs `Toplevel` (many) is the clearer split and mirrors tkinter's `Tk`/`Toplevel`.

- `App` is now the real class (`class App(_BaseWindow, tkinter.Tk)`); `Window = App` is a plain alias (the same class object). So `type(app).__name__`, `repr`, and tracebacks read **`App`**, while `ttk.Window(...)`, `isinstance(x, Window)`, and existing `class MyApp(ttk.Window)` subclasses keep working unchanged.
- `App` is exported at top level and added to `__all__`. `Toplevel` is untouched.

### `theme` canonical, `themename` permanent alias
`Style` already used `theme`; only the window classes were out of step.

- `theme` is the second positional on `App`/`Window` (`App("Title", "darkly")` still means theme); both `theme=` and `themename=` are accepted on `App`/`Window`/`Style` (canonical `theme` wins if both are given).
- **`Style.theme_use(themename)` / `theme_create(themename)` deliberately keep `themename`** — they override `ttk.Style` methods whose tkinter parameter is literally `themename`, so they keep Tk's spelling for drop-in compatibility. This sharpens the 2.0 naming convention (authored constructors → `theme`; ttk.Style method overrides → Tk spelling) rather than breaking it.

### Docstring sweep (per the request)
So no non-canonical name stays engrained: updated source docstrings/examples and user-facing runtime error strings to lead with `App`/`theme` — the widget/dialog/validation docstring examples (`ttk.Window()` → `ttk.App()`), the `__main__` demo, `window.py`/`__init__.py` module docstrings and param docs, the `Style`/`Theme` "create an App/Style" errors, `themes/user.py`, and the theme migration guide examples. Left alone (correct): the `theme_use`/`theme_create` `themename` params (Tk overrides) and a comment describing pre-2.0 code.

### Tests
- `tests/test_window_api.py` (+5): `App is Window`, canonical type name, `isinstance` via the alias, `Style` `theme`/`themename` resolution incl. theme-wins-when-both, and the signature shape (`theme` positional-or-keyword, `themename` keyword-only).
- `tests/test_scaling.py`: updated the source-order assertion (`class Window` → `class App`, `Style(themename` → `Style(theme`).
- Full headless suite: **501 passed**; the two failures are the known pre-existing flakes (`nl.msg` localization + the order-dependent `test_color_helpers`), both confirmed pre-existing on `2.0`. Warning-free import verified under `-W error::DeprecationWarning`.

### Docs / notes
- `development/2_0_breaking_changes.md` — new index row + section (New — no break).
- `development/2_0_theme_migration.md` — examples lead with `ttk.App(theme=...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
