### PR TITLE
Track compat/utilities progress + add pre-release review plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,10 +204,21 @@ tk/ttk widgets taking `bootstyle=`/`autostyle=`, and positional args to now-
 keyword-only APIs — found **no other crash-class bugs** in `src/`; the only extra
 finding was the `__main__` demo tripping its own deprecation warnings, fixed in
 #1132 (`meter_size`/`amount_used`/`auto_hide`). Expected suite on `2.0` ~492
-(excl. the known `nl.msg` localization flake). **NEXT
-(deferred):** the **breaking/deprecation audit → *Migrating-to-2.0* guide** (see
-`2_0_breaking_changes.md`, the running log), and **docs Workstream H** — nav/IA
-skeleton + un-break the API `:::` stubs, per `development/2_0_docs_design.md` §11.
+(excl. the known `nl.msg` localization flake). **The compat & utilities initiative
+(the last substantive code work before release,
+`development/2_0_compat_and_utilities_design.md`) is now underway: Slice 1 (legacy
+theme-name auto-register, #1139), Slice 2 (`App`/`Window` + `theme`/`themename`
+aliases, #1140), and Slice 0 (`ttkbootstrap.utils` package + `utility`/`colorutils`
+shims, #1141) are MERGED into `2.0`; suite ~505 excl. the two known flakes. NEXT →
+the remaining slices in order: Slice 5 (deferred-config seam) → Slice 3
+(localization: msgcat fixes + `L()`/`LocaleVar`) → Slice 4 (typography `Fonts`
+utility) — all born into `utils/`.** **THEN (deferred to the end, by author
+decision):** the cumulative **pre-release review** per
+`development/2_0_prerelease_review_plan.md` (Track A agentic `2.0…master` sweep ·
+Track B human visual/cross-platform · Track C migration-contract validation),
+which subsumes the earlier breaking/deprecation-audit item; and **docs Workstream
+H** — nav/IA skeleton + un-break the API `:::` stubs, per
+`development/2_0_docs_design.md` §11.
 
 ## Repository layout
 

--- a/development/2_0_compat_and_utilities_design.md
+++ b/development/2_0_compat_and_utilities_design.md
@@ -235,12 +235,17 @@ bracket DSL (needs to intercept `font=` — framework territory).
 ## Suggested PR order
 
 1. **Utility organization** (Slice 0) — `utils/` package + source-only shims; the
-   home Slices 3/4/5 build into.
+   home Slices 3/4/5 build into. **DONE — #1141.**
 2. **Theme lazy-register** (Slice 1) — highest impact, unblocks every app; standalone.
+   **DONE — #1139.**
 3. **Naming aliases** (Slice 2) — `App`/`Window`, `theme`/`themename`; standalone.
+   **DONE — #1140.**
 4. **Deferred-config seam** (Slice 5 core) — small, enables localization & typography.
 5. **Localization** (Slice 3) — msgcat fixes + `L()`/`LocaleVar` + event.
 6. **Typography** (Slice 4) — `Fonts` utility, wired through the seam.
 
+(Actual merge order was 1/2/0, all standalone; the remaining three are 5 → 3 → 4.)
+
 Each is a small PR **branched from `2.0`** (not from a feature branch) with its
-own tests; each lands an entry in `2_0_breaking_changes.md`.
+own tests; each lands an entry in `2_0_breaking_changes.md`. After Slice 4, the
+cumulative capstone review runs per `2_0_prerelease_review_plan.md`.

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,6 +3,46 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
+_Last updated: 2026-07-09 (**Compat & utilities — Slices 0/1/2 MERGED into `2.0`;
+pre-release review plan written**). Working through the compat & utilities
+initiative (`development/2_0_compat_and_utilities_design.md`, the last substantive
+code work before release). **Merged this session:** **#1139** Slice 1 (theme compat
+— `theme_use` on a legacy (pre-2.0) name no longer hard-stops; it lazily
+adapts+registers that one theme via `theme_from_legacy_dict`→`register_theme`,
+warns once per name, and builds it — so `Window(themename="darkly")` works again;
+`install_legacy_themes()` stays the bulk register); **#1140** Slice 2 (naming —
+`App` is now the canonical root class, `Window = App` a permanent non-deprecated
+alias; `theme` canonical on `App`/`Window`/`Style` ctors with `themename` a
+permanent alias; `theme_use`/`theme_create` keep Tk's `themename`; full source
+docstring/example/error-message sweep to the canonical names per author request);
+**#1141** Slice 0 (utilities — new first-class `ttkbootstrap.utils` package:
+`color.py`←colorutils, `scaling.py`+`platform.py`←utility; old `utility`/`colorutils`
+modules become warn-and-forward shims like `publisher.py`; all first-party callers
+migrated so import stays warning-free; a high-effort `/code-review` caught one
+low-sev gap — `utils` didn't re-export the color-model constants — fixed in the
+same PR). Expected suite on `2.0` ~**505 passed** excl. the two known flakes
+(`nl.msg` localization env flake + the order-dependent `test_color_helpers`
+*Duplicate element TSpinbox.uparrow*, which is a real theme-rebuild bug, not
+noise). Every slice: branch from `2.0` → PR → author merge (one in flight), entry
+in `2_0_breaking_changes.md`, migration-guide touch-ups.
+
+**>>> NEXT-SESSION PICKUP:** finish the remaining compat & utilities slices in the
+design's order — **Slice 5** (deferred-config pending-apply seam; enables 3 & 4) →
+**Slice 3** (localization: msgcat `tk.call` fixes + `L()`/`LocaleVar` +
+`<<LocaleChanged>>`) → **Slice 4** (typography: a `Fonts` utility over the standard
+Tk named fonts). Slices 3/4/5 are **born into `utils/`**. **THEN**, as the capstone
+before an RC, run the cumulative pre-release review per the new
+**`development/2_0_prerelease_review_plan.md`** (Track A agentic `2.0…master` sweep
+· Track B human visual/cross-platform · Track C migration-contract validation +
+green-suite / install-smoke gates). Decision (author, 2026-07-09): **continue the
+initiative, run the full review at the end**, not now.
+
+**Env note (unchanged):** repo `.venv` fails to launch on this box (exit 127); use
+`.venv-home/Scripts/python.exe` for python/pytest (run with `-p no:cacheprovider`).
+Leave the user's `gallery/` WIP untouched.
+
+Prior entry (2026-07-08) follows._
+
 _Last updated: 2026-07-08 (**Remaining shipped-widget API review — COMPLETE; the
 whole widget-review series (PRs 0–7) is MERGED into `2.0`**). The all-widgets API
 review (design + all forks in `development/2_0_widget_api_review_design.md`) is

