### PR TITLE
Organize public utilities into a utils/ package (Slice 0)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -16,6 +16,7 @@
 | Theme model, `Theme`, default theme, ramp addressing | API | `development/2_0_theme_migration.md` |
 | **Legacy theme names auto-register on use (no hard-stop)** | Fix/Deprecated | this doc, below (Slice 1) |
 | **`App` (canonical) / `Window` alias; `theme` / `themename` alias** | New | this doc, below (Slice 2) |
+| **`utils/` package; `utility`/`colorutils` → warn-and-forward shims** | Deprecated | this doc, below (Slice 0) |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -68,6 +69,42 @@ while keeping its deprecation nudge (a per-name `DeprecationWarning`).
 
 **Not changed.** The default theme: `ttk.Window()` with no name still renders
 `bootstrap-light` — a documented *visual* change, not a crash.
+
+---
+
+## Utilities reorganized into a `utils/` package  *(Deprecated old paths — no break)*
+
+**What.** The public utility helpers now live in a first-class **`ttkbootstrap.utils`**
+package instead of the pre-2.0 scatter (`ttkbootstrap.utility` grab-bag +
+`ttkbootstrap.colorutils`):
+
+- `utils/color.py` — `color_to_rgb`/`color_to_hex`/`color_to_hsl`/
+  `update_hsl_value`/`contrast_color`/`conform_color_model` (was `colorutils`).
+- `utils/scaling.py` — `enable_high_dpi_awareness`, `scale_size` (from `utility`).
+- `utils/platform.py` — `windowing_system` (from `utility`).
+- `utils/__init__.py` re-exports the whole surface, so `from ttkbootstrap.utils
+  import ...` reaches everything from one namespace.
+
+The old module paths **still work** as thin **warn-and-forward shims** (same
+pattern as `ttkbootstrap.publisher`): importing `ttkbootstrap.utility` or
+`ttkbootstrap.colorutils` emits a one-time `DeprecationWarning` and re-exports the
+moved names (including the `colorutils` model constants and the two
+already-internal `utility` forwards). Removed in 3.0. Everything also stays
+re-exported at the **top level** (`ttk.scale_size`, `ttk.contrast_color`, …) — the
+primary discovery path — unchanged.
+
+**Migration.** `from ttkbootstrap.utility import scale_size` →
+`from ttkbootstrap.utils import scale_size` (or keep using `ttk.scale_size`);
+`from ttkbootstrap import colorutils` → `from ttkbootstrap import utils`. No
+behavior changed — the functions are the same objects.
+
+**Why.** Utilities are a first-class concern in ttkbootstrap (a styling
+extension) in a way they aren't in a widget library, so they get a deliberate,
+discoverable home instead of a `utility.py` grab-bag plus a separate
+`colorutils.py`. This also gives the later 2.0 slices (typography, deferred-config)
+a place to be *born* rather than bolted onto the grab-bag. The old paths shim
+rather than break, matching "prefer deprecation over hard breaks." (The shims are
+source-only back-compat and are not documented; docs present `utils/` as the home.)
 
 ---
 

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -54,7 +54,7 @@ from tkinter.ttk import (
 )
 
 # The styling primitives. Importing style here only pulls in submodules
