### PR TITLE
2.0 pre-release review fixes + light/dark toggle & icon_only utilities

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -20,6 +20,7 @@
 | **Deferred-config seam + `ttk.set_default_button()` pre-root setter** | New | this doc, below (Slice 5) |
 | **Localization: msgcat bug fixes + `L()` / `LocaleVar` / `set_locale`** | Fix/New | this doc, below (Slice 3) |
 | **Typography: `ttk.Fonts` + `ttk.set_global_family()` over the Tk named fonts** | New | this doc, below (Slice 4) |
+| **Light/dark theme mode toggle (`theme_mode`/`toggle_theme_mode`)** | New | this doc, below |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -46,6 +47,40 @@
 | **Inputs: focus color on focus only (not hover)** | Visual | this doc, below |
 | **`card` / `highlight` frames: hairline border (`RAISED`, no bevel)** | Visual | this doc, below |
 | **Control-height parity + check/radio/menubutton focus rings** | Visual | this doc, below |
+
+---
+
+## Light/dark theme mode toggle  *(New)*
+
+**What.** A small utility over the light/dark theme pairing that was previously
+implicit. Every built-in family ships a `<family>-light` / `<family>-dark` pair,
+but there was no first-class way to flip between them. Named `theme_mode` (not
+bare `mode`) so it does not collide with the widget `mode` option
+(`Progressbar`/`Floodgauge` determinate/indeterminate). Now:
+
+- `style.theme_mode` → `"light"` or `"dark"` (the active theme's type).
+- `style.toggle_theme_mode()` → switch to the counterpart, returns the new mode.
+- `style.use_theme_mode("light" | "dark")` → set a specific mode (e.g. to follow
+  an OS preference).
+- `style.set_theme_modes(light=..., dark=...)` and `App(light_theme=...,
+  dark_theme=...)` → optionally *designate* the pair.
+- `App`/`Toplevel` expose `theme_mode` / `toggle_theme_mode()` /
+  `use_theme_mode()` / `set_theme_modes()` as convenience delegates to the
+  singleton `Style`.
+
+**Counterpart resolution.** If a pair is designated, toggling switches between
+exactly those two themes (they may cross families, e.g. `bootstrap-light` ↔
+`dracula-dark`). Otherwise the counterpart is derived from the `<family>-light` /
+`<family>-dark` naming convention. If neither yields a counterpart (a single
+legacy theme with no sibling), toggling warns and no-ops.
+
+**Why.** The anchor-theme model already generates matched light/dark pairs; this
+exposes the toggle every app was otherwise hand-rolling (string-swapping the
+`-light`/`-dark` suffix). Rides the existing theme walk — no engine change, and a
+toggle emits `<<ThemeChanged>>` like any `theme_use`.
+
+**Scope note.** This is a *utility*, not a widget — it fits the 2.0 "no new
+*widgets*" rule. No migration required; purely additive.
 
 ---
 
@@ -310,7 +345,12 @@ a light button on a colored header); use `neutral` for "no emphasis, follow the
 theme."
 
 **Scope.** Buttons (and the extending button-family widgets — see below).
-`NEUTRAL_FAMILIES` in `constants.py` gates where it is advertised.
+`NEUTRAL_FAMILIES` in `constants.py` (`button`/`menubutton`/`toolbutton`) gates
+where it is advertised **and enforced**: the resolver drops `neutral` on any
+other family (e.g. `Label`, `Entry`, `Scale`) back to that family's default
+style with a loud warning (raise under `set_bootstyle_strict(True)`) rather than
+building it. Before that gate, `neutral` on a non-button family resolved to an
+undefined color and crashed widget construction — see the pre-release review fix.
 
 **Migration.** None required. Optionally replace `bootstyle="light"` buttons that
 were standing in for a quiet/subtle button with `bootstyle="neutral"` — it will
@@ -625,13 +665,26 @@ with deprecated aliases.
 **What.** New public surface for putting a theme-aware Bootstrap Icons glyph on a
 widget (design `development/2_0_icon_theme_awareness_design.md`):
 
-- `ttk.apply_icon(widget, name, *, size=14, states=None, compound=None)` — renders
-  the glyph following the widget's style `foreground` (so it inverts on
-  outline/toggle, mutes when disabled) and re-renders on `<<ThemeChanged>>`.
-- `icon=`/`icon_size=` keyword sugar on every blessed ttk widget (`BootMixin`) —
-  routes to `apply_icon` after the base style resolves.
+- `ttk.apply_icon(widget, name, *, size=None, states=None, compound=None,
+  icon_only=False)` — renders the glyph following the widget's style `foreground`
+  (so it inverts on outline/toggle, mutes when disabled) and re-renders on
+  `<<ThemeChanged>>`.
+- `icon=`/`icon_size=`/`icon_only=` keyword sugar on every blessed ttk widget
+  (`BootMixin`) — routes to `apply_icon` after the base style resolves.
 - Supported on label-image widgets (`Button`/`Label`/`Menubutton`/`Checkbutton`/
   `Radiobutton`); other classes raise `TypeError`.
+
+**Icon-only controls (`icon_only=True`).** Renders the widget as a compact
+icon-only control: hides text (`compound=image`) and applies a fixed default glyph
+size + symmetric padding chosen together for the expected height (a button is
+`size + 2*padding + chrome`; the pair `size=17, padding=3` lands on the ~29 px
+normal-button height, the glyph a touch larger than the text line). So every
+default icon-only control is a **square about a normal button's height, and all of
+them the same size**. Both defaults are **overridable, and an override changes the
+control's size — by design**: `icon_size=` sizes the glyph (bigger glyph → bigger
+square) and a widget `padding=` (a ttk instance option, which overrides the style
+padding) sets your own — e.g. a dense toolbar button. Without an `icon=`,
+`icon_only=True` warns and is ignored.
 
 **Why.** A bare `Icon(...)` used as `image=` bakes its color once and goes stale on
 a theme switch — style-delivered icons (builder recipes) were theme-aware, inline
@@ -646,7 +699,12 @@ restores the base style. The static `Icon(...)` escape hatch is unchanged (a raw
 `-image`, no style, not themed).
 
 **Not breaking.** Purely additive; no existing signature changed. First-party: the
-datepicker header carets were migrated onto `apply_icon` (internal, no API change).
+datepicker header carets were migrated onto `apply_icon` (internal, no API change),
+and the icon-only controls (datepicker nav chevrons, `Tableview` pagination/reset
+buttons, the `DateEntry` calendar button) now use `icon_only=True` instead of
+hand-tuned per-site padding/size — they render as uniform squares the button
+height (a minor visual tidy: the `DateEntry` glyph is 17 vs the old 18, and the
+chevrons/pagination buttons are now square rather than the wider default).
 
 ## Tableview pagination: glyph nav buttons + boundary-disable  *(behavior)*
 
@@ -728,6 +786,9 @@ rename was coordinated across the date-picker dialog layer:
   remain as date-typed synonyms.
 - On unparseable text the entry is flagged **`invalid`** on blur (`<FocusOut>`).
 - New **`position=`** passthrough to the picker popup.
+- The constructor's default **`bootstyle`** is now explicitly `"primary"` (was an
+  empty default that resolved to the primary look anyway) — codifies the existing
+  1.x appearance, no visible change.
 
 **Migration.** The old `dateformat`/`firstweekday`/`startdate` spellings are accepted
 through 2.x with a `DeprecationWarning` naming the new form (via `style/_compat.py`),
@@ -901,8 +962,9 @@ int. Nothing warns — these are source-level breaks, not deprecations.
 - **The constructor is keyword-only** after `title, message`.
 - **A bad `position` anchor now raises `ValueError`** (was silently dropped to
   the OS default). `position` stays a 3-tuple `(x, y, anchor)`.
-- **`set_geometry()` is now private (`_set_geometry` internals)** — it was public
-  but always internal. `titlefont` internal attribute → `title_font`.
+- **`set_geometry()` is removed** — it was public but always internal; its logic
+  is now inlined into the toast's private setup/geometry path. `titlefont`
+  internal attribute → `title_font`.
 
 *Additive.*
 - **Concurrent toasts no longer overlap.** Toasts anchored to the same screen
@@ -1244,6 +1306,13 @@ Only those two are packaged; the source PNGs are build inputs, not shipped.
 titlebar/taskbar icon looked soft at larger sizes. A packed `.ico` lets Windows
 pick the crisp frame per DPI/context; macOS/Linux take a full-size PNG. Rebuild
 the `.ico` with `python tools/make_app_ico.py` after changing the source PNGs.
+
+**Child toplevels inherit it.** On Windows the `.ico` is applied with
+`wm_iconbitmap(default=...)` (and a user-supplied `.ico` path likewise), so
+dialogs, pickers, and other toplevels inherit the app icon instead of showing the
+Tk feather — matching the `iconphoto(True, ...)` default flag used on macOS/Linux.
+(Pre-release-review fix: without `-default` the icon was set on the root window
+only.)
 
 ---
 

