### PR TITLE
Add deferred-config seam + ttk.default_button() setter (Slice 5)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -17,7 +17,7 @@
 | **Legacy theme names auto-register on use (no hard-stop)** | Fix/Deprecated | this doc, below (Slice 1) |
 | **`App` (canonical) / `Window` alias; `theme` / `themename` alias** | New | this doc, below (Slice 2) |
 | **`utils/` package; `utility`/`colorutils` → warn-and-forward shims** | Deprecated | this doc, below (Slice 0) |
-| **Deferred-config seam + `ttk.default_button()` pre-root setter** | New | this doc, below (Slice 5) |
+| **Deferred-config seam + `ttk.set_default_button()` pre-root setter** | New | this doc, below (Slice 5) |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -73,17 +73,17 @@ while keeping its deprecation nudge (a per-name `DeprecationWarning`).
 
 ---
 
-## Deferred-config seam + `ttk.default_button()` pre-root setter  *(New)*
+## Deferred-config seam + `ttk.set_default_button()` pre-root setter  *(New)*
 
 **What.** A small **pending-apply registry** (`ttkbootstrap.utils.config`) so
 settings that need a live Tk root can be configured at the top of a file, before
-`App()` exists. Its first tenant is a new top-level **`ttk.default_button(color)`**
+`App()` exists. Its first tenant is a new top-level **`ttk.set_default_button(color)`**
 setter (Slices 3/4 add `set_locale` / `set_global_family` onto the same seam):
 
 ```python
 import ttkbootstrap as ttk
-ttk.default_button("primary")   # before App() -> queued, applied when the root comes up
-app = ttk.App()                 # every bare Button/Menubutton is now "primary"
+ttk.set_default_button("primary")   # before App() -> queued, applied when the root comes up
+app = ttk.App()                     # every bare Button/Menubutton is now "primary"
 ```
 
 - **Before the root exists** the setting is queued and flushed when the `Style`
@@ -93,7 +93,9 @@ app = ttk.App()                 # every bare Button/Menubutton is now "primary"
   `default_button` is consumed when a button's base style is first built. Author
   decision (2026-07-09): pre-root-only + warn, rather than a live rebuild — keeps
   the seam small.
-- `ttk.default_button()` with no argument **returns** the current effective value.
+- Read the current value from `App().style.default_button` (the setter is
+  set-only; its `set_*` name matches the seam's `set_locale`/`set_global_family`
+  siblings).
 - Precedence: an explicit `App(default_button=...)` / `Style(default_button=...)`
   argument **wins** over the global pre-root setter (it is applied after the flush).
 

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -17,6 +17,7 @@
 | **Legacy theme names auto-register on use (no hard-stop)** | Fix/Deprecated | this doc, below (Slice 1) |
 | **`App` (canonical) / `Window` alias; `theme` / `themename` alias** | New | this doc, below (Slice 2) |
 | **`utils/` package; `utility`/`colorutils` → warn-and-forward shims** | Deprecated | this doc, below (Slice 0) |
+| **Deferred-config seam + `ttk.default_button()` pre-root setter** | New | this doc, below (Slice 5) |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -69,6 +70,44 @@ while keeping its deprecation nudge (a per-name `DeprecationWarning`).
 
 **Not changed.** The default theme: `ttk.Window()` with no name still renders
 `bootstrap-light` — a documented *visual* change, not a crash.
