### PR TITLE
Fix macOS popup positioning: toast off-screen, get_date below window

### DIFF
--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -124,6 +124,16 @@ class DatePickerDialog:
         # output, so the ambient (C) locale is exactly what's wanted.
 
         self.parent = parent
+        # On aqua, window_type="tooltip" makes the popup a native borderless
+        # popover (MacWindowStyle) -- the same treatment tooltips/toasts use --
+        # since a plain override-redirect window positions unreliably there.
+        # Gate it to aqua: on x11 it sets `-type tooltip`, which some window
+        # managers make non-focusable, which would break THIS calendar's
+        # focus_force()/Escape/arrow-key navigation (unlike a passive tooltip).
+        _ref = self.parent if self.parent is not None else tkinter._default_root
+        window_kwargs = {}
+        if _ref is not None and windowing_system(_ref) == "aqua":
+            window_kwargs["window_type"] = "tooltip"
         self.root = ttk.Toplevel(
             title=title,
             transient=self.parent,
@@ -132,11 +142,7 @@ class DatePickerDialog:
             minsize=(226, 1),
             iconify=True,
             override_redirect=True,
-            # On aqua this maps to a native borderless popover (MacWindowStyle),
-            # the same treatment tooltips/toasts use -- a plain override-redirect
-            # window positions unreliably there. No-op on win32; sets `-type` on
-            # x11. (override_redirect is itself a no-op on aqua.)
-            window_type="tooltip",
+            **window_kwargs,
         )
         # Outside-click / Escape dismissal bookkeeping. The popup is frameless
         # (no titlebar 'X'), so a click outside its bounds -- or Escape -- cancels

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -10,6 +10,7 @@ from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
 from ttkbootstrap.internal.positioning import (
     below_widget,
+    center_on_parent,
     center_on_screen,
     ensure_on_screen,
 )
@@ -531,8 +532,18 @@ class DatePickerDialog:
         # titlebar_height=0: the popup is frameless, so no decoration to reserve.
         if position is not None:
             x, y = ensure_on_screen(self.root, *position, titlebar_height=0)
-        elif self.parent:
+        elif self.parent and not isinstance(
+                self.parent, (tkinter.Tk, tkinter.Toplevel)):
+            # A dropdown *target* (e.g. a DateEntry's entry field): drop the
+            # calendar directly below it.
             x, y = below_widget(self.root, self.parent)
+        elif self.parent:
+            # The parent is a whole window (e.g. Querybox.get_date(parent=app)):
+            # centering on it is right -- dropping "below" it would land the
+            # popup at the window's bottom edge / off it.
+            x, y = ensure_on_screen(
+                self.root, *center_on_parent(self.root, self.parent),
+                titlebar_height=0)
         else:
             x, y = ensure_on_screen(self.root, *center_on_screen(self.root), titlebar_height=0)
         self.root.geometry(f"+{x}+{y}")

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -131,7 +131,12 @@ class DatePickerDialog:
             topmost=True,
             minsize=(226, 1),
             iconify=True,