--- a/development/2_0_prerelease_review_plan.md
+++ b/development/2_0_prerelease_review_plan.md
@@ -77,21 +77,38 @@ rewrite (the guide is the docs' migration page).
 
 ## Gates before tagging an RC
 
-- [ ] **Deterministically green suite.** Root-cause the two "flakes" rather than
-      wave them through: the `test_color_helpers` *Duplicate element
-      TSpinbox.uparrow* failure is a real order-dependent theme-rebuild bug, not
-      noise; confirm `nl.msg`/`zh_cn.msg` is genuinely env-only (Tcl can't read
-      the catalog) and not a real localization regression.
-- [ ] **Clean-env install smoke.** Build the wheel, `pip install` into a fresh
-      venv, import warning-free (`-W error::DeprecationWarning`), and construct
-      one of every widget/dialog. Catches missing package-data / subpackages
-      (assets globs don't recurse; the new `utils/` subpackage; icon font).
-- [ ] **Min-Python parse.** 3.10 grammar parse of all `src/` + PEP 649
-      annotation evaluation (the sweep the color PRs ran).
-- [ ] **Warning-free import** of `ttkbootstrap` and every submodule; the
-      deprecation shims warn *only* when the old path is actually used.
-- [ ] **Docs stubs.** The broken API `:::` stubs that crash mkdocstrings are
-      release-blocking (Workstream H §11).
+- [x] **Deterministically green suite.** Both "flakes" root-caused (2026-07-09):
+      the `test_color_helpers` *Duplicate element TSpinbox.uparrow* was a **real**
+      theme-rebuild bug — `element_create` was not idempotent, so any recipe re-run
+      on an already-materialized ttk theme (a test force-build, or a production
+      `_theme_styles`/Tcl desync) crashed. **Fixed** by an idempotent
+      `Style.element_create` override (`style/engine.py`) that no-ops when the
+      element already exists in the current theme; +14 regression tests. The
+      `nl.msg` failure (`test_msgcat`/`test_set`) is **confirmed genuinely
+      env-only**: the localization file flips pass/fail across identical runs
+      (6/6 pass in some runs, one transient `couldn't read file nl.msg: No error`
+      in others), the catalog is present and readable, and ttkbootstrap only calls
+      the standard `::msgcat::mclocale`. Not a regression; a transient Tcl file-read
+      hiccup. (Optional: de-flake by retrying the msgcat load in the test.)
+- [x] **Clean-env install smoke** (2026-07-09). Built the wheel, `pip install`ed
+      into a fresh venv, imported warning-free (`-W error::DeprecationWarning`), and
+      constructed one of every widget + dialog. **Pass** — all subpackages ship
+      (incl. `utils/`), the `assets/icons/bootstrap.ttf` font + `assets/elements`
+      + `assets/app_icons` + json manifests are present; the non-recursive globs
+      dropped nothing (asset dirs are one level deep and each is listed).
+      **Finding: `pyproject.toml` version is still `1.20.4`** — bump before tagging.
+- [x] **Min-Python parse** (2026-07-09). 3.10 (`py -V:3.10`) `py_compile` of all
+      84 `src/` files: clean. PEP 649 annotation force-eval: 352 targets resolve;
+      the single `get_type_hints`-on-`constants` `Final` complaint is a
+      module-level-`Final` artifact, not an evaluation failure.
+- [x] **Warning-free import** (2026-07-09) of `ttkbootstrap` and all 83 submodules;
+      the only three that warn (`colorutils`/`utility`/`publisher`) do so **only**
+      when the old path is imported directly — correct shim behavior.
+- [ ] **Docs stubs.** 9 broken API `:::` stubs in `docs/en/api` point at removed
+      paths — `ttkbootstrap.icons` (Emoji/Icon), `ttkbootstrap.scrolled`,
+      `ttkbootstrap.tableview`, `ttkbootstrap.toast`, `ttkbootstrap.tooltip`.
+      They crash mkdocstrings; repoint to `ttkbootstrap.widgets.*` / delete the
+      icons stubs. Release-blocking; **belongs to Workstream H** (docs).
 
 ## Sequencing
 
@@ -116,11 +133,50 @@ tag RC  ──►  Workstream H docs  ──►  final release
 
 ## Known latent items already logged (feed the triage)
 
-- `test_color_helpers` order-dependent *Duplicate element TSpinbox.uparrow*
-  (theme-rebuild path) — real bug, currently reads as a flake.
-- `center_on_screen` negative-origin multi-monitor bug (parked from PR B).
+- ~~`test_color_helpers` order-dependent *Duplicate element TSpinbox.uparrow*~~ —
+  **FIXED** 2026-07-09 (idempotent `Style.element_create`; see the green-suite gate).
+- `center_on_screen` negative-origin multi-monitor bug (parked from PR B) — still
+  open; a "Recenter window" button in the Track B harness exercises it.
 - `colorutils`/`utils.color` `color_to_rgb` swallows errors with a bare
   `except: print('this')` — behavior-preserving-move wart, worth fixing pre-3.0.
 - Cross-platform gates owed but never eyeballed: win32 AppUserModelID/taskbar
   icon, aqua `overrideredirect`/`MacWindowStyle` popups, multi-monitor centering.
-- Docs Workstream H: nav/IA skeleton + un-break the API `:::` stubs.
+- Docs Workstream H: nav/IA skeleton + un-break the API `:::` stubs (9 broken —
+  see the docs-stubs gate).
+
+## Pre-release review run — 2026-07-09 (results)
+
+**Track A (agentic sweep)** — 8-subsystem Workflow + adversarial verify. 5
+candidates, 2 confirmed:
+- **RELEASE-BLOCKER (FIXED):** `bootstyle="neutral"` crashed construction on every
+  non-button widget family (Label/Entry/Checkbutton/Progressbar/Scale/Scrollbar/
+  Combobox). `neutral` is in the global color vocab + the canonical `BootStyle`
+  Literal + exported `NEUTRAL`, but `NEUTRAL_FAMILIES` was consulted only by the
+  reference generator, never enforced at runtime → `Colors.get("neutral")` → None →
+  TclError/TypeError inside the recipe, before `build_style`'s graceful fallback.
+  Fixed: the resolver now gates `neutral` on `NEUTRAL_FAMILIES`, dropping it to the
+  family default with a loud warning (raise in strict mode). +14 regression tests.
+- **POST-RELEASE (open, minor/cosmetic):** `DatePickerDialog` highlights the wrong
+  day when browsing away from the selected month. 2.0 added `datevar.set(day)` for
+  the toolbutton "on" look, but the shared `datevar` is only re-set in the branch
+  that matches the selected month, so navigating to another month leaves it pinned
+  and that month's same day-number renders falsely selected. `datepicker.py:360`.
+  The returned selection is correct (grid-coord based); purely a cosmetic stray
+  highlight while browsing. Fix = reset/track `datevar` per redraw. **Author's call
+  whether to fix now or defer.**
+
+**Track B (visual/cross-platform)** — human-gated, cannot be automated. Delivered
+`examples/prerelease_visual_review.py`: a single warning-clean window with one of
+every native + shipped widget in its states, a theme picker + light/dark toggle, a
+dialogs launcher, a "Recenter window" button (for the parked multi-monitor bug),
+and the run-matrix checklist in its docstring. **The eyeball pass itself is still
+owed** (light/dark × 100/125/150/200% DPI × win32/aqua/x11).
+
+**Track C (migration contract)** — mechanical `master→2.0` public-surface diff
+(runtime `inspect.signature` + `dir()`), reconciled against
+`2_0_breaking_changes.md`. **No silent breaks; no phantom entries.** 9 top-level
+removals (1 real+documented `icons`, 3 shim-forwarded+documented, 5 incidental
+typing-name leakage), 13 constructor signature changes all documented, no dropped
+`__all__`/widget/dialog exports. Two doc nits fixed: the Toast `set_geometry` entry
+referenced a non-existent `_set_geometry`; DateEntry's `""`→`"primary"` default was
+unstated.

--- a/examples/prerelease_visual_review.py
+++ b/examples/prerelease_visual_review.py
@@ -1,0 +1,277 @@
+"""ttkbootstrap 2.0 pre-release visual review harness (Track B).
+
+A single-window "everything bagel" that constructs one of every native ttk
+widget and every shipped ttkbootstrap widget, in their common states, plus a
+launcher for every dialog. Built for the human-gated visual / cross-platform
+pass of the 2.0 pre-release review (`development/2_0_prerelease_review_plan.md`,
+Track B): the eyeball pass is one window, not thirty.
+
+Run it once per cell of the matrix:
+
+    Platforms : win32 (primary), macOS/aqua, Linux/x11 (if reachable)
+    Modes     : light + dark (use the "Toggle light/dark" button, or the theme
+                picker for the full catalog)
+    DPI       : 100 / 125 / 150 / 200 %  (set the OS display scaling, or launch
+                with `TK_SCALING` / `Window(scaling=...)`)
+
+What to look for (non-exhaustive):
+  - button family: solid / outline / ghost / link / toolbutton / toggle read
+    correctly incl. the `neutral` default; 1px hairline borders are crisp.
+  - inputs: focus ring shows on focus only (not hover); disabled/readonly fills.
+  - indicators: check / radio / switch / scale / scrollbar / progressbar glyphs
+    are sharp at every DPI; striped progressbar trough is flat.
+  - icons: date caret, spinbox/combobox/menubutton arrows, Messagebox glyphs,
+    Tableview sort + pagination glyphs follow the theme foreground.
+  - theme switch repaints every mounted widget (no stale colors / leftover art).
+  - dialogs: open each one light + dark; DatePicker highlights the *selected*
+    day only (watch the parked "stale highlight while browsing months" issue).
+
+Known parked bug to confirm here (memory `center-on-screen-negative-origin-bug`):
+  on a multi-monitor layout, `place_window_center` / `center_on_screen` can put
+  the window at a negative origin off-screen. Use "Recenter window" after moving
+  the app onto a secondary monitor.
+"""
+import datetime
+
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+from ttkbootstrap.dialogs import Messagebox, Querybox
+from ttkbootstrap.dialogs import (
+    MessageDialog, DatePickerDialog, FontDialog, ColorChooserDialog,
+)
+from ttkbootstrap.widgets import ToolTip, ToastNotification
+
+COLORS = ("primary", "secondary", "success", "info", "warning", "danger",
+          "light", "dark", "neutral")
+
+
+def _labeled(parent, text):
+    lf = ttk.Labelframe(parent, text=text, padding=8)
+    lf.pack(fill=X, pady=4, padx=4, anchor=N)
+    return lf
+
+
+def build_button_family(parent):
+    lf = _labeled(parent, "Button family (solid / outline / ghost / link)")
+    for variant, suffix in (("solid", ""), ("outline", "-outline"),
+                            ("ghost", "-ghost")):
+        row = ttk.Frame(lf)
+        row.pack(fill=X, pady=1)
+        ttk.Label(row, text=variant, width=8).pack(side=LEFT)
+        for c in COLORS:
+            ttk.Button(row, text=c, bootstyle=f"{c}{suffix}").pack(
+                side=LEFT, padx=1, fill=X, expand=YES)
+    row = ttk.Frame(lf)
+    row.pack(fill=X, pady=1)
+    ttk.Label(row, text="link", width=8).pack(side=LEFT)
+    for c in COLORS:
+        ttk.Button(row, text=c, bootstyle=f"{c}-link").pack(
+            side=LEFT, padx=1, fill=X, expand=YES)
+    # a disabled + a default (neutral) button
+    row = ttk.Frame(lf)
+    row.pack(fill=X, pady=(4, 1))
+    ttk.Button(row, text="default (neutral)").pack(side=LEFT, padx=2)
+    ttk.Button(row, text="disabled", state=DISABLED).pack(side=LEFT, padx=2)
+    b = ttk.Button(row, text="hover me for a tooltip", bootstyle="info-outline")
+    b.pack(side=LEFT, padx=2)
+    ToolTip(b, text="This is a ToolTip.", bootstyle="info-inverse")
+
+    # icon-only buttons: square, same height as a normal button; compare against
+    # a normal button and an icon+text button on the same row.
+    row = ttk.Frame(lf)
+    row.pack(fill=X, pady=(6, 1))
+    ttk.Label(row, text="icon-only", width=8).pack(side=LEFT)
+    ttk.Button(row, text="Normal").pack(side=LEFT, padx=2)
+    ttk.Button(row, icon="floppy", text="Save").pack(side=LEFT, padx=2)
+    for glyph, style in (("gear-fill", "primary"), ("bell-fill", "info"),
+                         ("trash-fill", "danger-outline"), ("search", "ghost"),
+                         ("three-dots", "secondary")):
+        ttk.Button(row, icon=glyph, icon_only=True, bootstyle=style).pack(
+            side=LEFT, padx=2)
+    ttk.Button(row, icon="x-lg", icon_only=True, state=DISABLED).pack(
+        side=LEFT, padx=2)
+    # explicit overrides (deliberately a different size): a bigger glyph, then a
+    # dense small-padding toolbar button -- separated so the default set above
+    # reads as one uniform height.
+    ttk.Label(row, text="overrides:").pack(side=LEFT, padx=(12, 2))
+    ttk.Button(row, icon="plus-lg", icon_only=True, icon_size=24,
+               bootstyle="success").pack(side=LEFT, padx=2)
+    ttk.Button(row, icon="list", icon_only=True, padding=2,
+               bootstyle="dark").pack(side=LEFT, padx=2)
+
+
+def build_toggles(parent):
+    lf = _labeled(parent, "Check / radio / toolbutton / toggle")
+    row = ttk.Frame(lf)
+    row.pack(fill=X)
+    c1 = ttk.Checkbutton(row, text="checked")
+    c1.pack(side=LEFT, padx=6)
+    c1.invoke()
+    ttk.Checkbutton(row, text="unchecked").pack(side=LEFT, padx=6)
+    ttk.Checkbutton(row, text="disabled", state=DISABLED).pack(side=LEFT, padx=6)
+    r1 = ttk.Radiobutton(row, text="radio on", value=1)
+    r1.pack(side=LEFT, padx=6)
+    r1.invoke()
+    ttk.Radiobutton(row, text="radio off", value=2).pack(side=LEFT, padx=6)
+
+    row = ttk.Frame(lf)
+    row.pack(fill=X, pady=(6, 0))
+    t1 = ttk.Checkbutton(row, text="success toolbutton",
+                         bootstyle="success-toolbutton")
+    t1.pack(side=LEFT, padx=6)
+    t1.invoke()
+    t2 = ttk.Checkbutton(row, text="round toggle",
+                         bootstyle="success-round-toggle")
+    t2.pack(side=LEFT, padx=6)
+    t2.invoke()
+    ttk.Checkbutton(row, text="square toggle",
+                    bootstyle="square-toggle").pack(side=LEFT, padx=6)
+
+
+def build_inputs(parent):
+    lf = _labeled(parent, "Inputs (focus ring on focus only; readonly/disabled)")
+    e = ttk.Entry(lf)
+    e.insert(END, "entry — click to focus")
+    e.pack(fill=X, pady=2)
+    ro = ttk.Entry(lf)
+    ro.insert(END, "readonly entry")
+    ro.configure(state="readonly")
+    ro.pack(fill=X, pady=2)
+    de = ttk.Entry(lf, state=DISABLED)
+    de.pack(fill=X, pady=2)
+    sb = ttk.Spinbox(lf, from_=0, to=100)
+    sb.set(42)
+    sb.pack(fill=X, pady=2)
+    cbo = ttk.Combobox(lf, values=["alpha", "bravo", "charlie"])
+    cbo.current(0)
+    cbo.pack(fill=X, pady=2)
+    ttk.DateEntry(lf).pack(fill=X, pady=2)
+
+
+def build_indicators(parent):
+    lf = _labeled(parent, "Scale / progress / scrollbar / meter / floodgauge")
+    ttk.Scale(lf, from_=0, to=100, value=60).pack(fill=X, pady=3)
+    ttk.Progressbar(lf, value=55, bootstyle="success").pack(fill=X, pady=3)
+    ttk.Progressbar(lf, value=70, bootstyle="info-striped").pack(fill=X, pady=3)
+    ttk.Progressbar(lf, value=40, bootstyle="thin").pack(fill=X, pady=3)
+    sbar = ttk.Scrollbar(lf, orient=HORIZONTAL)
+    sbar.set(0.2, 0.6)
+    sbar.pack(fill=X, pady=3)
+    row = ttk.Frame(lf)
+    row.pack(fill=X, pady=4)
+    ttk.Meter(row, amount_used=45, subtext="meter", bootstyle="info",
+              meter_size=140, interactive=True).pack(side=LEFT, padx=8)
+    fg = ttk.Floodgauge(row, value=66, text="floodgauge", bootstyle="warning")
+    fg.pack(side=LEFT, fill=X, expand=YES, padx=8)
+
+
+def build_data(parent):
+    lf = _labeled(parent, "Treeview / Tableview / ScrolledText / Notebook")
+    nb = ttk.Notebook(lf)
+    nb.pack(fill=BOTH, expand=YES)
+
+    tv = ttk.Treeview(nb, columns=[0, 1], show=HEADINGS, height=4)
+    tv.heading(0, text="City")
+    tv.heading(1, text="Rank")
+    for r in [("Auckland", 1), ("Paris", 2), ("Maui", 3), ("Tahiti", 4)]:
+        tv.insert("", END, values=r)
+    nb.add(tv, text="Treeview")
+
+    tbl = ttk.Tableview(
+        nb,
+        coldata=["Name", "Score"],
+        rowdata=[("Ada", 95), ("Linus", 88), ("Grace", 99), ("Alan", 77)],
+        paginated=True,
+        searchable=True,
+        pagesize=3,
+    )
+    nb.add(tbl, text="Tableview")
+
+    st = ttk.ScrolledText(nb, height=5, auto_hide=True)
+    st.insert(END, "ScrolledText — auto-hiding scrollbar.\n" * 12)
+    nb.add(st, text="ScrolledText")
+
+
+def build_dialog_launcher(parent, app):
+    lf = _labeled(parent, "Dialogs (open each; check light + dark)")
+    row1 = ttk.Frame(lf)
+    row1.pack(fill=X, pady=2)
+    row2 = ttk.Frame(lf)
+    row2.pack(fill=X, pady=2)
+
+    def toast():
+        ToastNotification(title="Toast", message="A toast notification.",
+                          duration=3000, bootstyle="info").show_toast()
+
+    buttons = [
+        ("Info box", lambda: Messagebox.show_info("An info message.", "Info")),
+        ("Question", lambda: Messagebox.yesno("Proceed?", "Question")),
+        ("OK/Cancel", lambda: Messagebox.okcancel("Confirm action.", "Confirm")),
+        ("Get string", lambda: Querybox.get_string(prompt="Your name?")),
+        ("Get date", lambda: Querybox.get_date(parent=app)),
+        ("Font dialog", lambda: FontDialog(parent=app).show()),
+        ("Color chooser", lambda: ColorChooserDialog(parent=app).show()),
+        ("Message dialog",
+         lambda: MessageDialog("A custom MessageDialog.", title="Dialog",
+                               buttons=["Cancel", "OK:primary"]).show()),
+        ("Toast", toast),
+    ]
+    for i, (label, cmd) in enumerate(buttons):
+        parent_row = row1 if i < 5 else row2
+        ttk.Button(parent_row, text=label, command=cmd,
+                   bootstyle="secondary-outline").pack(
+            side=LEFT, padx=2, fill=X, expand=YES)
+
+
+def build_controls(parent, app):
+    bar = ttk.Frame(parent, padding=(8, 6))
+    bar.pack(fill=X)
+    style = app.style
+    themes = style.theme_names()
+
+    ttk.Label(bar, text="Theme:").pack(side=LEFT)
+    picker = ttk.Combobox(bar, values=themes, width=22)
+    picker.set(style.theme.name)
+    picker.pack(side=LEFT, padx=6)
+    picker.bind("<<ComboboxSelected>>",
+                lambda e: style.theme_use(picker.get()))
+
+    def on_toggle():
+        app.toggle_theme_mode()  # switches the current family's -light/-dark sibling
+        picker.set(style.theme.name)
+
+    ttk.Button(bar, text="Toggle light/dark", command=on_toggle,
+               bootstyle="primary").pack(side=LEFT, padx=4)
+    ttk.Button(bar, text="Recenter window", bootstyle="secondary-outline",
+               command=app.place_window_center).pack(side=LEFT, padx=4)
+    ttk.Label(bar, text="  (matrix: light/dark × 100/125/150/200% DPI × "
+                        "win32/aqua/x11)").pack(side=LEFT, padx=8)
+
+
+def main():
+    app = ttk.Window("ttkbootstrap 2.0 — pre-release visual review",
+                     themename="bootstrap-light", minsize=(1180, 720))
+    build_controls(app, app)
+    ttk.Separator(app).pack(fill=X)
+
+    body = ttk.Frame(app, padding=6)
+    body.pack(fill=BOTH, expand=YES)
+    left = ttk.Frame(body)
+    left.pack(side=LEFT, fill=BOTH, expand=YES)
+    right = ttk.Frame(body)
+    right.pack(side=LEFT, fill=BOTH, expand=YES)
+
+    build_button_family(left)
+    build_toggles(left)
+    build_inputs(left)
+    build_dialog_launcher(left, app)
+
+    build_indicators(right)
+    build_data(right)
+
+    app.place_window_center()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ttkbootstrap"
-version = "1.20.4"
+version = "2.0.0"
 description = "A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -329,6 +329,15 @@ class DatePickerDialog:
         self._current_month_days()
         self.frm_dates = ttk.Frame(self.frm_calendar).pack(fill=BOTH, expand=YES)
 
+        # All day cells share `datevar`; a Radiobutton is "selected" when its
+        # value equals it. Clear it to a value no cell uses (days are 1..31) so a
+        # month other than the selected one shows no selection -- the match
+        # branch below re-sets it to the selected day only when this redraw is of
+        # the selected month. Without this reset, `datevar` stays pinned to the
+        # selected day number and that day is spuriously highlighted in every
+        # month the user browses to.
+        self.datevar.set(0)
+
         for row, weekday_list in enumerate(self.monthdays):
             for col, day in enumerate(weekday_list):
                 self.frm_dates.columnconfigure(col, weight=1)
@@ -384,7 +393,7 @@ class DatePickerDialog:
             command=self.on_prev_year,
             bootstyle="ghost",
             icon="chevron-double-left",
-            padding=4,
+            icon_only=True,
         )
         self.prev_year.pack(side=LEFT, fill=Y)
         self.prev_period = ttk.Button(
@@ -392,7 +401,7 @@ class DatePickerDialog:
             command=self.on_prev_month,
             bootstyle="ghost",
             icon="chevron-left",
-            padding=4
+            icon_only=True,
         )
         self.prev_period.pack(side=LEFT, fill=Y)
 
@@ -409,7 +418,7 @@ class DatePickerDialog:
             command=self.on_next_month,
             bootstyle="ghost",
             icon="chevron-right",
-            padding=4
+            icon_only=True,
         )
         self.next_period.pack(side=LEFT, fill=Y)
 
