### PR TITLE
Typography: Fonts utility over the Tk named fonts (Slice 4)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -19,6 +19,7 @@
 | **`utils/` package; `utility`/`colorutils` → warn-and-forward shims** | Deprecated | this doc, below (Slice 0) |
 | **Deferred-config seam + `ttk.set_default_button()` pre-root setter** | New | this doc, below (Slice 5) |
 | **Localization: msgcat bug fixes + `L()` / `LocaleVar` / `set_locale`** | Fix/New | this doc, below (Slice 3) |
+| **Typography: `ttk.Fonts` + `ttk.set_global_family()` over the Tk named fonts** | New | this doc, below (Slice 4) |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -167,6 +168,50 @@ every i18n app expects. The spec-object model and Babel-backed value formatting
 (`LV`) are intentionally **out** — they need a widget mixin / a new dependency
 (framework territory); the helpers here work on **vanilla** widgets via
 tkinter's own variable + virtual-event seams.
+
+---
+
+## Typography: `ttk.Fonts` + `ttk.set_global_family()` over the Tk named fonts  *(New)*
+
+**What.** A tiny typography utility (`ttkbootstrap.utils.fonts`) over the
+**standard Tk named fonts** — the ones every interpreter ships (`TkDefaultFont`,
+`TkTextFont`, `TkFixedFont`, `TkHeadingFont`, `TkMenuFont`, `TkCaptionFont`,
+`TkSmallCaptionFont`, `TkIconFont`, `TkTooltipFont`). No new font vocabulary and
+no `font="body[bold]"` bracket DSL (both would need to intercept `font=` —
+framework territory).
+
+- **`ttk.set_global_family(family, *, mono_family=None)`** — the headline
+  one-liner: retint every proportional named font at once (and `TkFixedFont` from
+  `mono_family`). A **module-level** setter riding the Slice 5 deferred-config
+  seam, so it can be called at the top of a file before `App()` (queued, applied
+  when the root comes up) or live against an existing root.
+- **`ttk.Fonts`** — a namespace of classmethods operating on the *live* root:
+  `set_global_family` · `configure(name, **opts)` (tweak one named font) ·
+  `describe(name=None)` / `names()` (see the resolved family/size/weight/slant) ·
+  `create_alias(name, **opts)` (register a user named font, e.g. `font="Body"`) ·
+  `reset()` (drop cached wrappers — called from `App.destroy`, same root-rebind
+  hazard `Style` clears).
+
+```python
+import ttkbootstrap as ttk
+ttk.set_global_family("Inter", mono_family="Cascadia Code")  # before or after App()
+app = ttk.App()
+ttk.Fonts.configure("TkHeadingFont", size=18, weight="bold")
+ttk.Fonts.create_alias("Body", family="Inter", size=11)      # font="Body" everywhere
+print(ttk.Fonts.describe())                                  # {'TkDefaultFont': {...}, ...}
+```
+
+Re-exported at the top level (`ttk.Fonts` / `ttk.set_global_family`) and through
+`ttkbootstrap.utils`.
+
+**Why.** "How do I change the global font?" had no supported answer — widgets
+read `TkDefaultFont` / built ad-hoc `font.Font(...)` with no central control.
+The standard named fonts already exist in every interpreter, every widget reads
+them, and `font="TkHeadingFont"` works on stock tkinter widgets with zero
+interception — so retinting them is the whole-app font change, no widget
+ownership required. A parallel token set (`body` / `heading-lg`) would be
+overhead to document and sync for no payoff, and the bracket DSL fails the
+boundary rule.
 
 ---
 

--- a/development/2_0_compat_and_utilities_design.md
+++ b/development/2_0_compat_and_utilities_design.md
@@ -238,6 +238,41 @@ overhead to document and sync for no payoff.
 **Out.** The token scale as a *new vocabulary*, and the `font="body[bold]"`
 bracket DSL (needs to intercept `font=` — framework territory).
 