--- a/development/2_0_prerelease_review_plan.md
+++ b/development/2_0_prerelease_review_plan.md
@@ -1,0 +1,126 @@
+# ttkbootstrap 2.0 — pre-release review plan
+
+> The capstone review before tagging a 2.0 RC. Per-PR review (design pass →
+> fork → diff review → suite) caught issues *inside* each slice; this plan
+> covers what no single PR review ever saw: the **cumulative `2.0…master`
+> delta as a whole**, the seams between PRs, and the things that predate the
+> review discipline. Living checklist — tick items as they close.
+
+## When this runs
+
+**At the end of the compat & utilities initiative, not before.** Slices 5/3/4
+are still to land (`2_0_compat_and_utilities_design.md`); running the cumulative
+sweep now would only have to be redone against the final tree. The design doc
+calls these slices "the last substantive code work before release," so this
+review is the natural capstone once they're merged. (Individual items the author
+flags in the meantime still get normal per-PR review.)
+
+## Why a cumulative pass is needed
+
+Two properties of 2.0 drive the whole strategy:
+
+1. **A large share of the changes are structurally invisible to the headless
+   suite** — window/positioning/aqua/win32 chrome, DPI scaling, and the visual
+   restyles (buttons, scrollbars, inputs, icons, themes). Green CI says nothing
+   about whether they *look* right or work off-Windows.
+2. **It's a breaking release with a migration contract.** `2_0_breaking_changes.md`
+   / the *Migrating to 2.0* guide must match the actual public-API delta in both
+   directions, or users hit undocumented breaks (or chase documented ones that
+   don't exist).
+
+## The three tracks
+
+### Track A — agentic correctness + API sweep (automatable)
+
+Fan out over the cumulative `2.0…master` diff, **decomposed by subsystem** so
+each agent holds one area in context. Adversarially verify every candidate;
+triage into *release-blocker* vs *post-release*.
+
+Subsystem partition (one finder cluster each):
+- style engine / theme-walk / image cache / singleton lifecycle
+- bootstyle grammar + `_compat` normalization/strictness
+- widgets (`widgets/` — the ConfigureDelegationMixin family)
+- dialogs (`dialogs/` — Messagebox/Querybox/pickers)
+- window / Toplevel / `internal/positioning`
+- themes / anchor model / legacy adapter / `utils/`
+- the deprecation-shim surface (publisher, colorutils, utility, tableview et al.)
+
+Tooling: `/code-review ultra <2.0 branch>` (multi-agent cloud review of the
+branch) is purpose-built for this; a `Workflow` with the subsystem partition is
+the alternative when finer control is wanted. **Dry-run first** on the current
+branch to size the finding volume before the full pass.
+
+### Track B — human-gated visual + cross-platform (cannot be automated)
+
+The accumulated "owed visual gates" from the handoffs live here. No agent can
+close this.
+
+- **Platforms:** win32 (primary), plus macOS/aqua and Linux/x11 if reachable.
+- **Matrix:** light + dark, at 100 / 125 / 150 / 200 % DPI.
+- **Known-parked bug to close here:** `center_on_screen` negative-origin on a
+  multi-monitor layout (memory `center-on-screen-negative-origin-bug`; the
+  order-dependent `test_center_on_screen` failure is its headless shadow).
+- **Harness:** a single "everything-bagel" script that constructs one of every
+  widget + dialog so the eyeball pass is one window, not thirty. (`gallery/` and
+  `examples/` already have most of the pieces.)
+
+### Track C — migration-contract validation
+
+Mechanically diff the **public API surface** (`master` vs `2.0`) — exported
+names, class signatures, kwargs, return shapes — and reconcile against
+`2_0_breaking_changes.md`:
+- every real break is documented (no silent break), and
+- every documented break is real (no phantom entry).
+
+Gaps in either direction are findings. Doubles as QA for the Workstream-H docs
+rewrite (the guide is the docs' migration page).
+
+## Gates before tagging an RC
+
+- [ ] **Deterministically green suite.** Root-cause the two "flakes" rather than
+      wave them through: the `test_color_helpers` *Duplicate element
+      TSpinbox.uparrow* failure is a real order-dependent theme-rebuild bug, not
+      noise; confirm `nl.msg`/`zh_cn.msg` is genuinely env-only (Tcl can't read
+      the catalog) and not a real localization regression.
+- [ ] **Clean-env install smoke.** Build the wheel, `pip install` into a fresh
+      venv, import warning-free (`-W error::DeprecationWarning`), and construct
+      one of every widget/dialog. Catches missing package-data / subpackages
+      (assets globs don't recurse; the new `utils/` subpackage; icon font).
+- [ ] **Min-Python parse.** 3.10 grammar parse of all `src/` + PEP 649
+      annotation evaluation (the sweep the color PRs ran).
+- [ ] **Warning-free import** of `ttkbootstrap` and every submodule; the
+      deprecation shims warn *only* when the old path is actually used.
+- [ ] **Docs stubs.** The broken API `:::` stubs that crash mkdocstrings are
+      release-blocking (Workstream H §11).
+
+## Sequencing
+
+```
+finish Slices 5 → 3 → 4   (normal per-PR review)
+      │
+      ▼
+freeze cleanup work
+      │
+      ▼
+Track A agentic sweep  ──►  triage: release-blocker vs post-release
+      │
+      ▼
+Track B human visual / cross-platform passes
+      │
+      ▼
+fix release-blockers only  ──►  green suite + install smoke
+      │
+      ▼
+tag RC  ──►  Workstream H docs  ──►  final release
+```
+
+## Known latent items already logged (feed the triage)
+
+- `test_color_helpers` order-dependent *Duplicate element TSpinbox.uparrow*
+  (theme-rebuild path) — real bug, currently reads as a flake.
+- `center_on_screen` negative-origin multi-monitor bug (parked from PR B).
+- `colorutils`/`utils.color` `color_to_rgb` swallows errors with a bare
+  `except: print('this')` — behavior-preserving-move wart, worth fixing pre-3.0.
+- Cross-platform gates owed but never eyeballed: win32 AppUserModelID/taskbar
+  icon, aqua `overrideredirect`/`MacWindowStyle` popups, multi-monitor centering.
+- Docs Workstream H: nav/IA skeleton + un-break the API `:::` stubs.


### PR DESCRIPTION
Planning/tracking update — no code changes.

## What
- **New `development/2_0_prerelease_review_plan.md`** — the capstone cumulative review to run once the compat & utilities initiative finishes. Three tracks:
  - **Track A** — agentic correctness + API sweep over the whole `2.0…master` delta, decomposed by subsystem (the seams no per-PR review saw). `/code-review ultra <2.0 branch>` or a Workflow.
  - **Track B** — human-gated visual + cross-platform (win32/aqua/x11, light+dark, 100–200% DPI) — the part CI structurally can't see; folds in the owed visual gates + the parked `center_on_screen` multi-monitor bug.
  - **Track C** — migration-contract validation: mechanical public-API delta reconciled against `2_0_breaking_changes.md`, both directions.
  - Plus RC gates: deterministically-green suite (root-cause the `test_color_helpers` *Duplicate element TSpinbox.uparrow* order-dependent bug), clean-env wheel install smoke, warning-free import, docs stubs.
- **Handoff + CLAUDE.md + compat design doc** updated to record Slices 0/1/2 merged (#1141/#1139/#1140) and the remaining order (5 → 3 → 4).

## Decision captured
Continue the compat & utilities initiative and run the full cumulative review **at the end**, not per-item — individual flagged items still get normal per-PR review.

Leaves the author's `gallery/` WIP untouched.