-            override_redirect=True
+            override_redirect=True,
+            # On aqua this maps to a native borderless popover (MacWindowStyle),
+            # the same treatment tooltips/toasts use -- a plain override-redirect
+            # window positions unreliably there. No-op on win32; sets `-type` on
+            # x11. (override_redirect is itself a no-op on aqua.)
+            window_type="tooltip",
         )
         # Outside-click / Escape dismissal bookkeeping. The popup is frameless
         # (no titlebar 'X'), so a click outside its bounds -- or Escape -- cancels

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -181,8 +181,13 @@ class DatePickerDialog:
                 If True (default), block until the dialog is closed; read the
                 selection from :attr:`result` afterward.
         """
-        if position is not None:
-            self._set_window_position(position)
+        # Position while still withdrawn, THEN show, so the popup never flashes
+        # at the window manager's default spot before moving to its real place.
+        # update_idletasks first so the size used for centering/anchoring is the
+        # fully-laid-out one, not a partial measurement.
+        self.root.update_idletasks()
+        self._set_window_position(position)
+        self.root.deiconify()
         self.root.lift()
         self.root.focus_force()
         self._arm_dismiss()
@@ -320,10 +325,10 @@ class DatePickerDialog:
         self._draw_titlebar()
         self._draw_calendar()
 
-        # make toplevel visible
+        # Actualize geometry but stay withdrawn -- show() positions the popup and
+        # then deiconifies it, so it never flashes on screen during construction
+        # (notably with autoshow=False, e.g. Querybox.get_date / DateEntry).
         self.root.update_idletasks()
-        self.root.deiconify()
-        self._set_window_position()
 
     def _draw_calendar(self) -> None:
         self._set_title()

--- a/src/ttkbootstrap/internal/positioning.py
+++ b/src/ttkbootstrap/internal/positioning.py
@@ -48,21 +48,19 @@ def _monitor_at_point(x: int, y: int) -> Optional[Rect]:
 
 
 def _window_size(window: tkinter.Misc) -> Tuple[int, int]:
-    """Best-available (width, height): the realized (mapped) size, else the
-    requested size before the window has been mapped.
+    """The size a widget actually occupies: its realized (mapped) size, else its
+    requested size before it has been mapped. Also used for drop targets/parents.
 
-    ``winfo_width``/``winfo_height`` return ``1`` until the window is mapped, so
-    fall back to the request only then. Do NOT ``max()`` the two: once mapped, a
-    window whose content wants more than its actual size reports a larger
-    ``reqheight`` than it occupies, and using that inflated value mis-centers the
-    window (e.g. pinning it to the top of a small screen instead of centering)."""
-    width = window.winfo_width()
-    height = window.winfo_height()
-    if width <= 1:
-        width = window.winfo_reqwidth()
-    if height <= 1:
-        height = window.winfo_reqheight()
-    return width, height
+    Use ``winfo_ismapped()`` (not a ``winfo_width <= 1`` sniff, which a genuinely
+    1px window -- e.g. the datepicker's ``minsize=(226, 1)`` -- would trip): a
+    mapped widget's realized size IS its footprint. Do NOT ``max()`` it with the
+    request -- once mapped, content that wants more than its box reports a larger
+    ``reqheight``/``reqwidth`` than it occupies, and that inflated value
+    mis-centers/mis-anchors (e.g. pinning a window to the top of a small screen).
+    A withdrawn/unmapped widget has no realized size, so its request is best."""
+    if window.winfo_ismapped():
+        return window.winfo_width(), window.winfo_height()
+    return window.winfo_reqwidth(), window.winfo_reqheight()
 
 
 def center_on_screen(window: tkinter.Misc) -> Tuple[int, int]:
@@ -102,8 +100,8 @@ def center_on_parent(window: tkinter.Misc, parent: tkinter.Misc) -> Tuple[int, i
     w_width, w_height = _window_size(window)
     p_x = parent.winfo_rootx()
     p_y = parent.winfo_rooty()
-    p_width = max(parent.winfo_width(), parent.winfo_reqwidth())
-    p_height = max(parent.winfo_height(), parent.winfo_reqheight())
+    # actual occupied size, not the inflated content request (see _window_size)
+    p_width, p_height = _window_size(parent)
     x = p_x + max(0, (p_width - w_width) // 2)
     y = p_y + max(0, (p_height - w_height) // 2)
     return int(x), int(y)
@@ -130,7 +128,8 @@ def below_widget(
     _, w_height = _window_size(window)
     tx = target.winfo_rootx()
     ty = target.winfo_rooty()
-    t_height = max(target.winfo_height(), target.winfo_reqheight())
+    # actual occupied height, not the inflated content request (see _window_size)
+    _, t_height = _window_size(target)
 
     monitor = _monitor_at_point(tx, ty)
     if monitor:

--- a/src/ttkbootstrap/internal/positioning.py
+++ b/src/ttkbootstrap/internal/positioning.py
@@ -48,10 +48,20 @@ def _monitor_at_point(x: int, y: int) -> Optional[Rect]:
 
 
 def _window_size(window: tkinter.Misc) -> Tuple[int, int]:
-    """Best-available (width, height): the realized size, or the requested
-    size before the window has been mapped."""
-    width = max(window.winfo_reqwidth(), window.winfo_width())
-    height = max(window.winfo_reqheight(), window.winfo_height())
+    """Best-available (width, height): the realized (mapped) size, else the
+    requested size before the window has been mapped.
+
+    ``winfo_width``/``winfo_height`` return ``1`` until the window is mapped, so
+    fall back to the request only then. Do NOT ``max()`` the two: once mapped, a
+    window whose content wants more than its actual size reports a larger
+    ``reqheight`` than it occupies, and using that inflated value mis-centers the
+    window (e.g. pinning it to the top of a small screen instead of centering)."""
+    width = window.winfo_width()
+    height = window.winfo_height()
+    if width <= 1:
+        width = window.winfo_reqwidth()
+    if height <= 1:
+        height = window.winfo_reqheight()
     return width, height
 
 

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -380,23 +380,33 @@ class ToastNotification:
         tl = self.toplevel
         tl.update_idletasks()  # actualize the requested geometry
         anchor = self._anchor
-        x_anchor = "+" if "w" in anchor else "-"
-        y_anchor = "+" if "n" in anchor else "-"
 
-        screen_w = tl.winfo_screenwidth() // 2
-        screen_h = tl.winfo_screenheight() // 2
-        top_w = tl.winfo_reqwidth() // 2
-        top_h = tl.winfo_reqheight() // 2
+        screen_w = tl.winfo_screenwidth()
+        screen_h = tl.winfo_screenheight()
+        # The toast is floored to its minsize, so use the size it actually
+        # occupies -- reqwidth/reqheight alone undershoot the floor.
+        win_w = max(tl.winfo_reqwidth(), tl.minsize()[0])
+        win_h = max(tl.winfo_reqheight(), tl.minsize()[1])
+        inset_x, inset_y = self.position[0], self.position[1]
 
-        if "e" not in anchor and "w" not in anchor:
-            xpos = screen_w - top_w
+        # Absolute positive coordinates from the top-left. A negative offset
+        # geometry ("-x") for an east/south anchor is unreliable on aqua for a
+        # borderless window (the toast lands half off-screen), so resolve the
+        # edge distances to an explicit left/top origin instead.
+        if "w" in anchor:
+            xpos = inset_x
+        elif "e" in anchor:
+            xpos = screen_w - win_w - inset_x
         else:
-            xpos = self.position[0]
-        if "n" not in anchor and "s" not in anchor:
-            ypos = screen_h - top_h
-        else:
-            ypos = self.position[1]
+            xpos = (screen_w - win_w) // 2
 
         # the stack offset moves the toast away from its anchored edge
-        ypos += offset
-        return f"{x_anchor}{xpos}{y_anchor}{ypos}"
+        # (downward from a top anchor, upward from a bottom anchor)
+        if "n" in anchor:
+            ypos = inset_y + offset
+        elif "s" in anchor:
+            ypos = screen_h - win_h - inset_y - offset
+        else:
+            ypos = (screen_h - win_h) // 2
+
+        return f"+{max(0, xpos)}+{max(0, ypos)}"

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -221,9 +221,12 @@ class ToastNotification:
         icon_lbl = Label(
             self.container,
             bootstyle=f"{self.bootstyle}-inverse",
-            anchor=NW,
+            anchor=CENTER,
         )
-        icon_lbl.grid(row=0, column=0, rowspan=2, sticky=NSEW, padx=(5, 0))
+        # rowspan=2 -> the icon cell is as tall as the title+message block;
+        # anchor=CENTER vertically centers the glyph against that block instead
+        # of pinning it to the top (matching the Messagebox icon alignment).
+        icon_lbl.grid(row=0, column=0, rowspan=2, sticky=NSEW, padx=(10, 0))
         if self.icon:
             # Theme-aware glyph: follows the (inverse) label foreground and
             # re-renders on a theme switch.

--- a/src/ttkbootstrap/widgets/toast.py
+++ b/src/ttkbootstrap/widgets/toast.py
@@ -404,12 +404,13 @@ class ToastNotification:
             xpos = (screen_w - win_w) // 2
 
         # the stack offset moves the toast away from its anchored edge
-        # (downward from a top anchor, upward from a bottom anchor)
+        # (downward from a top anchor, upward from a bottom anchor; downward from
+        # a vertically-centered 'e'/'w' anchor, so those still stack too).
         if "n" in anchor:
             ypos = inset_y + offset
         elif "s" in anchor:
             ypos = screen_h - win_h - inset_y - offset
         else:
-            ypos = (screen_h - win_h) // 2
+            ypos = (screen_h - win_h) // 2 + offset
 
         return f"+{max(0, xpos)}+{max(0, ypos)}"

--- a/tests/test_toast_api.py
+++ b/tests/test_toast_api.py
@@ -171,6 +171,22 @@ def test_two_toasts_stack_without_overlap(root):
     t2.hide()
 
 
+def test_horizontal_anchor_toasts_still_stack(root):
+    # 'e'/'w' anchors are vertically centered; concurrent ones must still get the
+    # stack offset (regression: the absolute-geometry rewrite applied the offset
+    # only in the n/s branches, so e/w toasts overlapped).
+    t1 = ToastNotification("A", "a", position=(5, 0, "e"))
+    t2 = ToastNotification("B", "b", position=(5, 0, "e"))
+    t1.show_toast()
+    t2.show_toast()
+    root.update_idletasks()
+    assert _ypos(t1) != _ypos(t2)  # not overlapping
+    expected = t1._height + t1._scaled_gap()
+    assert abs(abs(_ypos(t2) - _ypos(t1)) - expected) <= 2
+    t1.hide()
+    t2.hide()
+
+
 def test_dismiss_reflows_remaining(root):
     t1 = ToastNotification("One", "first", position=(5, 50, "se"))
     t2 = ToastNotification("Two", "second", position=(5, 50, "se"))

--- a/tests/test_toast_api.py
+++ b/tests/test_toast_api.py
@@ -37,7 +37,8 @@ def _reset_stack():
 
 
 def _ypos(toast):
-    """The signed y offset from a toast's geometry string (e.g. '300x75-5-110')."""
+    """The absolute y coordinate from a toast's geometry string (e.g.
+    '300x75+2255+1315')."""
     m = re.search(r"([+-]\d+)([+-]\d+)$", toast.toplevel.geometry())
     return int(m.group(2))
 
@@ -160,9 +161,11 @@ def test_two_toasts_stack_without_overlap(root):
     assert t1._height >= t1.toplevel.minsize()[1]
     assert t1._height == max(t1.toplevel.winfo_reqheight(), t1.toplevel.minsize()[1])
     # t2 is offset from t1 by its full occupied height + the gap, so the two
-    # windows are exactly one gap apart (no overlap).
+    # windows are exactly one gap apart (no overlap). Geometry is now absolute
+    # positive coords and the SE stack grows upward (y decreases), so compare the
+    # magnitude of the gap between the two.
     expected = t1._height + t1._scaled_gap()
-    assert abs((abs(y2) - abs(y1)) - expected) <= 2
+    assert abs(abs(y2 - y1) - expected) <= 2
     assert len(_TOAST_STACK._corners["se"]) == 2
     t1.hide()
     t2.hide()


### PR DESCRIPTION
Two cross-platform positioning bugs surfaced in the **Track B visual pass on a MacBook**. Both fixed by resolving to robust coordinates; **win32 verified**, **aqua needs a visual re-test** (I can't render aqua here).

## Toast lands half off-screen (aqua)
The default aqua placement (NE / top-right) emitted a **negative-offset geometry** (`"-x+y"` = x px from the right edge). Negative geometry is unreliable for a borderless (`window_type='tooltip'`) window on aqua — Tk mis-places it and the toast lands half off the right edge. `_compute_geometry` now resolves **every** anchor to **absolute positive** coordinates from the window's actual (minsize-floored) size, so the geometry is always `+x+y`.
- Behaviour-preserving on win32/x11 — verified the default is still bottom-right, stacked upward, fully on-screen.

## `get_date` calendar drops to the bottom of the main window
`Querybox.get_date(parent=app)` passes the **main window** as `parent`, which fell into the `below_widget` **dropdown** path → the calendar dropped below the whole window (at its bottom edge / off it). `_set_window_position` now uses the dropdown path **only for a child-widget target** (a `DateEntry`'s entry field); a `Tk`/`Toplevel` parent **centers on it** instead.
- DateEntry (parent = entry field) is unchanged — verified it still drops directly below the entry.

## Notes
- Toast stack test updated for the absolute-positive geometry.
- **Suite: 566 passed** excl. the known `nl.msg` localization env flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01519DDeAhmTTqLDdpzkEqd7