### PR TITLE
Localization: msgcat bug fixes + L()/LocaleVar/set_locale (Slice 3)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -18,6 +18,7 @@
 | **`App` (canonical) / `Window` alias; `theme` / `themename` alias** | New | this doc, below (Slice 2) |
 | **`utils/` package; `utility`/`colorutils` → warn-and-forward shims** | Deprecated | this doc, below (Slice 0) |
 | **Deferred-config seam + `ttk.set_default_button()` pre-root setter** | New | this doc, below (Slice 5) |
+| **Localization: msgcat bug fixes + `L()` / `LocaleVar` / `set_locale`** | Fix/New | this doc, below (Slice 3) |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -110,6 +111,62 @@ font next) share the same chicken-and-egg — they need a root but users want to
 them before one exists. One tiny lazy-until-root registry solves them all,
 mirroring the style builder's own lazy-until-root model, instead of each growing
 its own workaround. Deliberately a registry, **not** a config framework.
+
+---
+
+## Localization: msgcat bug fixes + `L()` / `LocaleVar` / `set_locale`  *(Fix + New)*
+
+**What.** The `MessageCatalog` msgcat wrapper (`localization/msgcat.py`) is fixed
+and given three ergonomic helpers, all dependency-free.
+
+*Bug fixes (behavioral — correctness):*
+
+- **`tk.eval(f"…")` → `tk.call(…)`** across `translate`/`locale`/`set`/`set_many`/
+  `load`/`max`. The old hand-built command strings (`{%s}` brace-wrapping +
+  `.strip('"')`) mangled any source/argument containing `{ } [ ] $` or spaces;
+  `tk.call` passes each argument as a proper Tcl value (no quoting, no injection).
+  The private `__join` helper is gone. `translate`'s `%`-style format arguments are
+  unchanged (msgcat still applies them).
+- **`preferences()`** now returns every non-empty preference (`[p for p in items
+  if p]`) instead of slicing off the last item — that slice assumed a trailing
+  empty root locale that Tcl 8.7 no longer emits, silently dropping a real
+  preference.
+- **Locale normalization** (`normalize_locale`): `de-DE` / `pt_BR` → `de_de` /
+  `pt_br` on `locale()` / `set()` / `set_many()`, so `locale("de-DE")` reliably
+  matches the catalog.
+
+*New:*
+
+- **`<<LocaleChanged>>`** virtual event, emitted on the default root when
+  `locale(new)` sets a new locale — the runtime-relocalize hook ttkbootstrap
+  lacked.
+- **`ttk.L(src, *args, **kwargs)`** — the universal `_()` idiom: `translate(src)`
+  then Python `str.format`. Uses `{}` fields (sidesteps the Tcl `format` path);
+  resolved at call time.
+- **`ttk.LocaleVar`** — a `StringVar` that re-translates its source on
+  `<<LocaleChanged>>`; pass it as `textvariable=` to any (vanilla or themed)
+  widget for live language switching. `stop_tracking()` releases the binding.
+- **`ttk.set_locale(locale)`** — the pre-root locale setter, riding the Slice 5
+  deferred-config seam (queued before `App()`, applied live if a root exists).
+
+```python
+import ttkbootstrap as ttk
+ttk.set_locale("de")                       # before App() -> queued, applied at root
+app = ttk.App()
+label = ttk.Label(app, textvariable=ttk.LocaleVar(app, "Save"))  # live-translating
+ttk.set_locale("fr")                       # label re-translates itself
+```
+
+All three helpers are re-exported at the top level (`ttk.L` / `ttk.LocaleVar` /
+`ttk.set_locale`) and through `ttkbootstrap.utils`; `ttkbootstrap.localization`
+stays the canonical home.
+
+**Why.** i18n was quietly buggy for any non-ASCII-simple message, and there was
+no supported way to switch languages at runtime or to write the `_()`-style call
+every i18n app expects. The spec-object model and Babel-backed value formatting
+(`LV`) are intentionally **out** — they need a widget mixin / a new dependency
+(framework territory); the helpers here work on **vanilla** widgets via
+tkinter's own variable + virtual-event seams.
 
 ---
 

--- a/development/2_0_compat_and_utilities_design.md
+++ b/development/2_0_compat_and_utilities_design.md
@@ -199,8 +199,13 @@ fixing shared bugs and adding two ergonomic helpers, all dependency-free.
   `ttkbootstrap.utils` (lazily via module `__getattr__`, so importing `utils`
   during style-package init does not pull in the `localization → window` chain
   before `window` is ready), and at the top level (`ttk.L` / `ttk.LocaleVar` /
-  `ttk.set_locale`). `LocaleVar` binds on the root (not `bind_all`) so the
-  tracking binding is scoped and removable by funcid.
+  `ttk.set_locale`). All live `LocaleVar`s are driven by a **single**
+  `<<LocaleChanged>>` binding on the default root (where `locale()` fires the
+  event) via a module `WeakSet` -- not a per-var binding on the var's `master`
+  (which may be a child/Toplevel the root-generated event never reaches). Weak
+  refs mean a dropped `LocaleVar` is collected with no cleanup call; opting out
+  is just leaving the set (no per-var `unbind`, which mis-fires before Python
+  3.13 / Tk clobbers all bindings for the sequence).
 - **Tests**: `tests/localization/test_locale_helpers.py` (+17), using a throwaway
   `zz` locale so no bundled `.msg` is auto-loaded (never touches the
   environment-flaky `nl`). The existing `test_msgcat.py` format/escaping tests