@@ -418,7 +427,7 @@ class DatePickerDialog:
             command=self.on_next_year,
             bootstyle="ghost",
             icon="chevron-double-right",
-            padding=4
+            icon_only=True,
         )
         self.next_year.pack(side=LEFT, fill=Y)
 

--- a/src/ttkbootstrap/dialogs/message.py
+++ b/src/ttkbootstrap/dialogs/message.py
@@ -2,6 +2,7 @@
 
 import textwrap
 import tkinter
+import warnings
 from typing import Any, Callable, List, Optional, Tuple
 
 import ttkbootstrap as ttk
@@ -138,12 +139,18 @@ class MessageDialog(Dialog):
         if self._icon:
             icon_lbl = self._create_icon_label(container)
             if icon_lbl is not None:
-                icon_lbl.pack(side=LEFT, anchor=N, padx=(0, 5))
+                # Center the icon against the message so a single-line message
+                # sits level with the icon's middle (top-anchoring left the icon
+                # hanging below a short line); a taller multi-line message instead
+                # centers the icon against the block.
+                icon_lbl.pack(side=LEFT, anchor=CENTER, padx=(0, 5))
 
         if self._message:
+            msg_frame = ttk.Frame(container)
             for msg in self._message.split("\n"):
                 message = "\n".join(textwrap.wrap(msg, width=self._width))