+### Slice 4 — IMPLEMENTED (2026-07-09)
+
+Shipped as `ttkbootstrap/utils/fonts.py`, mirroring the Slice 3/5 pattern (a live
+engine surface + a thin deferred-seam setter):
+
+- **`Fonts`** namespace class (live-root classmethods): `set_global_family(family,
+  *, mono_family=None)` retints the eight proportional standard named fonts
+  (`TkDefaultFont`/`TkTextFont`/`TkMenuFont`/`TkHeadingFont`/`TkCaptionFont`/
+  `TkSmallCaptionFont`/`TkIconFont`/`TkTooltipFont`), `TkFixedFont` only when
+  `mono_family` is given; `configure(name, **opts)`; `describe(name=None)` (resolved
+  `.actual()` specs — one font or all managed); `names()` (the managed set);
+  `create_alias(name, **opts)` (a user named font); `reset()` (clears the wrapper
+  cache). Fonts absent on a platform are skipped/guarded (`TclError`).
+- **Module-level `set_global_family(family, *, mono_family=None)`** — rides the
+  Slice 5 seam via `config.defer("global_family", …)`: queued before a root,
+  applied live if one exists. The deferred-seam sibling of `set_locale` /
+  `set_default_button`.
+- **Wrapper cache** (`_font_cache`, name→`font.Font`) with a `_tk`-identity
+  staleness guard, cleared by `Fonts.reset()` **wired into `App.destroy`** (the
+  same singleton/root-rebind hazard `Style` clears). `_named_font` imports `window`
+  function-locally so `utils/__init__` can import `fonts` eagerly without pulling
+  the `utils → window` chain during style-package init.
+- **Exposure**: re-exported from `utils/__init__` and top level
+  (`ttk.Fonts` / `ttk.set_global_family`).
+- **Decisions / deferrals**: kept a `Fonts` namespace class (like `MessageCatalog`)
+  + a module setter (like `set_locale`), rather than all-module-functions, so the
+  live surface reads as one thing. The **optional macOS pt→pixel size bump** and
+  platform-aware default families from the sketch were **dropped** for 2.0 — extra
+  per-platform surface for a "keep it tiny" utility; `set_global_family` covers the
+  actual FAQ. `reset()` was **kept** (the root-rebind hazard is real).
+- **Tests**: `tests/test_fonts_api.py` (+10), snapshotting/restoring the managed
+  named fonts (interpreter-global on the shared session root). Suite green: **539
+  passed** excl. the two known flakes (`nl.msg` env + the order-dependent
+  `test_color_helpers` *Duplicate element* rebuild bug); warning-free import.
+
 ## Slice 5 — The deferred-config seam
 
 (See "Cross-cutting" above.) The small pending-apply registry, wired to:
@@ -304,10 +339,11 @@ Resolved forks:
 4. **Deferred-config seam** (Slice 5 core) — small, enables localization & typography.
 5. **Localization** (Slice 3) — msgcat fixes + `L()`/`LocaleVar` + event.
    **DONE — #1144.**
-6. **Typography** (Slice 4) — `Fonts` utility, wired through the seam.
+6. **Typography** (Slice 4) — `Fonts` utility, wired through the seam. **DONE.**
 