--- a/development/2_0_compat_and_utilities_design.md
+++ b/development/2_0_compat_and_utilities_design.md
@@ -182,6 +182,30 @@ fixing shared bugs and adding two ergonomic helpers, all dependency-free.
   reuse the name `LV` for a variable (collides with bootstack's meaning); the
   live handle is `LocaleVar`.
 
+### Slice 3 — IMPLEMENTED (#TBD, 2026-07-09)
+
+- **msgcat bug fixes** (`localization/msgcat.py`): every command moved from
+  `tk.eval(f"…")` to `tk.call(…)` (`translate`/`locale`/`set`/`set_many`/`load`/
+  `max`), deleting `__join`; `translate`'s `%`-style args are preserved (msgcat
+  applies them). `preferences()` now keeps every non-empty entry. Added module
+  `normalize_locale()` (`-`→`_`, lowercase), applied on `locale`/`set`/`set_many`.
+- **`<<LocaleChanged>>`** emitted on the default root by `locale(new)` (constant
+  `LOCALE_CHANGED` in msgcat).
+- **Ergonomic helpers** born in `localization/api.py`: `L(src, *args, **kwargs)`
+  (translate + Python `str.format`), `LocaleVar(StringVar)` (re-translates on
+  `<<LocaleChanged>>`; `set_source()` / `stop_tracking()`), `set_locale(locale)`
+  (rides the Slice 5 seam via `config.defer("locale", …)`).
+- **Exposure**: re-exported from `localization/__init__.py`, surfaced through
+  `ttkbootstrap.utils` (lazily via module `__getattr__`, so importing `utils`
+  during style-package init does not pull in the `localization → window` chain
+  before `window` is ready), and at the top level (`ttk.L` / `ttk.LocaleVar` /
+  `ttk.set_locale`). `LocaleVar` binds on the root (not `bind_all`) so the
+  tracking binding is scoped and removable by funcid.
+- **Tests**: `tests/localization/test_locale_helpers.py` (+17), using a throwaway
+  `zz` locale so no bundled `.msg` is auto-loaded (never touches the
+  environment-flaky `nl`). The existing `test_msgcat.py` format/escaping tests
+  still pass unchanged, confirming the `tk.call` move is behavior-preserving.
+
 ## Slice 4 — Typography: a tiny `Fonts` utility over the standard Tk named fonts
 
 The FAQ ("how do I change the global font?") has no answer today — widgets read
@@ -274,9 +298,11 @@ Resolved forks:
    **DONE — #1140.**
 4. **Deferred-config seam** (Slice 5 core) — small, enables localization & typography.
 5. **Localization** (Slice 3) — msgcat fixes + `L()`/`LocaleVar` + event.
+   **DONE — #TBD.**
 6. **Typography** (Slice 4) — `Fonts` utility, wired through the seam.
 
-(Actual merge order was 1/2/0, all standalone; the remaining three are 5 → 3 → 4.)
+(Actual merge order was 1/2/0, all standalone; the remaining three are 5 → 3 → 4.
+Slice 5 and Slice 3 done; Slice 4 next.)
 
 Each is a small PR **branched from `2.0`** (not from a feature branch) with its
 own tests; each lands an entry in `2_0_breaking_changes.md`. After Slice 4, the