-                ttk.Label(container, text=message).pack(pady=(0, 3), fill=X, anchor=N)
+                ttk.Label(msg_frame, text=message).pack(pady=(0, 3), fill=X, anchor=N)
+            msg_frame.pack(side=LEFT, fill=X, expand=True, anchor=CENTER)
         container.pack(fill=X, expand=True)
 
     def _create_icon_label(self, container: tkinter.Misc) -> "Optional[ttk.Label]":
@@ -172,7 +179,12 @@ class MessageDialog(Dialog):
                 continue
             self._img = image
             return label
-        print("MessageDialog icon is invalid")
+        warnings.warn(
+            f"MessageDialog icon {self._icon!r} could not be loaded as an image "
+            "name, base64 data, or file path; no icon will be shown.",
+            UserWarning,
+            stacklevel=2,
+        )
         return None
 
     def create_buttonbox(self, master: tkinter.Misc) -> None:
@@ -196,7 +208,7 @@ class MessageDialog(Dialog):
             elif is_default:
                 bootstyle = "primary"
             else:
-                bootstyle = "secondary"
+                bootstyle = "default"
 
             if self._localize is True:
                 text = MessageCatalog.translate(text)

--- a/src/ttkbootstrap/dialogs/query.py
+++ b/src/ttkbootstrap/dialogs/query.py
@@ -116,16 +116,15 @@ class QueryDialog(Dialog):
             text=MessageCatalog.translate("Submit"),
             command=self.on_submit,
         )
-        submit.pack(padx=5, side=RIGHT)
+        submit.pack(padx=2, side=RIGHT)
         submit.lower()
 
         cancel = ttk.Button(
             master=frame,
-            bootstyle="secondary",
             text=MessageCatalog.translate("Cancel"),
             command=self.on_cancel,
         )
-        cancel.pack(padx=5, side=RIGHT)
+        cancel.pack(padx=2, side=RIGHT)
         cancel.lower()
 
         ttk.Separator(self._toplevel).pack(fill=X)

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -7,6 +7,7 @@ and opt-in-global delivery primitives. Top layer of the `style` package.
 """
 import difflib
 import re
+import warnings
 from tkinter import Grid, Pack, Place, TclError, ttk
 
 from ttkbootstrap.constants import (
@@ -15,6 +16,8 @@ from ttkbootstrap.constants import (
     BOOTSTYLE_INTERNAL_MODIFIERS,
     BOOTSTYLE_FAMILIES,
     BOOTSTYLE_ORIENTS,
+    NEUTRAL,
+    NEUTRAL_FAMILIES,
     BootStyle,
 )
 from ttkbootstrap.style import _compat
@@ -601,6 +604,18 @@ class Bootstyle:
             widget, style_string, warn=True, **kwargs
         )
         variant = modifier or DEFAULT_VARIANT
+
+        # `neutral` is a no-accent fill that only the button-family recipes
+        # implement (constants.NEUTRAL_FAMILIES). For any other family it
+        # resolves to a color the theme never defines (Colors.get("neutral")
+        # -> None), which crashes the recipe mid-build. Treat it like an invalid
+        # color for that family: fail loudly for a bootstyle string, then drop
+        # the color and fall back to the family's default style.
+        if color == NEUTRAL and family not in NEUTRAL_FAMILIES:
+            if is_bootstyle:
+                _compat.report_invalid("color", f"{NEUTRAL}-{family}", style_string)
+            color = ""
+
         ttkstyle = _build_ttkstyle_name(color, modifier, orient, family)
 
         # build style if not existing (example: theme changed)
@@ -883,14 +898,16 @@ class BootMixin(FluentGeometryMixin):
 
             **kwargs:
                 Keyword arguments forwarded to the wrapped ttk widget's
-                constructor. ``bootstyle``, ``style``, ``icon``, and
-                ``icon_size`` are consumed here rather than forwarded.
+                constructor. ``bootstyle``, ``style``, ``icon``, ``icon_size``,
+                and ``icon_only`` are consumed here rather than forwarded.
         """
         # capture bootstyle, style, and icon arguments
         bootstyle = kwargs.pop("bootstyle", "")
         style = kwargs.pop("style", "") or ""
         icon = kwargs.pop("icon", None)
-        icon_size = kwargs.pop("icon_size", 14)
+        # size defaults inside apply_icon (icon-only-aware); None = "not given"
+        icon_size = kwargs.pop("icon_size", None)
+        icon_only = kwargs.pop("icon_only", False)
 
         # instantiate the underlying ttk widget first so winfo_class() is
         # available to the resolver below
@@ -922,7 +939,12 @@ class BootMixin(FluentGeometryMixin):
             # style (see ttkbootstrap.apply_icon).
             if icon:
                 from ttkbootstrap.style.icons import apply_icon
-                apply_icon(self, icon, size=icon_size)
+                apply_icon(self, icon, size=icon_size, icon_only=icon_only)
+            elif icon_only:
+                warnings.warn(
+                    "icon_only=True has no effect without icon=...; ignoring.",
+                    UserWarning, stacklevel=2,
+                )
         except AttributeError:
             # Third-party widgets (e.g. tkcalendar.Calendar) override
             # configure() and may touch instance attributes not yet set when
@@ -953,6 +975,7 @@ class BootMixin(FluentGeometryMixin):
         # capture icon changes; applied after the base style resolves below
         icon = kwargs.pop("icon", _UNSET)
         icon_size = kwargs.pop("icon_size", _UNSET)
+        icon_only = kwargs.pop("icon_only", _UNSET)
 
         # set configuration
         bootstyle = kwargs.pop("bootstyle", "")
@@ -972,20 +995,31 @@ class BootMixin(FluentGeometryMixin):
         # otherwise a base-style change under an existing icon re-derives it onto
         # the new base. The _tb_applying_icon guard skips the re-derive while
         # apply_icon is itself setting the derived style (avoids recursion).
-        if icon is not _UNSET or icon_size is not _UNSET:
+        if icon is not _UNSET or icon_size is not _UNSET or icon_only is not _UNSET:
             from ttkbootstrap.style.icons import apply_icon
             existing = getattr(self, "_tb_icon", None)
             name = icon if icon is not _UNSET else (existing["name"] if existing else None)
-            size = icon_size if icon_size is not _UNSET else (existing["size"] if existing else 14)
+            # size: explicit wins; else if icon_only was just toggled, re-default
+            # (None -> apply_icon's icon-only-aware default); else keep the spec's.
+            if icon_size is not _UNSET:
+                size = icon_size
+            elif icon_only is not _UNSET:
+                size = None
+            else:
+                size = existing["size"] if existing else None
             states = existing["states"] if existing else None
             compound = existing["compound"] if existing else None
