### PR TITLE
Surface color PR 1: resolver + design pass

### DIFF
--- a/development/2_0_surface_color_design.md
+++ b/development/2_0_surface_color_design.md
@@ -1,0 +1,260 @@
+# ttkbootstrap 2.0 — Surface Color (design pass)
+
+> Design pass for a **surface-color** capability: let any widget be told the
+> background surface it sits on, so widgets placed on a non-application-background
+> surface (a card, a chrome bar, an accent-colored toolbar) style and render
+> correctly. Follows the 2.0 hard rule (design pass before implementation). Pair
+> with `2_0_theme_anchor_design.md` (Workstream E), `2_0_bootstyle_grammar_design.md`
+> (Workstream D), and `2_0_engine_design.md` (Workstream A).
+>
+> **Status: CONFIRMED (author sign-off 2026-07-10).** Motivating case + the accept-
+> regular-color-tokens requirement raised while running
+> `gallery/collapsing_frame.py`. All gating forks resolved: surface = separate
+> kwarg (§5.1); minimal named set `background`+`card` (§5.2); auto on-surface
+> foreground (§5.3); sigil `@<surface>` — verified safe (§5.4); manual-only /
+> auto-inheritance deferred to Phase 2 (§5.5); raw-hex hatch deferred (§9.3).
+> Implementation proceeds PR-by-PR per §6, starting with **PR 1** (resolver +
+> `card` token + on-surface fg; no behavior change).
+
+## 1. Why this, why now
+
+Every built style today implicitly assumes **widget background == theme
+background** (`colors.bg`). The moment a widget sits on a different surface, the
+assumption leaks and the widget no longer matches its container. It surfaced
+running old `examples/`/`gallery/` demos — most sharply in
+`gallery/collapsing_frame.py`:
+
+- The section header `frm` is an **accent frame** (`bootstyle=style_color`, e.g.
+  `primary`/`danger`/`success`).
+- The toggle button is `f'{style_color}-link'`. The link builder hardcodes
+  `background=builder.colors.bg` (`style/builders/button.py:250`, and every state
+  map entry `:270-272`), so the button paints the **application** background, not
+  the accent frame it lives on. It cannot "ghost" against the toolbar.
+
+The author also added a hairline **border** to the button family (#1096/#1127).
+That border is drawn from a bg-derived `bordercolor`; on a non-default surface the
+hairline shows against the wrong color, so even the "fake it with a matching bg"
+trick no longer works. A true `ghost`/`link`/`outline` button is the right tool —
+but today it only ever resolves against the one background, so it can't blend into
+anything else.
+
+This is a **correctness gap** in the theming model (visibly wrong rendering on
+non-default surfaces), not a new feature — which keeps it inside the 2.0
+"no new features" fence. It is cross-cutting (style-name scheme + every affected
+builder), so it gets its own design pass like the other workstreams.
+
+**Reference project:** bootstack (`D:/Development/bootstack`) has a mature,
+first-class surface/elevation system; we borrow **mechanisms**, not its API
+(memory `prefer-bootstack-reference`). Key files cited inline.
+
+## 2. Scope & non-goals
+
+**In scope:**
+- A `surface=` keyword on ttkb widgets (via `BootMixin`/`AutoStyleMixin`),
+  resolved through a single surface resolver.
+- A small set of theme-derived **named surface tokens** (§5.2).
+- Surface participating in the **style name** (one namespaced segment, emitted
+  only when non-default) and, for free, in the **asset cache key**.
+- Builder refactor: the affected `colors.bg` sites (§3) resolve against `surface`.
+- Auto **on-surface foreground** so text/glyphs stay legible on the new surface.
+
+**Non-goals (this pass):**
+- **Auto/parent-inherited surface.** Bootstack auto-inherits a cached `_surface`
+  from the parent, but relies on its constructor monkey-patch — which ttkb 2.0
+  retired (PR 3). Explicit `surface=` only for 2.0; parent/container-derived
+  surface is a clean **Phase 2 fast-follow** through `BootMixin.__init__` (§7).
+- No continuous `[+N]` elevation mini-language (bootstack's `elevate()`); named
+  tokens + accent tokens + hex cover the need.
+- No new widgets. No bootstyle-grammar vocabulary changes (surface stays orthogonal
+  to the closed D vocab).
+
+## 3. Ground-truth: the surface-dependent sites
+
+Confirmed by survey + direct read. Every flat/trough/outline/off-indicator region
+pulls the app background from one anchor, `builder.colors.bg`. Representative,
+`src/ttkbootstrap/style/`:
+
+**Style options (ttk):**
+- **button (solid)** `builders/button.py:66,68,69` — `bordercolor=border(fill)`,
+  `dark/lightcolor=fill`. Fill is the *accent*, so surface-independent — **except**
+  `neutral`/`default`, whose `neutral_fill` raises from bg.
+- **button (outline)** `:175-178` — `background`/`darkcolor`/`lightcolor` = `colors.bg`.
+- **button (neutral outline)** `:96-137` — `surface = colors.bg` throughout.
+- **button (link)** `:250,270-272` — `background=colors.bg` in configure + all states.
+- **button (ghost)** `:298,310-311` — `surface=colors.bg` **and** hover/pressed
+  washes are `mute(fg, surface, …)`; surface enters the fill *and* the blend math.
+- **checkbutton/radiobutton** — label bg inherited from `.`; off-state indicator
+  glyphs recolored `white=colors.bg` (radiobutton.py:51,53).
+- **toggle** — `off_track=border(colors.bg)`, style `background=colors.bg`, selected
+  map `background=colors.bg`, switch assets `black=colors.bg`.
+- **frame** `frame.py:23,28` — `background=colors.bg`.
+- **label** `label.py:32,35,…` — `background=colors.bg` (+ inverse variants).
+- **scale / progressbar / scrollbar** — trough/surface = `border(colors.bg)` /
+  `colors.bg`; slider/handle glyphs recolored `white=colors.bg`.
+
+**Assets (already keyed correctly — no pipeline work):** the recolor glyphs
+(`style/assets.py:140` key `("recolor", name, size, white, black, magenta, transform)`)
+pass the surface color *as a color channel*, so a different surface yields a
+distinct cached PNG with correctly-matched anti-aliased edges automatically. Icon
+glyphs render on a transparent canvas (`style/icons.py`) → surface-agnostic. **The
+asset half is free**; the work is style-name + builder plumbing only.
+
+## 4. Design
+
+### 4a. The surface resolver (accept named tokens AND regular color tokens)
+
+One entry point on the builder, mirroring bootstack's `color(token)`
+(`bootstack/style/style_builder_base.py:117-192`), resolving three input dialects
+to a concrete color:
+
+1. **Named surface token** → theme lookup (`background` default, plus the §5.2 set).
+   Theme-reactive: re-resolves on theme walk, so it follows light↔dark.
+2. **Accent color token** (`primary`/`success`/`light`/`dark`/… — the full
+   `BOOTSTYLE_COLORS` vocab) → `colors.get(token)`. **This is the author's
+   load-bearing requirement:** a ghost/link/outline button must be able to ghost
+   against an accent toolbar (`surface="primary"`), which today is impossible.
+3. **Raw hex** (`"#1b1e21"`) → passthrough. A **static** escape hatch — does *not*
+   follow theme switches (frozen), unlike named/accent tokens. Documented as such.
+
+### 4b. On-surface foreground (auto)
+
+Changing the surface can strand the foreground (dark text on a dark card, or a
+default ghost's `colors.fg` on a `primary` toolbar). The resolver also yields an
+**on-surface fg** via the existing contrast helper (`on_color(surface)` /
+`colorutils`), used wherever a builder currently reads `colors.fg` for a
+surface-relative element. The bootstyle *color* still independently sets the
+accent parts — so `bootstyle="light-ghost", surface="primary"` gives light text
+on a primary wash, while a bare `surface="primary"` ghost auto-flips its default
+`colors.fg` to `on_color(primary)`.
+
+### 4c. Style-name segment (namespaced, readable, non-default only)
+
+Emit **one extra segment**, only when `surface != <default>`, prepended to the
+existing `{color}.{Modifier}.{Orient}.{TFamily}` scheme
+(`bootstyle.py:_build_ttkstyle_name`):
+
+```
+@<surface>.{color}.{Modifier}.{Orient}.{TFamily}
+```
+
+e.g. `@primary.info.Ghost.TButton`, `@card.success.TButton`. Raw-hex surfaces
+get a short deterministic hash segment (`@a1b2c3.…`), confining opacity to that
+one case.
+
+Diverging from bootstack (which hashes the whole options dict → opaque
+`bs[a1b2c3d4].success.TButton`): ttkb keeps **readable** names because Workstream
+D's whole point is a legible closed vocabulary with a *generated reference table*.
+
+**The segment MUST be namespaced with a sigil.** Surface values overlap the
+*entire* color vocabulary (`primary`, `light`, `dark`, …) and even the internal
+`card` frame modifier, so a bare segment is ambiguous (`primary.Ghost.TButton` —
+is `primary` the bootstyle color or the surface?). The `@` sigil disambiguates and
+lets the segment round-trip through the theme-walk's dotted-name parser
+(`_classify_style_name` — which we teach to recognize a leading-`@` component as a
+surface token). See §5.4 (LOCKED).
+
+### 4d. Live theme switching
+
+Because the surface is encoded as a **token** in the (readable) style name — not a
+resolved hex — the version-stamped theme walk (Workstream A) rebuilds the right
+style for the new theme automatically: the segment re-resolves to the new theme's
+surface/accent color. This is the reason named/accent tokens are the blessed path
+and raw hex is only an escape hatch (§4a.3).
+
+### 4e. Frames are surface producers, not consumers
+
+A `ttk.Frame` fills its whole area with its `bootstyle` color, so a `primary`
+frame **is** a `primary` surface — for a frame the accent and the surface it
+presents to children are the same color. A frame has no transparent halo / flat-
+vs-fill tension (it just paints a rectangle), so:
+
+- **`surface=` on a plain frame is redundant** with its bootstyle color — the frame
+  *defines* the surface; it does not consume one.
+- **Consumers are the non-frame widgets on top of it** (ghost/link/outline button,
+  check/radio/toggle, scale) — the ones with edges that must blend. That's where
+  `surface=` earns its keep.
+- **The one frame that *does* consume a surface is the bordered `card` variant**:
+  its hairline border is bg-derived, so a card on a `primary` bar needs
+  `surface="primary"` for the border to match. Plain frames don't have this.
+
+This is why bootstack treats frames specially (`CONTAINER_CLASSES = {'TFrame'}`): a
+frame *sources* its children's surface from its own accent. That is the **Phase 2**
+auto-inheritance hook (§7) — in `collapsing_frame.py` the accent `frm` would hand
+`surface=<its accent>` to the ghost button automatically, no `surface=` written.
+Phase 1 keeps it explicit; the model is the same: **the frame produces the surface,
+the widgets on it consume it.**
+
+## 5. Decisions / gating forks
+
+### 5.1 Surface = separate kwarg, not a bootstyle token — **AGREED**
+Folding surface into the bootstyle string would blow open the closed D vocabulary.
+Orthogonal kwarg: `bootstyle="success-toggle", surface="card"`.
+
+### 5.2 How large a named surface family? — **LOCKED: minimal (`background` + `card`)**
+`background` (default) + `card` (one elevate), derived by lightening/darkening bg
+per mode (bootstack `theme_provider.py:305-410`), aligned with the existing `card`
+frame variant and `inputbg`. Expandable later; *not* porting bootstack's full 7.
+Accent tokens work as surfaces regardless of this set — this fork was only about
+the named *neutral* surfaces.
+
+### 5.3 Auto on-surface foreground — **AGREED (auto-derive)**
+Derive fg from surface via the contrast helper; otherwise text is unreadable on a
+dark card / accent toolbar.
+
+### 5.4 Style-name sigil — **LOCKED: `@<surface>`**
+`@primary.info.Ghost.TButton`, `@card.success.TButton`; raw hex → `@<hash>.…`.
+Chosen for the small footprint (one char, no extra token). **Verified safe**
+(headless, 2026-07-10): `@` is not special in Tcl strings, and a ttk style name
+carrying an `@` segment round-trips through `configure`/`lookup`/`map`, the
+`-style` widget option, **and** ttk's left-strip dotted-parent inheritance
+(`@primary.info.Ghost.TButton` correctly inherits from `TButton`). Tk's `@`
+special-casing is confined to font / bitmap-cursor / canvas-index parsers, none of
+which style-name resolution invokes → platform-independent (worth an aqua/x11
+eyeball in the visual pass, but the resolution path is shared C code). Remaining
+work is ttkb-side only: `_classify_style_name` learns a leading-`@` component ==
+surface token.
+
+### 5.5 Manual only for 2.0; defer auto-inheritance — **AGREED**
+Explicit `surface=` this pass; parent/container-derived surface = Phase 2 (§7).
+
+## 6. Implementation sketch (PR breakdown)
+
+Proposed, PR-by-PR per the 2.0 hard rule:
+
+- **PR 1 — resolver + theme tokens.** Add the surface resolver (§4a) + on-surface
+  fg (§4b) on the builder; add the minimal named-surface set to the theme model
+  (§5.2). No behavior change yet (default surface == `colors.bg`). Tests: resolver
+  dialects (named/accent/hex), theme-reactivity.
+- **PR 2 — style-name segment + kwarg plumbing.** `surface=` on the mixins →
+  resolver; namespaced segment (§4c) emitted only when non-default; round-trip
+  through `_classify_style_name`; theme-walk rebuild (§4d). Tests: name assembly,
+  parse round-trip, default-surface produces today's exact names (no regression).
+- **PR 3 — builder migration.** Point the §3 `colors.bg` sites at the resolved
+  surface, starting with the button family (the motivating case), then
+  check/radio/toggle/frame/label/scale/progressbar/scrollbar. Asset recolor falls
+  out for free. Update `gallery/collapsing_frame.py` as the acceptance proof
+  (ghost/link button on the accent toolbar). Visual spot-check light↔dark.
+
+## 7. Phase 2 (deferred, not this pass)
+
+Parent/container-inherited surface: `BootMixin.__init__` reads the master's cached
+resolved surface (bootstack's `_surface` pattern, `style_resolver.py:271-289`);
+container frames (accent or card) source their children's surface from their own
+fill. Big ergonomics win, but "spooky action" and a larger mechanism — designed
+separately once the manual path is proven.
+
+## 8. Compat / breaking
+
+Additive: `surface=` defaults to the app background, so **every existing style
+name and appearance is byte-for-byte unchanged** when `surface` is unset. No
+deprecation needed; log a `2_0_breaking_changes.md` entry only if any default
+rendering shifts (it should not). New public surface: the `surface=` kwarg + the
+named-surface tokens (feed the Workstream-H docs / BootStyle reference).
+
+## 9. Open questions for the author
+
+1. ~~§5.2 named surface set~~ — **LOCKED: minimal `background` + `card`.**
+2. ~~§5.4 sigil~~ — **LOCKED: `@<surface>`** (verified safe).
+3. ~~Raw-hex surfaces in PR 1?~~ — **LOCKED: deferred.** PR 1/2/3 ship the theme-
+   reactive path only (named `card` + accent tokens); the static hex hatch is a
+   later PR.

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -116,6 +116,17 @@ BOOTSTYLE_FAMILIES: Final = (
 )
 BOOTSTYLE_ORIENTS: Final = ("horizontal", "vertical")
 
+# Named neutral surfaces a widget can be placed on (2.0 surface-color). The
+# *surface* is the background a widget renders against; the style engine resolves
+# it to a concrete color (style/builders_ttk.py `resolve_surface`). `background`
+# is the application default -- the only surface that produces no style-name
+# segment; `card` is a mode-aware raised panel. Accent colors (BOOTSTYLE_COLORS)
+# are ALSO valid surfaces (resolved separately), so a ghost/outline/link control
+# can blend into an accent container. A non-default surface prefixes the style
+# name with an `@<surface>.` segment. Raw-hex surfaces are deferred.
+DEFAULT_SURFACE: Final = "background"
+BOOTSTYLE_SURFACES: Final = ("background", "card")
+
 # ---------------------------------------------------------------------------
 # Canonical bootstyle strings (generated). The closed set of bootstyle values
 # that resolve to a real ttk style, derived from the vocabulary above x the
@@ -457,6 +468,7 @@ __all__ = [
     # bootstyle vocabulary (single source of truth)
     "BOOTSTYLE_COLORS", "BOOTSTYLE_MODIFIERS", "BOOTSTYLE_INTERNAL_MODIFIERS",
     "BOOTSTYLE_BASES", "BOOTSTYLE_FAMILIES", "BOOTSTYLE_ORIENTS", "NEUTRAL_FAMILIES",
+    "BOOTSTYLE_SURFACES", "DEFAULT_SURFACE",
     # constants
     "NO", "FALSE", "OFF", "YES", "TRUE", "ON",
     "N", "S", "W", "E", "NW", "SW", "NE", "SE", "NS", "EW", "NSEW", "CENTER",

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -1,5 +1,6 @@
 """Per-theme coordinator for private ttk widget-family style recipes."""
 
+import warnings
 from tkinter import ttk
 
 from ttkbootstrap.constants import *
@@ -27,6 +28,7 @@ from ttkbootstrap.style.theme import (
 _TROUGH_SHADE = 0.2    # recessed dark-theme track/trough behind a filled bar
 _STRIPE_TINT = 0.2     # lighter diagonal highlight over a progress bar
 _MUTE_AMOUNT = 0.4     # unchecked-indicator muting
+_CARD_ELEVATION = 0.06  # mode-aware raise of the background for the `card` surface
 
 
 class StyleBuilderTTK:
@@ -144,6 +146,53 @@ class StyleBuilderTTK:
         See `_accent_on_color`.
         """
         return _accent_on_color(color)
+
+    def card_surface(self) -> str:
+        """Return the `card` surface: a mode-aware raise of the background.
+
+        Darkens the background in a light theme, lightens it in a dark theme, so
+        a card reads as a subtly raised panel in either mode. Derived from
+        `colors.bg` at build time, so it follows theme switches.
+        """
+        bg = self.colors.bg
+        if self.is_light_theme:
+            return self.shade(bg, _CARD_ELEVATION)
+        return self.tint(bg, _CARD_ELEVATION)
+
+    def resolve_surface(self, surface: str | None = None) -> str:
+        """Resolve a surface token to a concrete background color.
+
+        The *surface* is the background a widget is placed on. Accepts:
+
+          - `None` / `""` / `"background"` -- the application background
+            (`colors.bg`); the default, and the only surface that produces no
+            style-name segment.
+          - `"card"` -- a mode-aware raised surface (`card_surface`).
+          - an accent color name (`primary`, `success`, ..., `neutral`) -- that
+            color, so a ghost/outline/link control can blend into an accent
+            container (e.g. an accent toolbar).
+
+        Named and accent surfaces are theme-reactive: they re-resolve on a theme
+        switch. An unknown token warns and falls back to the background. Raw-hex
+        surfaces are not yet accepted (deferred).
+        """
+        if not surface or surface == DEFAULT_SURFACE:
+            return self.colors.bg
+        if surface == "card":
+            return self.card_surface()
+        if surface in BOOTSTYLE_COLORS:
+            if surface == NEUTRAL:
+                # local import breaks the builders<-utils cycle
+                from ttkbootstrap.style.builders.utils import neutral_fill
+                return neutral_fill(self)
+            return self.colors.get(surface)
+        warnings.warn(
+            f"Unknown surface {surface!r}; falling back to the application "
+            f"background. Valid surfaces: {', '.join(BOOTSTYLE_SURFACES)}, an "
+            f"accent color, or 'neutral'.",
+            stacklevel=2,
+        )
+        return self.colors.bg
 
     def build_style(
         self,

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -1,9 +1,10 @@
 """Per-theme coordinator for private ttk widget-family style recipes."""
 
-import warnings
+from difflib import get_close_matches
 from tkinter import ttk
 
 from ttkbootstrap.constants import *
+from ttkbootstrap.style._compat import report_invalid
 from ttkbootstrap.style.assets import Assets
 from ttkbootstrap.style.builders import load_builders
 from ttkbootstrap.style.builders.registry import (
@@ -173,8 +174,11 @@ class StyleBuilderTTK:
             container (e.g. an accent toolbar).
 
         Named and accent surfaces are theme-reactive: they re-resolve on a theme
-        switch. An unknown token warns and falls back to the background. Raw-hex
-        surfaces are not yet accepted (deferred).
+        switch. An unknown token routes through the shared strictness gate --
+        warn-and-fall-back-to-background by default, raise under strict mode
+        (`set_bootstyle_strict` / `TTKBOOTSTRAP_STRICT`), matching how the
+        resolver treats an unknown bootstyle token. Raw-hex surfaces are not yet
+        accepted (deferred).
         """
         if not surface or surface == DEFAULT_SURFACE:
             return self.colors.bg
@@ -186,11 +190,10 @@ class StyleBuilderTTK:
                 from ttkbootstrap.style.builders.utils import neutral_fill
                 return neutral_fill(self)
             return self.colors.get(surface)
-        warnings.warn(
-            f"Unknown surface {surface!r}; falling back to the application "
-            f"background. Valid surfaces: {', '.join(BOOTSTYLE_SURFACES)}, an "
-            f"accent color, or 'neutral'.",
-            stacklevel=2,
+        vocab = (*BOOTSTYLE_SURFACES, *BOOTSTYLE_COLORS)
+        report_invalid(
+            "surface", surface, surface,
+            suggestions=get_close_matches(surface, vocab, n=2),
         )
         return self.colors.bg
 

--- a/tests/test_surface_color.py
+++ b/tests/test_surface_color.py
@@ -51,6 +51,24 @@ def test_unknown_surface_warns_and_falls_back(root):
     assert value == b.colors.bg
 
 
+def test_unknown_surface_raises_in_strict_mode(root):
+    """Strict mode turns the unknown-surface warning into a hard error, matching
+    how the resolver treats an unknown bootstyle token."""
+    from ttkbootstrap.style._compat import (
+        is_bootstyle_strict,
+        set_bootstyle_strict,
+    )
+
+    b = _builder()
+    prior = is_bootstyle_strict()
+    set_bootstyle_strict(True)
+    try:
+        with pytest.raises(ValueError):
+            b.resolve_surface("bogus-surface")
+    finally:
+        set_bootstyle_strict(prior)
+
+
 def test_raw_hex_surface_is_deferred(root):
     """A raw hex is not yet a valid surface -- it warns and falls back."""
     b = _builder()

--- a/tests/test_surface_color.py
+++ b/tests/test_surface_color.py
@@ -1,0 +1,73 @@
+"""Surface-color resolver tests (2.0 surface-color, PR 1).
+
+Covers `StyleBuilderTTK.resolve_surface` / `card_surface`: the named-neutral +
+accent surface dialects, the default = application background, mode-aware `card`
+derivation, theme-reactivity, and the unknown-token warn-and-fallback. Raw-hex
+surfaces are deferred to a later PR and are expected to warn here.
+"""
+import pytest
+
+from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
+from ttkbootstrap.style.builders.utils import neutral_fill
+
+
+def _builder():
+    """A non-building builder bound to the current theme (introspection only)."""
+    return StyleBuilderTTK(build=False)
+
+
+def test_default_surface_is_background(root):
+    b = _builder()
+    assert b.resolve_surface() == b.colors.bg
+    assert b.resolve_surface(None) == b.colors.bg
+    assert b.resolve_surface("") == b.colors.bg
+    assert b.resolve_surface("background") == b.colors.bg
+
+
+def test_card_surface_differs_from_background(root):
+    b = _builder()
+    card = b.resolve_surface("card")
+    assert card != b.colors.bg
+    assert card == b.card_surface()
+
+
+def test_accent_surface_resolves_to_color(root):
+    b = _builder()
+    assert b.resolve_surface("primary") == b.colors.primary
+    assert b.resolve_surface("danger") == b.colors.danger
+    assert b.resolve_surface("light") == b.colors.light
+    assert b.resolve_surface("dark") == b.colors.dark
+
+
+def test_neutral_surface_is_the_neutral_fill(root):
+    b = _builder()
+    assert b.resolve_surface("neutral") == neutral_fill(b)
+
+
+def test_unknown_surface_warns_and_falls_back(root):
+    b = _builder()
+    with pytest.warns(UserWarning):
+        value = b.resolve_surface("bogus-surface")
+    assert value == b.colors.bg
+
+
+def test_raw_hex_surface_is_deferred(root):
+    """A raw hex is not yet a valid surface -- it warns and falls back."""
+    b = _builder()
+    with pytest.warns(UserWarning):
+        value = b.resolve_surface("#123456")
+    assert value == b.colors.bg
+
+
+def test_card_surface_is_theme_reactive(root):
+    """`card` re-resolves off the new background on a theme switch."""
+    style = root.style
+    style.theme_use("bootstrap-light")
+    light_card = _builder().resolve_surface("card")
+
+    style.theme_use("bootstrap-dark")
+    dark_card = _builder().resolve_surface("card")
+
+    # different backgrounds -> different card surfaces (the fixture restores the
+    # original theme on teardown).
+    assert light_card != dark_card


### PR DESCRIPTION
## Surface color — PR 1 of 3 (foundation)

First PR of the **surface-color** workstream: let a widget be told the background surface it sits on, so controls placed on a non-application-background surface (a card, an accent toolbar) style and render correctly. Surfaced running old `examples/`/`gallery/` demos — sharpest in `gallery/collapsing_frame.py`, where a `link` toggle button on an accent header paints the app background (`colors.bg`) instead of the accent frame it lives on, so it can't "ghost."

Design pass (CONFIRMED): `development/2_0_surface_color_design.md`.

**This PR is additive only — no builder consumes the resolver yet, so every existing style name and appearance is byte-for-byte unchanged.**

### What's here
- **`constants.py`** — `BOOTSTYLE_SURFACES` (`background`, `card`) + `DEFAULT_SURFACE` vocab, exported via `__all__`. Accent colors double as surfaces (resolved separately); a non-default surface will prefix the style name with an `@<surface>.` segment (verified Tcl/Tk-safe — round-trips configure/lookup/map/`-style` + left-strip inheritance).
- **`style/builders_ttk.py`** — `StyleBuilderTTK.resolve_surface()` (named-neutral + accent dialects; `neutral`→`neutral_fill`; unknown token routes through the shared `_compat` strictness gate — warn-and-fall-back by default, raise under `set_bootstyle_strict`/`TTKBOOTSTRAP_STRICT`, with a difflib "did you mean" hint; raw hex deferred) and `card_surface()` (mode-aware raise of the background, theme-reactive).
- **`tests/test_surface_color.py`** — resolver dialects, mode-aware `card`, theme-reactivity, warn-and-fallback, strict-mode raise (+8).

### Locked design decisions
- Surface = a separate `surface=` kwarg, orthogonal to the closed bootstyle grammar.
- Named-neutral set kept minimal: `background` + `card`.
- Style-name sigil `@<surface>` (verified safe).
- Auto on-surface foreground for legibility.
- Manual only for 2.0; parent/container auto-inheritance deferred to Phase 2.
- Raw-hex surfaces deferred.

### Next
- **PR 2** — the `@<surface>` style-name segment + `surface=` kwarg plumbing + teaching `_classify_style_name` the leading-`@` component (includes surface-token case normalization).
- **PR 3** — migrate the builders' `colors.bg` sites onto the resolved surface (button family first), with `collapsing_frame.py` as the acceptance proof.

### Review
A high-effort `/code-review` ran on this PR: **no correctness bugs.** Its top finding (unknown surface bypassed the strict gate) is **fixed here** (commit 2). Two minor cleanup items were deferred by design — `card_surface`/`neutral_fill` de-dup → PR 3; case normalization → PR 2.

Suite: **581 passed** (excl. the two known env flakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)