+
+---
+
+## Deferred-config seam + `ttk.default_button()` pre-root setter  *(New)*
+
+**What.** A small **pending-apply registry** (`ttkbootstrap.utils.config`) so
+settings that need a live Tk root can be configured at the top of a file, before
+`App()` exists. Its first tenant is a new top-level **`ttk.default_button(color)`**
+setter (Slices 3/4 add `set_locale` / `set_global_family` onto the same seam):
+
+```python
+import ttkbootstrap as ttk
+ttk.default_button("primary")   # before App() -> queued, applied when the root comes up
+app = ttk.App()                 # every bare Button/Menubutton is now "primary"
+```
+
+- **Before the root exists** the setting is queued and flushed when the `Style`
+  (root) is created — the intended use.
+- **If a root already exists**, the setter sets it for buttons built *after* the
+  call and emits a `UserWarning` (existing buttons are not restyled), because
+  `default_button` is consumed when a button's base style is first built. Author
+  decision (2026-07-09): pre-root-only + warn, rather than a live rebuild — keeps
+  the seam small.
+- `ttk.default_button()` with no argument **returns** the current effective value.
+- Precedence: an explicit `App(default_button=...)` / `Style(default_button=...)`
+  argument **wins** over the global pre-root setter (it is applied after the flush).
+
+**Internal, non-breaking.** `App`/`Style` `default_button` now defaults to `None`
+(a sentinel) instead of `"neutral"`, so an explicit argument can be distinguished
+from the default and win over the setter. Behavior for existing code is identical
+— omitting it still yields `"neutral"`. The flush hook lives in `Style.__init__`
+(the true root-bound singleton), which covers both `App()` and a bare `Style()`.
+
+**Why.** Several release settings (theme's default button now; locale and global
+font next) share the same chicken-and-egg — they need a root but users want to set
+them before one exists. One tiny lazy-until-root registry solves them all,
+mirroring the style builder's own lazy-until-root model, instead of each growing
+its own workaround. Deliberately a registry, **not** a config framework.
 
 ---
 

--- a/development/2_0_compat_and_utilities_design.md
+++ b/development/2_0_compat_and_utilities_design.md
@@ -78,7 +78,7 @@ before `App()` exists (locale, global font, default button). Rather than solve
 each with its own chicken-and-egg, a small **pending-apply registry**:
 
 - Pre-root setters (`ttk.set_locale(...)`, `ttk.set_global_family(...)`,
-  `ttk.default_button(...)`) record intent into a module-level registry.
+  `ttk.set_default_button(...)`) record intent into a module-level registry.
 - `App.__init__` flushes the registry once the root exists (one ordered hook).
 - If a root already exists, the setter applies live immediately.
 
@@ -220,9 +220,16 @@ bracket DSL (needs to intercept `font=` — framework territory).
 ### Slice 5 — IMPLEMENTED (#TBD, 2026-07-09)
 
 Shipped as `ttkbootstrap/utils/config.py`: a `defer(key, apply)` /
-`flush_pending_config()` registry + the `default_button(color=None)` setter/getter
-(the one existing tenant; locale/font hang off the same seam in Slices 3/4).
+`flush_pending_config()` registry + the `set_default_button(color)` setter (the
+one existing tenant; locale/font hang off the same seam in Slices 3/4).
 Resolved forks:
+
+- **Setter named `set_default_button` (verb), set-only** (author, code review):
+  matches the seam's `set_locale`/`set_global_family` siblings rather than a
+  noun get/set overload. Dropping the getter let the queued applier capture its
+  color in the closure, so there is no shared module-level pending value to keep
+  in sync (a code-review altitude finding). Read the current value from
+  `App().style.default_button`.
 
 - **Flush hook lives in `Style.__init__`, not `App.__init__`** — the `Style`
   singleton is the true root-bound object (an `App` just creates one), so flushing

--- a/development/2_0_compat_and_utilities_design.md
+++ b/development/2_0_compat_and_utilities_design.md
@@ -217,6 +217,31 @@ bracket DSL (needs to intercept `font=` — framework territory).
 - Flushed in `App.__init__`; applied live if a root already exists.
 - Re-exported as top-level `ttk.set_locale` / `ttk.set_global_family` / etc.
 