-            apply_icon(self, name, size=size, states=states, compound=compound)
+            only = (icon_only if icon_only is not _UNSET
+                    else (existing.get("icon_only", False) if existing else False))
+            apply_icon(self, name, size=size, states=states,
+                       compound=compound, icon_only=only)
         elif (base_changed and getattr(self, "_tb_icon", None)
                 and not getattr(self, "_tb_applying_icon", False)):
             from ttkbootstrap.style.icons import apply_icon
             spec = self._tb_icon
             apply_icon(self, spec["name"], size=spec["size"],
-                       states=spec["states"], compound=spec["compound"])
+                       states=spec["states"], compound=spec["compound"],
+                       icon_only=spec.get("icon_only", False))
 
         return result
 

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -7,7 +7,7 @@ content-addressed image cache. Split out of the monolithic `style.py` in 2.0.
 import json
 import warnings
 from tkinter import TclError, ttk
-from typing import Any
+from typing import Any, Optional
 
 from ttkbootstrap.internal import utility as util
 from ttkbootstrap.constants import *
@@ -64,7 +64,8 @@ class Style(ttk.Style):
         else:
             return Style.instance
 
-    def __init__(self, theme=None, default_button=None, *, themename=None):
+    def __init__(self, theme=None, default_button=None, *, themename=None,
+                 light_theme=None, dark_theme=None):
         """
         Parameters:
 
@@ -72,6 +73,15 @@ class Style(ttk.Style):
                 The name of the theme to use when styling the widget.
                 `themename` is a permanent, non-deprecated alias accepted for
                 the same purpose (pre-2.0 spelling); pass either.
+
+            light_theme, dark_theme (str):
+                Optionally designate the themes that `toggle_theme_mode()` /
+                `use_theme_mode()` switch between. If omitted, the counterpart
+                is derived from the `<family>-light` / `<family>-dark` naming
+                convention, so designation is only needed to pin a specific
+                pair (e.g. a light theme from one family with a dark theme from
+                another). Read once on the first `Style`/`App`; ignored on the
+                existing singleton (set later via `set_theme_modes(...)`).
 
             default_button (str):
                 The color a bare `Button`/`Menubutton` (no `bootstyle`) uses.
@@ -96,6 +106,10 @@ class Style(ttk.Style):
         self._style_registry = set()  # all styles used
         self._theme_styles = {}  # styles used in theme
         self._theme_names = set()
+        # Optional designated light/dark theme pair for use_theme_mode()/
+        # toggle_theme_mode(); None means "derive from the -light/-dark naming".
+        self._light_theme = None
+        self._dark_theme = None
         # Monotonic counter bumped on every theme switch. The theme walk
         # repaints (and restamps) only widgets stamped older than this, so a
         # widget is repainted at most once per switch. Replaces the old
@@ -124,6 +138,9 @@ class Style(ttk.Style):
         config.flush_pending_config()
         if default_button is not None:
             self.default_button = default_button
+
+        if light_theme is not None or dark_theme is not None:
+            self.set_theme_modes(light=light_theme, dark=dark_theme)
 
         self.theme_use(theme)
 
@@ -284,6 +301,102 @@ class Style(ttk.Style):
         self._theme_version += 1
         self._theme_walk()
 
+    # ------------------------------------------------------------------ #
+    # Light/dark theme mode toggling
+    # ------------------------------------------------------------------ #
+    @property
+    def theme_mode(self) -> Optional[str]:
+        """The active theme mode (`"light"` or `"dark"`).
+
+        Reads the active theme's type; `None` before a theme is applied.
+        """
+        theme = getattr(self, "theme", None)
+        return theme.type if theme is not None else None
+
+    def set_theme_modes(self, light: str = None, dark: str = None) -> None:
+        """Designate the light and/or dark theme that `use_theme_mode()` /
+        `toggle_theme_mode()` switch between.
+
+        By default the counterpart is derived from the `<family>-light` /
+        `<family>-dark` naming convention, so this is only needed to pin a
+        specific pair (e.g. a light theme from one family with a dark theme
+        from another). Each name must be a registered theme; a name whose own
+        type disagrees with the slot it is assigned to earns a warning.
+
+        Parameters:
+
+            light (str):
+                Theme to use as the light-mode target.
+
+            dark (str):
+                Theme to use as the dark-mode target.
+        """
+        for mode, name in (("light", light), ("dark", dark)):
+            if name is None:
+                continue
+            if name not in self._theme_names:
+                raise ValueError(f"{name!r} is not a registered theme name.")
+            definition = self._theme_definitions.get(name)
+            if definition is not None and definition.type != mode:
+                warnings.warn(
+                    f"designating {name!r} (a {definition.type} theme) as the "
+                    f"{mode} theme; toggling will not change appearance the way "
+                    "a matching-type theme would.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            setattr(self, f"_{mode}_theme", name)
+
+    def _theme_for_mode(self, mode: str) -> Optional[str]:
+        """Resolve the theme name for `mode`: a designated theme if set, else
+        the `<current-family>-<mode>` sibling if it is registered, else None.
+        """
+        designated = getattr(self, f"_{mode}_theme", None)
+        if designated:
+            return designated
+        current = self.theme.name if getattr(self, "theme", None) else DEFAULT_THEME
+        family = current
+        for suffix in ("-light", "-dark"):
+            if current.endswith(suffix):
+                family = current[: -len(suffix)]
+                break
+        candidate = f"{family}-{mode}"
+        return candidate if candidate in self._theme_names else None
+
+    def use_theme_mode(self, mode: str) -> Optional[str]:
+        """Switch to the light or dark theme (the designated one, else the
+        current family's `-light`/`-dark` sibling).
+
+        Returns the resulting mode. No-ops with a warning if no counterpart
+        exists (e.g. a single legacy theme with no sibling).
+
+        Parameters:
+
+            mode (str):
+                `"light"` or `"dark"`.
+        """
+        mode = str(mode).lower()
+        if mode not in ("light", "dark"):
+            raise ValueError(f"mode must be 'light' or 'dark', got {mode!r}")
+        target = self._theme_for_mode(mode)
+        if target is None:
+            warnings.warn(
+                f"no {mode} theme for {self.theme.name!r}; designate one via "
+                f"set_theme_modes({mode}=...) or use a theme that has a "
+                f"'-{mode}' variant.",
+                UserWarning,
+                stacklevel=2,
+            )
+            return self.theme_mode
+        if target != self.theme.name:
+            self.theme_use(target)
+        return self.theme_mode
+
+    def toggle_theme_mode(self) -> Optional[str]:
+        """Toggle between the light and dark theme, returning the new mode."""
+        other = "dark" if self.theme_mode == "light" else "light"
+        return self.use_theme_mode(other)
+
     def theme_create(self, themename: str, parent: str = None, settings: dict = None) -> None:
         """
         Create a new theme in the Tcl interpreter. If the parent is a registered
@@ -422,6 +535,23 @@ class Style(ttk.Style):
     def _build_configure(self, style, **kw):
         """Calls configure of superclass; used by style builder classes."""
         super().configure(style, **kw)
+
+    def element_create(self, elementname, etype, *args, **kw):
+        """Create a ttk element, idempotently within the current theme.
+
+        ttk raises ``Duplicate element`` if the same element name is created
+        twice in one theme. Every ttkbootstrap theme maps to a single
+        clam-derived Tcl theme with fixed colors, so an element only ever needs
+        to be created once per theme; the second run of a recipe -- whether a
+        test that force-rebuilds a style, or a production theme-rebuild after
+        the per-theme style registry (`_theme_styles`) desyncs from the Tcl
+        theme -- must be a safe no-op, not a crash. The `configure`/`layout`/
+        `map` steps that follow are already idempotent, so skipping the redundant
+        element create makes the whole recipe re-runnable.
+        """
+        if elementname in self.element_names():
+            return
+        super().element_create(elementname, etype, *args, **kw)
 
     def _load_themes(self, EXTERNAL_THEMES=None):
         """Register the curated 2.0 theme catalog (and any user themes).

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -360,6 +360,19 @@ _ICON_WIDGET_CLASSES = frozenset({
     "TCheckbutton", "TRadiobutton",
 })
 
+#: Default logical glyph size for a normal icon (icon + text).
+_ICON_SIZE = 14
+#: Default logical glyph size + symmetric padding for an icon-only widget. The
+#: pair is chosen once for the expected height: a button is
+#: ``content + 2*padding + chrome``, and a normal button (text lineheight ~15,
+#: base padding 4, chrome ~6) is ~29 px, so ``size + 2*padding = 23`` lands an
+#: icon-only square on that same height. 17 + 2*3 = 23 -> a compact square the
+#: height of a normal button, with a glyph a touch larger than the text line.
+#: Both are logical units (DPI-scaled). Explicit ``icon_size=`` / ``padding=``
+#: override them, and then the control's size changes to match (by design).
+_ICON_ONLY_SIZE = 17
+_ICON_ONLY_PADDING = 3
+
 # A derived icon style is named "Icon<8 hex>.<base style>"; this strips the
 # prefix back to the base so re-applies are idempotent.
 _ICON_STYLE_PREFIX = re.compile(r"^Icon[0-9a-f]{8}\.")
@@ -381,7 +394,7 @@ def _widget_has_text(widget):
         return False
 
 
-def _build_icon_style(style, base, name, size, states, compound):
+def _build_icon_style(style, base, name, size, states, compound, icon_only=False):
     """(Re)configure a derived ``Icon<hash>.<base>`` style and return its name.
 
     Renders one glyph per state in that state's *base foreground* color (so the
@@ -394,7 +407,15 @@ def _build_icon_style(style, base, name, size, states, compound):
     assets = Assets(style)
     states = states or {}
 
-    key = f"{base}|{name}|{size}|{sorted(states.items())}|{compound}"
+    # icon-only: image-only compound + the fixed symmetric padding chosen (with
+    # the default size) so the default control is a square ~a normal button's
+    # height. Fixed, not derived: an explicit size/padding just changes the size.
+    padding = None
+    if icon_only:
+        compound = "image"  # ttk compound value; no tkinter constant for it
+        padding = assets.scaling.logical(_ICON_ONLY_PADDING)
+
+    key = f"{base}|{name}|{size}|{sorted(states.items())}|{compound}|{padding}"
     digest = hashlib.md5(key.encode("utf-8")).hexdigest()[:8]
     derived = f"Icon{digest}.{base}"
 
@@ -422,6 +443,8 @@ def _build_icon_style(style, base, name, size, states, compound):
     config = {"image": rest_image}
     if compound is not None:
         config["compound"] = compound
+    if padding is not None:
+        config["padding"] = padding
     style.configure(derived, **config)
     if image_map:
         style.map(derived, image=image_map)
@@ -450,7 +473,7 @@ def _rebuild_widget_icon(widget):
     try:
         derived = _build_icon_style(
             style, spec["base"], spec["name"], spec["size"],
-            spec["states"], spec["compound"],
+            spec["states"], spec["compound"], spec.get("icon_only", False),
         )
         _set_icon_style(widget, derived)
     except tk.TclError:
@@ -481,7 +504,8 @@ def _clear_widget_icon(widget):
     return None
 
 
-def apply_icon(widget, name, *, size=14, states=None, compound=None):
+def apply_icon(widget, name, *, size=None, states=None, compound=None,
+               icon_only=False):
     """Put a theme-aware Bootstrap Icons glyph on ``widget``.
 
     Unlike a bare `Icon(...)` used as ``image=``, this tracks the active theme and
@@ -514,7 +538,15 @@ def apply_icon(widget, name, *, size=14, states=None, compound=None):
 
         compound (str | None):
             The ttk ``-compound`` option (icon/text arrangement). Defaults to
-            ``LEFT`` when the widget has text, else icon-only.
+            ``LEFT`` when the widget has text, else icon-only. Ignored (forced to
+            ``IMAGE``) when ``icon_only`` is set.
+
+        icon_only (bool):
+            Render the widget as an icon-only control: hide any text
+            (``compound=IMAGE``) and give it a symmetric padding that makes it a
+            square the same height as a normal widget. The default glyph is a
+            touch larger; an explicit ``size`` (and a widget ``padding=`` option,
+            which wins over the style) still take precedence.
 
     Returns the derived ttk style name, or ``None`` when the icon was cleared.
     """
@@ -533,18 +565,21 @@ def apply_icon(widget, name, *, size=14, states=None, compound=None):
             f"API, not a widget-level style.)"
         )
 