-# (colorutils, constants, themes); it does not depend on the widget classes
+# (utils, constants, themes); it does not depend on the widget classes
 # defined below, so it is safe this early in package init.
 from ttkbootstrap.style import (
     Bootstyle, Style, FluentGeometryMixin, BootMixin, AutoStyleMixin,
@@ -73,16 +73,15 @@ from ttkbootstrap.style import (
 # Opt-in migration path for the pre-2.0 theme names (Workstream E/F).
 from ttkbootstrap.themes.legacy import install_legacy_themes
 
-# Public utilities re-exported at the top level for convenience. The
-# `ttkbootstrap.utility` / `ttkbootstrap.colorutils` module paths remain valid;
-# these names just make `ttk.scale_size(...)` / `ttk.contrast_color(...)` work
-# the same way the widgets and dialogs are reachable as `ttk.<Name>`.
-from ttkbootstrap.utility import (
+# Public utilities re-exported at the top level for convenience, so
+# `ttk.scale_size(...)` / `ttk.contrast_color(...)` work the same way the widgets
+# and dialogs are reachable as `ttk.<Name>`. Their home is the `ttkbootstrap.utils`
+# package (2.0); the old `ttkbootstrap.utility` / `ttkbootstrap.colorutils`
+# module paths still work as warn-and-forward shims (removed in 3.0).
+from ttkbootstrap.utils import (
     enable_high_dpi_awareness,
     scale_size,
     windowing_system,
-)
-from ttkbootstrap.colorutils import (
     color_to_rgb,
     color_to_hex,
     color_to_hsl,

--- a/src/ttkbootstrap/colorutils.py
+++ b/src/ttkbootstrap/colorutils.py
@@ -1,218 +1,31 @@
-"""Color utility functions for ttkbootstrap.
+"""Deprecated location for ttkbootstrap's color utilities.
 
-Convert between color models (RGB, HSL, HEX, and named colors) and manipulate
-colors by adjusting hue, saturation, and luminance.
+The color helpers have moved to `ttkbootstrap.utils` (implemented in
+`ttkbootstrap.utils.color`). This shim re-exports them for backward
+compatibility and will be removed in 3.0. Import from `ttkbootstrap.utils`
+(or the top-level `ttkbootstrap` namespace) instead.
 """
-from PIL import ImageColor
-from colorsys import rgb_to_hls
+import warnings
 
-__all__ = [
-    "color_to_rgb",
-    "color_to_hex",
-    "color_to_hsl",
-    "update_hsl_value",
-    "contrast_color",
-    "conform_color_model",
-]
+warnings.warn(
+    "ttkbootstrap.colorutils has moved to ttkbootstrap.utils; this shim will "
+    "be removed in 3.0.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-RGB = 'rgb'
-HSL = 'hsl'
-HEX = 'hex'
-NAME = 'name'
-
-HUE = 360
-SAT = 100
-LUM = 100
-
-
-def color_to_rgb(color, model=HEX):
-    """Convert color value to rgb.
-
-    The color and model parameters represent the color to be converted.
-    The value is expected to be a string for "name" and "hex" models and
-    a Tuple or List for "rgb" and "hsl" models.
-    
-    Parameters:
-        
-        color (Any):
-            The color values for the model being converted.
-            
-        model (str):
-            The color model being converted.
-    
-    Returns:
-
-        tuple[int, int, int]:
-            The rgb color values.
-    """
-    color_ = conform_color_model(color, model)    
-    try:
-        return ImageColor.getrgb(color_)
-    except:
-        print('this')
-    
-def color_to_hex(color, model=RGB):
-    """Convert color value to hex.
-
-    The color and model parameters represent the color to be converted.
-    The value is expected to be a string for "name" and "hex" models and
-    a Tuple or List for "rgb" and "hsl" models.
-    
-    Parameters:
-        
-        color (Any):
-            The color values for the model being converted.
-            
-        model (str):
-            The color model being converted.
-    
-    Returns:
-    
-        str:
-            The hexadecimal color value.
-    """
-    r, g, b = color_to_rgb(color, model)
-    return f'#{r:02x}{g:02x}{b:02x}'
-
-def color_to_hsl(color, model=HEX):
-    """Convert color value to hsl.
-
-    The color and model parameters represent the color to be converted.
-    The value is expected to be a string for "name" and "hex" models and
-    a Tuple or List for "rgb" and "hsl" models.
-    
-    Parameters:
-        
-        color (Any):
-            The color values for the model being converted.
-            
-        model (str):
-            The color model being converted.
-    
-    Returns:
-
-        tuple[int, int, int]:
-            The hsl color values.
-    """
-    r, g, b = color_to_rgb(color, model)
-    hls = rgb_to_hls(r/255, g/255, b/255)
-    h = int(hls[0]*HUE)
-    l = int(hls[1]*LUM)
-    s = int(hls[2]*SAT)
-    return h, s, l
-
-def update_hsl_value(color, hue=None, sat=None, lum=None, inmodel=HSL, outmodel=HSL):
-    """Change hue, saturation, or lumenosity of the color based on the
-    hue, sat, lum parameters provided.
-    
-    Parameters:
-
-        color (Any):
-            The color
-
-        hue (int):
-            A number between 0 and 360.
-
-        sat (int):
-            A number between 0 and 100.
-
-        lum (int):
-            A number between 0 and 100.
-
-        inmodel (str):
-            The color model used by the color to be changed. One of
-            hsl, rgb, hex, name.
-
-        outmodel (str):
-            The color value model to be returned when the color is
-            changed. One of hsl, rgb, hex.
-
-    Returns:
-
-        Union[tuple[int, int, int], str]:
-            The color value based on the selected color model.
-    """
-    h, s, l = color_to_hsl(color, inmodel)
-    if hue is not None:
-        h = hue
-    if sat is not None:
-        s = sat
-    if lum is not None:
-        l = lum
-    if outmodel == RGB:
-        return color_to_rgb([h, s, l], HSL)
-    elif outmodel == HEX:
-        return color_to_hex([h, s, l], HSL)
-    else:
-        return h, s, l
-
-
-"""
-https://stackoverflow.com/questions/1855884/determine-font-color-based-on-background-color
-
-"""
-
-def contrast_color(color, model=RGB, darkcolor='#000', lightcolor='#fff'):
-    """Returns the best matching contrasting light or dark color for
-    the given color.
-    
-    Parameters:
-
-        color (Any):
-            The color value to evaluate.
-
-        model (str):
-            The model of the color value to be evaluated. 'rgb' by 
-            default.
-
-        darkcolor (Any):
-            The color value to be returned when the constrasting color 
-            should be dark.
-
-        lightcolor (Any):
-            The color value to be returned when the constrasting color
-            should be light.
-
-    Returns:
-
-        str:
-            The matching color value.
-    """
-    if model != RGB:
-        r, g, b = color_to_rgb(color, model)
-    else:
-        r, g, b = color
-
-    luminance = ((0.299 * r) + (0.587 * g) + (0.114 * b))/255
-    if luminance > 0.5:
-        return darkcolor
-    else:
-        return lightcolor
-
-
-def conform_color_model(color, model):
-    """Conform the color values to a string that can be interpreted
-    by the `PIL.ImageColor.getrgb method`.
-
-    Parameters:
-
-        color (Union[tuple[int, int, int], str]):
-            The color value to conform.
-
-        model (str):
-            One of 'hsl', 'rgb', 'hex', or 'name'.
-
-    Returns:
-
-        str:
-            A color value string that can be used as a parameter in the
-            PIL.ImageColor.getrgb method.
-    """    
-    if model == HSL:
-        h, s, l = color
-        return f'hsl({h},{s}%,{l}%)'
-    elif model == RGB:
-        r, g, b = color
-        return f'rgb({r},{g},{b})'
-    else:
-        return color
+from ttkbootstrap.utils.color import (  # noqa: F401,E402
+    RGB,
+    HSL,
+    HEX,
+    NAME,
+    HUE,
+    SAT,
+    LUM,
+    color_to_rgb,
+    color_to_hex,
+    color_to_hsl,
+    update_hsl_value,
+    contrast_color,
+    conform_color_model,
+)

--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, Tuple
 import ttkbootstrap as ttk
 from ttkbootstrap.internal.utility import center_on_parent
 from ttkbootstrap.internal.positioning import ensure_on_screen
-from ttkbootstrap.utility import windowing_system
+from ttkbootstrap.utils import windowing_system
 
 
 class Dialog(BaseWidget):

--- a/src/ttkbootstrap/dialogs/colorchooser.py
+++ b/src/ttkbootstrap/dialogs/colorchooser.py
@@ -12,7 +12,7 @@ from PIL import ImageColor
 
 import ttkbootstrap as ttk
 from ttkbootstrap import utils
-from ttkbootstrap.utils.color import HEX, HSL, HUE, LUM, RGB, SAT
+from ttkbootstrap.utils import HEX, HSL, HUE, LUM, RGB, SAT
 from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
 from ttkbootstrap.widgets.tooltip import ToolTip

--- a/src/ttkbootstrap/dialogs/colorchooser.py
+++ b/src/ttkbootstrap/dialogs/colorchooser.py
@@ -11,8 +11,8 @@ from typing import Any, List, Optional, Tuple
 from PIL import ImageColor
 
 import ttkbootstrap as ttk
-from ttkbootstrap import colorutils, utility
-from ttkbootstrap.colorutils import HEX, HSL, HUE, LUM, RGB, SAT
+from ttkbootstrap import utils
+from ttkbootstrap.utils.color import HEX, HSL, HUE, LUM, RGB, SAT
 from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
 from ttkbootstrap.widgets.tooltip import ToolTip
@@ -85,8 +85,8 @@ class ColorChooser(ttk.Frame):
 
         # color variables
         r, g, b = ImageColor.getrgb(self.initialcolor)
-        h, s, l = colorutils.color_to_hsl((r, g, b), RGB)
-        hx = colorutils.color_to_hex((r, g, b), RGB)
+        h, s, l = utils.color_to_hsl((r, g, b), RGB)
+        hx = utils.color_to_hex((r, g, b), RGB)
 
         self.hue = ttk.IntVar(value=h)
         self.sat = ttk.IntVar(value=s)
@@ -97,10 +97,10 @@ class ColorChooser(ttk.Frame):
         self.hex = ttk.StringVar(value=hx)
 
         # widget sizes (adjusted by widget scaling)
-        self.spectrum_height = utility.scale_size(self, 240)
-        self.spectrum_width = utility.scale_size(self, 530)  # looks better on Mac OS
-        # self.spectrum_width = utility.scale_size(self, 480)
-        self.spectrum_point = utility.scale_size(self, 12)
+        self.spectrum_height = utils.scale_size(self, 240)
+        self.spectrum_width = utils.scale_size(self, 530)  # looks better on Mac OS
+        # self.spectrum_width = utils.scale_size(self, 480)
+        self.spectrum_point = utils.scale_size(self, 12)
 
         # build widgets
         spectrum_frame = ttk.Frame(self.notebook)
@@ -149,11 +149,11 @@ class ColorChooser(ttk.Frame):
     def create_spectrum_indicator(self) -> None:
         """Create a square indicator that displays in the position of
         the selected color"""
-        s = utility.scale_size(self, 10)
-        width = utility.scale_size(self, 2)
+        s = utils.scale_size(self, 10)
+        width = utils.scale_size(self, 2)
         values = self.get_variables()
         x1, y1 = self.coords_from_color(values.hex)
-        colorutils.contrast_color(values.hex, 'hex')
+        utils.contrast_color(values.hex, 'hex')
         tag = ['spectrum-indicator']
         self.color_spectrum.create_rectangle(
             x1, y1, x1 + s, y1 + s, width=width, tags=[tag])
@@ -176,7 +176,7 @@ class ColorChooser(ttk.Frame):
             lum = int(l * LUM)
             row = []
             for color in colors:
-                color = colorutils.update_hsl_value(
+                color = utils.update_hsl_value(
                     color=color,
                     lum=lum,
                     inmodel='hex',
@@ -225,7 +225,7 @@ class ColorChooser(ttk.Frame):
             autostyle=False
         )
         old.pack(side=LEFT, fill=BOTH, expand=YES, padx=(0, 2))
-        contrastfg = colorutils.contrast_color(
+        contrastfg = utils.contrast_color(
             color=self.initialcolor,
             model='hex',
         )
@@ -336,7 +336,7 @@ class ColorChooser(ttk.Frame):
         # add color points to scale
         for x, l in enumerate(range(0, width, xf)):
             lum = l / width * LUM
-            fill = colorutils.update_hsl_value(
+            fill = utils.update_hsl_value(
                 color=values.hex,
                 lum=lum,
                 inmodel='hex',
@@ -367,7 +367,7 @@ class ColorChooser(ttk.Frame):
     def coords_from_color(self, hexcolor: str) -> Tuple[float, float]:
         """Get the coordinates on the color spectrum from the color
         value"""
-        h, s, _ = colorutils.color_to_hsl(hexcolor)
+        h, s, _ = utils.color_to_hsl(hexcolor)
         x = (h / HUE) * self.spectrum_width
         y = (1 - (s / SAT)) * self.spectrum_height
         return x, y
@@ -380,8 +380,8 @@ class ColorChooser(ttk.Frame):
         h = int(min(HUE, max(0, (HUE / WIDTH) * x)))
         s = int(min(SAT, max(0, SAT - ((SAT / HEIGHT) * y))))
         l = 50
-        hx = colorutils.color_to_hex([h, s, l], 'hsl')
-        r, g, b = colorutils.color_to_rgb(hx)
+        hx = utils.color_to_hex([h, s, l], 'hsl')
+        r, g, b = utils.color_to_rgb(hx)
         return ColorValues(h, s, l, r, g, b, hx)
 
     def set_variables(self, h: int, s: int, l: int, r: int, g: int, b: int, hx: str) -> None:
@@ -409,7 +409,7 @@ class ColorChooser(ttk.Frame):
     def update_preview(self) -> None:
         """Update the color in the preview frame"""
         hx = self.hex.get()
-        fg = colorutils.contrast_color(
+        fg = utils.contrast_color(
             color=hx,
             model='hex',
         )
@@ -423,7 +423,7 @@ class ColorChooser(ttk.Frame):
         xf = self.spectrum_point
         for x, l in enumerate(range(0, width, xf)):
             lum = l / width * LUM
-            fill = colorutils.update_hsl_value(
+            fill = utils.update_hsl_value(
                 color=values.hex,
                 lum=lum,
                 inmodel='hex',
@@ -448,7 +448,7 @@ class ColorChooser(ttk.Frame):
         self.color_spectrum.moveto('spectrum-indicator', x, y)
         self.color_spectrum.tag_raise('spectrum-indicator')
         # adjust the outline color based on contrast of background
-        color = colorutils.contrast_color(values.hex, 'hex')
+        color = utils.contrast_color(values.hex, 'hex')
         self.color_spectrum.itemconfig('spectrum-indicator', outline=color)
 
     # color events
@@ -459,16 +459,16 @@ class ColorChooser(ttk.Frame):
         values = self.get_variables()
         if model == HEX:
             hx = values.hex
-            r, g, b = colorutils.color_to_rgb(hx)
-            h, s, l = colorutils.color_to_hsl(hx)
+            r, g, b = utils.color_to_rgb(hx)
+            h, s, l = utils.color_to_hsl(hx)
         elif model == RGB:
             r, g, b = values.r, values.g, values.b
-            h, s, l = colorutils.color_to_hsl([r, g, b], 'rgb')
-            hx = colorutils.color_to_hex([r, g, b])
+            h, s, l = utils.color_to_hsl([r, g, b], 'rgb')
+            hx = utils.color_to_hex([r, g, b])
         elif model == HSL:
             h, s, l = values.h, values.s, values.l
-            r, g, b = colorutils.color_to_rgb([h, s, l], 'hsl')
-            hx = colorutils.color_to_hex([h, s, l], 'hsl')
+            r, g, b = utils.color_to_rgb([h, s, l], 'hsl')
+            hx = utils.color_to_hex([h, s, l], 'hsl')
         self.set_variables(h, s, l, r, g, b, hx)
         self.update_preview()
         self.update_luminance_indicator()

--- a/src/ttkbootstrap/dialogs/colordropper.py
+++ b/src/ttkbootstrap/dialogs/colordropper.py
@@ -11,7 +11,7 @@ from PIL import ImageGrab, ImageTk
 from PIL.Image import Resampling
 
 import ttkbootstrap as ttk
-from ttkbootstrap import colorutils, utility
+from ttkbootstrap import utils
 from ttkbootstrap.constants import *
 
 ColorChoice = namedtuple('ColorChoice', 'rgb hsl hex')
@@ -53,10 +53,10 @@ class ColorDropperDialog:
     def build_zoom_toplevel(self, master: tk.Misc) -> None:
         """Build the toplevel widget that shows the zoomed version of
         the pixels underneath the mouse cursor."""
-        height = utility.scale_size(self.toplevel, 100)
-        width = utility.scale_size(self.toplevel, 100)
-        text_xoffset = utility.scale_size(self.toplevel, 50)
-        text_yoffset = utility.scale_size(self.toplevel, 50)
+        height = utils.scale_size(self.toplevel, 100)
+        width = utils.scale_size(self.toplevel, 100)
+        text_xoffset = utils.scale_size(self.toplevel, 50)
+        text_yoffset = utils.scale_size(self.toplevel, 50)
         toplevel = ttk.Toplevel(master=master)
         toplevel.transient(master=master)
         if self.toplevel and self.toplevel.winsys == 'x11':
@@ -93,8 +93,8 @@ class ColorDropperDialog:
         the toplevel widget"""
         # add logic here to capture the image color
         hx = self.get_hover_color()
-        hsl = colorutils.color_to_hsl(hx)
-        rgb = colorutils.color_to_rgb(hx)
+        hsl = utils.color_to_hsl(hx)
+        rgb = utils.color_to_rgb(hx)
         self.result.set(ColorChoice(rgb, hsl, hx))
         if self.toplevel:
             self.toplevel.destroy()
@@ -130,7 +130,7 @@ class ColorDropperDialog:
         self.zoom_image: ImageTk.PhotoImage = ImageTk.PhotoImage(self.zoom_data)
         self.zoom_canvas.itemconfig('image', image=self.zoom_image)
         hover_color = self.get_hover_color()
-        contrast_color = colorutils.contrast_color(hover_color, 'hex')
+        contrast_color = utils.contrast_color(hover_color, 'hex')
         self.zoom_canvas.itemconfig('indicator', fill=contrast_color)
 
     def get_hover_color(self) -> str:
@@ -139,7 +139,7 @@ class ColorDropperDialog:
         x = x1 + (x2 - x1) // 2
         y = y1 + (y2 - y2) // 2
         r, g, b = self.zoom_data.getpixel((x, y))
-        hx = colorutils.color_to_hex((r, g, b))
+        hx = utils.color_to_hex((r, g, b))
         return hx
 
     def show(self) -> None:
@@ -164,10 +164,10 @@ class ColorDropperDialog:
         self.zoom_toplevel: Optional[ttk.Toplevel] = None
         self.zoom_data: Any = None
         self.zoom_image: Optional[ImageTk.PhotoImage] = None
-        self.zoom_height: int = utility.scale_size(self.toplevel, 100)
-        self.zoom_width: int = utility.scale_size(self.toplevel, 100)
-        self.zoom_xoffset: int = utility.scale_size(self.toplevel, 10)
-        self.zoom_yoffset: int = utility.scale_size(self.toplevel, 10)
+        self.zoom_height: int = utils.scale_size(self.toplevel, 100)
+        self.zoom_width: int = utils.scale_size(self.toplevel, 100)
+        self.zoom_xoffset: int = utils.scale_size(self.toplevel, 10)
+        self.zoom_yoffset: int = utils.scale_size(self.toplevel, 10)
 
         self.build_zoom_toplevel(self.toplevel)
         self.toplevel.grab_set()

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -13,7 +13,7 @@ from ttkbootstrap.internal.positioning import (
     center_on_screen,
     ensure_on_screen,
 )
-from ttkbootstrap.utility import windowing_system
+from ttkbootstrap.utils import windowing_system
 from ttkbootstrap.style._compat import normalize_datepicker_kwargs
 
 

--- a/src/ttkbootstrap/dialogs/fontdialog.py
+++ b/src/ttkbootstrap/dialogs/fontdialog.py
@@ -5,7 +5,7 @@ from tkinter import font
 from typing import Any, Optional
 
 import ttkbootstrap as ttk
-from ttkbootstrap import utility
+from ttkbootstrap import utils
 from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
 from ttkbootstrap.dialogs.base import Dialog
@@ -79,8 +79,8 @@ class FontDialog(Dialog):
                 self._families.add(f)
 
     def create_body(self, master: tkinter.Misc) -> None:
-        width = utility.scale_size(master, 600)
-        height = utility.scale_size(master, 500)
+        width = utils.scale_size(master, 600)
+        height = utils.scale_size(master, 500)
         self._toplevel.geometry(f"{width}x{height}")
 
         # A borderless Treeview: the list border is carried by a wrapping frame
@@ -137,7 +137,7 @@ class FontDialog(Dialog):
             columns=[0],
             style="Flat.Treeview",
         )
-        listbox.column(0, width=utility.scale_size(listbox, 250))
+        listbox.column(0, width=utils.scale_size(listbox, 250))
 
         listbox_vbar = ttk.Scrollbar(
             listbox_frame,
@@ -176,7 +176,7 @@ class FontDialog(Dialog):
 
         sizes_listbox = ttk.Treeview(
             sizes_frame, height=7, columns=[0], show="", style="Flat.Treeview")
-        sizes_listbox.column(0, width=utility.scale_size(sizes_listbox, 24))
+        sizes_listbox.column(0, width=utils.scale_size(sizes_listbox, 24))
 
         sizes = [*range(8, 13), *range(13, 30, 2), 36, 48, 72]
         for s in sizes:

--- a/src/ttkbootstrap/internal/utility.py
+++ b/src/ttkbootstrap/internal/utility.py
@@ -2,7 +2,7 @@
 
 These are implementation details with no backward-compatibility guarantee.
 Public utility functions (`enable_high_dpi_awareness`, `scale_size`) live in
-the top-level `ttkbootstrap.utility` module.
+the `ttkbootstrap.utils` package.
 """
 
 

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -13,7 +13,7 @@ from types import MappingProxyType
 
 from PIL import ImageColor
 
-from ttkbootstrap import colorutils
+from ttkbootstrap import utils
 from ttkbootstrap.constants import *
 
 
@@ -609,7 +609,7 @@ class Colors:
             tuple[float, float, float]:
                 The rgb color value, each channel normalized to 0-1.
         """
-        r, g, b = colorutils.color_to_rgb(color)
+        r, g, b = utils.color_to_rgb(color)
         return r / 255, g / 255, b / 255
 
     @staticmethod
@@ -635,7 +635,7 @@ class Colors:
         r_ = int(r * 255)
         g_ = int(g * 255)
         b_ = int(b * 255)
-        return colorutils.color_to_hex((r_, g_, b_))
+        return utils.color_to_hex((r_, g_, b_))
 
     @staticmethod
     def update_hsv(color, hd=0, sd=0, vd=0):

--- a/src/ttkbootstrap/utility.py
+++ b/src/ttkbootstrap/utility.py
@@ -1,135 +1,34 @@
-"""Public utility functions for ttkbootstrap.
+"""Deprecated location for ttkbootstrap's public utility functions.
 
-High-DPI awareness and size-scaling helpers for ttkbootstrap applications.
+The public helpers have moved to `ttkbootstrap.utils` (`enable_high_dpi_awareness`
+and `scale_size` in `ttkbootstrap.utils.scaling`; `windowing_system` in
+`ttkbootstrap.utils.platform`). This shim re-exports them for backward
+compatibility and will be removed in 3.0. Import from `ttkbootstrap.utils` (or
+the top-level `ttkbootstrap` namespace) instead.
 """
 import warnings
 
-# Helpers that used to live here but are implementation details. They now live
-# in ttkbootstrap.internal.utility; accessing them through this module is
-# deprecated and the forwarding will be removed in 3.0.
+warnings.warn(
+    "ttkbootstrap.utility has moved to ttkbootstrap.utils; this shim will be "
+    "removed in 3.0.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from ttkbootstrap.utils.scaling import (  # noqa: F401,E402
+    enable_high_dpi_awareness,
+    scale_size,
+)
+from ttkbootstrap.utils.platform import windowing_system  # noqa: F401,E402
+
+# Two helpers that used to live here are implementation details and moved to
+# ttkbootstrap.internal.utility; accessing them through this module still works
+# (and this whole module is deprecated anyway), removed in 3.0.
 _MOVED_TO_INTERNAL = ("get_image_name", "center_on_parent")
 
 
 def __getattr__(name):
     if name in _MOVED_TO_INTERNAL:
-        warnings.warn(
-            f"ttkbootstrap.utility.{name} is internal and has moved to "
-            f"ttkbootstrap.internal.utility.{name}; this forwarding will be "
-            "removed in 3.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         from ttkbootstrap.internal import utility as internal_utility
         return getattr(internal_utility, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def enable_high_dpi_awareness(root=None, scaling=None):
-    """Enable high dpi awareness.
-
-    **Windows OS**  
-    Call the method BEFORE creating the `Tk` object. No parameters
-    required.
-
-    **Linux OS**  
-    Must provided the `root` and `scaling` parameters. Call the method 
-    AFTER creating the `Tk` object. A number between 1.6 and 2.0 is 
-    usually suffient to scale for high-dpi screen.
-
-    !!! warning
-        If the `root` argument is provided, then `scaling` must also
-        be provided. Otherwise, there is no effect.
-
-    Parameters:
-    
-        root (tk.Tk):
-            The root widget
-
-        scaling (float):
-            Sets and queries the current scaling factor used by Tk to 
-            convert between physical units (for example, points, 
-            inches, or millimeters) and pixels. The number argument is 
-            a floating point number that specifies the number of pixels 
-            per point on window's display. If the window argument is 
-            omitted, it defaults to the main window. If the number 
-            argument is omitted, the current value of the scaling 
-            factor is returned.
-
-            A “point” is a unit of measurement equal to 1/72 inch. A 
-            scaling factor of 1.0 corresponds to 1 pixel per point, 
-            which is equivalent to a standard 72 dpi monitor. A scaling 
-            factor of 1.25 would mean 1.25 pixels per point, which is 
-            the setting for a 90 dpi monitor; setting the scaling factor 
-            to 1.25 on a 72 dpi monitor would cause everything in the 
-            application to be displayed 1.25 times as large as normal. 
-            The initial value for the scaling factor is set when the 
-            application starts, based on properties of the installed 
-            monitor, but it can be changed at any time. Measurements 
-            made after the scaling factor is changed will use the new 
-            scaling factor, but it is undefined whether existing 
-            widgets will resize themselves dynamically to accommodate 
-            the new scaling factor.
-    """
-    # Keep the existing system-DPI-aware behavior. Per-monitor-v2 awareness
-    # requires live style rebuilding when a window crosses displays, which is
-    # outside ttkbootstrap's current scaling contract.
-    try:
-        from ctypes import windll
-        try:
-            windll.shcore.SetProcessDpiAwareness(1)
-        except Exception:
-            windll.user32.SetProcessDPIAware()
-    except Exception:
-        pass
-
-    try:
-        if root is not None and scaling is not None:
-            root.tk.call('tk', 'scaling', scaling)
-    except Exception:
-        pass
-
-
-def scale_size(widget, size):
-    """Scale the size based on the scaling factor of tkinter. 
-    This is used most frequently to adjust the assets for 
-    image-based widget layouts and pixel-valued geometry.
-
-    `size` is expressed in logical UI units. Conversion uses the scaling
-    service attached to the widget's root and rounds half away from zero.
-
-    Parameters:
-
-        widget (Widget):
-            The widget object.
-
-        size (int | float | list | tuple):
-            A number or sequence of numbers in logical UI units.
-
-    Returns:
-
-        int | list:
-            An integer or list of integers representing the new size.
-    """
-    from ttkbootstrap.style.scaling import Scaling
-
-    return Scaling.for_widget(widget).logical(size)
-
-
-def windowing_system(widget):
-    """Return the Tk windowing system for `widget`'s display.
-
-    One of `'win32'` (Windows), `'aqua'` (macOS), or `'x11'` (Linux/Unix).
-    Wraps `widget.tk.call('tk', 'windowingsystem')` so platform checks read the
-    same everywhere instead of repeating the raw Tcl call.
-
-    Parameters:
-
-        widget (Misc):
-            Any widget (or the root) whose interpreter is queried.
-
-    Returns:
-
-        str:
-            The windowing system identifier.
-    """
-    return str(widget.tk.call('tk', 'windowingsystem'))

--- a/src/ttkbootstrap/utils/__init__.py
+++ b/src/ttkbootstrap/utils/__init__.py
@@ -16,6 +16,17 @@ Later 2.0 slices add `fonts` (typography) and `config` (deferred-config seam)
 here, and re-export the `localization` helpers through this namespace.
 """
 from ttkbootstrap.utils.color import (
+    # color-model selector constants (usable as the `model=` argument). Not in
+    # `__all__` (they weren't in colorutils' `__all__` either -- semi-internal),
+    # but re-exported so `from ttkbootstrap.utils import RGB` resolves for anyone
+    # migrating off the deprecated `ttkbootstrap.colorutils` path.
+    RGB,
+    HSL,
+    HEX,
+    NAME,
+    HUE,
+    SAT,
+    LUM,
     color_to_rgb,
     color_to_hex,
     color_to_hsl,

--- a/src/ttkbootstrap/utils/__init__.py
+++ b/src/ttkbootstrap/utils/__init__.py
@@ -1,0 +1,45 @@
+"""Public utilities for ttkbootstrap — the first-class home for the helpers an
+app developer reaches for: color math, scaling / HiDPI, and platform checks.
+
+This package replaces the pre-2.0 scatter (`ttkbootstrap.colorutils` +
+`ttkbootstrap.utility`). Those old module paths still work as thin
+warn-and-forward shims (removed in 3.0); new code should import from here (or
+from the top-level `ttkbootstrap` namespace, where the whole surface is
+re-exported for `ttk.<tab>` discovery).
+
+Submodules:
+    color     — color-model conversion and manipulation
+    scaling   — `enable_high_dpi_awareness`, `scale_size`
+    platform  — `windowing_system`
+
+Later 2.0 slices add `fonts` (typography) and `config` (deferred-config seam)
+here, and re-export the `localization` helpers through this namespace.
+"""
+from ttkbootstrap.utils.color import (
+    color_to_rgb,
+    color_to_hex,
+    color_to_hsl,
+    update_hsl_value,
+    contrast_color,
+    conform_color_model,
+)
+from ttkbootstrap.utils.scaling import (
+    enable_high_dpi_awareness,
+    scale_size,
+)
+from ttkbootstrap.utils.platform import windowing_system
+
+__all__ = [
+    # color
+    "color_to_rgb",
+    "color_to_hex",
+    "color_to_hsl",
+    "update_hsl_value",
+    "contrast_color",
+    "conform_color_model",
+    # scaling
+    "enable_high_dpi_awareness",
+    "scale_size",
+    # platform
+    "windowing_system",
+]

--- a/src/ttkbootstrap/utils/color.py
+++ b/src/ttkbootstrap/utils/color.py
@@ -1,0 +1,218 @@
+"""Color utility functions for ttkbootstrap.
+
+Convert between color models (RGB, HSL, HEX, and named colors) and manipulate
+colors by adjusting hue, saturation, and luminance.
+"""
+from PIL import ImageColor
+from colorsys import rgb_to_hls
+
+__all__ = [
+    "color_to_rgb",
+    "color_to_hex",
+    "color_to_hsl",
+    "update_hsl_value",
+    "contrast_color",
+    "conform_color_model",
+]
+
+RGB = 'rgb'
+HSL = 'hsl'
+HEX = 'hex'
+NAME = 'name'
+
+HUE = 360
+SAT = 100
+LUM = 100
+
+
+def color_to_rgb(color, model=HEX):
+    """Convert color value to rgb.
+
+    The color and model parameters represent the color to be converted.
+    The value is expected to be a string for "name" and "hex" models and
+    a Tuple or List for "rgb" and "hsl" models.
+    
+    Parameters:
+        
+        color (Any):
+            The color values for the model being converted.
+            
+        model (str):
+            The color model being converted.
+    
+    Returns:
+
+        tuple[int, int, int]:
+            The rgb color values.
+    """
+    color_ = conform_color_model(color, model)    
+    try:
+        return ImageColor.getrgb(color_)
+    except:
+        print('this')
+    
+def color_to_hex(color, model=RGB):
+    """Convert color value to hex.
+
+    The color and model parameters represent the color to be converted.
+    The value is expected to be a string for "name" and "hex" models and
+    a Tuple or List for "rgb" and "hsl" models.
+    
+    Parameters:
+        
+        color (Any):
+            The color values for the model being converted.
+            
+        model (str):
+            The color model being converted.
+    
+    Returns:
+    
+        str:
+            The hexadecimal color value.
+    """
+    r, g, b = color_to_rgb(color, model)
+    return f'#{r:02x}{g:02x}{b:02x}'
+
+def color_to_hsl(color, model=HEX):
+    """Convert color value to hsl.
+
+    The color and model parameters represent the color to be converted.
+    The value is expected to be a string for "name" and "hex" models and
+    a Tuple or List for "rgb" and "hsl" models.
+    
+    Parameters:
+        
+        color (Any):
+            The color values for the model being converted.
+            
+        model (str):
+            The color model being converted.
+    
+    Returns:
+
+        tuple[int, int, int]:
+            The hsl color values.
+    """
+    r, g, b = color_to_rgb(color, model)
+    hls = rgb_to_hls(r/255, g/255, b/255)
+    h = int(hls[0]*HUE)
+    l = int(hls[1]*LUM)
+    s = int(hls[2]*SAT)
+    return h, s, l
+
+def update_hsl_value(color, hue=None, sat=None, lum=None, inmodel=HSL, outmodel=HSL):
+    """Change hue, saturation, or lumenosity of the color based on the
+    hue, sat, lum parameters provided.
+    
+    Parameters:
+
+        color (Any):
+            The color
+
+        hue (int):
+            A number between 0 and 360.
+
+        sat (int):
+            A number between 0 and 100.
+
+        lum (int):
+            A number between 0 and 100.
+
+        inmodel (str):
+            The color model used by the color to be changed. One of
+            hsl, rgb, hex, name.
+
+        outmodel (str):
+            The color value model to be returned when the color is
+            changed. One of hsl, rgb, hex.
+
+    Returns:
+
+        Union[tuple[int, int, int], str]:
+            The color value based on the selected color model.
+    """
+    h, s, l = color_to_hsl(color, inmodel)
+    if hue is not None:
+        h = hue
+    if sat is not None:
+        s = sat
+    if lum is not None:
+        l = lum
+    if outmodel == RGB:
+        return color_to_rgb([h, s, l], HSL)
+    elif outmodel == HEX:
+        return color_to_hex([h, s, l], HSL)
+    else:
+        return h, s, l
+
+
+"""
+https://stackoverflow.com/questions/1855884/determine-font-color-based-on-background-color
+
+"""
+
+def contrast_color(color, model=RGB, darkcolor='#000', lightcolor='#fff'):
+    """Returns the best matching contrasting light or dark color for
+    the given color.
+    
+    Parameters:
+
+        color (Any):
+            The color value to evaluate.
+
+        model (str):
+            The model of the color value to be evaluated. 'rgb' by 
+            default.
+
+        darkcolor (Any):
+            The color value to be returned when the constrasting color 
+            should be dark.
+
+        lightcolor (Any):
+            The color value to be returned when the constrasting color
+            should be light.
+
+    Returns:
+
+        str:
+            The matching color value.
+    """
+    if model != RGB:
+        r, g, b = color_to_rgb(color, model)
+    else:
+        r, g, b = color
+
+    luminance = ((0.299 * r) + (0.587 * g) + (0.114 * b))/255
+    if luminance > 0.5:
+        return darkcolor
+    else:
+        return lightcolor
+
+
+def conform_color_model(color, model):
+    """Conform the color values to a string that can be interpreted
+    by the `PIL.ImageColor.getrgb method`.
+
+    Parameters:
+
+        color (Union[tuple[int, int, int], str]):
+            The color value to conform.
+
+        model (str):
+            One of 'hsl', 'rgb', 'hex', or 'name'.
+
+    Returns:
+
+        str:
+            A color value string that can be used as a parameter in the
+            PIL.ImageColor.getrgb method.
+    """    
+    if model == HSL:
+        h, s, l = color
+        return f'hsl({h},{s}%,{l}%)'
+    elif model == RGB:
+        r, g, b = color
+        return f'rgb({r},{g},{b})'
+    else:
+        return color

--- a/src/ttkbootstrap/utils/platform.py
+++ b/src/ttkbootstrap/utils/platform.py
@@ -1,0 +1,21 @@
+"""Platform / windowing-system helpers for ttkbootstrap applications."""
+
+
+def windowing_system(widget):
+    """Return the Tk windowing system for `widget`'s display.
+
+    One of `'win32'` (Windows), `'aqua'` (macOS), or `'x11'` (Linux/Unix).
+    Wraps `widget.tk.call('tk', 'windowingsystem')` so platform checks read the
+    same everywhere instead of repeating the raw Tcl call.
+
+    Parameters:
+
+        widget (Misc):
+            Any widget (or the root) whose interpreter is queried.
+
+    Returns:
+
+        str:
+            The windowing system identifier.
+    """
+    return str(widget.tk.call('tk', 'windowingsystem'))

--- a/src/ttkbootstrap/utils/scaling.py
+++ b/src/ttkbootstrap/utils/scaling.py
@@ -1,0 +1,92 @@
+"""High-DPI awareness and size-scaling helpers for ttkbootstrap applications."""
+
+
+def enable_high_dpi_awareness(root=None, scaling=None):
+    """Enable high dpi awareness.
+
+    **Windows OS**
+    Call the method BEFORE creating the `Tk` object. No parameters
+    required.
+
+    **Linux OS**
+    Must provided the `root` and `scaling` parameters. Call the method
+    AFTER creating the `Tk` object. A number between 1.6 and 2.0 is
+    usually suffient to scale for high-dpi screen.
+
+    !!! warning
+        If the `root` argument is provided, then `scaling` must also
+        be provided. Otherwise, there is no effect.
+
+    Parameters:
+
+        root (tk.Tk):
+            The root widget
+
+        scaling (float):
+            Sets and queries the current scaling factor used by Tk to
+            convert between physical units (for example, points,
+            inches, or millimeters) and pixels. The number argument is
+            a floating point number that specifies the number of pixels
+            per point on window's display. If the window argument is
+            omitted, it defaults to the main window. If the number
+            argument is omitted, the current value of the scaling
+            factor is returned.
+
+            A “point” is a unit of measurement equal to 1/72 inch. A
+            scaling factor of 1.0 corresponds to 1 pixel per point,
+            which is equivalent to a standard 72 dpi monitor. A scaling
+            factor of 1.25 would mean 1.25 pixels per point, which is
+            the setting for a 90 dpi monitor; setting the scaling factor
+            to 1.25 on a 72 dpi monitor would cause everything in the
+            application to be displayed 1.25 times as large as normal.
+            The initial value for the scaling factor is set when the
+            application starts, based on properties of the installed
+            monitor, but it can be changed at any time. Measurements
+            made after the scaling factor is changed will use the new
+            scaling factor, but it is undefined whether existing
+            widgets will resize themselves dynamically to accommodate
+            the new scaling factor.
+    """
+    # Keep the existing system-DPI-aware behavior. Per-monitor-v2 awareness
+    # requires live style rebuilding when a window crosses displays, which is
+    # outside ttkbootstrap's current scaling contract.
+    try:
+        from ctypes import windll
+        try:
+            windll.shcore.SetProcessDpiAwareness(1)
+        except Exception:
+            windll.user32.SetProcessDPIAware()
+    except Exception:
+        pass
+
+    try:
+        if root is not None and scaling is not None:
+            root.tk.call('tk', 'scaling', scaling)
+    except Exception:
+        pass
+
+
+def scale_size(widget, size):
+    """Scale the size based on the scaling factor of tkinter.
+    This is used most frequently to adjust the assets for
+    image-based widget layouts and pixel-valued geometry.
+
+    `size` is expressed in logical UI units. Conversion uses the scaling
+    service attached to the widget's root and rounds half away from zero.
+
+    Parameters:
+
+        widget (Widget):
+            The widget object.
+
+        size (int | float | list | tuple):
+            A number or sequence of numbers in logical UI units.
+
+    Returns:
+
+        int | list:
+            An integer or list of integers representing the new size.
+    """
+    from ttkbootstrap.style.scaling import Scaling
+
+    return Scaling.for_widget(widget).logical(size)

--- a/src/ttkbootstrap/widgets/floodgauge.py
+++ b/src/ttkbootstrap/widgets/floodgauge.py
@@ -8,7 +8,7 @@ from tkinter import Event, Misc, TclError
 from typing import Any, Optional, Union
 
 from ttkbootstrap import Canvas, DoubleVar, IntVar, Progressbar, StringVar
-from ttkbootstrap.colorutils import contrast_color
+from ttkbootstrap.utils import contrast_color
 from ttkbootstrap.constants import DETERMINATE, HORIZONTAL, PRIMARY
 from ttkbootstrap.internal.configure_delegation import (
     ConfigureDelegationMixin,

--- a/src/ttkbootstrap/widgets/meter.py
+++ b/src/ttkbootstrap/widgets/meter.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, Union
 from PIL import Image, ImageDraw, ImageTk
 from PIL.Image import Resampling
 
-from ttkbootstrap import DoubleVar, Frame, Label, StringVar, utility
+from ttkbootstrap import DoubleVar, Frame, Label, StringVar, utils
 from ttkbootstrap.constants import CENTER, DEFAULT, FULL, LEFT, RIGHT, S, Y
 from ttkbootstrap.internal.configure_delegation import (
     ConfigureDelegationMixin,
@@ -309,11 +309,11 @@ class Meter(ConfigureDelegationMixin, Frame):
     # -- scaling seam -------------------------------------------------------- #
     def _physical_size(self) -> int:
         """Physical (dpi-scaled) meter size in pixels from the logical size."""
-        return utility.scale_size(self, self._meter_size)
+        return utils.scale_size(self, self._meter_size)
 
     def _physical_thickness(self) -> int:
         """Physical (dpi-scaled) indicator thickness from the logical value."""
-        return utility.scale_size(self, self._meter_thickness)
+        return utils.scale_size(self, self._meter_thickness)
 
     def _update_meter(self, *_: Any) -> None:
         """Redraw the indicator and refresh the display text on value change."""

--- a/src/ttkbootstrap/widgets/scrolled.py
+++ b/src/ttkbootstrap/widgets/scrolled.py
@@ -12,7 +12,7 @@ import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
 from ttkbootstrap.internal.configure_delegation import ConfigureDelegationMixin
 from ttkbootstrap.style._compat import normalize_scrolled_kwargs, warn_deprecated
-from ttkbootstrap.utility import windowing_system
+from ttkbootstrap.utils import windowing_system
 
 # Small pad at both long-axis ends of a scrollbar so it isn't flush against the
 # container edge -- applied on both ends because either can sit at the border

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -10,7 +10,7 @@ from tkinter import font
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import ttkbootstrap as ttk
-from ttkbootstrap import utility
+from ttkbootstrap import utils
 from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
 from ttkbootstrap.style._compat import warn_deprecated
@@ -2092,7 +2092,7 @@ class Tableview(ttk.Frame):
     def autofit_columns(self):
         """Autofit all columns in the current view"""
         f = font.nametofont("TkDefaultFont")
-        pad = utility.scale_size(self, 20)
+        pad = utils.scale_size(self, 20)
         col_widths = []
 
         # measure header sizes
@@ -2312,8 +2312,8 @@ class Tableview(ttk.Frame):
         from PIL import Image, ImageTk
         from ttkbootstrap.style.icons import IconRenderer
 
-        size = utility.scale_size(self, 14)
-        gap = utility.scale_size(self, 6)
+        size = utils.scale_size(self, 14)
+        gap = utils.scale_size(self, 6)
         glyph = IconRenderer.render(name, size, fg)  # physical-pixel PIL RGBA
         canvas = Image.new("RGBA", (glyph.width + gap, glyph.height), (0, 0, 0, 0))
         canvas.paste(glyph, (gap, 0))  # pad on the leading side (text | gap | glyph)
@@ -2493,7 +2493,7 @@ class Tableview(ttk.Frame):
         an oversized bar. Bounding it in a fixed, DPI-scaled height frame keeps
         the divider inset and lets the (shorter) controls set the bar height.
         """
-        height, width = utility.scale_size(self, [20, 1])
+        height, width = utils.scale_size(self, [20, 1])
         box = ttk.Frame(parent, height=height, width=width)
         box.pack_propagate(False)
         box.pack(side=RIGHT, padx=10)
@@ -2507,7 +2507,7 @@ class Tableview(ttk.Frame):
         self.view.bind("<Button-1>", self._header_leftclick)
 
         if not self.disable_right_click:
-            if utility.windowing_system(self) == "aqua":
+            if utils.windowing_system(self) == "aqua":
                 sequence = "<Button-2>"
             else:
                 sequence = "<Button-3>"

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -200,7 +200,7 @@ class ToastNotification:
         """Create, place, and show the toast; returns ``self`` (a dismiss handle)."""
         from tkinter import _default_root
 
-        from ttkbootstrap import Frame, Label, Toplevel, apply_icon, utility
+        from ttkbootstrap import Frame, Label, Toplevel, apply_icon, utils
 
         self._hidden = False
 
@@ -208,7 +208,7 @@ class ToastNotification:
         # with the tooltip); set it at construction, so probe the windowing
         # system from the existing root before creating the Toplevel.
         if _default_root is not None and "window_type" not in self.kwargs:
-            if utility.windowing_system(_default_root) == "aqua":
+            if utils.windowing_system(_default_root) == "aqua":
                 self.kwargs["window_type"] = "tooltip"
 
         self.toplevel = Toplevel(**self.kwargs)
@@ -239,7 +239,7 @@ class ToastNotification:
         Label(
             self.container,
             text=self.message,
-            wraplength=utility.scale_size(self.toplevel, 300),
+            wraplength=utils.scale_size(self.toplevel, 300),
             bootstyle=f"{self.bootstyle}-inverse",
             anchor=NW,
         ).grid(row=1, column=1, sticky=NSEW, padx=10, pady=(0, 5))
@@ -323,13 +323,13 @@ class ToastNotification:
 
     # -- setup / geometry ---------------------------------------------------- #
     def _setup(self, window) -> None:
-        from ttkbootstrap import utility
+        from ttkbootstrap import utils
 
-        winsys = utility.windowing_system(window)
+        winsys = utils.windowing_system(window)
         self.toplevel.configure(relief=RAISED)
 
         if "minsize" not in self.kwargs:
-            w, h = utility.scale_size(self.toplevel, [300, 75])
+            w, h = utils.scale_size(self.toplevel, [300, 75])
             self.toplevel.minsize(w, h)
 
         # heading font
@@ -343,21 +343,21 @@ class ToastNotification:
         # default position by windowing system
         if self.position is None:
             if winsys == "win32":
-                x, y = utility.scale_size(self.toplevel, [5, 50])
+                x, y = utils.scale_size(self.toplevel, [5, 50])
                 self.position = (x, y, SE)
             elif winsys == "x11":
-                x, y = utility.scale_size(self.toplevel, [0, 0])
+                x, y = utils.scale_size(self.toplevel, [0, 0])
                 self.position = (x, y, SE)
             else:  # aqua (window_type='tooltip' was set at construction)
-                x, y = utility.scale_size(self.toplevel, [50, 50])
+                x, y = utils.scale_size(self.toplevel, [50, 50])
                 self.position = (x, y, NE)
 
         self._anchor = str(self.position[-1]).lower()
 
     def _scaled_gap(self) -> int:
-        from ttkbootstrap import utility
+        from ttkbootstrap import utils
         try:
-            return utility.scale_size(self.toplevel, _ToastStack._GAP)
+            return utils.scale_size(self.toplevel, _ToastStack._GAP)
         except Exception:
             return _ToastStack._GAP
 

--- a/src/ttkbootstrap/widgets/tooltip.py
+++ b/src/ttkbootstrap/widgets/tooltip.py
@@ -9,7 +9,7 @@ from tkinter import Event, Misc
 from typing import Any, Literal, Optional
 
 import ttkbootstrap as ttk
-from ttkbootstrap import utility
+from ttkbootstrap import utils
 from ttkbootstrap.constants import *
 from ttkbootstrap.internal.positioning import ensure_on_screen
 
@@ -113,7 +113,7 @@ class ToolTip:
         self.justify = justify
         self.image = image
         self.bootstyle = bootstyle
-        self.wraplength = wraplength or utility.scale_size(self.widget, 300)
+        self.wraplength = wraplength or utils.scale_size(self.widget, 300)
         self.toplevel = None
         self.delay = delay
         self.position = position.lower() if position else None

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -13,7 +13,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Optional, Tuple, Union
 
-from ttkbootstrap import utility
+from ttkbootstrap import utils
 from ttkbootstrap.constants import *
 from ttkbootstrap.internal import positioning
 from ttkbootstrap.style import Style, Bootstyle
@@ -492,17 +492,17 @@ class App(_BaseWindow, tkinter.Tk):
         _require_single_root(self)
 
         if high_dpi:
-            utility.enable_high_dpi_awareness()
+            utils.enable_high_dpi_awareness()
 
         # On win32, tag the process so the taskbar shows the app icon rather
         # than the generic python.exe one (bootstack app.py:534-540).
         self._set_app_user_model_id()
 
         super().__init__(**kwargs)
-        self.winsys: str = utility.windowing_system(self)
+        self.winsys: str = utils.windowing_system(self)
 
         if scaling is not None:
-            utility.enable_high_dpi_awareness(self, scaling)
+            utils.enable_high_dpi_awareness(self, scaling)
 
         self._setup_icon(iconphoto, default_data=_DEFAULT_ICON_DATA)
         self.title(title)
@@ -671,7 +671,7 @@ class Toplevel(_BaseWindow, tkinter.Toplevel):
         tool_window = aliases.get("tool_window", tool_window)
 
         super().__init__(**kwargs)
-        self.winsys: str = utility.windowing_system(self)
+        self.winsys: str = utils.windowing_system(self)
 
         # On aqua, give a borderless popup type (tooltip/splash/...) a native
         # macOS window class instead of the default chrome, so it isn't drawn

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from ttkbootstrap import utility
+from ttkbootstrap import utils
 from ttkbootstrap.style.assets import Assets
 from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
 from ttkbootstrap.style.elements import RecolorRenderer
@@ -119,7 +119,7 @@ def test_public_utility_reuses_root_service():
     root = _FakeRoot("x11", (4 / 3) * 1.5)
     service = Scaling.for_widget(root)
     assert Scaling.for_widget(root) is service
-    assert utility.scale_size(root, [22, 6]) == [33, 9]
+    assert utils.scale_size(root, [22, 6]) == [33, 9]
 
 
 def test_style_builder_utility_and_assets_share_root_service(root):
@@ -132,11 +132,11 @@ def test_window_and_style_initialize_scaling_before_style_builds():
     package = Path(__file__).parents[1] / "src" / "ttkbootstrap"
     window_source = (package / "window.py").read_text(encoding="utf-8")
     init_source = window_source[window_source.index("class App"):]
-    assert init_source.index("utility.enable_high_dpi_awareness()") < init_source.index(
+    assert init_source.index("utils.enable_high_dpi_awareness()") < init_source.index(
         "super().__init__(**kwargs)"
     )
     assert init_source.index("super().__init__(**kwargs)") < init_source.index(
-        "utility.enable_high_dpi_awareness(self, scaling)"
+        "utils.enable_high_dpi_awareness(self, scaling)"
     ) < init_source.index("self._style = Style(theme")
 
     engine_source = (package / "style" / "engine.py").read_text(encoding="utf-8")

--- a/tests/test_utility_api.py
+++ b/tests/test_utility_api.py
@@ -38,6 +38,14 @@ def test_utils_package_exposes_the_full_surface():
         assert name in utils.__all__, f"{name} missing from utils.__all__"
 
 
+def test_utils_reexports_color_model_constants():
+    # the color-model selector constants must resolve from the canonical package
+    # too (so migrating `from ttkbootstrap.colorutils import RGB` -> `.utils`
+    # doesn't ImportError), even though they stay out of __all__.
+    from ttkbootstrap.utils import RGB, HSL, HEX, NAME, HUE, SAT, LUM
+    assert (RGB, HSL, HEX, NAME) == ("rgb", "hsl", "hex", "name")
+
+
 def test_top_level_names_are_the_utils_objects():
     # the re-exports must be the real functions, not shadowing copies
     assert ttk.scale_size is utils.scale_size

--- a/tests/test_utility_api.py
+++ b/tests/test_utility_api.py
@@ -1,11 +1,18 @@
 """Headless tests for the 2.0 public-utility surface.
 
-Covers that the utility/colorutils helpers are reachable at the top level
-(`ttk.<name>`) and that the new `windowing_system` helper matches the raw Tcl
-call it consolidates.
+Covers that the color / scaling / platform helpers are reachable at the top
+level (`ttk.<name>`) and through the canonical `ttkbootstrap.utils` package,
+that `windowing_system` matches the raw Tcl call it consolidates, and that the
+old `ttkbootstrap.utility` / `ttkbootstrap.colorutils` module paths still work
+as warn-and-forward shims (Slice 0).
 """
+import importlib
+import sys
+
+import pytest
+
 import ttkbootstrap as ttk
-from ttkbootstrap import colorutils, utility
+from ttkbootstrap import utils
 
 
 # --------------------------------------------------------------------------
@@ -25,11 +32,40 @@ def test_public_utilities_are_top_level_and_in_all():
         assert name in ttk.__all__, f"{name} missing from ttk.__all__"
 
 
-def test_top_level_names_are_the_module_objects():
+def test_utils_package_exposes_the_full_surface():
+    for name in _UTILITY_NAMES + _COLOR_NAMES:
+        assert hasattr(utils, name), f"utils.{name} is missing"
+        assert name in utils.__all__, f"{name} missing from utils.__all__"
+
+
+def test_top_level_names_are_the_utils_objects():
     # the re-exports must be the real functions, not shadowing copies
-    assert ttk.scale_size is utility.scale_size
-    assert ttk.windowing_system is utility.windowing_system
-    assert ttk.contrast_color is colorutils.contrast_color
+    assert ttk.scale_size is utils.scale_size
+    assert ttk.windowing_system is utils.windowing_system
+    assert ttk.contrast_color is utils.contrast_color
+
+
+# --------------------------------------------------------------------------
+# back-compat shims (ttkbootstrap.utility / ttkbootstrap.colorutils)
+# --------------------------------------------------------------------------
+
+def test_legacy_utility_module_warns_but_forwards():
+    # drop any cached module so the module-level warning re-fires regardless of
+    # test order
+    sys.modules.pop("ttkbootstrap.utility", None)
+    with pytest.warns(DeprecationWarning, match="moved to ttkbootstrap.utils"):
+        legacy_utility = importlib.import_module("ttkbootstrap.utility")
+    assert legacy_utility.scale_size is utils.scale_size
+    assert legacy_utility.windowing_system is utils.windowing_system
+
+
+def test_legacy_colorutils_module_warns_but_forwards():
+    sys.modules.pop("ttkbootstrap.colorutils", None)
+    with pytest.warns(DeprecationWarning, match="moved to ttkbootstrap.utils"):
+        legacy_colorutils = importlib.import_module("ttkbootstrap.colorutils")
+    assert legacy_colorutils.contrast_color is utils.contrast_color
+    # the model constants (not in __all__) still resolve through the shim
+    assert legacy_colorutils.HEX == "hex" and legacy_colorutils.RGB == "rgb"
 
 
 # --------------------------------------------------------------------------
@@ -45,7 +81,7 @@ def test_windowing_system_returns_known_value(root):
 
 
 # --------------------------------------------------------------------------
-# scale_size + colorutils behave through the top-level names
+# scale_size + color helpers behave through the top-level names
 # --------------------------------------------------------------------------
 
 def test_scale_size_scales_a_pair(root):
@@ -53,6 +89,7 @@ def test_scale_size_scales_a_pair(root):
     assert isinstance(scaled, list) and len(scaled) == 2
 
 
-def test_colorutils_round_trip():
-    assert ttk.color_to_rgb("#ff5733", model=colorutils.HEX) == (255, 87, 51)
-    assert ttk.color_to_hex((255, 87, 51), model=colorutils.RGB) == "#ff5733"
+def test_color_helpers_round_trip():
+    from ttkbootstrap.utils.color import HEX, RGB
+    assert ttk.color_to_rgb("#ff5733", model=HEX) == (255, 87, 51)
+    assert ttk.color_to_hex((255, 87, 51), model=RGB) == "#ff5733"


### PR DESCRIPTION
## Slice 0 — Utility organization (`utils/` package)

Third of the compat & utilities slices (`development/2_0_compat_and_utilities_design.md`), and the structural home that Slices 3/4/5 (localization, typography, deferred-config) get **born into**.

### What
Replace the pre-2.0 scatter (`ttkbootstrap.utility` grab-bag + `ttkbootstrap.colorutils`) with a first-class **`ttkbootstrap.utils`** package:

```
utils/
  __init__.py   # re-exports the whole public surface from one namespace
  color.py      # <- colorutils.py (color-model conversion + manipulation)
  scaling.py    # enable_high_dpi_awareness, scale_size   (from utility.py)
  platform.py   # windowing_system                        (from utility.py)
```

`fonts.py` (Slice 4) and `config.py` (Slice 5) are *born here* later; localization re-export through `utils` also lands with Slice 3.

### Back-compat (no break)
The old module paths become thin **warn-and-forward shims** — same pattern as `ttkbootstrap.publisher`. Importing `ttkbootstrap.utility` / `ttkbootstrap.colorutils` emits a one-time `DeprecationWarning` and re-exports the moved names (including the `colorutils` model constants `RGB`/`HSL`/`HEX`/… and the two already-internal `utility` forwards `get_image_name`/`center_on_parent`). Removed in 3.0. The top-level re-exports (`ttk.scale_size`, `ttk.contrast_color`, …) are **unchanged** — still the primary discovery path.

**Migration:** `from ttkbootstrap.utility import scale_size` → `from ttkbootstrap.utils import scale_size` (or keep `ttk.scale_size`); `from ttkbootstrap import colorutils` → `from ttkbootstrap import utils`. No behavior changed — same function objects.

### Internal migration
Every first-party caller now imports from `ttkbootstrap.utils`, so **`import ttkbootstrap` stays warning-free**: `window`, `style/theme`, `meter`, `tooltip`, `tableview`, `toast`, `floodgauge`, `scrolled`, and the color/font/date/base dialogs. The private `ttkbootstrap.internal.utility` (`get_image_name`/`center_on_parent`) is untouched.

### Tests
- `test_utility_api.py` rewritten onto `ttkbootstrap.utils` + coverage that the package exposes the full surface **and** that the old shims warn-but-forward (made order-independent by forcing a fresh import).
- `test_scaling.py`: import + the window.py source-order assertion strings updated (`utility.` → `utils.`).
- Full headless suite: **504 passed**; the two failures are the known pre-existing flakes (`nl.msg` localization + the order-dependent `test_color_helpers`), both confirmed pre-existing on `2.0`. Warning-free import verified under `-W error::DeprecationWarning`; all 17 migrated modules import clean; shims warn + forward (incl. internal forwarding) verified.

### Notes / scope
- Behavior-preserving move: `utils/color.py` is `colorutils.py` verbatim (the pre-existing `except: print('this')` wart in `color_to_rgb` is carried over, not fixed here).
- The design's **Utilities docs section** is a Workstream-H (docs rewrite) deliverable, not part of this code slice; the shims are deliberately source-only back-compat (undocumented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