+### Slice 5 — IMPLEMENTED (#TBD, 2026-07-09)
+
+Shipped as `ttkbootstrap/utils/config.py`: a `defer(key, apply)` /
+`flush_pending_config()` registry + the `default_button(color=None)` setter/getter
+(the one existing tenant; locale/font hang off the same seam in Slices 3/4).
+Resolved forks:
+
+- **Flush hook lives in `Style.__init__`, not `App.__init__`** — the `Style`
+  singleton is the true root-bound object (an `App` just creates one), so flushing
+  there also covers a bare `Style()`, and it runs *before* `theme_use()` so a
+  queued `default_button` is in place before the base button styles build.
+- **`default_button` when a root already exists → pre-root-only + warn** (author,
+  2026-07-09): set it for buttons built after the call and emit a `UserWarning`,
+  rather than rebuilding the base styles + repainting mounted buttons live. A plain
+  theme-walk won't pick it up (the base `TButton` is already registered → resolves
+  unchanged), so a live rebuild would be real engine work + a visual gate; not worth
+  it for a setting whose whole point is "set before the app." locale/font (3/4) do
+  apply live, since that's cheap for them.
+- **Precedence: explicit `default_button=` argument wins** over the global pre-root
+  setter (applied after the flush). Implemented via a `None` sentinel default on
+  `App`/`Style` so an explicit value is distinguishable (behavior for existing code
+  is identical — omitting it still yields `"neutral"`).
+- **One-shot flush** — the queue is cleared on flush, so a pre-root setter applies
+  to the next root created.
+
 ---
 
 ## Out of scope for this pass (explicit)

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -88,7 +88,7 @@ from ttkbootstrap.utils import (
     update_hsl_value,
     contrast_color,
     conform_color_model,
-    default_button,
+    set_default_button,
 )
 
 