-    if compound is None and _widget_has_text(widget):
+    if size is None:
+        size = _ICON_ONLY_SIZE if icon_only else _ICON_SIZE
+    if not icon_only and compound is None and _widget_has_text(widget):
         compound = tk.LEFT
 
     base = _icon_base_style(widget)
-    derived = _build_icon_style(style, base, name, size, states, compound)
+    derived = _build_icon_style(style, base, name, size, states, compound,
+                                icon_only)
     _set_icon_style(widget, derived)
 
     # remember the spec so a <<ThemeChanged>> (or a bootstyle change that re-calls
     # apply_icon) can rebuild the glyphs for the new theme
     widget._tb_icon = {
         "base": base, "name": name, "size": size,
-        "states": states, "compound": compound,
+        "states": states, "compound": compound, "icon_only": icon_only,
     }
     # single bind: replace, never stack, on repeated apply_icon calls
     old = getattr(widget, "_tb_icon_bindid", None)

--- a/src/ttkbootstrap/widgets/dateentry.py
+++ b/src/ttkbootstrap/widgets/dateentry.py
@@ -56,10 +56,6 @@ class DateEntry(ConfigureDelegationMixin, Frame):
     # coercing the live entry text to a date.
     _FALLBACK_FORMATS = ("%Y-%m-%d", "%m/%d/%Y")
 
-    # Logical size of the calendar-button glyph (shared by construction and the
-    # `button_icon` configure delegate so live changes match the initial render).
-    _BUTTON_ICON_SIZE = 18
-
     def __init__(
             self,
             master: Optional[Misc] = None,
@@ -163,7 +159,7 @@ class DateEntry(ConfigureDelegationMixin, Frame):
             command=self._on_date_ask,
             bootstyle=self._bootstyle,
             icon=self._button_icon,
-            icon_size=self._BUTTON_ICON_SIZE,
+            icon_only=True,
             padding=2
         )
         # The button is *placed* over the entry's right edge (not packed beside
@@ -220,7 +216,7 @@ class DateEntry(ConfigureDelegationMixin, Frame):
         if value is None:
             return self._button_icon
         self._button_icon = value
-        apply_icon(self.button, value, size=self._BUTTON_ICON_SIZE)
+        apply_icon(self.button, value, icon_only=True)
 
     @configure_delegate("start_date")
     def _cfg_start_date(self, value):

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -2423,6 +2423,7 @@ class Tableview(ttk.Frame):
                 frame,
                 bootstyle=GHOST,
                 icon="arrow-counterclockwise",
+                icon_only=True,
                 command=self.reset_table,
             ).pack(side=LEFT)
 
@@ -2437,6 +2438,7 @@ class Tableview(ttk.Frame):
             pageframe,
             bootstyle=GHOST,
             icon="arrow-counterclockwise",
+            icon_only=True,
             command=self.reset_table,
         ).pack(side=RIGHT, fill=Y)
 
@@ -2448,6 +2450,7 @@ class Tableview(ttk.Frame):
             master=pageframe,
             bootstyle=GHOST,
             icon="chevron-bar-right",
+            icon_only=True,
             command=self.goto_last_page,
         )
         self._pagelast.pack(side=RIGHT, fill=Y)
@@ -2455,6 +2458,7 @@ class Tableview(ttk.Frame):
             master=pageframe,
             bootstyle=GHOST,
             icon="chevron-right",
+            icon_only=True,
             command=self.goto_next_page,
         )
         self._pagenext.pack(side=RIGHT, fill=Y)
@@ -2463,6 +2467,7 @@ class Tableview(ttk.Frame):
             master=pageframe,
             bootstyle=GHOST,
             icon="chevron-left",
+            icon_only=True,
             command=self.goto_prev_page,
         )
         self._pageprev.pack(side=RIGHT, fill=Y)
@@ -2470,6 +2475,7 @@ class Tableview(ttk.Frame):
             master=pageframe,
             bootstyle=GHOST,
             icon="chevron-bar-left",
+            icon_only=True,
             command=self.goto_first_page,
         )
         self._pagefirst.pack(side=RIGHT, fill=Y)

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -246,10 +246,15 @@ class ToastNotification:
 
         self.toplevel.bind("<ButtonPress>", self.hide)
 
-        # measure the requested size (valid even while withdrawn) BEFORE placing,
-        # so the stack offset is correct and there is no reposition flash.
+        # measure the on-screen height (valid even while withdrawn) BEFORE
+        # placing, so the stack offset is correct and there is no reposition
+        # flash. The toast is floored to its `minsize`, so the height it actually
+        # occupies is the larger of the requested and minimum heights; using
+        # reqheight alone undershoots and the stacked toasts overlap.
         self.toplevel.update_idletasks()
-        self._height = self.toplevel.winfo_reqheight()
+        self._height = max(
+            self.toplevel.winfo_reqheight(), self.toplevel.minsize()[1]
+        )
 
         _TOAST_STACK.add(self)
         self._reposition()

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -200,6 +200,26 @@ class _BaseWindow:
         """Return a reference to the `ttkbootstrap.style.Style` object."""
         return Style.get_instance()
 
+    # -- light/dark theme mode (convenience delegates to Style) ------------
+
+    @property
+    def theme_mode(self) -> Optional[str]:
+        """The active theme mode (`"light"` or `"dark"`)."""
+        return self.style.theme_mode
+
+    def set_theme_modes(self, light: Optional[str] = None,
+                        dark: Optional[str] = None) -> None:
+        """Designate the light/dark theme pair the toggle switches between."""
+        self.style.set_theme_modes(light=light, dark=dark)
+
+    def use_theme_mode(self, mode: str) -> Optional[str]:
+        """Switch to the light or dark theme; returns the resulting mode."""
+        return self.style.use_theme_mode(mode)
+
+    def toggle_theme_mode(self) -> Optional[str]:
+        """Toggle between the light and dark theme; returns the new mode."""
+        return self.style.toggle_theme_mode()
+
     # -- setup helpers -----------------------------------------------------
 
     def _setup_icon(self, iconphoto: Optional[str], default_data: Optional[str] = None) -> None:
@@ -222,11 +242,19 @@ class _BaseWindow:
             return
         try:
             path = str(iconphoto)
+            # The application root's icon is the app-wide default, so child
+            # toplevels (dialogs, pickers) inherit it instead of the Tk feather;
+            # a secondary `Toplevel`'s own icon applies to that window only (it
+            # must not re-skin the whole app).
+            app_wide = isinstance(self, tkinter.Tk)
             if path.lower().endswith('.ico') and self.winsys == 'win32':
-                self.wm_iconbitmap(path)
+                if app_wide:
+                    self.wm_iconbitmap(default=path)
+                else:
+                    self.wm_iconbitmap(path)
             else:
                 self._icon = tkinter.PhotoImage(file=path, master=self)