-(Actual merge order was 1/2/0, all standalone; the remaining three are 5 → 3 → 4.
-Slice 5 and Slice 3 done; Slice 4 next.)
+(Actual merge order was 1/2/0, all standalone; the remaining three landed 5 → 3 →
+4. **All slices complete** — next is the cumulative capstone review per
+`2_0_prerelease_review_plan.md`.)
 
 Each is a small PR **branched from `2.0`** (not from a feature branch) with its
 own tests; each lands an entry in `2_0_breaking_changes.md`. After Slice 4, the

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,6 +3,27 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
+_Last updated: 2026-07-09 (**Compat & utilities — Slice 4 (typography) OPENED as
+#1145; the initiative's code work is now COMPLETE pending merge**). **Slice 4**
+adds `ttkbootstrap/utils/fonts.py` — a tiny surface over the standard Tk named
+fonts: module-level **`ttk.set_global_family(family, *, mono_family=None)`** (rides
+the Slice 5 deferred-config seam — queued before `App()`, live if a root exists),
+plus a **`ttk.Fonts`** namespace of live-root classmethods (`set_global_family` /
+`configure` / `describe` / `names` / `create_alias` / `reset`); `Fonts.reset()` is
+wired into `App.destroy` (root-rebind hazard). No new font vocabulary / no bracket
+DSL (boundary rule); the optional macOS size-bump + platform default families were
+dropped as scope creep. Re-exported top level + through `utils`. Mirrors the Slice
+3/5 shape. `tests/test_fonts_api.py` (+10); suite **539 passed** excl. the two known
+flakes (`nl.msg` env + order-dependent `test_color_helpers` *Duplicate element*);
+warning-free import. **PR #1145 against `2.0`, holding for author merge.** With 5→3→4
+done, **all compat & utilities slices are complete.** **>>> NEXT (author decision):
+the cumulative pre-release review** per `development/2_0_prerelease_review_plan.md`
+(Track A agentic `2.0…master` sweep · Track B human visual/cross-platform · Track C
+migration-contract validation), then docs Workstream H. Env: `.venv-home/Scripts/
+python.exe` launches on this box (repo `.venv` exits 127); run pytest with
+`-p no:cacheprovider`. Leave the user's `gallery/text_reader.py` WIP untouched (not
+staged). Prior entry follows._
+
 _Last updated: 2026-07-09 (**Compat & utilities — Slices 0/1/2 MERGED into `2.0`;
 pre-release review plan written**). Working through the compat & utilities
 initiative (`development/2_0_compat_and_utilities_design.md`, the last substantive

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -89,6 +89,8 @@ from ttkbootstrap.utils import (
     contrast_color,
     conform_color_model,
     set_default_button,
+    Fonts,
+    set_global_family,
 )
 
 
@@ -315,6 +317,8 @@ __all__ = [
     "contrast_color",
     "conform_color_model",
     "set_default_button",
+    "Fonts",
+    "set_global_family",
 
     # Localization
     "L",

--- a/src/ttkbootstrap/utils/__init__.py
+++ b/src/ttkbootstrap/utils/__init__.py
@@ -9,11 +9,12 @@ re-exported for `ttk.<tab>` discovery).
 
 Submodules:
     color     — color-model conversion and manipulation
+    fonts     — typography over the standard Tk named fonts
     scaling   — `enable_high_dpi_awareness`, `scale_size`
     platform  — `windowing_system`
+    config    — the deferred-config seam (pre-root setters)
 
-Later 2.0 slices add `fonts` (typography) and `config` (deferred-config seam)
-here, and re-export the `localization` helpers through this namespace.
+The `localization` helpers are also re-exported through this namespace.
 """
 from ttkbootstrap.utils.color import (
     # color-model selector constants (usable as the `model=` argument). Not in
@@ -40,6 +41,7 @@ from ttkbootstrap.utils.scaling import (
 )
 from ttkbootstrap.utils.platform import windowing_system
 from ttkbootstrap.utils.config import set_default_button
+from ttkbootstrap.utils.fonts import Fonts, set_global_family
 
 # Localization helpers live in the `localization` package (the i18n engine stays
 # there); they are surfaced here for discoverability. Imported lazily via
@@ -70,6 +72,9 @@ __all__ = [
     "scale_size",
     # platform
     "windowing_system",
+    # fonts (typography over the standard Tk named fonts)
+    "Fonts",
+    "set_global_family",
     # deferred config (pre-root setters)
     "set_default_button",
     # localization (surfaced lazily from the localization package)

--- a/src/ttkbootstrap/utils/fonts.py
+++ b/src/ttkbootstrap/utils/fonts.py
@@ -13,7 +13,9 @@ Two surfaces:
 
 - `Fonts` -- a namespace of classmethods operating on the *live* root:
   `set_global_family` / `configure` / `describe` / `names` / `create_alias` /
-  `reset`. Each needs an interpreter, so call them after `App()` exists.
+  `reset`. Each needs an interpreter, so call them after `App()` exists -- a
+  pre-root call raises a clear "too early" `RuntimeError` (it does not spawn a
+  stray root); for the pre-root case use the module-level `set_global_family`.
 - `set_global_family(family, *, mono_family=None)` -- the headline one-liner as
   a **module-level** function that rides the deferred-config seam (Slice 5): set
   it at the top of a file before `App()` and it applies when the root comes up;
@@ -54,7 +56,9 @@ def _named_font(name: str) -> font.Font:
     # utils/__init__, so it must not pull in window at module load.
     from ttkbootstrap.window import get_default_root
 
-    root = get_default_root()
+    # pass `what` so a pre-root call raises a clear "too early" error instead of
+    # get_default_root() silently spawning a stray Tk() the real App won't use.
+    root = get_default_root("configure fonts")
     cached = _font_cache.get(name)
     if cached is not None and cached._tk is root.tk:
         return cached
@@ -113,7 +117,7 @@ class Fonts:
         """
         from ttkbootstrap.window import get_default_root
 
-        root = get_default_root()
+        root = get_default_root("create a font alias")
         if name in font.names(root):
             # already registered -> reconfigure rather than error on duplicate
             alias = font.nametofont(name, root=root)

--- a/src/ttkbootstrap/utils/fonts.py
+++ b/src/ttkbootstrap/utils/fonts.py
@@ -1,0 +1,181 @@
+"""Typography helpers over the standard Tk named fonts.
+
+A small utility for the FAQ that had no answer before 2.0 -- "how do I change
+the global font?" -- built on the **standard Tk named fonts** every interpreter
+already ships (`TkDefaultFont`, `TkTextFont`, `TkFixedFont`, ...). Because every
+widget reads those fonts, retinting them restyles the whole app with zero
+interception, and `font="TkHeadingFont"` keeps working on stock tkinter
+widgets. There is no ttkbootstrap font vocabulary and no bracket DSL -- a
+parallel `body`/`heading-lg` token set would be overhead to document and sync
+for no payoff (see the boundary rule in the compat & utilities design note).
+
+Two surfaces:
+
+- `Fonts` -- a namespace of classmethods operating on the *live* root:
+  `set_global_family` / `configure` / `describe` / `names` / `create_alias` /
+  `reset`. Each needs an interpreter, so call them after `App()` exists.
+- `set_global_family(family, *, mono_family=None)` -- the headline one-liner as
+  a **module-level** function that rides the deferred-config seam (Slice 5): set
+  it at the top of a file before `App()` and it applies when the root comes up;
+  if a root already exists it applies live.
+"""
+import tkinter
+from tkinter import font
+from typing import Any, Optional
+
+# The standard Tk named fonts. The proportional set is retinted together by
+# `set_global_family(family=...)`; `TkFixedFont` is the monospace font and gets
+# `mono_family` instead. Some names (Tooltip/Icon/SmallCaption) are absent on
+# some platforms -- lookups guard for that -- so this is the *canonical* set, not
+# a promise every one exists in a given interpreter.
+PROPORTIONAL_FONTS = (
+    "TkDefaultFont",
+    "TkTextFont",
+    "TkMenuFont",
+    "TkHeadingFont",
+    "TkCaptionFont",
+    "TkSmallCaptionFont",
+    "TkIconFont",
+    "TkTooltipFont",
+)
+MONOSPACE_FONTS = ("TkFixedFont",)
+
+# Cache of `font.Font` wrappers keyed by named-font name. Wrappers pin a Tcl
+# interpreter, so a wrapper cached against a root that was later destroyed is
+# stale; `_named_font` re-fetches when the interpreter no longer matches, and
+# `Fonts.reset()` (wired into `App.destroy`) clears the cache proactively.
+_font_cache: "dict[str, font.Font]" = {}
+
+
+def _named_font(name: str) -> font.Font:
+    """Return the `font.Font` wrapper for named font `name` on the live root."""
+    # local import breaks the utils <- window import chain (window imports the
+    # style package, which imports utils) -- fonts is imported eagerly by
+    # utils/__init__, so it must not pull in window at module load.
+    from ttkbootstrap.window import get_default_root
+
+    root = get_default_root()
+    cached = _font_cache.get(name)
+    if cached is not None and cached._tk is root.tk:
+        return cached
+    resolved = font.nametofont(name, root=root)
+    _font_cache[name] = resolved
+    return resolved
+
+
+class Fonts:
+    """Namespace of typography helpers over the standard Tk named fonts.
+
+    Every method operates on the live application root, so call them once `App()`
+    exists. For the pre-root "set it at the top of the file" case use the
+    module-level `set_global_family`, which rides the deferred-config seam.
+    """
+
+    @classmethod
+    def set_global_family(cls, family: str, *, mono_family: Optional[str] = None) -> None:
+        """Retint every proportional named font to `family` in one call.
+
+        The headline typography one-liner: because widgets read the standard
+        named fonts, this restyles the whole app. `TkFixedFont` (the monospace
+        font, used by `Text`/console-style widgets) is left alone unless
+        `mono_family` is given. Named fonts absent on the current platform are
+        skipped.
+        """
+        for name in PROPORTIONAL_FONTS:
+            try:
+                _named_font(name).configure(family=family)
+            except tkinter.TclError:
+                continue  # not present on this platform
+        if mono_family is not None:
+            for name in MONOSPACE_FONTS:
+                try:
+                    _named_font(name).configure(family=mono_family)
+                except tkinter.TclError:
+                    continue
+
+    @classmethod
+    def configure(cls, name: str, **opts: Any) -> None:
+        """Tweak a single named font (`family`/`size`/`weight`/`slant`/...).
+
+        Thin wrapper over `font.nametofont(name).configure(**opts)`; the change
+        is seen live by every widget that reads that named font.
+        """
+        _named_font(name).configure(**opts)
+
+    @classmethod
+    def create_alias(cls, name: str, **opts: Any) -> font.Font:
+        """Register a user named font `name` and return its `font.Font`.
+
+        A convenience over `font.Font(name=name, ...)` so an app can define its
+        own named font once and refer to it by name (`font="Body"`) everywhere,
+        the same seam the standard `Tk*Font` names use. Returns the wrapper for
+        further tweaking; re-registering a name reconfigures it.
+        """
+        from ttkbootstrap.window import get_default_root
+
+        root = get_default_root()
+        if name in font.names(root):
+            # already registered -> reconfigure rather than error on duplicate
+            alias = font.nametofont(name, root=root)
+            if opts:
+                alias.configure(**opts)
+        else:
+            alias = font.Font(root=root, name=name, exists=False, **opts)
+        _font_cache[name] = alias
+        return alias
+
+    @classmethod
+    def names(cls) -> "tuple[str, ...]":
+        """Return the standard named fonts this utility manages (see `describe`)."""
+        return PROPORTIONAL_FONTS + MONOSPACE_FONTS
+
+    @classmethod
+    def describe(cls, name: Optional[str] = None) -> dict:
+        """Return each named font's resolved family/size/weight/slant/... .
+
+        With `name`, return the one font's actual options; otherwise a mapping of
+        every managed named font (from `names()`) to its actual options. The
+        "see what the fonts actually are" helper; fonts absent on the platform
+        are omitted from the full mapping.
+        """
+        if name is not None:
+            return dict(_named_font(name).actual())
+        result = {}
+        for n in cls.names():
+            try:
+                result[n] = dict(_named_font(n).actual())
+            except tkinter.TclError:
+                continue
+        return result
+
+    @classmethod
+    def reset(cls) -> None:
+        """Drop the cached `font.Font` wrappers.
+
+        Called from `App.destroy` so wrappers pinned to a destroyed root are not
+        reused by a later root (the same singleton/root-rebind hazard `Style`
+        clears). The named fonts themselves live in the interpreter and die with
+        it; this only clears our Python-side cache.
+        """
+        _font_cache.clear()
+
+
+def set_global_family(family: str, *, mono_family: Optional[str] = None) -> None:
+    """Set the global proportional (and, optionally, monospace) font family.
+
+    Called **before** `App()` exists, the setting is queued and applied when the
+    root is created (the intended top-of-file use). If a root already exists it
+    applies immediately. `mono_family`, when given, retints `TkFixedFont` too.
+
+    This is the deferred-config-seam sibling of `set_locale` /
+    `set_default_button`; for live tweaks against an existing root call
+    `Fonts.set_global_family` / `Fonts.configure` directly.
+    """
+    # local import breaks the utils.fonts <- utils.config <- style cycle; the
+    # seam applies now if a root exists, else queues under "global_family".
+    from ttkbootstrap.utils import config
+
+    config.defer(
+        "global_family",
+        lambda: Fonts.set_global_family(family, mono_family=mono_family),
+    )

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -540,6 +540,10 @@ class App(_BaseWindow, tkinter.Tk):
         # Clear the process-wide singleton (a class attribute) so a later root
         # rebinds the Style cleanly instead of reusing this destroyed one.
         Style.instance = None
+        # Drop cached named-font wrappers pinned to this (now dead) root, so a
+        # later root does not reuse them -- same root-rebind hazard as Style.
+        from ttkbootstrap.utils.fonts import Fonts
+        Fonts.reset()
         super().destroy()
 
 

--- a/tests/test_fonts_api.py
+++ b/tests/test_fonts_api.py
@@ -1,0 +1,165 @@
+"""Headless tests for the 2.0 typography utility (Slice 4).
+
+`ttkbootstrap.utils.fonts` is a tiny surface over the standard Tk named fonts:
+the `Fonts` namespace (live-root helpers) plus the module-level
+`set_global_family`, which rides the deferred-config seam (Slice 5) so it can be
+called before `App()` exists.
+
+The suite shares one session root, and named fonts are interpreter-global, so
+every test that retints a font snapshots and restores it via the
+`restore_fonts` fixture to avoid bleeding into other tests.
+"""
+import warnings
+from tkinter import font
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.style import Style
+from ttkbootstrap.utils import config, fonts
+from ttkbootstrap.utils.fonts import Fonts
+
+
+@pytest.fixture
+def restore_fonts(root):
+    """Snapshot + restore the managed named fonts, the wrapper cache, and the
+    pending-config registry so a test that pokes them does not leak."""
+    before = {}
+    for name in Fonts.names():
+        try:
+            before[name] = dict(font.nametofont(name, root=root).actual())
+        except Exception:
+            pass
+    pending_before = dict(config._pending)
+    try:
+        yield root
+    finally:
+        for name, spec in before.items():
+            try:
+                font.nametofont(name, root=root).configure(**spec)
+            except Exception:
+                pass
+        Fonts.reset()
+        config._pending.clear()
+        config._pending.update(pending_before)
+
+
+# --------------------------------------------------------------------------
+# exposure
+# --------------------------------------------------------------------------
+
+def test_surface_is_exported():
+    assert ttk.set_global_family is fonts.set_global_family
+    assert ttk.Fonts is Fonts
+    assert "set_global_family" in ttk.__all__
+    assert "Fonts" in ttk.__all__
+    from ttkbootstrap import utils
+    assert utils.set_global_family is fonts.set_global_family
+    assert utils.Fonts is Fonts
+    assert "set_global_family" in utils.__all__
+    assert "Fonts" in utils.__all__
+
+
+# --------------------------------------------------------------------------
+# Fonts namespace (live root)
+# --------------------------------------------------------------------------
+
+def test_set_global_family_retints_proportional_fonts(restore_fonts):
+    root = restore_fonts
+    Fonts.set_global_family("Georgia")
+    for name in fonts.PROPORTIONAL_FONTS:
+        try:
+            actual = font.nametofont(name, root=root).actual("family")
+        except Exception:
+            continue  # not on this platform
+        assert actual == "Georgia", name
+
+
+def test_set_global_family_leaves_fixed_font_unless_mono_given(restore_fonts):
+    root = restore_fonts
+    fixed_before = font.nametofont("TkFixedFont", root=root).actual("family")
+    Fonts.set_global_family("Georgia")
+    assert font.nametofont("TkFixedFont", root=root).actual("family") == fixed_before
+    Fonts.set_global_family("Georgia", mono_family="Courier New")
+    assert font.nametofont("TkFixedFont", root=root).actual("family") == "Courier New"
+
+
+def test_configure_tweaks_a_single_named_font(restore_fonts):
+    root = restore_fonts
+    default_before = font.nametofont("TkDefaultFont", root=root).actual("size")
+    Fonts.configure("TkHeadingFont", size=22)
+    assert font.nametofont("TkHeadingFont", root=root).actual("size") == 22
+    # a sibling proportional font is untouched -- configure targets one font
+    assert font.nametofont("TkDefaultFont", root=root).actual("size") == default_before
+
+
+def test_names_lists_the_managed_fonts():
+    names = Fonts.names()
+    assert "TkDefaultFont" in names
+    assert "TkFixedFont" in names
+    assert set(fonts.PROPORTIONAL_FONTS + fonts.MONOSPACE_FONTS) == set(names)
+
+
+def test_describe_all_and_single(restore_fonts):
+    all_specs = Fonts.describe()
+    assert "TkDefaultFont" in all_specs
+    assert "family" in all_specs["TkDefaultFont"]
+    one = Fonts.describe("TkDefaultFont")
+    assert one["family"] == all_specs["TkDefaultFont"]["family"]
+
+
+def test_create_alias_registers_a_named_font(restore_fonts):
+    root = restore_fonts
+    alias = Fonts.create_alias("TtkbTestBody", family="Georgia", size=13)
+    try:
+        assert alias.actual("family") == "Georgia"
+        # resolvable by name from a fresh lookup -> usable as font="TtkbTestBody"
+        assert font.nametofont("TtkbTestBody", root=root).actual("size") == 13
+        # re-registering the same name reconfigures rather than erroring
+        again = Fonts.create_alias("TtkbTestBody", size=20)
+        assert again.actual("size") == 20
+        assert font.nametofont("TtkbTestBody", root=root).actual("size") == 20
+    finally:
+        try:
+            root.tk.call("font", "delete", "TtkbTestBody")
+        except Exception:
+            pass
+
+
+def test_reset_clears_the_wrapper_cache(restore_fonts):
+    Fonts.describe()  # populates the cache
+    assert fonts._font_cache
+    Fonts.reset()
+    assert not fonts._font_cache
+
+
+# --------------------------------------------------------------------------
+# module-level set_global_family -- the deferred-config seam
+# --------------------------------------------------------------------------
+
+def test_module_set_global_family_applies_live_when_root_exists(restore_fonts):
+    root = restore_fonts
+    # a root exists (session root), so the seam applies immediately, no queue
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ttk.set_global_family("Georgia")
+    assert font.nametofont("TkDefaultFont", root=root).actual("family") == "Georgia"
+    assert "global_family" not in config._pending
+
+
+def test_module_set_global_family_queues_before_root(restore_fonts, monkeypatch):
+    root = restore_fonts
+    config._pending.clear()
+    # simulate "no root yet" -> the setter queues silently instead of applying
+    monkeypatch.setattr(Style, "instance", None)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ttk.set_global_family("Georgia", mono_family="Courier New")
+    assert "global_family" in config._pending
+
+    # root is back -> flush runs the queued applier
+    monkeypatch.undo()
+    config.flush_pending_config()
+    assert font.nametofont("TkDefaultFont", root=root).actual("family") == "Georgia"
+    assert font.nametofont("TkFixedFont", root=root).actual("family") == "Courier New"
+    assert "global_family" not in config._pending

--- a/tests/test_fonts_api.py
+++ b/tests/test_fonts_api.py
@@ -9,6 +9,7 @@ The suite shares one session root, and named fonts are interpreter-global, so
 every test that retints a font snapshots and restores it via the
 `restore_fonts` fixture to avoid bleeding into other tests.
 """
+import tkinter
 import warnings
 from tkinter import font
 
@@ -131,6 +132,16 @@ def test_reset_clears_the_wrapper_cache(restore_fonts):
     assert fonts._font_cache
     Fonts.reset()
     assert not fonts._font_cache
+
+
+def test_live_method_before_root_raises_not_spawns_phantom(monkeypatch):
+    # with no default root, a live Fonts.* call must raise a clear "too early"
+    # error rather than silently spawning a stray Tk() the real App won't use
+    monkeypatch.setattr(tkinter, "_default_root", None)
+    with pytest.raises(RuntimeError, match="[Tt]oo early"):
+        Fonts.configure("TkDefaultFont", size=12)
+    # and it did not create a phantom default root as a side effect
+    assert tkinter._default_root is None
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
The final utility slice of the compat & utilities initiative (`development/2_0_compat_and_utilities_design.md`). Closes the FAQ "how do I change the global font?", which had no supported answer.

## What

New `ttkbootstrap/utils/fonts.py` — a tiny typography surface over the **standard Tk named fonts** (`TkDefaultFont`, `TkTextFont`, `TkFixedFont`, `TkHeadingFont`, ...). Because every widget reads those named fonts, retinting them restyles the whole app with zero interception, and `font="TkHeadingFont"` keeps working on stock tkinter widgets.

- **`ttk.set_global_family(family, *, mono_family=None)`** — the headline one-liner, a **module-level** setter riding the Slice 5 deferred-config seam: queued before `App()` (applied when the root comes up) or live against an existing root. Retints the eight proportional named fonts; `TkFixedFont` only when `mono_family` is given.
- **`ttk.Fonts`** — a namespace of live-root classmethods: `set_global_family` · `configure(name, **opts)` · `describe(name=None)` / `names()` · `create_alias(name, **opts)` (a user named font, e.g. `font="Body"`) · `reset()`.
- **`Fonts.reset()` wired into `App.destroy`** — drops cached `font.Font` wrappers pinned to a dead root (same singleton/root-rebind hazard `Style` clears).

Re-exported at top level (`ttk.Fonts` / `ttk.set_global_family`) and through `ttkbootstrap.utils`. Mirrors the Slice 3/5 shape (a live engine surface + a thin deferred-seam setter).

## Out of scope (boundary rule)

No new font vocabulary (`body`/`heading-lg`) and no `font="body[bold]"` bracket DSL — both would need to intercept `font=` (framework territory). The optional macOS pt→pixel size bump + platform-aware default families from the design sketch were dropped for 2.0 (extra per-platform surface for a "keep it tiny" utility).

## Tests

`tests/test_fonts_api.py` (+10), snapshotting/restoring the interpreter-global named fonts on the shared session root. Full suite **539 passed** excl. the two known flakes (`nl.msg` env flake + the order-dependent `test_color_helpers` *Duplicate element* rebuild bug); warning-free import.

With this slice, all compat & utilities slices are complete — next is the cumulative pre-release review per `2_0_prerelease_review_plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)