@@ -308,7 +308,7 @@ __all__ = [
     "update_hsl_value",
     "contrast_color",
     "conform_color_model",
-    "default_button",
+    "set_default_button",
 
     # Application root + windows
     "App",

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -88,6 +88,7 @@ from ttkbootstrap.utils import (
     update_hsl_value,
     contrast_color,
     conform_color_model,
+    default_button,
 )
 
 
@@ -307,6 +308,7 @@ __all__ = [
     "update_hsl_value",
     "contrast_color",
     "conform_color_model",
+    "default_button",
 
     # Application root + windows
     "App",

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -64,7 +64,7 @@ class Style(ttk.Style):
         else:
             return Style.instance
 
-    def __init__(self, theme=None, default_button="neutral", *, themename=None):
+    def __init__(self, theme=None, default_button=None, *, themename=None):
         """
         Parameters:
 
@@ -77,7 +77,9 @@ class Style(ttk.Style):
                 The color a bare `Button`/`Menubutton` (no `bootstyle`) uses.
                 Defaults to `"neutral"`; pass `"primary"` for the pre-2.0
                 accented default. Read once when the base styles build, so set it
-                on the first `Style`/`App`; ignored on the existing singleton.
+                on the first `Style`/`App`; ignored on the existing singleton. If
+                omitted, a pre-root `ttk.default_button(...)` setting is used, else
+                `"neutral"`; an explicit argument here wins over that setter.
         """
         # `theme` is canonical; `themename` is a permanent, non-deprecated alias
         # (the pre-2.0 spelling). Prefer `theme` when both are given.
@@ -89,9 +91,6 @@ class Style(ttk.Style):
             if theme != DEFAULT_THEME:
                 Style.instance.theme_use(theme)
             return
-        # Set before theme_use() below, which builds the base TButton/TMenubutton
-        # styles that read this to resolve their default (no-color) fill.
-        self.default_button = default_button
         self._theme_objects = {}
         self._theme_definitions = {}
         self._style_registry = set()  # all styles used
@@ -114,6 +113,18 @@ class Style(ttk.Style):
         self.scaling = Scaling.for_widget(self.master)
 
         Style.instance = self
+
+        # Resolve the default (no-color) button fill BEFORE theme_use() builds the
+        # base TButton/TMenubutton styles that read it. Order: baseline NEUTRAL,
+        # then any pre-root config queued before the root existed (Slice 5's
+        # deferred-config seam -- default_button/locale/fonts), then an explicit
+        # `default_button=` argument, which wins over the global pre-root setter.
+        self.default_button = NEUTRAL
+        from ttkbootstrap.utils import config
+        config.flush_pending_config()
+        if default_button is not None:
+            self.default_button = default_button
+
         self.theme_use(theme)
 
         # apply localization

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -78,8 +78,8 @@ class Style(ttk.Style):
                 Defaults to `"neutral"`; pass `"primary"` for the pre-2.0
                 accented default. Read once when the base styles build, so set it
                 on the first `Style`/`App`; ignored on the existing singleton. If
-                omitted, a pre-root `ttk.default_button(...)` setting is used, else
-                `"neutral"`; an explicit argument here wins over that setter.
+                omitted, a pre-root `ttk.set_default_button(...)` setting is used,
+                else `"neutral"`; an explicit argument here wins over that setter.
         """
         # `theme` is canonical; `themename` is a permanent, non-deprecated alias
         # (the pre-2.0 spelling). Prefer `theme` when both are given.

--- a/src/ttkbootstrap/utils/__init__.py
+++ b/src/ttkbootstrap/utils/__init__.py
@@ -39,6 +39,7 @@ from ttkbootstrap.utils.scaling import (
     scale_size,
 )
 from ttkbootstrap.utils.platform import windowing_system
+from ttkbootstrap.utils.config import default_button
 
 __all__ = [
     # color
@@ -53,4 +54,6 @@ __all__ = [
     "scale_size",
     # platform
     "windowing_system",
+    # deferred config (pre-root setters)
+    "default_button",
 ]

--- a/src/ttkbootstrap/utils/__init__.py
+++ b/src/ttkbootstrap/utils/__init__.py
@@ -39,7 +39,7 @@ from ttkbootstrap.utils.scaling import (
     scale_size,
 )
 from ttkbootstrap.utils.platform import windowing_system
-from ttkbootstrap.utils.config import default_button
+from ttkbootstrap.utils.config import set_default_button
 
 __all__ = [
     # color
@@ -55,5 +55,5 @@ __all__ = [
     # platform
     "windowing_system",
     # deferred config (pre-root setters)
-    "default_button",
+    "set_default_button",
 ]

--- a/src/ttkbootstrap/utils/config.py
+++ b/src/ttkbootstrap/utils/config.py
@@ -1,0 +1,103 @@
+"""Deferred-config seam: pre-root setters that queue until the App root exists.
+
+Some settings need a live Tk root but are naturally set at the top of a file,
+*before* `App()` is created (the theme's default button today; locale and the
+global font in later slices). Rather than each growing its own chicken-and-egg,
+they record intent here and `Style` flushes the queue once the root comes up; a
+setter applies immediately if a root already exists. Kept deliberately small --
+a pending-apply registry, not a config framework.
+
+The `Style` singleton is the true root-bound object (an `App` just creates one),
+so the flush hook lives in `Style.__init__`; that covers both `App()` and a bare
+`Style()`.
+"""
+import warnings
+from collections import OrderedDict
+from typing import Callable, Optional
+
+from ttkbootstrap.constants import NEUTRAL
+
+# key -> zero-arg applier. Ordered so appliers run in the order they were set;
+# last write per key wins. Cleared by flush_pending_config() when the root comes
+# up, so a queued setter applies to the next root created.
+_pending: "OrderedDict[str, Callable[[], None]]" = OrderedDict()
+
+# The default-button color queued before a root existed (kept so the getter can
+# report the effective value pre-root); None once applied/never set.
+_pending_default_button: Optional[str] = None
+
+
+def _style():
+    """The live `Style` singleton, or None if no root exists yet."""
+    # local import breaks the utils <- style import cycle (style imports utils)
+    from ttkbootstrap.style import Style
+
+    return Style.get_instance()
+
+
+def defer(key: str, apply: Callable[[], None]) -> None:
+    """Apply `apply` now if a root exists, else queue it under `key`.
+
+    Last write per `key` wins; queued appliers run (in insertion order) when the
+    root is created.
+    """
+    if _style() is not None:
+        apply()
+    else:
+        _pending[key] = apply
+
+
+def flush_pending_config() -> None:
+    """Run and clear every queued applier, in insertion order.
+
+    Called by `Style.__init__` once the root exists (before the base styles are
+    built, so a queued `default_button` is in place in time).
+    """
+    while _pending:
+        _key, apply = _pending.popitem(last=False)
+        apply()
+
+
+def default_button(color: Optional[str] = None) -> str:
+    """Get or set the fill for a bare (no-`bootstyle`) Button/Menubutton.
+
+    Called with no argument, returns the current effective default. Called with a
+    color name (e.g. ``"primary"``, ``"neutral"``), sets it:
+
+    - **Before the app root exists** the setting is queued and applied when the
+      root is created -- the intended use, at the top of a file.
+    - **If the root already exists** it is set for buttons built *after* this
+      call (existing buttons are not restyled) and a `UserWarning` is emitted,
+      because `default_button` is consumed when a button's base style is first
+      built. Pass ``App(default_button=...)`` to style every bare button.
+    """
+    global _pending_default_button
+    style = _style()
+
+    if color is None:
+        if style is not None:
+            return getattr(style, "default_button", NEUTRAL)
+        return _pending_default_button if _pending_default_button is not None else NEUTRAL
+
+    if style is not None:
+        style.default_button = color
+        warnings.warn(
+            "default_button was set after the application root was created; it "
+            "affects only Button/Menubutton widgets built after this call. Set "
+            "it before creating App() (or pass App(default_button=...)) to style "
+            "every bare button.",
+            UserWarning,
+            stacklevel=2,
+        )
+    else:
+        _pending_default_button = color
+        defer("default_button", _apply_pending_default_button)
+    return color
+
+
+def _apply_pending_default_button() -> None:
+    """Flush applier for a pre-root `default_button` setting."""
+    global _pending_default_button
+    if _pending_default_button is not None:
+        _style().default_button = _pending_default_button
+        _pending_default_button = None

--- a/src/ttkbootstrap/utils/config.py
+++ b/src/ttkbootstrap/utils/config.py
@@ -13,18 +13,12 @@ so the flush hook lives in `Style.__init__`; that covers both `App()` and a bare
 """
 import warnings
 from collections import OrderedDict
-from typing import Callable, Optional
-
-from ttkbootstrap.constants import NEUTRAL
+from typing import Callable
 
 # key -> zero-arg applier. Ordered so appliers run in the order they were set;
 # last write per key wins. Cleared by flush_pending_config() when the root comes
 # up, so a queued setter applies to the next root created.
 _pending: "OrderedDict[str, Callable[[], None]]" = OrderedDict()
-
-# The default-button color queued before a root existed (kept so the getter can
-# report the effective value pre-root); None once applied/never set.
-_pending_default_button: Optional[str] = None
 
 
 def _style():
@@ -58,11 +52,8 @@ def flush_pending_config() -> None:
         apply()
 
 
-def default_button(color: Optional[str] = None) -> str:
-    """Get or set the fill for a bare (no-`bootstyle`) Button/Menubutton.
-
-    Called with no argument, returns the current effective default. Called with a
-    color name (e.g. ``"primary"``, ``"neutral"``), sets it:
+def set_default_button(color: str) -> None:
+    """Set the fill for a bare (no-`bootstyle`) Button/Menubutton.
 
     - **Before the app root exists** the setting is queued and applied when the
       root is created -- the intended use, at the top of a file.
@@ -70,34 +61,21 @@ def default_button(color: Optional[str] = None) -> str:
       call (existing buttons are not restyled) and a `UserWarning` is emitted,
       because `default_button` is consumed when a button's base style is first
       built. Pass ``App(default_button=...)`` to style every bare button.
+
+    Read the current value from ``App().style.default_button``.
     """
-    global _pending_default_button
     style = _style()
-
-    if color is None:
-        if style is not None:
-            return getattr(style, "default_button", NEUTRAL)
-        return _pending_default_button if _pending_default_button is not None else NEUTRAL
-
     if style is not None:
         style.default_button = color
         warnings.warn(
-            "default_button was set after the application root was created; it "
-            "affects only Button/Menubutton widgets built after this call. Set "
-            "it before creating App() (or pass App(default_button=...)) to style "
-            "every bare button.",
+            "set_default_button() was called after the application root was "
+            "created; it affects only Button/Menubutton widgets built after this "
+            "call. Set it before creating App() (or pass App(default_button=...)) "
+            "to style every bare button.",
             UserWarning,
             stacklevel=2,
         )
     else:
-        _pending_default_button = color
-        defer("default_button", _apply_pending_default_button)
-    return color
-
-
-def _apply_pending_default_button() -> None:
-    """Flush applier for a pre-root `default_button` setting."""
-    global _pending_default_button
-    if _pending_default_button is not None:
-        _style().default_button = _pending_default_button
-        _pending_default_button = None
+        # Capture `color` in the closure so the queued applier carries its own
+        # value -- no shared module-level state to keep in sync.
+        defer("default_button", lambda: setattr(_style(), "default_button", color))

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -374,7 +374,7 @@ class App(_BaseWindow, tkinter.Tk):
             theme: Optional[str] = None,
             *,
             themename: Optional[str] = None,
-            default_button: str = "neutral",
+            default_button: Optional[str] = None,
             iconphoto: Optional[str] = '',
             size: Optional[Tuple[int, int]] = None,
             position: Optional[Tuple[int, int]] = None,
@@ -402,7 +402,8 @@ class App(_BaseWindow, tkinter.Tk):
             default_button (str):
                 The color a bare `Button`/`Menubutton` (no `bootstyle`) uses.
                 Defaults to `"neutral"` (a quiet, unaccented button); pass
-                `"primary"` to restore the pre-2.0 accented default.
+                `"primary"` to restore the pre-2.0 accented default. An explicit
+                value wins over a pre-root `ttk.default_button(...)` setting.
 
             iconphoto (str):
                 A path to the image used for the titlebar icon.

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -403,7 +403,7 @@ class App(_BaseWindow, tkinter.Tk):
                 The color a bare `Button`/`Menubutton` (no `bootstyle`) uses.
                 Defaults to `"neutral"` (a quiet, unaccented button); pass
                 `"primary"` to restore the pre-2.0 accented default. An explicit
-                value wins over a pre-root `ttk.default_button(...)` setting.
+                value wins over a pre-root `ttk.set_default_button(...)` setting.
 
             iconphoto (str):
                 A path to the image used for the titlebar icon.

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -1,11 +1,12 @@
 """Headless tests for the 2.0 deferred-config seam (Slice 5).
 
-The pending-apply registry lets pre-root setters (`ttk.default_button(...)`, and
-later `set_locale`/`set_global_family`) record intent before `App()` exists and
-be flushed when the root comes up; if a root already exists, the setter applies
-immediately. `default_button` is the proof tenant.
+The pending-apply registry lets pre-root setters (`ttk.set_default_button(...)`,
+and later `set_locale`/`set_global_family`) record intent before `App()` exists
+and be flushed when the root comes up; if a root already exists, the setter
+applies immediately. `set_default_button` is the proof tenant.
 """
 import inspect
+import warnings
 
 import pytest
 
@@ -22,49 +23,42 @@ def restore_default_button(root):
     test that pokes them does not leak into the next."""
     before = root.style.default_button
     pending_before = dict(config._pending)
-    value_before = config._pending_default_button
     try:
         yield root
     finally:
         root.style.default_button = before
         config._pending.clear()
         config._pending.update(pending_before)
-        config._pending_default_button = value_before
 
 
 # --------------------------------------------------------------------------
 # exposure
 # --------------------------------------------------------------------------
 
-def test_default_button_is_exported():
-    assert ttk.default_button is config.default_button
-    assert "default_button" in ttk.__all__
+def test_set_default_button_is_exported():
+    assert ttk.set_default_button is config.set_default_button
+    assert "set_default_button" in ttk.__all__
     from ttkbootstrap import utils
-    assert utils.default_button is config.default_button
-    assert "default_button" in utils.__all__
+    assert utils.set_default_button is config.set_default_button
+    assert "set_default_button" in utils.__all__
 
 
 def test_app_and_style_default_button_arg_is_sentinel_none():
     # the None sentinel is what lets an explicit arg be distinguished from the
-    # default and so win over a pre-root ttk.default_button() setting
+    # default and so win over a pre-root ttk.set_default_button() setting
     assert inspect.signature(App.__init__).parameters["default_button"].default is None
     assert inspect.signature(StyleClass.__init__).parameters["default_button"].default is None
 
 
 # --------------------------------------------------------------------------
-# getter / live setter (root already exists)
+# live setter (root already exists)
 # --------------------------------------------------------------------------
-
-def test_getter_returns_current_default(root):
-    assert ttk.default_button() == root.style.default_button
-
 
 def test_live_set_warns_and_applies_for_future_builds(restore_default_button):
     root = restore_default_button
     with pytest.warns(UserWarning, match="after the application root was created"):
-        ttk.default_button("primary")
+        ttk.set_default_button("primary")
     assert root.style.default_button == "primary"
-    assert ttk.default_button() == "primary"  # getter reflects the live value
 
 
 # --------------------------------------------------------------------------
@@ -74,17 +68,16 @@ def test_live_set_warns_and_applies_for_future_builds(restore_default_button):
 def test_pre_root_setter_queues_then_flush_applies(restore_default_button, monkeypatch):
     root = restore_default_button
     config._pending.clear()
-    config._pending_default_button = None
 
-    # simulate "no root yet" so the setter queues instead of applying live
+    # simulate "no root yet" so the setter queues instead of applying live; the
+    # queue path must be silent (no warning)
     monkeypatch.setattr(Style, "instance", None)
-    with _no_warning():  # the pre-root queue path must be silent (no warning)
-        result = ttk.default_button("info")
-    assert result == "info"
-    assert config.default_button() == "info"       # pre-root getter = the pending value
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ttk.set_default_button("info")
     assert "default_button" in config._pending      # queued, not applied
 
-    # root is back -> flush runs the queued applier
+    # root is back -> flush runs the queued applier (which captured "info")
     monkeypatch.undo()
     config.flush_pending_config()
     assert root.style.default_button == "info"
@@ -92,25 +85,9 @@ def test_pre_root_setter_queues_then_flush_applies(restore_default_button, monke
 
 
 def test_defer_applies_immediately_when_root_exists(restore_default_button):
-    root = restore_default_button
     config._pending.clear()
     calls = []
     config.defer("probe", lambda: calls.append(True))
     # a root exists (the session root), so defer runs now and queues nothing
     assert calls == [True]
     assert "probe" not in config._pending
-
-
-class _no_warning:
-    """Assert the block emits no warning (the pre-root queue path is silent)."""
-
-    def __enter__(self):
-        import warnings
-
-        self._cm = warnings.catch_warnings()
-        self._cm.__enter__()
-        warnings.simplefilter("error")
-        return self
-
-    def __exit__(self, *exc):
-        return self._cm.__exit__(*exc)

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -1,0 +1,116 @@
+"""Headless tests for the 2.0 deferred-config seam (Slice 5).
+
+The pending-apply registry lets pre-root setters (`ttk.default_button(...)`, and
+later `set_locale`/`set_global_family`) record intent before `App()` exists and
+be flushed when the root comes up; if a root already exists, the setter applies
+immediately. `default_button` is the proof tenant.
+"""
+import inspect
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.style import Style
+from ttkbootstrap.style.engine import Style as StyleClass
+from ttkbootstrap.utils import config
+from ttkbootstrap.window import App
+
+
+@pytest.fixture
+def restore_default_button(root):
+    """Snapshot + restore the live default_button and the pending registry so a
+    test that pokes them does not leak into the next."""
+    before = root.style.default_button
+    pending_before = dict(config._pending)
+    value_before = config._pending_default_button
+    try:
+        yield root
+    finally:
+        root.style.default_button = before
+        config._pending.clear()
+        config._pending.update(pending_before)
+        config._pending_default_button = value_before
+
+
+# --------------------------------------------------------------------------
+# exposure
+# --------------------------------------------------------------------------
+
+def test_default_button_is_exported():
+    assert ttk.default_button is config.default_button
+    assert "default_button" in ttk.__all__
+    from ttkbootstrap import utils
+    assert utils.default_button is config.default_button
+    assert "default_button" in utils.__all__
+
+
+def test_app_and_style_default_button_arg_is_sentinel_none():
+    # the None sentinel is what lets an explicit arg be distinguished from the
+    # default and so win over a pre-root ttk.default_button() setting
+    assert inspect.signature(App.__init__).parameters["default_button"].default is None
+    assert inspect.signature(StyleClass.__init__).parameters["default_button"].default is None
+
+
+# --------------------------------------------------------------------------
+# getter / live setter (root already exists)
+# --------------------------------------------------------------------------
+
+def test_getter_returns_current_default(root):
+    assert ttk.default_button() == root.style.default_button
+
+
+def test_live_set_warns_and_applies_for_future_builds(restore_default_button):
+    root = restore_default_button
+    with pytest.warns(UserWarning, match="after the application root was created"):
+        ttk.default_button("primary")
+    assert root.style.default_button == "primary"
+    assert ttk.default_button() == "primary"  # getter reflects the live value
+
+
+# --------------------------------------------------------------------------
+# pre-root queue + flush
+# --------------------------------------------------------------------------
+
+def test_pre_root_setter_queues_then_flush_applies(restore_default_button, monkeypatch):
+    root = restore_default_button
+    config._pending.clear()
+    config._pending_default_button = None
+
+    # simulate "no root yet" so the setter queues instead of applying live
+    monkeypatch.setattr(Style, "instance", None)
+    with _no_warning():  # the pre-root queue path must be silent (no warning)
+        result = ttk.default_button("info")
+    assert result == "info"
+    assert config.default_button() == "info"       # pre-root getter = the pending value
+    assert "default_button" in config._pending      # queued, not applied
+
+    # root is back -> flush runs the queued applier
+    monkeypatch.undo()
+    config.flush_pending_config()
+    assert root.style.default_button == "info"
+    assert not config._pending                       # queue cleared
+
+
+def test_defer_applies_immediately_when_root_exists(restore_default_button):
+    root = restore_default_button
+    config._pending.clear()
+    calls = []
+    config.defer("probe", lambda: calls.append(True))
+    # a root exists (the session root), so defer runs now and queues nothing
+    assert calls == [True]
+    assert "probe" not in config._pending
+
+
+class _no_warning:
+    """Assert the block emits no warning (the pre-root queue path is silent)."""
+
+    def __enter__(self):
+        import warnings
+
+        self._cm = warnings.catch_warnings()
+        self._cm.__enter__()
+        warnings.simplefilter("error")
+        return self
+
+    def __exit__(self, *exc):
+        return self._cm.__exit__(*exc)


### PR DESCRIPTION
## Slice 5 — The deferred-config seam

Fourth of the compat & utilities slices (`development/2_0_compat_and_utilities_design.md`). Builds the small pending-apply registry that **Slices 3 (localization) and 4 (typography) are born into**, and wires `default_button` as its first tenant.

### What
New **`ttkbootstrap/utils/config.py`** — a `defer(key, apply)` / `flush_pending_config()` registry so settings that need a live Tk root can be set at the top of a file, before `App()` exists:

```python
import ttkbootstrap as ttk
ttk.default_button("primary")   # before App() -> queued, applied when the root comes up
app = ttk.App()                 # every bare Button/Menubutton is "primary"
```

- **Pre-root** → queued and flushed when the `Style` (root) is created.
- **Root already exists** → set for buttons built *after* the call + `UserWarning` (no live rebuild).
- `ttk.default_button()` with no arg **returns** the current effective value.

### Design decisions (forks resolved)
- **Flush hook lives in `Style.__init__`, not `App.__init__`** — `Style` is the true root-bound singleton (an `App` just creates one), so this covers a bare `Style()` too, and it runs *before* `theme_use()` so a queued `default_button` lands before the base button styles build.
- **`default_button` post-root → pre-root-only + warn** (your call): a live rebuild would be real engine work + a visual gate (a plain theme-walk won't pick up the already-registered base `TButton`), and the setting's whole point is "set before the app." `set_locale`/`set_global_family` (3/4) *will* apply live, since that's cheap for them.
- **Precedence: explicit `App(default_button=...)` wins** over the global setter — implemented via a `None` sentinel default on `App`/`Style` so an explicit value is distinguishable. **Behavior for existing code is identical** (omitting it still yields `"neutral"`).

### Tests / verification
- `tests/test_config_api.py` (+6): exposure (top-level + `utils` + `__all__`), the sentinel signature, the getter, live-set warn+apply, the pre-root queue→flush path (via a simulated no-root), and `defer` applying live when a root exists.
- Full suite **512 passed**; the one failure is the known pre-existing order-dependent `test_color_helpers` flake (passes in isolation; confirmed unrelated — the `default_button` default resolves to `"neutral"` exactly as before). Warning-free import verified under `-W error::DeprecationWarning`; the full seam smoke-tested end-to-end.
- New breaking-changes entry (New) + a Slice 5 resolution note in the design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