--- a/development/2_0_compat_and_utilities_design.md
+++ b/development/2_0_compat_and_utilities_design.md
@@ -182,7 +182,7 @@ fixing shared bugs and adding two ergonomic helpers, all dependency-free.
   reuse the name `LV` for a variable (collides with bootstack's meaning); the
   live handle is `LocaleVar`.
 
-### Slice 3 — IMPLEMENTED (#TBD, 2026-07-09)
+### Slice 3 — IMPLEMENTED (#1144, 2026-07-09)
 
 - **msgcat bug fixes** (`localization/msgcat.py`): every command moved from
   `tk.eval(f"…")` to `tk.call(…)` (`translate`/`locale`/`set`/`set_many`/`load`/
@@ -246,7 +246,7 @@ bracket DSL (needs to intercept `font=` — framework territory).
 - Flushed in `App.__init__`; applied live if a root already exists.
 - Re-exported as top-level `ttk.set_locale` / `ttk.set_global_family` / etc.
 
-### Slice 5 — IMPLEMENTED (#TBD, 2026-07-09)
+### Slice 5 — IMPLEMENTED (#1143, 2026-07-09)
 
 Shipped as `ttkbootstrap/utils/config.py`: a `defer(key, apply)` /
 `flush_pending_config()` registry + the `set_default_button(color)` setter (the
@@ -303,7 +303,7 @@ Resolved forks:
    **DONE — #1140.**
 4. **Deferred-config seam** (Slice 5 core) — small, enables localization & typography.
 5. **Localization** (Slice 3) — msgcat fixes + `L()`/`LocaleVar` + event.
-   **DONE — #TBD.**
+   **DONE — #1144.**
 6. **Typography** (Slice 4) — `Fonts` utility, wired through the seam.
 
 (Actual merge order was 1/2/0, all standalone; the remaining three are 5 → 3 → 4.

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -260,6 +260,12 @@ from ttkbootstrap.dialogs import (
     Querybox,
 )
 
+# Localization helpers re-exported at the top level (`ttk.L`, `ttk.set_locale`,
+# `ttk.LocaleVar`). Imported after `window` above so the localization -> window
+# import chain resolves cleanly. The `ttkbootstrap.localization` package remains
+# the canonical home / import path.
+from ttkbootstrap.localization import L, LocaleVar, set_locale
+
 __all__ = [
     # Tk exports
     "Tk", "Menu", "Text", "Canvas", "TkFrame", "TkLabel", "LabelFrame", "Variable", "StringVar", "IntVar", "BooleanVar",
@@ -309,6 +315,11 @@ __all__ = [
     "contrast_color",
     "conform_color_model",
     "set_default_button",
+
+    # Localization
+    "L",
+    "LocaleVar",
+    "set_locale",
 
     # Application root + windows
     "App",

--- a/src/ttkbootstrap/localization/__init__.py
+++ b/src/ttkbootstrap/localization/__init__.py
@@ -1,7 +1,12 @@
 """Localization package: msgcat-based message catalog and built-in locale data."""
 from ttkbootstrap.localization.msgs import initialize_localities
 from ttkbootstrap.localization.msgcat import MessageCatalog
+from ttkbootstrap.localization.api import L, LocaleVar, set_locale
 
-
-
-
+__all__ = [
+    "initialize_localities",
+    "MessageCatalog",
+    "L",
+    "LocaleVar",
+    "set_locale",
+]

--- a/src/ttkbootstrap/localization/api.py
+++ b/src/ttkbootstrap/localization/api.py
@@ -10,10 +10,31 @@ Three dependency-free conveniences on top of the msgcat engine:
   for live language switching on vanilla widgets via `textvariable=`.
 """
 import tkinter
+import weakref
 from typing import Any, Optional
 
 from ttkbootstrap.localization.msgcat import LOCALE_CHANGED, MessageCatalog
 from ttkbootstrap.window import get_default_root
+
+# Weak references to the live LocaleVars, plus the roots the dispatcher is bound
+# on. `tkinter.Variable` (and a `weakref.ref` to it) is unhashable, so the vars
+# are tracked in a dict keyed by id(); each ref's finalizer pops its entry, so a
+# dropped LocaleVar leaves the registry with no explicit unbind.
+_locale_var_refs: "dict[int, weakref.ref]" = {}
+_dispatch_roots: "weakref.WeakSet[tkinter.Misc]" = weakref.WeakSet()
+
+
+def _dispatch_locale_change(event: Optional[tkinter.Event] = None) -> None:
+    """Re-translate every live `LocaleVar` (one root binding drives them all)."""
+    for key, ref in list(_locale_var_refs.items()):
+        var = ref()
+        if var is None:
+            continue
+        try:
+            var._retranslate()
+        except tkinter.TclError:
+            # the var's interpreter is gone; drop it so we stop retrying
+            _locale_var_refs.pop(key, None)
 
 
 def set_locale(locale: str) -> None:
@@ -51,8 +72,11 @@ class LocaleVar(tkinter.StringVar):
     re-translates itself. Format args, if any, are applied with Python
     `str.format` (like `L`).
 
-    The variable tracks the locale for its whole lifetime. If it outlives the
-    widgets that use it, call `stop_tracking()` to release the binding.
+    Every live `LocaleVar` is driven by a single `<<LocaleChanged>>` binding on
+    the application root (where `locale()` generates the event), regardless of
+    the variable's own `master`. The registry holds only weak references, so a
+    dropped `LocaleVar` is collected without any cleanup call; use
+    `stop_tracking()` to opt one out explicitly while keeping it alive.
     """
 
     def __init__(
@@ -67,11 +91,19 @@ class LocaleVar(tkinter.StringVar):
         self._args = args
         self._kwargs = kwargs
         super().__init__(master, name=name)
-        # Bind on the root (where locale() generates the event) rather than
-        # bind_all, so the binding is scoped and removable by funcid.
-        self._root = master or get_default_root()
-        self._bind_id: Optional[str] = self._root.bind(
-            LOCALE_CHANGED, self._retranslate, add="+"
+        # Bind the shared dispatcher on the *default root* -- the widget on which
+        # locale() generates <<LocaleChanged>> -- not on `master`, which may be a
+        # child/Toplevel the event would never reach. One binding per root drives
+        # every registered var, so opting out is just leaving the WeakSet (no
+        # per-var unbind, which mis-fires across Tk/Python versions).
+        root = get_default_root()
+        if root not in _dispatch_roots:
+            root.bind(LOCALE_CHANGED, _dispatch_locale_change, add="+")
+            _dispatch_roots.add(root)
+        # ref finalizer pops the entry when this var is collected
+        self._key = id(self)
+        _locale_var_refs[self._key] = weakref.ref(
+            self, lambda _ref, key=self._key: _locale_var_refs.pop(key, None)
         )
         self._retranslate()
 
@@ -88,7 +120,7 @@ class LocaleVar(tkinter.StringVar):
         self._retranslate()
 
     def stop_tracking(self) -> None:
-        """Stop re-translating on `<<LocaleChanged>>` (releases the binding)."""
-        if self._bind_id is not None:
-            self._root.unbind(LOCALE_CHANGED, self._bind_id)
-            self._bind_id = None
+        """Stop re-translating on `<<LocaleChanged>>` (leaves it at its current
+        value). Also happens automatically when the variable is garbage-collected.
+        """
+        _locale_var_refs.pop(self._key, None)

--- a/src/ttkbootstrap/localization/api.py
+++ b/src/ttkbootstrap/localization/api.py
@@ -1,0 +1,94 @@
+"""Ergonomic localization helpers layered over `MessageCatalog`.
+
+Three dependency-free conveniences on top of the msgcat engine:
+
+- `set_locale(locale)` -- the pre-root locale setter (rides the deferred-config
+  seam, so it can be called at the top of a file before `App()` exists).
+- `L(src, *args, **kwargs)` -- the universal `_()` idiom: translate then
+  Python-`str.format`.
+- `LocaleVar` -- a `StringVar` that re-translates itself on `<<LocaleChanged>>`,
+  for live language switching on vanilla widgets via `textvariable=`.
+"""
+import tkinter
+from typing import Any, Optional
+
+from ttkbootstrap.localization.msgcat import LOCALE_CHANGED, MessageCatalog
+from ttkbootstrap.window import get_default_root
+
+
+def set_locale(locale: str) -> None:
+    """Set the application locale.
+
+    Called **before** `App()` exists, the locale is queued and applied when the
+    root is created (the intended top-of-file use). If a root already exists it
+    applies immediately, emitting `<<LocaleChanged>>` so live `LocaleVar`s
+    re-translate.
+    """
+    # local import breaks the localization <- utils.config <- style cycle; the
+    # seam applies now if a root exists, else queues under "locale".
+    from ttkbootstrap.utils import config
+
+    config.defer("locale", lambda: MessageCatalog.locale(locale))
+
+
+def L(src: str, *args: Any, **kwargs: Any) -> str:
+    """Translate `src` for the current locale, then Python-`str.format` it.
+
+    The universal i18n idiom (`_()`), resolved at call time -- correct for the
+    common "pick the locale at startup" case. Uses Python `str.format` (`{}` /
+    `{0}` / `{name}` fields), sidestepping the Tcl `format` path; for `%`-style
+    specifiers use `MessageCatalog.translate` instead.
+    """
+    return MessageCatalog.translate(src).format(*args, **kwargs)
+
+
+class LocaleVar(tkinter.StringVar):
+    """A `StringVar` that re-translates its source on `<<LocaleChanged>>`.
+
+    Hold a source string and show its translation for the current locale; pass
+    it as `textvariable=` to any (vanilla or themed) widget for live language
+    switching -- when `set_locale(...)` changes the locale, the variable
+    re-translates itself. Format args, if any, are applied with Python
+    `str.format` (like `L`).
+
+    The variable tracks the locale for its whole lifetime. If it outlives the
+    widgets that use it, call `stop_tracking()` to release the binding.
+    """
+
+    def __init__(
+        self,
+        master: Optional[tkinter.Misc] = None,
+        src: str = "",
+        *args: Any,
+        name: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        self._src = src
+        self._args = args
+        self._kwargs = kwargs
+        super().__init__(master, name=name)
+        # Bind on the root (where locale() generates the event) rather than
+        # bind_all, so the binding is scoped and removable by funcid.
+        self._root = master or get_default_root()
+        self._bind_id: Optional[str] = self._root.bind(
+            LOCALE_CHANGED, self._retranslate, add="+"
+        )
+        self._retranslate()
+
+    def _retranslate(self, event: Optional[tkinter.Event] = None) -> None:
+        self.set(
+            MessageCatalog.translate(self._src).format(*self._args, **self._kwargs)
+        )
+
+    def set_source(self, src: str, *args: Any, **kwargs: Any) -> None:
+        """Replace the source string (and any format args) and re-translate now."""
+        self._src = src
+        self._args = args
+        self._kwargs = kwargs
+        self._retranslate()
+
+    def stop_tracking(self) -> None:
+        """Stop re-translating on `<<LocaleChanged>>` (releases the binding)."""
+        if self._bind_id is not None:
+            self._root.unbind(LOCALE_CHANGED, self._bind_id)
+            self._bind_id = None

--- a/src/ttkbootstrap/localization/msgcat.py
+++ b/src/ttkbootstrap/localization/msgcat.py
@@ -3,28 +3,34 @@
 A Python interface to the Tcl/Tk msgcat system: translate UI text by the user's
 locale, set locale preferences, register per-language translations, and format
 translated messages. See https://www.tcl.tk/man/tcl/TclCmd/msgcat.html.
+
+All commands go through ``tk.call`` (not ``tk.eval`` with hand-built command
+strings): each argument is passed as a proper Tcl value, so source strings
+containing ``{ } [ ] $`` or spaces are handled without quoting tricks or
+injection risk.
 """
 from os import PathLike
 from typing import Any, Optional, Union
 
 from ttkbootstrap.window import get_default_root
 
+#: Virtual event fired on the default root when the locale changes, so live
+#: widgets (e.g. ``LocaleVar``) can re-translate themselves.
+LOCALE_CHANGED = "<<LocaleChanged>>"
+
+
+def normalize_locale(code: str) -> str:
+    """Canonicalize a locale code so it reliably matches msgcat's catalog.
+
+    msgcat matches locales case-insensitively using ``_`` as the region
+    separator; this maps the common ``de-DE`` / ``pt_BR`` variants onto that
+    canonical form (``de_de`` / ``pt_br``).
+    """
+    return str(code).replace("-", "_").lower()
+
 
 class MessageCatalog:
     """Static wrapper for the Tcl/Tk `::msgcat` message catalog commands."""
-
-    @staticmethod
-    def __join(*args: Any) -> str:
-        """Join multiple format arguments into a joined argument string."""
-        new_args = []
-        for arg in args:
-            if isinstance(arg, str):
-                # remove surrounding quotes
-                stripped = str(arg).strip('"')
-                new_args.append("{%s}" % stripped)
-            else:
-                new_args.append(str(arg))
-        return " ".join(new_args)
 
     @staticmethod
     def translate(src: str, *fmtargs: Any) -> str:
@@ -44,8 +50,10 @@ class MessageCatalog:
                 The string to be translated.
 
             *fmtargs (Any, optional):
-                Extra arguments passed internally to the
-                [format](https://www.tcl-lang.org/man/tcl/TclCmd/format.html) package.
+                Extra arguments passed internally to the Tcl
+                [format](https://www.tcl-lang.org/man/tcl/TclCmd/format.html)
+                command (msgcat applies `%`-style specifiers). For the Python
+                `str.format` idiom, use `L` instead.
 
         Returns:
 
@@ -53,11 +61,7 @@ class MessageCatalog:
                 The translated string.
         """
         root = get_default_root()
-
-        command = '::msgcat::mc {%s}' % src
-        if fmtargs:
-            command = f"{command} {MessageCatalog.__join(*fmtargs)}"
-        return root.tk.eval(command)
+        return root.tk.call("::msgcat::mc", src, *fmtargs)
 
     @staticmethod
     def locale(newlocale: Optional[str] = None) -> str:
@@ -65,6 +69,9 @@ class MessageCatalog:
         omitted, the current locale is returned, otherwise the current
         locale is set to newlocale. The initial locale defaults to the
         locale specified in the user's environment.
+
+        Setting a new locale emits a `<<LocaleChanged>>` virtual event on the
+        default root so live widgets can re-translate.
 
         Parameters:
 
@@ -79,8 +86,11 @@ class MessageCatalog:
                 string.
         """
         root = get_default_root()
-        command = "::msgcat::mclocale"
-        return root.tk.eval(f'{command} {newlocale or ""}')
+        if newlocale:
+            result = root.tk.call("::msgcat::mclocale", normalize_locale(newlocale))
+            root.event_generate(LOCALE_CHANGED, when="tail")
+            return result
+        return root.tk.call("::msgcat::mclocale")
 
     @staticmethod
     def preferences() -> list[str]:
@@ -95,12 +105,11 @@ class MessageCatalog:
                 Locales preferred by the user.
         """
         root = get_default_root()
-        command = "::msgcat::mcpreferences"
-        items = root.tk.eval(command).split(" ")
-        if len(items) > 0:
-            return items[0:-1]
-        else:
-            return []
+        items = root.tk.splitlist(root.tk.call("::msgcat::mcpreferences"))
+        # Keep every non-empty preference. Older code dropped the last item to
+        # skip a trailing empty root locale, but Tcl 8.7 no longer emits it, so
+        # that slice silently discarded a real preference.
+        return [p for p in items if p]
 
     @staticmethod
     def load(dirname: Union[str, PathLike[str]]) -> int:
@@ -123,8 +132,7 @@ class MessageCatalog:
         msgs = Path(dirname).as_posix()  # format path for tcl/tk
 
         root = get_default_root()
-        command = "::msgcat::mcload"
-        return int(root.tk.eval(f"{command} [list {msgs}]"))
+        return int(root.tk.call("::msgcat::mcload", msgs))
 
     @staticmethod
     def set(locale: str, src: str, translated: Optional[str] = None) -> None:
@@ -145,8 +153,7 @@ class MessageCatalog:
                 src is used.
         """
         root = get_default_root()
-        command = "::msgcat::mcset"
-        root.tk.eval('%s %s {%s} {%s}' % (command, locale, src, translated or ""))
+        root.tk.call("::msgcat::mcset", normalize_locale(locale), src, translated or "")
 
     @staticmethod
     def set_many(locale: str, *args: str) -> int:
@@ -168,10 +175,9 @@ class MessageCatalog:
                 The number of translation sets.
         """
         root = get_default_root()
-        command = "::msgcat::mcmset"
-        messages = " ".join(['{%s}' % x for x in args])
-        out = f"{command} {locale} {{{messages}}}"
-        return int(root.tk.eval(out))
+        # mcmset takes a single {src trans ...} list; passing the tuple lets
+        # Tkinter build a proper Tcl list (no manual brace-wrapping).
+        return int(root.tk.call("::msgcat::mcmset", normalize_locale(locale), args))
 
     @staticmethod
     def max(*src: str) -> int:
@@ -191,8 +197,7 @@ class MessageCatalog:
                 The length of the longest str.
         """
         root = get_default_root()
-        command = "::msgcat::mcmax"
-        return int(root.tk.eval(f'{command} {" ".join(src)}'))
+        return int(root.tk.call("::msgcat::mcmax", *src))
 
 
 if __name__ == "__main__":

--- a/src/ttkbootstrap/utils/__init__.py
+++ b/src/ttkbootstrap/utils/__init__.py
@@ -41,6 +41,22 @@ from ttkbootstrap.utils.scaling import (
 from ttkbootstrap.utils.platform import windowing_system
 from ttkbootstrap.utils.config import set_default_button
 
+# Localization helpers live in the `localization` package (the i18n engine stays
+# there); they are surfaced here for discoverability. Imported lazily via
+# module `__getattr__` so that importing `utils` -- which happens during style/
+# package init -- does not pull in the localization -> window import chain before
+# window is ready.
+_LOCALIZATION_EXPORTS = ("L", "LocaleVar", "set_locale")
+
+
+def __getattr__(name):
+    if name in _LOCALIZATION_EXPORTS:
+        from ttkbootstrap import localization
+
+        return getattr(localization, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     # color
     "color_to_rgb",
@@ -56,4 +72,8 @@ __all__ = [
     "windowing_system",
     # deferred config (pre-root setters)
     "set_default_button",
+    # localization (surfaced lazily from the localization package)
+    "L",
+    "LocaleVar",
+    "set_locale",
 ]

--- a/tests/localization/test_locale_helpers.py
+++ b/tests/localization/test_locale_helpers.py
@@ -131,6 +131,39 @@ def test_localevar_translates_on_locale_change(locale_reset):
     var.stop_tracking()
 
 
+def test_localevar_tracks_with_non_root_master(locale_reset):
+    # a LocaleVar whose master is a child widget (the natural `LocaleVar(self,
+    # ...)` inside a view) must still update: the event fires on the root, so the
+    # binding lives there, not on `master`.
+    root = locale_reset
+    frame = ttk.Frame(root)
+    MessageCatalog.set("zz", "Save", "Speichern")
+    MessageCatalog.locale("en")
+    var = LocaleVar(frame, "Save")
+    assert var.get() == "Save"
+    MessageCatalog.locale("zz")
+    root.update()
+    assert var.get() == "Speichern"
+    var.stop_tracking()
+
+
+def test_localevar_stop_tracking_is_isolated(locale_reset):
+    # stopping one var must not stop others (a per-var unbind by funcid would
+    # clobber every <<LocaleChanged>> binding before Python 3.13)
+    root = locale_reset
+    MessageCatalog.set("zz", "A", "Aa")
+    MessageCatalog.set("zz", "B", "Bb")
+    MessageCatalog.locale("en")
+    a = LocaleVar(root, "A")
+    b = LocaleVar(root, "B")
+    a.stop_tracking()
+    MessageCatalog.locale("zz")
+    root.update()
+    assert a.get() == "A"       # stopped
+    assert b.get() == "Bb"      # still tracking
+    b.stop_tracking()
+
+
 def test_localevar_stop_tracking_releases_binding(locale_reset):
     root = locale_reset
     MessageCatalog.set("zz", "Dog", "Hond")

--- a/tests/localization/test_locale_helpers.py
+++ b/tests/localization/test_locale_helpers.py
@@ -1,0 +1,172 @@
+"""Headless tests for the 2.0 localization slice (Slice 3).
+
+Covers the msgcat bug fixes (`tk.call` escaping, `preferences()` no-drop,
+locale normalization, the `<<LocaleChanged>>` event) and the ergonomic helpers
+(`L`, `LocaleVar`, `set_locale`). Uses a throwaway locale code (`zz`) so no
+bundled `.msg` catalog is auto-loaded -- in particular it never touches `nl`,
+whose Tk-packaged catalog is unreadable in this environment.
+"""
+import warnings
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap import localization
+from ttkbootstrap.localization import MessageCatalog, L, LocaleVar, set_locale
+from ttkbootstrap.localization.msgcat import normalize_locale
+from ttkbootstrap.style import Style
+from ttkbootstrap.utils import config
+
+
+@pytest.fixture
+def locale_reset(root):
+    """Snapshot + restore the active locale and pending config around a test."""
+    before = MessageCatalog.locale()
+    pending_before = dict(config._pending)
+    try:
+        yield root
+    finally:
+        MessageCatalog.locale(before or "en")
+        config._pending.clear()
+        config._pending.update(pending_before)
+
+
+# --------------------------------------------------------------------------
+# exposure
+# --------------------------------------------------------------------------
+
+def test_helpers_exported_at_top_level():
+    assert ttk.L is L
+    assert ttk.LocaleVar is LocaleVar
+    assert ttk.set_locale is set_locale
+    for name in ("L", "LocaleVar", "set_locale"):
+        assert name in ttk.__all__
+
+
+def test_helpers_exported_through_utils():
+    from ttkbootstrap import utils
+
+    assert utils.L is L
+    assert utils.set_locale is set_locale
+    assert utils.LocaleVar is LocaleVar
+    for name in ("L", "LocaleVar", "set_locale"):
+        assert name in utils.__all__
+
+
+# --------------------------------------------------------------------------
+# normalize_locale
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [("de-DE", "de_de"), ("pt_BR", "pt_br"), ("EN", "en"), ("zh_CN", "zh_cn")],
+)
+def test_normalize_locale(raw, expected):
+    assert normalize_locale(raw) == expected
+
+
+# --------------------------------------------------------------------------
+# msgcat bug fixes
+# --------------------------------------------------------------------------
+
+def test_translate_passes_special_chars_without_mangling(locale_reset):
+    # braces / brackets / dollar in an argument used to break the eval path
+    template = "value: '%s'"
+    assert MessageCatalog.translate(template, "[a] {b} $c") == "value: '[a] {b} $c'"
+
+
+def test_preferences_has_no_empty_entries(locale_reset):
+    prefs = MessageCatalog.preferences()
+    assert isinstance(prefs, list)
+    assert "" not in prefs
+
+
+def test_locale_normalizes_on_set(locale_reset):
+    # "ZZ" -> "zz"; a throwaway code so no bundled catalog is loaded
+    MessageCatalog.locale("ZZ")
+    assert MessageCatalog.locale() == "zz"
+
+
+def test_locale_change_emits_event(locale_reset):
+    root = locale_reset
+    root.update()  # drain any <<LocaleChanged>> events queued by prior teardowns
+    fired = []
+    funcid = root.bind("<<LocaleChanged>>", lambda e: fired.append(True), add="+")
+    try:
+        MessageCatalog.locale("zz")
+        root.update()
+        assert fired == [True]
+    finally:
+        root.unbind("<<LocaleChanged>>", funcid)
+
+
+# --------------------------------------------------------------------------
+# L()
+# --------------------------------------------------------------------------
+
+def test_L_translates_then_python_formats(locale_reset):
+    MessageCatalog.set("zz", "Hello, {}!", "Zzhello, {}!")
+    MessageCatalog.locale("zz")
+    assert L("Hello, {}!", "world") == "Zzhello, world!"
+
+
+def test_L_untranslated_falls_back_to_source(locale_reset):
+    MessageCatalog.locale("zz")
+    assert L("Untranslated {0}", "x") == "Untranslated x"
+
+
+# --------------------------------------------------------------------------
+# LocaleVar
+# --------------------------------------------------------------------------
+
+def test_localevar_translates_on_locale_change(locale_reset):
+    root = locale_reset
+    MessageCatalog.set("zz", "Cat", "Kat")
+    MessageCatalog.locale("en")
+    var = LocaleVar(root, "Cat")
+    assert var.get() == "Cat"          # english source, no translation
+    MessageCatalog.locale("zz")        # emits <<LocaleChanged>>
+    root.update()
+    assert var.get() == "Kat"          # var re-translated itself
+    var.stop_tracking()
+
+
+def test_localevar_stop_tracking_releases_binding(locale_reset):
+    root = locale_reset
+    MessageCatalog.set("zz", "Dog", "Hond")
+    MessageCatalog.locale("en")
+    var = LocaleVar(root, "Dog")
+    var.stop_tracking()
+    MessageCatalog.locale("zz")
+    root.update()
+    assert var.get() == "Dog"          # unchanged: no longer tracking
+
+
+def test_localevar_formats_args(locale_reset):
+    MessageCatalog.locale("en")
+    var = LocaleVar(None, "Count: {}", 3)
+    assert var.get() == "Count: 3"
+    var.stop_tracking()
+
+
+# --------------------------------------------------------------------------
+# set_locale (deferred-config seam)
+# --------------------------------------------------------------------------
+
+def test_set_locale_applies_live_when_root_exists(locale_reset):
+    set_locale("zz")
+    assert MessageCatalog.locale() == "zz"
+
+
+def test_set_locale_queues_before_root(locale_reset, monkeypatch):
+    config._pending.clear()
+    monkeypatch.setattr(Style, "instance", None)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")   # queue path must be silent
+        set_locale("zz")
+    assert "locale" in config._pending    # queued, not applied
+
+    monkeypatch.undo()
+    config.flush_pending_config()
+    assert MessageCatalog.locale() == "zz"
+    assert not config._pending


### PR DESCRIPTION
Slice 3 of the compat & utilities initiative (`development/2_0_compat_and_utilities_design.md`). Fixes the msgcat wrapper and adds three dependency-free ergonomic helpers, all working on **vanilla** tkinter widgets per the slice's boundary rule.

## Bug fixes — `localization/msgcat.py`
- **`tk.eval(f"…")` → `tk.call(…)`** across `translate`/`locale`/`set`/`set_many`/`load`/`max`. The old hand-built command strings (`{%s}` brace-wrapping + `.strip('"')`) mangled any source/argument containing `{ } [ ] $` or spaces; `tk.call` passes each arg as a proper Tcl value. Deleted `__join`. `translate`'s `%`-style format args are preserved (msgcat applies them).
- **`preferences()`** keeps every non-empty entry instead of slicing off the last — that trailing empty root locale is gone in Tcl 8.7, so the slice silently dropped a real preference.
- **`normalize_locale()`**: `de-DE` / `pt_BR` → `de_de` / `pt_br`, applied on `locale`/`set`/`set_many`.

## New
- **`<<LocaleChanged>>`** virtual event emitted on the root by `locale(new)`.
- **`ttk.L(src, *args, **kwargs)`** — translate + Python `str.format` (the `_()` idiom).
- **`ttk.LocaleVar`** — a `StringVar` that re-translates on `<<LocaleChanged>>` for live language switching via `textvariable=`.
- **`ttk.set_locale(locale)`** — pre-root setter riding the Slice 5 deferred-config seam.

Helpers born in `localization/api.py`, re-exported from `localization`, surfaced through `ttkbootstrap.utils` (lazily via `__getattr__` to avoid the `localization → window` import cycle during style-package init) and at the top level.

### `LocaleVar` mechanism
All live `LocaleVar`s are driven by a **single** `<<LocaleChanged>>` binding on the default root — the widget where `locale()` fires the event — via a module-level registry of weakly-referenced vars (an `id`-keyed dict, since `tkinter.Variable` is unhashable). This is deliberately **not** a per-var binding on the var's own `master`:
- a var's `master` may be a child/`Toplevel` the root-generated event never reaches, so a per-`master` binding silently fails to update;
- opting out (`stop_tracking()`) is just leaving the registry — no per-var `Misc.unbind(seq, funcid)`, which clobbers *all* bindings for the sequence before Python 3.13 (repo floor is 3.10);
- weak refs mean a dropped `LocaleVar` is collected with no cleanup call (no lifetime leak).

**Out** (fail the boundary rule): the spec-object `L()`, Babel `LV`, any new font/token vocabulary.

## Tests
`tests/localization/test_locale_helpers.py` (+19), using a throwaway `zz` locale so no bundled `.msg` autoloads (never touches the env-flaky `nl`) — including regressions for the non-root-master and `stop_tracking`-isolation cases. The existing `test_msgcat.py` format/escaping tests pass unchanged → the `tk.call` move is behavior-preserving. Full headless suite: 530 passed, with only the two documented pre-existing flakes (`nl.msg`, spinbox-element ordering), both confirmed failing identically on base `2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)