-                self.iconphoto(True, self._icon)
+                self.iconphoto(app_wide, self._icon)
         except tkinter.TclError:
             warnings.warn(
                 f"iconphoto path {iconphoto!r} could not be loaded; "
@@ -248,7 +276,9 @@ class _BaseWindow:
         try:
             if self.winsys == 'win32':
                 if _APP_ICON_ICO.is_file():
-                    self.wm_iconbitmap(str(_APP_ICON_ICO))
+                    # `default=` propagates the icon to every future toplevel
+                    # (dialogs/pickers), which otherwise show the Tk feather.
+                    self.wm_iconbitmap(default=str(_APP_ICON_ICO))
                     return
             elif _APP_ICON_PNG.is_file():
                 self._icon = tkinter.PhotoImage(master=self, file=str(_APP_ICON_PNG))
@@ -374,6 +404,8 @@ class App(_BaseWindow, tkinter.Tk):
             theme: Optional[str] = None,
             *,
             themename: Optional[str] = None,
+            light_theme: Optional[str] = None,
+            dark_theme: Optional[str] = None,
             default_button: Optional[str] = None,
             iconphoto: Optional[str] = '',
             size: Optional[Tuple[int, int]] = None,
@@ -520,7 +552,10 @@ class App(_BaseWindow, tkinter.Tk):
 
         apply_class_bindings(self)
         apply_all_bindings(self)
-        self._style = Style(theme, default_button=default_button)
+        self._style = Style(
+            theme, default_button=default_button,
+            light_theme=light_theme, dark_theme=dark_theme,
+        )
 
     @staticmethod
     def _set_app_user_model_id() -> None:

--- a/tests/test_bootstyle_grammar.py
+++ b/tests/test_bootstyle_grammar.py
@@ -241,6 +241,40 @@ def test_invalid_pair_warns_for_our_widget(root):
         ttk.Button(root, bootstyle="thin")
 
 
+@pytest.mark.parametrize(
+    "factory",
+    [ttk.Label, ttk.Entry, ttk.Checkbutton, ttk.Radiobutton, ttk.Progressbar,
+     ttk.Scale, ttk.Scrollbar, ttk.Combobox, ttk.Spinbox, ttk.Frame],
+)
+def test_neutral_on_non_button_family_falls_back_not_crashes(root, factory):
+    # `neutral` is a real color but only the button-family recipes implement it
+    # (constants.NEUTRAL_FAMILIES); on any other family it used to resolve to
+    # Colors.get("neutral") -> None and crash the recipe mid-build. It must now
+    # loud-fail and fall back to the family default, never crash construction.
+    with pytest.warns(UserWarning, match="neutral-"):
+        widget = factory(root, bootstyle="neutral")
+    applied = widget.cget("style")
+    assert applied  # a real, built default style, not an unusable fragment
+    assert root.style.style_exists_in_theme(applied)
+
+
+@pytest.mark.parametrize(
+    "factory, bootstyle, expected_name",
+    [
+        (ttk.Button, "neutral", "neutral.TButton"),
+        (ttk.Button, "neutral-outline", "neutral.Outline.TButton"),
+        (ttk.Button, "neutral-toolbutton", "neutral.Toolbutton"),
+        (ttk.Menubutton, "neutral", "neutral.TMenubutton"),
+    ],
+)
+def test_neutral_still_builds_for_button_family(root, factory, bootstyle, expected_name):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # button-family neutral must be warning-free
+        widget = factory(root, bootstyle=bootstyle)
+    assert widget.cget("style") == expected_name
+    assert root.style.style_exists_in_theme(expected_name)
+
+
 def test_valid_widget_construction_is_warning_free(root):
     with warnings.catch_warnings():
         warnings.simplefilter("error")

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -14,6 +14,7 @@ import ttkbootstrap as ttk
 from ttkbootstrap.dialogs import Messagebox, Querybox
 from ttkbootstrap.dialogs.base import Dialog
 from ttkbootstrap.dialogs.message import MessageDialog
+from ttkbootstrap.dialogs.query import QueryDialog
 from ttkbootstrap.dialogs.datepicker import DatePickerDialog
 
 
@@ -127,6 +128,56 @@ def test_datepicker_result_is_none_until_a_day_is_selected(root):
             chooser.root.destroy()
         except Exception:
             pass
+
+
+def test_datepicker_selection_highlight_does_not_bleed_across_months(root):
+    # Regression: `datevar` (shared by every day cell) was only re-set in the
+    # branch matching the selected month, so browsing to another month left it
+    # pinned to the selected day number and that day was spuriously highlighted
+    # in every month. Each redraw must clear it (0 = no cell) and re-select the
+    # day only in the selected month.
+    import datetime
+    picker = DatePickerDialog(
+        parent=root, start_date=datetime.date(2026, 7, 9), autoshow=False
+    )
+    try:
+        assert picker.datevar.get() == 9          # selected month: day is selected
+        picker.on_next_month()
+        assert picker.datevar.get() == 0          # other month: nothing selected
+        picker.on_next_year()
+        assert picker.datevar.get() == 0
+        picker.on_prev_year()
+        picker.on_prev_month()
+        assert picker.datevar.get() == 9          # back to selected month: restored
+    finally:
+        try:
+            picker.root.destroy()
+        except Exception:
+            pass
+
+
+def test_message_and_query_dialogs_use_consistent_button_spacing(root):
+    # Regression: QueryDialog packed its Submit/Cancel buttons with padx=5 while
+    # MessageDialog uses padx=2, so the Querybox button row read visibly looser
+    # than the Messagebox row. The two sibling dialogs must space buttons alike.
+    def button_padx(dlg):
+        dlg.build()
+        dlg._toplevel.withdraw()
+        pads = [
+            w.pack_info().get("padx")
+            for child in dlg._toplevel.winfo_children()
+            for w in child.winfo_children()
+            if isinstance(w, ttk.Button)
+        ]
+        dlg._toplevel.destroy()
+        return pads
+
+    md = button_padx(
+        MessageDialog("body", title="m", parent=root, buttons=["Cancel", "OK:primary"])
+    )
+    qd = button_padx(QueryDialog("prompt", title="q", parent=root))
+    assert md and qd
+    assert set(md) == set(qd) == {2}
 
 
 def test_datepicker_has_show_and_autoshow():

--- a/tests/test_icon_drop.py
+++ b/tests/test_icon_drop.py
@@ -25,8 +25,12 @@ def _icon_label_image(container):
     # is the icon Label when an icon was supplied.
     inner = container.winfo_children()[0]
     for w in inner.winfo_children():
+        # Only Labels carry an -image option; the message lives in a sub-frame
+        # that would raise on cget("image"), so gate on the class first.
+        if w.winfo_class() != "TLabel":
+            continue
         image = w.cget("image")
-        if w.winfo_class() == "TLabel" and image:
+        if image:
             # Tk may hand back a 1-tuple for the -image option; normalize to str.
             return image[0] if isinstance(image, tuple) else image
     return None

--- a/tests/test_icon_theme.py
+++ b/tests/test_icon_theme.py
@@ -136,3 +136,84 @@ def test_datepicker_carets_use_apply_icon(root):
         assert getattr(dp.prev_period, "_tb_icon", None)
     finally:
         dp.root.destroy()
+
+
+# --------------------------------------------------------------------------
+# icon_only: square, same height as a normal button; explicit overrides win
+# --------------------------------------------------------------------------
+
+def test_icon_only_is_square_and_matches_normal_height(root):
+    normal = ttk.Button(root, text="Normal")
+    normal.pack()
+    only = ttk.Button(root, icon="gear-fill", icon_only=True)
+    only.pack()
+    root.update_idletasks()
+    w, h = only.winfo_reqwidth(), only.winfo_reqheight()
+    assert abs(w - h) <= 1                                  # square (exact)
+    assert abs(h - normal.winfo_reqheight()) <= 1           # same height (exact)
+    # compound is image-only (text hidden)
+    assert str(root.style.lookup(only.cget("style"), "compound")) == "image"
+
+
+def test_icon_only_is_always_square_but_size_override_changes_the_control(root):
+    # Icon-only uses a fixed default (size, padding) pair, so the default is a
+    # square ~a normal button's height; it stays square at any size, but an
+    # explicit icon_size deliberately changes the control's size (not forced).
+    for size in (12, 16, 20, 24):
+        b = ttk.Button(root, icon="gear-fill", icon_only=True, icon_size=size)
+        b.pack()
+        root.update_idletasks()
+        w, h = b.winfo_reqwidth(), b.winfo_reqheight()
+        assert abs(w - h) <= 1, f"size={size} not square: {w}x{h}"
+    small = ttk.Button(root, icon="gear-fill", icon_only=True, icon_size=12)
+    big = ttk.Button(root, icon="gear-fill", icon_only=True, icon_size=24)
+    small.pack()
+    big.pack()
+    root.update_idletasks()
+    assert big.winfo_reqheight() > small.winfo_reqheight()  # size is not forced
+
+
+def test_icon_only_explicit_padding_wins(root):
+    # A widget `padding=` (instance option) overrides the icon_only style padding.
+    b = ttk.Button(root, icon="gear-fill", icon_only=True, padding=(12, 2))
+    b.pack()
+    root.update_idletasks()
+    assert b.cget("padding") == (12, 2)
+
+
+def test_icon_only_via_configure_toggles(root):
+    normal = ttk.Button(root, text="N")
+    normal.pack()
+    root.update_idletasks()
+    H = normal.winfo_reqheight()
+    b = ttk.Button(root, icon="gear-fill", text="Settings")
+    b.pack()
+    root.update_idletasks()
+    wide = b.winfo_reqwidth()
+    b.configure(icon_only=True)
+    root.update_idletasks()
+    assert abs(b.winfo_reqwidth() - b.winfo_reqheight()) <= 3   # now square
+    assert abs(b.winfo_reqheight() - H) <= 2
+    b.configure(icon="bell-fill")                               # icon_only persists
+    root.update_idletasks()
+    assert abs(b.winfo_reqwidth() - b.winfo_reqheight()) <= 3
+    b.configure(icon_only=False)                               # back to icon+text
+    root.update_idletasks()
+    assert b.winfo_reqwidth() > b.winfo_reqheight()
+
+
+def test_icon_only_recomputes_on_theme_change(root):
+    b = ttk.Button(root, icon="gear-fill", icon_only=True)
+    b.pack()
+    root.update_idletasks()
+    before = (b.winfo_reqwidth(), b.winfo_reqheight())
+    root.style.theme_use("bootstrap-dark")
+    root.update()
+    after = (b.winfo_reqwidth(), b.winfo_reqheight())
+    assert abs(after[0] - after[1]) <= 3           # still square after switch
+    assert abs(before[1] - after[1]) <= 2          # height stable
+
+
+def test_icon_only_without_icon_warns(root):
+    with pytest.warns(UserWarning, match="icon_only"):
+        ttk.Button(root, icon_only=True, text="x")

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -137,7 +137,7 @@ def test_window_and_style_initialize_scaling_before_style_builds():
     )
     assert init_source.index("super().__init__(**kwargs)") < init_source.index(
         "utils.enable_high_dpi_awareness(self, scaling)"
-    ) < init_source.index("self._style = Style(theme")
+    ) < init_source.index("self._style = Style(")
 
     engine_source = (package / "style" / "engine.py").read_text(encoding="utf-8")
     style_init = engine_source[engine_source.index("class Style"):]

--- a/tests/test_toast_api.py
+++ b/tests/test_toast_api.py
@@ -153,7 +153,14 @@ def test_two_toasts_stack_without_overlap(root):
 
     y1, y2 = _ypos(t1), _ypos(t2)
     assert y1 != y2  # non-overlapping
-    # t2 is offset from t1 by ~t1's height + the gap
+    # The offset basis must be the height the toast actually OCCUPIES on screen,
+    # which is floored to its minsize -- not the (smaller) requested height.
+    # Regression: using winfo_reqheight() alone undershot the floor and the
+    # stacked toasts overlapped by the minsize/reqheight gap.
+    assert t1._height >= t1.toplevel.minsize()[1]
+    assert t1._height == max(t1.toplevel.winfo_reqheight(), t1.toplevel.minsize()[1])
+    # t2 is offset from t1 by its full occupied height + the gap, so the two
+    # windows are exactly one gap apart (no overlap).
     expected = t1._height + t1._scaled_gap()
     assert abs((abs(y2) - abs(y1)) - expected) <= 2
     assert len(_TOAST_STACK._corners["se"]) == 2

--- a/tests/test_window_api.py
+++ b/tests/test_window_api.py
@@ -185,6 +185,42 @@ def test_toplevel_bad_iconphoto_path_warns_not_prints(root):
     top.destroy()
 
 
+def test_app_default_icon_uses_default_flag_on_win32(root):
+    # Regression: dialogs/pickers showed the Tk feather because the win32 app
+    # icon was applied via `wm_iconbitmap(path)` (no `-default`), so child
+    # toplevels did not inherit it. It must be applied with `default=` so it
+    # becomes the app-wide default for every future toplevel.
+    from ttkbootstrap.window import _APP_ICON_ICO, _DEFAULT_ICON_DATA
+    if not _APP_ICON_ICO.is_file():
+        pytest.skip("packaged .ico not present")
+    top = ttk.Toplevel(title="iconspy")
+    top.winsys = "win32"  # exercise the win32 branch regardless of host OS
+    recorded = {}
+    top.wm_iconbitmap = lambda bitmap=None, default=None: recorded.update(
+        bitmap=bitmap, default=default
+    )
+    top._apply_default_icon(_DEFAULT_ICON_DATA)
+    assert recorded.get("default") == str(_APP_ICON_ICO)
+    assert recorded.get("bitmap") is None  # not the per-window positional form
+    top.destroy()
+
+
+def test_toplevel_explicit_ico_is_per_window_not_app_wide(root):
+    # Regression: a secondary Toplevel's own .ico must apply to that window
+    # only, not become the app-wide default (which would re-skin App + every
+    # sibling toplevel). Only the root App's icon is app-wide (default=).
+    top = ttk.Toplevel(title="own-icon")
+    top.winsys = "win32"  # exercise the win32 branch regardless of host OS
+    recorded = {}
+    top.wm_iconbitmap = lambda bitmap=None, default=None: recorded.update(
+        bitmap=bitmap, default=default
+    )
+    top._setup_icon("C:/some/custom.ico", default_data=None)
+    assert recorded.get("default") is None                  # NOT app-wide
+    assert recorded.get("bitmap") == "C:/some/custom.ico"   # this window only
+    top.destroy()
+
+
 # --------------------------------------------------------------------------
 # style property + aqua guard
 # --------------------------------------------------------------------------

--- a/tests/widget_styles/test_theme_anchor.py
+++ b/tests/widget_styles/test_theme_anchor.py
@@ -246,3 +246,82 @@ def test_legacy_theme_use_lazy_registers_then_bulk_opt_in(root):
                 style._theme_styles.pop(name, None)
                 style._theme_objects.pop(name, None)
         style.theme_use("bootstrap-light")
+
+
+# --------------------------------------------------------------------------- #
+# Light/dark theme mode (theme_mode / toggle_theme_mode / use_theme_mode /
+# set_theme_modes)
+# --------------------------------------------------------------------------- #
+def test_mode_reflects_active_theme_type(root):
+    style = root.style
+    style.theme_use("bootstrap-light")
+    assert style.theme_mode == "light"
+    style.theme_use("bootstrap-dark")
+    assert style.theme_mode == "dark"
+
+
+def test_toggle_mode_swaps_family_sibling(root):
+    style = root.style
+    style.theme_use("bootstrap-light")
+    assert style.toggle_theme_mode() == "dark"
+    assert style.theme.name == "bootstrap-dark"
+    assert style.toggle_theme_mode() == "light"
+    assert style.theme.name == "bootstrap-light"
+
+
+def test_use_mode_is_explicit_and_idempotent(root):
+    style = root.style
+    style.theme_use("bootstrap-light")
+    assert style.use_theme_mode("dark") == "dark"
+    assert style.theme.name == "bootstrap-dark"
+    # already dark -> no-op, stays put
+    assert style.use_theme_mode("dark") == "dark"
+    assert style.theme.name == "bootstrap-dark"
+    with pytest.raises(ValueError):
+        style.use_theme_mode("sepia")
+
+
+def test_designated_pair_can_cross_families(root):
+    style = root.style
+    try:
+        style.set_theme_modes(light="bootstrap-light", dark="dracula-dark")
+        style.use_theme_mode("light")
+        assert style.theme.name == "bootstrap-light"
+        assert style.toggle_theme_mode() == "dark"
+        assert style.theme.name == "dracula-dark"
+    finally:
+        style._light_theme = style._dark_theme = None
+        style.theme_use("bootstrap-light")
+
+
+def test_set_mode_themes_rejects_unregistered_and_warns_on_type_mismatch(root):
+    style = root.style
+    with pytest.raises(ValueError):
+        style.set_theme_modes(light="no-such-theme")
+    try:
+        with pytest.warns(UserWarning, match="dark theme"):
+            style.set_theme_modes(light="bootstrap-dark")  # dark in the light slot
+    finally:
+        style._light_theme = style._dark_theme = None
+
+
+def test_toggle_without_sibling_warns_and_noops(root):
+    style = root.style
+    before = set(style._theme_names)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ttk.install_legacy_themes()
+        style.theme_use("darkly")  # a single legacy theme, no -light sibling
+        with pytest.warns(UserWarning, match="no light theme"):
+            assert style.toggle_theme_mode() == "dark"  # unchanged
+        assert style.theme.name == "darkly"
+    finally:
+        for name in list(style._theme_names):
+            if name not in before:
+                style._theme_names.discard(name)
+                style._theme_definitions.pop(name, None)
+                style._theme_styles.pop(name, None)
+                style._theme_objects.pop(name, None)
+        style._light_theme = style._dark_theme = None
+        style.theme_use("bootstrap-light")


### PR DESCRIPTION
Capstone **pre-release review** (`development/2_0_prerelease_review_plan.md`) plus two small theme/icon **utilities** and the dogfood that proves them. Suite **566 passed** excl. the known `nl.msg` localization env flake; warning-free import.

## Release-blocker fixes
- **`bootstyle="neutral"` crashed** construction on every non-button widget family (Label/Entry/Checkbutton/Progressbar/Scale/Scrollbar/Combobox) — `neutral` is in the vocab + exported + a canonical `BootStyle` literal, but `NEUTRAL_FAMILIES` was never enforced at runtime. The resolver now gates it and drops to the family default with a loud warning (raise in strict mode).
- **`Duplicate element TSpinbox.uparrow`** (order-dependent theme-rebuild crash, previously read as a flake) — `Style.element_create` is now idempotent within a theme (one clam-derived Tcl theme per ttkbootstrap theme ⇒ each element created once).

## Bug fixes from the visual pass
- **DatePicker** no longer stray-highlights the same day-number when browsing other months (reset the shared `datevar` each redraw).
- **Toast** stack no longer overlaps (offset basis is the minsize-floored height, not `winfo_reqheight`).
- **App icon** reaches dialogs/pickers on win32 (`wm_iconbitmap(default=…)`); a secondary `Toplevel`'s own icon stays **per-window** (caught in review).
- **Querybox** buttons match **Messagebox** spacing (`padx` 5→2).
- **Messagebox**: bad icon warns instead of `print()`; icon/message vertically centered.

## New utilities (utilities, not widgets)
- **Light/dark theme mode:** `Style.theme_mode` / `toggle_theme_mode` / `use_theme_mode` / `set_theme_modes`, `App(light_theme=…, dark_theme=…)`, delegated on `App`/`Toplevel`. Counterpart derives from the `<family>-light`/`-dark` convention by default; a designated pair can cross families. Named `theme_mode` (not `mode`) to avoid the widget `mode` option.
- **`icon_only=True`** on icon-bearing widgets: a fixed `(size, padding)` pair chosen once for the expected height, so the control is a **square ~a normal button's height** (all default icon-only controls uniform); explicit `icon_size=`/`padding=` override and change the size. **Dogfooded** onto the datepicker chevrons, Tableview pagination/reset buttons, and the DateEntry button (hand-tuned padding/size removed).

## Other
- `pyproject`: version **1.20.4 → 2.0.0**.
- Docs: `2_0_breaking_changes.md` + `2_0_prerelease_review_plan.md` updated (gates ticked, review results, migration-contract validated — no silent breaks).
- New `examples/prerelease_visual_review.py` — Track B "everything-bagel" harness.
- **Tests: +40.** A `/code-review` of this diff found one real bug (the Toplevel icon scoping, fixed above) + minor cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01519DDeAhmTTqLDdpzkEqd7