### PR TITLE
Surface color PR 2: mechanism + button family (bootstyle @token)

### DIFF
--- a/development/2_0_surface_color_design.md
+++ b/development/2_0_surface_color_design.md
@@ -9,10 +9,12 @@
 >
 > **Status: CONFIRMED (author sign-off 2026-07-10).** Motivating case + the accept-
 > regular-color-tokens requirement raised while running
-> `gallery/collapsing_frame.py`. All gating forks resolved: surface = separate
-> kwarg (§5.1); minimal named set `background`+`card` (§5.2); auto on-surface
-> foreground (§5.3); sigil `@<surface>` — verified safe (§5.4); manual-only /
-> auto-inheritance deferred to Phase 2 (§5.5); raw-hex hatch deferred (§9.3).
+> `gallery/collapsing_frame.py`. All gating forks resolved: surface = a `@surface`
+> token INSIDE `bootstyle`, no separate param (§5.1, reversed on review); minimal
+> named set `background`+`card` (§5.2); auto on-surface foreground (§5.3); sigil
+> `@<surface>` — verified safe (§5.4); manual-only / auto-inheritance deferred to
+> Phase 2 (§5.5); raw-hex hatch deferred (§9.3). Spaces are the recommended
+> bootstyle separator (`"@primary success ghost"`).
 > Implementation proceeds PR-by-PR per §6. **PR 1 (resolver + `card` token +
 > vocab; additive/no-behavior-change) is MERGED into `2.0` (#1149).** Next: PR 2.
 
@@ -186,9 +188,22 @@ the widgets on it consume it.**
 
 ## 5. Decisions / gating forks
 
-### 5.1 Surface = separate kwarg, not a bootstyle token — **AGREED**
-Folding surface into the bootstyle string would blow open the closed D vocabulary.
-Orthogonal kwarg: `bootstyle="success-toggle", surface="card"`.
+### 5.1 Surface delivery — **REVERSED (2026-07-10): a `@surface` token INSIDE `bootstyle`, no separate param**
+Originally a separate `surface=` kwarg. On review the author reframed it:
+**`bootstyle` is not "the accent param" — it is a compact spelling of the ttk
+style name** (color + variant + type), and the style name already carries the
+`@surface` segment. So surface belongs in the one pathway that spells the style
+name; a second `surface=` channel is redundant and reintroduced a whole class of
+two-axis reconcile bugs (clearing, preserve-across-change, `style=`+`surface=`
+conflicts — all found in review of the param version, all gone with one string).
+The `@` sigil (§5.4) is a *distinct sigil-prefixed token*, so it does **not** blow
+open the closed dash-slot vocabulary — the `BootStyle` `Literal` stays the core
+grammar and `@<surface>` is a documented optional prefix (`bootstyle` already
+accepts `str`). Spelling: `bootstyle="@primary success ghost"`. **Spaces are the
+recommended separator** (the tokenizer always accepted `[-\s]+`; easier to type,
+reads better). Deferred **spaces sweep** (regenerate the dash-joined `BootStyle`
+Literal + reference to spaces, touch up docstrings) happens before the docs
+initiative, not in the surface PRs. See memory `bootstyle-spaces-and-surface-token`.
 
 ### 5.2 How large a named surface family? — **LOCKED: minimal (`background` + `card`)**
 `background` (default) + `card` (one elevate), derived by lightening/darkening bg
@@ -229,15 +244,36 @@ Proposed, PR-by-PR per the 2.0 hard rule:
   expanding the 16-field `Colors` (avoids rippling every constructor). Unknown
   surface routes through the shared `_compat` strictness gate. No behavior change
   (default surface == `colors.bg`; nothing consumes it yet). Suite 581.
-- **PR 2 — style-name segment + kwarg plumbing.** `surface=` on the mixins →
-  resolver; namespaced segment (§4c) emitted only when non-default; round-trip
-  through `_classify_style_name`; theme-walk rebuild (§4d). Tests: name assembly,
-  parse round-trip, default-surface produces today's exact names (no regression).
-- **PR 3 — builder migration.** Point the §3 `colors.bg` sites at the resolved
-  surface, starting with the button family (the motivating case), then
-  check/radio/toggle/frame/label/scale/progressbar/scrollbar. Asset recolor falls
-  out for free. Update `gallery/collapsing_frame.py` as the acceptance proof
-  (ghost/link button on the accent toolbar). Visual spot-check light↔dark.
+**PR split revised (2026-07-10):** reading the code showed the style *name* and
+the surface *color* both live inside each recipe (recipes hand-build their name,
+which the resolver independently recomputes and requires to match — `bootstyle.py`
+`_build_ttkstyle_name` vs `button.py`; the `colors.bg` sites are recipe-local
+too). So the original name-then-color split touched every recipe twice. Split by
+**widget family** instead — each recipe touched once, and each PR is a visible,
+working feature.
+
+- **PR 2 — mechanism + button family.** The full engine + grammar plumbing:
+  a `@surface` token in `bootstyle` (tokenized by `_classify_tokens`, mirroring
+  `_classify_style_name`) → `update_ttk_widget_style` → `@surface` in
+  `_build_ttkstyle_name` (emitted only when non-default; shared `surface_segment`
+  helper so the built name and the looked-up name cannot drift) +
+  `_classify_style_name` round-trip (theme walk, §4d, normalized *leniently* so a
+  custom `@` style name never warns) → `build_style` threads it to the recipe via
+  transient builder state (`_surface`). Surface is case-normalized and validated
+  through the `_compat` gate against one shared vocab (`BOOTSTYLE_SURFACE_TOKENS`);
+  a **family gate** (`_SURFACE_FAMILIES`, initially `{button}`) makes not-yet-
+  migrated families safely ignore surface. The **button family**
+  (solid/outline/link/ghost/neutral-outline) is wired end-to-end — name prefix +
+  `resolve_surface` colors + auto on-surface fg (§4b, `on_surface_fg`: accent
+  surfaces flip to `on_color`, near-bg `card`/`neutral` keep the soft theme fg) —
+  as the `collapsing_frame` acceptance proof. **No `surface=` param** (§5.1). A
+  high-effort `/code-review` on the param version drove the reversal + these fixes.
+- **PR 3 — roll out to remaining consuming families.** Extend the same mechanism
+  (add each to `_SURFACE_FAMILIES`, point their `colors.bg` sites at
+  `resolve_surface`) to check/radio/toggle/scale/progressbar/scrollbar/label; the
+  recolor-glyph asset half falls out for free (§3). Update
+  `gallery/collapsing_frame.py`; visual spot-check light↔dark. Frames stay out
+  (surface *producers*, §4e).
 
 ## 7. Phase 2 (deferred, not this pass)
 
@@ -249,11 +285,12 @@ separately once the manual path is proven.
 
 ## 8. Compat / breaking
 
-Additive: `surface=` defaults to the app background, so **every existing style
-name and appearance is byte-for-byte unchanged** when `surface` is unset. No
+Additive: with no `@surface` token the bootstyle resolves exactly as before, so
+**every existing style name and appearance is byte-for-byte unchanged**. No
 deprecation needed; log a `2_0_breaking_changes.md` entry only if any default
-rendering shifts (it should not). New public surface: the `surface=` kwarg + the
-named-surface tokens (feed the Workstream-H docs / BootStyle reference).
+rendering shifts (it should not). New public surface: the `@<surface>` bootstyle
+token + the named-surface tokens (feed the Workstream-H docs / BootStyle
+reference). The deferred spaces sweep regenerates the reference in space form.
 
 ## 9. Open questions for the author
 
@@ -262,3 +299,21 @@ named-surface tokens (feed the Workstream-H docs / BootStyle reference).
 3. ~~Raw-hex surfaces in PR 1?~~ — **LOCKED: deferred.** PR 1/2/3 ship the theme-
    reactive path only (named `card` + accent tokens); the static hex hatch is a
    later PR.
+
+## 10. Accepted-by-design edges (PR 2 review)
+
+A high-effort `/code-review` on the reworked PR 2 found no structural bugs. Fixed:
+a stray bare `@` no longer warns; a capitalized surface-only typo (`@Primaryy`)
+now loud-fails like any typo; two docstrings trimmed of rationale. **Accepted as
+by-design** (styling is permissive, not paternalistic — memory
+`styling-permissive-not-paternalistic`):
+
+- **Invisible accent-on-accent** (`@primary outline` → fg == bg): the user's
+  choice; no contrast guard.
+- **Redundant identical style**: a solid opaque button on an accent surface forks
+  a distinct `@surface` style that renders the same — an accident of the color
+  scheme; not gated at variant granularity.
+- **Silent gate-drop**: a valid surface on a producer/not-yet-migrated family is
+  dropped silently (surface is "not applicable" there, not a typo). **Deferred to
+  PR 3:** the `_SURFACE_FAMILIES` graceful-degrade net (retry without the prefix if
+  a surfaced style did not build) lands as families are migrated.

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -126,6 +126,20 @@ BOOTSTYLE_ORIENTS: Final = ("horizontal", "vertical")
 # name with an `@<surface>.` segment. Raw-hex surfaces are deferred.
 DEFAULT_SURFACE: Final = "background"
 BOOTSTYLE_SURFACES: Final = ("background", "card")
+# The full accepted surface vocabulary: named neutral surfaces + every accent
+# color (an accent doubles as a surface). Single source of truth, shared by the
+# bootstyle-string validator and the builder's resolver so they cannot diverge.
+BOOTSTYLE_SURFACE_TOKENS: Final = (*BOOTSTYLE_SURFACES, *BOOTSTYLE_COLORS)
+
+
+def surface_segment(surface: str) -> str:
+    """Return the ``@<surface>.`` style-name prefix for a surface.
+
+    The default/empty surface returns ``""``.
+    """
+    if surface and surface != DEFAULT_SURFACE:
+        return f"@{surface}."
+    return ""
 
 # ---------------------------------------------------------------------------
 # Canonical bootstyle strings (generated). The closed set of bootstyle values
@@ -468,7 +482,8 @@ __all__ = [
     # bootstyle vocabulary (single source of truth)
     "BOOTSTYLE_COLORS", "BOOTSTYLE_MODIFIERS", "BOOTSTYLE_INTERNAL_MODIFIERS",
     "BOOTSTYLE_BASES", "BOOTSTYLE_FAMILIES", "BOOTSTYLE_ORIENTS", "NEUTRAL_FAMILIES",
-    "BOOTSTYLE_SURFACES", "DEFAULT_SURFACE",
+    "BOOTSTYLE_SURFACES", "DEFAULT_SURFACE", "BOOTSTYLE_SURFACE_TOKENS",
+    "surface_segment",
     # constants
     "NO", "FALSE", "OFF", "YES", "TRUE", "ON",
     "N", "S", "W", "E", "NW", "SW", "NE", "SE", "NS", "EW", "NSEW", "CENTER",

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -16,9 +16,12 @@ from ttkbootstrap.constants import (
     BOOTSTYLE_INTERNAL_MODIFIERS,
     BOOTSTYLE_FAMILIES,
     BOOTSTYLE_ORIENTS,
+    BOOTSTYLE_SURFACE_TOKENS,
+    DEFAULT_SURFACE,
     NEUTRAL,
     NEUTRAL_FAMILIES,
     BootStyle,
+    surface_segment,
 )
 from ttkbootstrap.style import _compat
 from ttkbootstrap.style.engine import Style
@@ -89,21 +92,71 @@ _SUGGESTION_POOL = tuple(
 _SENTINELS = frozenset({"", "default"})
 _TOKEN_SPLIT = re.compile(r"[-\s]+")
 
+# Surface vocabulary (2.0 surface-color). A surface is a named neutral surface OR
+# an accent color; it rides INSIDE the bootstyle string as an `@<surface>` token
+# (e.g. "@primary success ghost") and, when non-default, prefixes the style name
+# with an `@<surface>.` segment. `_SURFACE_FAMILIES` gates which families a recipe
+# consumes surface for yet -- it grows one PR at a time as families are migrated;
+# a surface for any other family is silently ignored (frames are intentionally
+# never in it -- they are surface producers, not consumers). The token vocab lives
+# once in constants (`BOOTSTYLE_SURFACE_TOKENS`).
+_SURFACE_TOKENS = frozenset(BOOTSTYLE_SURFACE_TOKENS)
+_SURFACE_FAMILIES = frozenset({"button"})
+
+
+def _normalize_surface(surface, family, source, warn):
+    """Normalize/validate a surface token to a canonical token or ``""``.
+
+    Lowercases and trims; maps the default/empty surface to ``""`` (no prefix).
+    An unrecognized token routes through the shared `_compat` strictness gate
+    (warn-and-drop by default, raise in strict) exactly like an unknown bootstyle
+    token -- but `warn` is False for the lenient already-built-style-name dialect,
+    so a custom ``@brand.TLabel`` style name never warns/raises on the theme walk.
+    A valid token for a family not yet surface-capable is dropped silently (the
+    rollout gate). Returns the token to embed in the style name, or ``""``.
+    """
+    if not surface:
+        return ""
+    surface = str(surface).strip().lower()
+    if not surface or surface == DEFAULT_SURFACE:
+        return ""
+    if surface not in _SURFACE_TOKENS:
+        if warn:
+            suggestions = difflib.get_close_matches(
+                surface, sorted(_SURFACE_TOKENS), n=1
+            )
+            _compat.report_invalid("surface", surface, source, suggestions)
+        return ""
+    if family not in _SURFACE_FAMILIES:
+        return ""
+    return surface
+
 
 def _classify_tokens(style_string, *, source=None, warn=False):
     """Split a bootstyle string and classify each token into a slot.
 
-    Returns ``(color, modifier, base, orient)`` -- the first token seen for each
-    slot (matching the pre-2.0 leftmost-wins behavior). When ``warn`` is true,
-    an unrecognized token and a duplicate-slot token are reported through the
-    `_compat` loud-failure path (warn by default, raise in strict mode).
+    Returns ``(color, modifier, base, orient, surface)`` -- the first token seen
+    for each slot (matching the pre-2.0 leftmost-wins behavior). A ``@<surface>``
+    token (2.0 surface-color) names the background the widget sits on; it is
+    position-free and may appear anywhere in the string
+    (``"@primary success ghost"``). When ``warn`` is true, an unrecognized token
+    and a duplicate-slot token are reported through the `_compat` loud-failure
+    path (warn by default, raise in strict mode). The surface token is only
+    *extracted* here; it is validated by `_normalize_surface`.
     """
     source = style_string if source is None else source
-    color = modifier = base = orient = ""
+    color = modifier = base = orient = surface = ""
     for token in _TOKEN_SPLIT.split(style_string.strip().lower()):
         if token in _SENTINELS:
             continue
-        if token in _COLORS:
+        if token.startswith("@"):
+            surf = token[1:]
+            if not surf:
+                continue  # a bare '@' carries no surface
+            if warn and surface and surf != surface:
+                _compat.report_invalid("surface", surf, source)
+            surface = surface or surf
+        elif token in _COLORS:
             if warn and color and token != color:
                 _compat.report_invalid("color", token, source)
             color = color or token
@@ -122,7 +175,7 @@ def _classify_tokens(style_string, *, source=None, warn=False):
                 token, _SUGGESTION_POOL, n=1
             )
             _compat.report_invalid("token", token, source, suggestions)
-    return color, modifier, base, orient
+    return color, modifier, base, orient, surface
 
 
 def _looks_like_style_name(style_string):
@@ -134,10 +187,15 @@ def _looks_like_style_name(style_string):
     or space (``"TFrame"``, ``"primary.Outline.TButton"``, ``"symbol.Link.
     TButton"``); a dotted string is always a style name. This lets the theme
     walk re-resolve a widget's dotted ``cget("style")`` (including a bare base
-    like ``"TFrame"``) without misreading it as a mistyped bootstyle.
+    like ``"TFrame"``) without misreading it as a mistyped bootstyle. A
+    leading-``@`` string with no ``.`` is a bootstyle carrying only a surface
+    token (``"@primaryy"``), not a built name -- so it stays on the loud
+    bootstyle path and a typo'd surface is reported.
     """
     if "." in style_string:
         return True
+    if style_string.startswith("@"):
+        return False
     return (
         "-" not in style_string
         and " " not in style_string
@@ -153,18 +211,21 @@ def _classify_style_name(name):
     (``"primary.Outline.TButton"``, ``"symbol.Link.TButton"``). The latter
     arrives from the theme-walk repaint (a widget's current ``cget("style")``),
     from `Style.configure` subclassing a base style, and from user-supplied
-    custom style names. Segments are split on ``.``; the class segment is
+    custom style names. Segments are split on ``.``; a leading ``@surface``
+    segment is the surface-color prefix (2.0 surface-color); the class segment is
     title-cased with an optional ``T`` prefix, so ``TButton`` -> ``button`` but
     ``Treeview``/``Toggle`` map directly. Unknown segments (custom prefixes such
     as ``symbol``) are ignored *without* warning -- style names legitimately
     carry them, unlike a user's bootstyle.
     """
-    color = modifier = base = orient = ""
+    color = modifier = base = orient = surface = ""
     for segment in name.split("."):
         seg = segment.strip().lower()
         if not seg or seg in _SENTINELS:
             continue
-        if seg in _COLORS:
+        if seg.startswith("@"):
+            surface = surface or seg[1:]
+        elif seg in _COLORS:
             color = color or seg
         elif seg in _MODIFIERS:
             modifier = modifier or seg
@@ -175,7 +236,7 @@ def _classify_style_name(name):
         elif seg.startswith("t") and seg[1:] in _FAMILIES:
             base = base or seg[1:]
         # else: an unknown custom segment -- ignore it silently
-    return color, modifier, base, orient
+    return color, modifier, base, orient, surface
 
 
 def _infer_family(widget):
@@ -192,13 +253,17 @@ def _infer_family(widget):
     return ""
 
 
-def _build_ttkstyle_name(color, modifier, orient, family):
+def _build_ttkstyle_name(color, modifier, orient, family, surface=""):
     """Assemble the dotted ttk style name from resolved slot tokens.
 
     Preserves the exact pre-2.0 casing: the color stays lowercase, the modifier
     and orientation are title-cased, and the family is title-cased with a ``T``
-    prefix unless it already starts with ``t`` (``Treeview``, ``Toplevel``).
+    prefix unless it already starts with ``t`` (``Treeview``, ``Toplevel``). A
+    non-default `surface` (2.0 surface-color) prefixes an ``@<surface>.`` segment
+    (lowercase); the default/empty surface adds nothing, so a surfaceless style
+    name is byte-for-byte the pre-surface name.
     """
+    surface = surface_segment(surface)
     color = f"{color}." if color else ""
     modifier = f"{modifier.title()}." if modifier else ""
     orient = f"{orient.title()}." if orient else ""
@@ -206,7 +271,7 @@ def _build_ttkstyle_name(color, modifier, orient, family):
         family = family.title()
     else:
         family = f"T{family.title()}"
-    return f"{color}{modifier}{orient}{family}"
+    return f"{surface}{color}{modifier}{orient}{family}"
 
 
 class Bootstyle:
@@ -244,7 +309,7 @@ class Bootstyle:
         """
         # an explicit base-type token in the string wins; otherwise infer the
         # family from the widget's Tcl class
-        _, _, base, _ = _classify_tokens(string)
+        _, _, base, _, _ = _classify_tokens(string)
         if base:
             return base
         return _infer_family(widget)
@@ -263,7 +328,7 @@ class Bootstyle:
             str:
                 A widget type keyword.
         """
-        _, modifier, _, _ = _classify_tokens(string)
+        _, modifier, _, _, _ = _classify_tokens(string)
         return modifier
 
     @staticmethod
@@ -330,7 +395,7 @@ class Bootstyle:
             str:
                 A color keyword.
         """
-        color, _, _, _ = _classify_tokens(string)
+        color, _, _, _, _ = _classify_tokens(string)
         return color
 
     @staticmethod
@@ -354,37 +419,51 @@ class Bootstyle:
                 A ttk style name
         """
         style_string = _compat.normalize_bootstyle(string)
-        color, modifier, _, orient, family = Bootstyle._parse_components(
-            widget, style_string, warn=False, **kwargs
+        color, modifier, _, orient, family, surface = (
+            Bootstyle._parse_components(
+                widget, style_string, warn=False, **kwargs
+            )
         )
-        return _build_ttkstyle_name(color, modifier, orient, family)
+        return _build_ttkstyle_name(color, modifier, orient, family, surface)
 
     @staticmethod
     def _parse_components(widget, style_string, *, warn, **kwargs):
         """Resolve a bootstyle/style string to ``(color, modifier, base,
-        orient, family)``.
+        orient, family, surface)``.
 
         A dotted input is an already-built ttk style name and is parsed
         leniently (`_classify_style_name`); a dashed/spaced input is a bootstyle
         and goes through the closed-vocab tokenizer, which fails loudly on
         unknown tokens when ``warn`` is set. ``family`` is the explicit base
-        token if present, else inferred from the widget.
+        token if present, else inferred from the widget. ``surface`` (2.0
+        surface-color) is carried in the string itself -- a ``@surface`` token in
+        a bootstyle, or a ``@surface`` segment in an already-built style name (the
+        theme-walk re-resolve). It is normalized/gated against the resolved family
+        (`_normalize_surface`). The already-built-style-name dialect normalizes
+        the surface *leniently* (``surface_warn=False``) so a custom ``@brand``
+        prefix never warns/raises, matching the lenient handling of other unknown
+        style-name segments.
         """
         if _looks_like_style_name(style_string):
-            color, modifier, base, orient = _classify_style_name(style_string)
+            color, modifier, base, orient, surface = (
+                _classify_style_name(style_string)
+            )
+            surface_warn = False
             if not orient:
                 orient = Bootstyle.ttkstyle_widget_orient(
                     widget, "", **kwargs
                 )
         else:
-            color, modifier, base, _ = _classify_tokens(
+            color, modifier, base, _, surface = _classify_tokens(
                 style_string, warn=warn
             )
+            surface_warn = warn
             orient = Bootstyle.ttkstyle_widget_orient(
                 widget, style_string, **kwargs
             )
         family = base or _infer_family(widget)
-        return color, modifier, base, orient, family
+        surface = _normalize_surface(surface, family, style_string, surface_warn)
+        return color, modifier, base, orient, family, surface
 
     @staticmethod
     def ttkstyle_method_name(widget=None, string=""):
@@ -569,6 +648,10 @@ class Bootstyle:
             style_string (str):
                 The style string to evaluate. May be the `style`, `ttkstyle`
                 or `bootstyle` argument depending on the context and scenario.
+                A surface (2.0 surface-color) rides inside it as an `@<surface>`
+                token (bootstyle) or `@<surface>.` segment (built style name);
+                when non-default it prefixes the style name and is threaded to
+                the builder.
 
             **kwargs:
                 Other optional keyword arguments.
@@ -600,8 +683,10 @@ class Bootstyle:
         # for an already-built ttk style name); build the ttk style name from
         # the resolved tokens rather than re-parsing the generated name.
         is_bootstyle = not _looks_like_style_name(style_string)
-        color, modifier, _, orient, family = Bootstyle._parse_components(
-            widget, style_string, warn=True, **kwargs
+        color, modifier, _, orient, family, surface = (
+            Bootstyle._parse_components(
+                widget, style_string, warn=True, **kwargs
+            )
         )
         variant = modifier or DEFAULT_VARIANT
 
@@ -616,12 +701,12 @@ class Bootstyle:
                 _compat.report_invalid("color", f"{NEUTRAL}-{family}", style_string)
             color = ""
 
-        ttkstyle = _build_ttkstyle_name(color, modifier, orient, family)
+        ttkstyle = _build_ttkstyle_name(color, modifier, orient, family, surface)
 
         # build style if not existing (example: theme changed)
         if not style.style_exists_in_theme(ttkstyle):
             builder: StyleBuilderTTK = style._get_builder()
-            if not builder.build_style(variant, family, color):
+            if not builder.build_style(variant, family, color, surface):
                 if family in _FAMILIES and variant != DEFAULT_VARIANT:
                     # An invalid modifier for one of our own widgets
                     # (e.g. "outline-scale"): fail loudly for a bootstyle string,
@@ -631,9 +716,13 @@ class Bootstyle:
                         _compat.report_invalid(
                             "combination", f"{modifier}-{family}", style_string
                         )
-                    ttkstyle = _build_ttkstyle_name(color, "", orient, family)
+                    ttkstyle = _build_ttkstyle_name(
+                        color, "", orient, family, surface
+                    )
                     if not style.style_exists_in_theme(ttkstyle) and (
-                        not builder.build_style(DEFAULT_VARIANT, family, color)
+                        not builder.build_style(
+                            DEFAULT_VARIANT, family, color, surface
+                        )
                     ):
                         return style_string
                 else:
@@ -964,7 +1053,8 @@ class BootMixin(FluentGeometryMixin):
 
             **kwargs:
                 Options to set, including ``bootstyle``, ``style``, ``icon``,
-                and ``icon_size``.
+                and ``icon_size``. A surface (2.0 surface-color) rides in the
+                ``bootstyle``/``style`` string as an ``@<surface>`` token.
         """
         # query a single option
         if cnf in ("bootstyle", "style"):

--- a/src/ttkbootstrap/style/builders/button.py
+++ b/src/ttkbootstrap/style/builders/button.py
@@ -21,21 +21,25 @@ def build_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "TButton"
 
+    # The surface the button sits on (2.0 surface-color); default == theme bg,
+    # so the branches below are byte-for-byte the pre-surface recipe when unset.
+    surface = builder.resolve_surface(builder._surface)
+
     # Every solid button carries a subtle border derived from its own fill
     # (`border(fill)` -- the fill blended toward its text color), so the shape
     # stays defined on any surface. `darkcolor`/`lightcolor` track the fill so
     # only the border ring shows (no clam bevel). `neutral` is just the
     # no-accent fill (a mode-aware raise of the surface) through this same path.
     if colorname == NEUTRAL:
-        ttk_style = f"{NEUTRAL}.{ttk_class}"
-        fill = neutral_fill(builder)
+        ttk_style = builder.surface_prefix(f"{NEUTRAL}.{ttk_class}")
+        fill = neutral_fill(builder, base=surface)
     elif any([colorname == DEFAULT, colorname == ""]):
         # The base (no-color) button follows the Style's default_button setting
         # (neutral by default; "primary" restores the pre-2.0 accented default).
-        ttk_style = ttk_class
-        fill = default_button_fill(builder)
+        ttk_style = builder.surface_prefix(ttk_class)
+        fill = default_button_fill(builder, base=surface)
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
         fill = builder.colors.get(colorname)
 
     on_fill = builder.on_color(fill)
@@ -92,9 +96,10 @@ def _build_neutral_outline_button_style(builder: StyleBuilderTTK, ttk_class):
     fill = the surface itself; border = `border(bg)`; text = normal `fg`. Hover
     fills with a subtle elevate of the surface (`active`), staying unaccented.
     """
-    ttk_style = f"{NEUTRAL}.{ttk_class}"
-    surface = builder.colors.bg
-    fg = builder.colors.fg
+    ttk_style = builder.surface_prefix(f"{NEUTRAL}.{ttk_class}")
+    surface = builder.resolve_surface(builder._surface)
+    # On a non-default surface the text must read against it, not the app bg.
+    fg = builder.on_surface_fg()
     hover = builder.active(surface)
     pressed = builder.pressed(surface)
     on_disabled = builder.disabled("text")
@@ -156,11 +161,14 @@ def build_outline_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         return
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
+        ttk_style = builder.surface_prefix(ttk_class)
         colorname = PRIMARY
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
 
+    # The surface the button sits on (2.0 surface-color); the flat rest fill and
+    # the clam dark/light regions track it so the outline stays flush.
+    surface = builder.resolve_surface(builder._surface)
     accent = builder.colors.get(colorname)
     pressed = accent
     hover = accent
@@ -172,10 +180,10 @@ def build_outline_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     builder.configure(
         ttk_style,
         foreground=accent,
-        background=builder.colors.bg,
+        background=surface,
         bordercolor=border,
-        darkcolor=builder.colors.bg,
-        lightcolor=builder.colors.bg,
+        darkcolor=surface,
+        lightcolor=surface,
         relief=tk.RAISED,
         borderwidth=1,  # 1px hairline; intentionally unscaled
         focusthickness=builder.scale_size(1),
@@ -229,16 +237,21 @@ def build_link_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     style_class = "Link.TButton"
 
+    # The surface the link sits on (2.0 surface-color); its (transparent-looking)
+    # background tracks it so the link is flush with an accent bar/card.
+    surface = builder.resolve_surface(builder._surface)
+    # On a non-default surface the default/light link text reads against it.
+    on_surface_default = builder.on_surface_fg()
 
     if any([colorname == DEFAULT, colorname == ""]):
-        on_surface = builder.colors.fg
-        ttk_style = style_class
+        on_surface = on_surface_default
+        ttk_style = builder.surface_prefix(style_class)
     elif colorname == LIGHT:
-        on_surface = builder.colors.fg
-        ttk_style = f"{colorname}.{style_class}"
+        on_surface = on_surface_default
+        ttk_style = builder.surface_prefix(f"{colorname}.{style_class}")
     else:
         on_surface = builder.colors.get(colorname)
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{style_class}")
 
     pressed = builder.colors.info
     hover = builder.colors.info
@@ -247,7 +260,7 @@ def build_link_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     builder.configure(
         ttk_style,
         foreground=on_surface,
-        background=builder.colors.bg,
+        background=surface,
         relief=tk.FLAT,
         focusthickness=builder.scale_size(1),
         focuscolor=on_surface,
@@ -267,9 +280,9 @@ def build_link_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             ("hover !disabled", pressed),
         ],
         background=[
-            ("disabled", builder.colors.bg),
-            ("pressed !disabled", builder.colors.bg),
-            ("hover !disabled", builder.colors.bg),
+            ("disabled", surface),
+            ("pressed !disabled", surface),
+            ("hover !disabled", surface),
         ]
     )
     # register ttkstyle
@@ -295,17 +308,22 @@ def build_ghost_button_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             The color label used to style the widget.
     """
     style_class = "Ghost.TButton"
-    surface = builder.colors.bg
+    # The surface the ghost sits on (2.0 surface-color): it is transparent at
+    # rest, so its background *is* the surface -- this is what lets it ghost on
+    # an accent bar/card instead of only the app background.
+    surface = builder.resolve_surface(builder._surface)
 
     if colorname in (DEFAULT, "", NEUTRAL):
         # default/neutral ghost: normal text, a neutral surface raise on hover
-        ttk_style = style_class if colorname in (DEFAULT, "") else f"{NEUTRAL}.{style_class}"
-        fg = builder.colors.fg
-        hover = neutral_fill(builder, 1)
-        pressed = neutral_fill(builder, 2)
+        base = style_class if colorname in (DEFAULT, "") else f"{NEUTRAL}.{style_class}"
+        ttk_style = builder.surface_prefix(base)
+        # On a non-default surface the text reads against it, not the app bg.
+        fg = builder.on_surface_fg()
+        hover = neutral_fill(builder, 1, base=surface)
+        pressed = neutral_fill(builder, 2, base=surface)
     else:
         # colored ghost: accent text, a subtle wash of the accent on hover
-        ttk_style = f"{colorname}.{style_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{style_class}")
         fg = builder.colors.get(colorname)
         hover = builder.mute(fg, surface, 0.16)
         pressed = builder.mute(fg, surface, 0.26)

--- a/src/ttkbootstrap/style/builders/utils.py
+++ b/src/ttkbootstrap/style/builders/utils.py
@@ -3,29 +3,32 @@
 from ttkbootstrap.constants import NEUTRAL
 
 
-def default_button_fill(builder):
+def default_button_fill(builder, base=None):
     """Return the fill for a bare (no-color) button/menubutton.
 
     Reads the Style's `default_button` setting (default `"neutral"`): returns
     the neutral elevation fill for `"neutral"`, or the resolved accent color
-    for any other color name.
+    for any other color name. `base` (2.0 surface-color) is the surface the
+    neutral fill elevates from; defaults to the theme background.
     """
     color = getattr(builder.style, "default_button", NEUTRAL)
     if color == NEUTRAL:
-        return neutral_fill(builder)
+        return neutral_fill(builder, base=base)
     return builder.colors.get(color)
 
 
-def neutral_fill(builder, level=1):
-    """Return a mode-aware elevation of the theme surface color.
+def neutral_fill(builder, level=1, base=None):
+    """Return a mode-aware elevation of a surface color.
 
     Darkens the surface in a light theme, lightens it in a dark theme, so an
     unaccented control reads as a subtly raised surface in either mode. `level`
     1 (~6%) is the quiet neutral fill; `level` 2 (~12%) is a stronger raise used
-    to distinguish an "on"/selected neutral state from the "off" fill.
+    to distinguish an "on"/selected neutral state from the "off" fill. `base`
+    (2.0 surface-color) is the surface to elevate from; defaults to the theme
+    background.
     """
     weight = level * 0.06
-    surface = builder.colors.bg
+    surface = builder.colors.bg if base is None else base
     if builder.is_light_theme:
         return builder.shade(surface, weight)
     return builder.tint(surface, weight)

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -47,6 +47,10 @@ class StyleBuilderTTK:
 
         self.style: Style = Style.get_instance()
         self.builder_tk = StyleBuilderTK()
+        # transient surface token for the recipe currently building (2.0
+        # surface-color); set/restored by `build_style`, read by surface-aware
+        # recipes via `surface_prefix`/`resolve_surface`.
+        self._surface = ""
 
         if build:
             self.create_theme()
@@ -190,10 +194,9 @@ class StyleBuilderTTK:
                 from ttkbootstrap.style.builders.utils import neutral_fill
                 return neutral_fill(self)
             return self.colors.get(surface)
-        vocab = (*BOOTSTYLE_SURFACES, *BOOTSTYLE_COLORS)
         report_invalid(
             "surface", surface, surface,
-            suggestions=get_close_matches(surface, vocab, n=2),
+            suggestions=get_close_matches(surface, BOOTSTYLE_SURFACE_TOKENS, n=2),
         )
         return self.colors.bg
 
@@ -202,10 +205,17 @@ class StyleBuilderTTK:
         variant: str,
         widget_family: str,
         colorname: str = DEFAULT,
+        surface: str = "",
         *,
         required: bool = False,
     ) -> bool:
-        """Invoke one registered recipe, returning whether its key exists."""
+        """Invoke one registered recipe, returning whether its key exists.
+
+        `surface` (2.0 surface-color) is the background the widget sits on; it is
+        exposed to the recipe as transient state (`self._surface`) for the
+        duration of the build and restored afterward (save/restore, so a recipe
+        that itself builds another style does not clobber it).
+        """
         load_builders()
         recipe = (
             get_builder(variant, widget_family)
@@ -219,8 +229,37 @@ class StyleBuilderTTK:
                     f"{(variant, widget_family)!r}"
                 )
             return False
-        recipe(self, colorname)
+        prev_surface = self._surface
+        self._surface = surface or ""
+        try:
+            recipe(self, colorname)
+        finally:
+            self._surface = prev_surface
         return True
+
+    def surface_prefix(self, name: str) -> str:
+        """Prefix a style name with the active `@<surface>.` segment, if any.
+
+        Recipes build their style name normally (`f"{color}.{ttk_class}"`) and
+        wrap it here. Uses the shared `surface_segment` (constants) that the
+        resolver's `_build_ttkstyle_name` also uses, so the *built* name and the
+        *looked-up* name cannot drift; a default/empty surface adds nothing.
+        """
+        return f"{surface_segment(self._surface)}{name}"
+
+    def on_surface_fg(self) -> str:
+        """Foreground that reads against the active surface (2.0 surface-color).
+
+        A genuine accent surface (primary/success/light/dark/...) needs a
+        contrast flip to `on_color`; the near-background neutral surfaces
+        (`background`/`card`/`neutral`) keep the theme's soft `fg`, so a control
+        on a card does not harden its text vs the same control on the app
+        background. No surface -> the theme `fg`.
+        """
+        surface = self._surface
+        if surface and surface in BOOTSTYLE_COLORS and surface != NEUTRAL:
+            return self.on_color(self.resolve_surface(surface))
+        return self.colors.fg
 
     def register_ttkstyle(self, style_name: str):
         """Mark `style_name` as built so the builder will not recreate it."""

--- a/tests/test_bootstyle_grammar.py
+++ b/tests/test_bootstyle_grammar.py
@@ -64,20 +64,25 @@ def test_reclassification_fixed_the_audit():
 @pytest.mark.parametrize(
     "text, expected",
     [
-        ("primary-outline", ("primary", "outline", "", "")),
-        ("success-round-toggle", ("success", "round", "toggle", "")),
-        ("info-striped", ("info", "striped", "", "")),
-        ("primary", ("primary", "", "", "")),
-        ("outline", ("", "outline", "", "")),
-        ("toolbutton", ("", "", "toolbutton", "")),
-        ("horizontal", ("", "", "", "horizontal")),
-        ("danger-inverse", ("danger", "inverse", "", "")),
+        # (color, modifier, base, orient, surface)
+        ("primary-outline", ("primary", "outline", "", "", "")),
+        ("success-round-toggle", ("success", "round", "toggle", "", "")),
+        ("info-striped", ("info", "striped", "", "", "")),
+        ("primary", ("primary", "", "", "", "")),
+        ("outline", ("", "outline", "", "", "")),
+        ("toolbutton", ("", "", "toolbutton", "", "")),
+        ("horizontal", ("", "", "", "horizontal", "")),
+        ("danger-inverse", ("danger", "inverse", "", "", "")),
         # order-free input still classifies to the same slots
-        ("outline-primary", ("primary", "outline", "", "")),
+        ("outline-primary", ("primary", "outline", "", "", "")),
         # whitespace separator is accepted alongside the dash
-        ("primary outline", ("primary", "outline", "", "")),
+        ("primary outline", ("primary", "outline", "", "", "")),
         # internal composite modifiers are valid tokens
-        ("primary-meter", ("primary", "meter", "", "")),
+        ("primary-meter", ("primary", "meter", "", "", "")),
+        # a @surface token (2.0 surface-color), position-free
+        ("@primary success ghost", ("success", "ghost", "", "", "primary")),
+        ("success ghost @primary", ("success", "ghost", "", "", "primary")),
+        ("@card ghost", ("", "ghost", "", "", "card")),
     ],
 )
 def test_classify_slots(text, expected):
@@ -85,9 +90,9 @@ def test_classify_slots(text, expected):
 
 
 def test_sentinels_classify_to_nothing():
-    assert _classify_tokens("default") == ("", "", "", "")
-    assert _classify_tokens("") == ("", "", "", "")
-    assert _classify_tokens("-primary-") == ("primary", "", "", "")
+    assert _classify_tokens("default") == ("", "", "", "", "")
+    assert _classify_tokens("") == ("", "", "", "", "")
+    assert _classify_tokens("-primary-") == ("primary", "", "", "", "")
 
 
 # --------------------------------------------------------------------------- #
@@ -96,7 +101,7 @@ def test_sentinels_classify_to_nothing():
 def test_unknown_token_is_silent_without_warn_flag():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        assert _classify_tokens("primaryy") == ("", "", "", "")
+        assert _classify_tokens("primaryy") == ("", "", "", "", "")
 
 
 def test_unknown_token_warns():
@@ -194,7 +199,7 @@ def test_every_registry_key_roundtrips():
         if variant != DEFAULT_VARIANT:
             tokens.append(variant)
         tokens.append(family)
-        color, modifier, base, _ = _classify_tokens("-".join(tokens))
+        color, modifier, base, _, _ = _classify_tokens("-".join(tokens))
         assert color == "primary"
         assert base == family
         assert (modifier or DEFAULT_VARIANT) == variant

--- a/tests/test_surface_grammar.py
+++ b/tests/test_surface_grammar.py
@@ -1,0 +1,204 @@
+"""Surface-color grammar + delivery tests (2.0 surface-color, PR 2).
+
+Surface rides INSIDE the bootstyle string as an `@<surface>` token (spaces are
+the recommended separator: `"@primary success ghost"`), producing a leading
+`@<surface>.` segment on the style name. Covers the token round-trip, the
+default-surface no-regression invariant, the family gate, case-normalization,
+the lenient handling of a custom `@` style name on the theme walk, the
+accent-vs-card foreground rule, and end-to-end delivery on the button family.
+"""
+import warnings
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.style import Style
+from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
+from ttkbootstrap.style.bootstyle import (
+    Bootstyle,
+    _build_ttkstyle_name,
+    _classify_style_name,
+    _classify_tokens,
+)
+
+
+def _lookup(app, style_name, option):
+    return app.tk.call("ttk::style", "lookup", style_name, f"-{option}")
+
+
+# --- grammar units -------------------------------------------------------- #
+
+def test_classify_tokens_extracts_surface():
+    color, modifier, base, orient, surface = _classify_tokens(
+        "@primary success ghost"
+    )
+    assert (color, modifier, surface) == ("success", "ghost", "primary")
+
+
+def test_surface_token_is_position_free():
+    # classified by content, so the @token may appear anywhere
+    for s in ("@primary success ghost", "success ghost @primary",
+              "success @primary ghost"):
+        c, m, b, o, surf = _classify_tokens(s)
+        assert (c, m, surf) == ("success", "ghost", "primary"), s
+
+
+def test_build_name_prefixes_non_default_surface():
+    assert (
+        _build_ttkstyle_name("info", "ghost", "", "button", "primary")
+        == "@primary.info.Ghost.TButton"
+    )
+
+
+def test_build_name_default_surface_is_unchanged():
+    base = _build_ttkstyle_name("info", "ghost", "", "button")
+    assert base == "info.Ghost.TButton"
+    assert _build_ttkstyle_name("info", "ghost", "", "button", "") == base
+    assert _build_ttkstyle_name("info", "ghost", "", "button", "background") == base
+
+
+def test_classify_style_name_extracts_surface():
+    color, modifier, base, orient, surface = _classify_style_name(
+        "@primary.info.Ghost.TButton"
+    )
+    assert (color, modifier, base, orient, surface) == (
+        "info", "ghost", "button", "", "primary"
+    )
+
+
+def test_name_round_trips_through_classify():
+    name = _build_ttkstyle_name("success", "link", "", "button", "card")
+    color, modifier, base, orient, surface = _classify_style_name(name)
+    assert _build_ttkstyle_name(color, modifier, orient, base, surface) == name
+
+
+# --- end-to-end delivery (surface as a bootstyle @token) ------------------ #
+
+def test_default_surface_names_unchanged(root):
+    """No @surface token -> exactly the pre-surface style names."""
+    assert ttk.Button(root, bootstyle="ghost").cget("style") == "Ghost.TButton"
+    assert (
+        ttk.Button(root, bootstyle="info ghost").cget("style")
+        == "info.Ghost.TButton"
+    )
+    assert (
+        ttk.Button(root, bootstyle="primary outline").cget("style")
+        == "primary.Outline.TButton"
+    )
+
+
+def test_ghost_ghosts_on_accent_surface(root):
+    """`@primary ghost` paints the accent, not the app background."""
+    style = Style.get_instance()
+    btn = ttk.Button(root, bootstyle="@primary ghost")
+    assert btn.cget("style") == "@primary.Ghost.TButton"
+    assert _lookup(root, btn.cget("style"), "background") == style.colors.primary
+
+
+def test_accent_surface_flips_foreground(root):
+    """On an accent surface the default ghost text flips to the contrast color."""
+    b = StyleBuilderTTK(build=False)
+    btn = ttk.Button(root, bootstyle="@primary ghost")
+    assert _lookup(root, btn.cget("style"), "foreground") == b.on_color(
+        b.colors.primary
+    )
+
+
+def test_card_surface_keeps_soft_foreground(root):
+    """A near-background `card` surface keeps the theme's soft fg (no hardening)."""
+    b = StyleBuilderTTK(build=False)
+    btn = ttk.Button(root, bootstyle="@card ghost")
+    assert btn.cget("style") == "@card.Ghost.TButton"
+    assert _lookup(root, btn.cget("style"), "foreground") == str(b.colors.fg)
+    assert _lookup(root, btn.cget("style"), "background") == b.card_surface()
+
+
+def test_link_and_outline_track_the_surface(root):
+    style = Style.get_instance()
+    lk = ttk.Button(root, bootstyle="@success link")
+    assert lk.cget("style") == "@success.Link.TButton"
+    assert _lookup(root, lk.cget("style"), "background") == style.colors.success
+
+    ol = ttk.Button(root, bootstyle="@success primary outline")
+    assert ol.cget("style") == "@success.primary.Outline.TButton"
+    assert _lookup(root, ol.cget("style"), "background") == style.colors.success
+
+
+def test_surface_token_is_case_normalized(root):
+    assert (
+        ttk.Button(root, bootstyle="@Primary ghost").cget("style")
+        == "@primary.Ghost.TButton"
+    )
+
+
+def test_frame_ignores_surface_family_gate(root):
+    """Frames are surface producers -- an @surface token is gated out."""
+    frm = ttk.Frame(root, bootstyle="@card primary")
+    assert "@" not in frm.cget("style")
+
+
+def test_unknown_surface_warns(root):
+    with pytest.warns(UserWarning):
+        btn = ttk.Button(root, bootstyle="@bogus ghost")
+    assert btn.cget("style") == "Ghost.TButton"
+
+
+def test_bare_at_token_is_silent(root):
+    """A stray bare '@' carries no surface and must not warn."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")   # any warning fails
+        btn = ttk.Button(root, bootstyle="@primary @ ghost")
+    assert btn.cget("style") == "@primary.Ghost.TButton"
+
+
+def test_capitalized_surface_only_typo_warns(root):
+    """A leading-@ typo with no other token stays on the loud bootstyle path."""
+    with pytest.warns(UserWarning):
+        btn = ttk.Button(root, bootstyle="@Primaryy")
+    assert btn.cget("style") == "TButton"
+
+
+def test_custom_at_style_name_is_lenient_on_theme_walk(root):
+    """A custom `@`-prefixed style name must NOT warn/raise on re-resolve."""
+    from ttkbootstrap.style._compat import (
+        is_bootstyle_strict,
+        set_bootstyle_strict,
+    )
+    lbl = ttk.Label(root)
+    lbl.configure(style="@brand.TLabel")   # custom style name carrying '@'
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")     # any warning becomes an error
+        Bootstyle.update_ttk_widget_style(lbl)   # simulate theme-walk repaint
+    # ... and strict mode must not raise on the lenient style-name dialect
+    prior = is_bootstyle_strict()
+    set_bootstyle_strict(True)
+    try:
+        Bootstyle.update_ttk_widget_style(lbl)  # no exception
+    finally:
+        set_bootstyle_strict(prior)
+
+
+def test_surface_style_is_theme_reactive(root):
+    style = Style.get_instance()
+    style.theme_use("bootstrap-light")
+    btn = ttk.Button(root, bootstyle="@primary ghost")
+    light_bg = _lookup(root, btn.cget("style"), "background")
+
+    style.theme_use("bootstrap-dark")
+    dark_bg = _lookup(root, btn.cget("style"), "background")
+
+    assert btn.cget("style") == "@primary.Ghost.TButton"  # name stable
+    assert light_bg != dark_bg  # repainted for the new theme's primary
+
+
+# --- configure-time (the bootstyle string is authoritative) --------------- #
+
+def test_configure_bootstyle_sets_and_clears_surface(root):
+    btn = ttk.Button(root, bootstyle="@card ghost")
+    assert btn.cget("style") == "@card.Ghost.TButton"
+    # a bootstyle without an @token clears the surface (string is authoritative)
+    btn.configure(bootstyle="ghost")
+    assert btn.cget("style") == "Ghost.TButton"
+    # and can move it to another surface
+    btn.configure(bootstyle="@primary success ghost")
+    assert btn.cget("style") == "@primary.success.Ghost.TButton"


### PR DESCRIPTION
## Surface color — PR 2 of 3 (mechanism + button family)

Second PR of the **surface-color** workstream (PR 1 = #1149). A widget can be told the background **surface** it sits on, so ghost/link/outline controls placed on a non-application-background surface (a card, an accent toolbar) style and render correctly. The motivating case is `gallery/collapsing_frame.py`, where a link/ghost button on an accent header could only ever resolve against the app background — so it couldn't "ghost."

Design pass: `development/2_0_surface_color_design.md`.

### The API: surface is a `@`-token inside `bootstyle` (no `surface=` param)

`bootstyle` is a compact spelling of the ttk style name, and the style name already carries the `@surface` segment — so surface rides **inside** the bootstyle string as a **position-free `@<surface>` token**, not a second channel. **Spaces are the recommended separator.**

```python
ttk.Button(root, bootstyle="@primary success ghost")   # a green ghost on a blue bar
#   -> style name: @primary.success.Ghost.TButton
```

A surface is a named neutral surface (`card`) **or** an accent color (`@primary`, so a control can ghost against an accent container). **Additive:** with no `@token` the bootstyle resolves exactly as before — every existing style name and appearance is **byte-for-byte unchanged**.

### What's here
- **`constants.py`** — `@surface` vocab + `surface_segment()` (the single `@<surface>.` formatter shared by the resolver and the builder, so the built name and the looked-up name cannot drift).
- **`style/bootstyle.py`** — `_classify_tokens` reads a `@surface` token; the segment prefixes the style name and round-trips through `_classify_style_name` on the theme walk (lenient — a custom `@` style name never warns); `_normalize_surface` case-normalizes + validates through the `_compat` strict gate; a **family gate** (`_SURFACE_FAMILIES`, initially `{button}`) makes not-yet-migrated families ignore surface (frames are producers, never in it).
- **`style/builders_ttk.py`** — `build_style` exposes surface to the recipe via transient `_surface`; `surface_prefix` + `on_surface_fg` (accent surfaces flip to `on_color`, near-bg `card`/`neutral` keep the soft theme fg).
- **`style/builders/{button,utils}.py`** — solid/outline/link/ghost/neutral-outline wired end-to-end.
- **`tests/`** — `test_surface_grammar.py` (+20), tokenizer cases widened.

### Review
**Two** high-effort `/code-review` passes gated this PR. The first drove the reversal from a `surface=` param to the `@`-token (which erased a whole class of two-axis reconcile bugs). The second found no structural bugs — cross-file and removed-behavior angles came back clean. Accepted-by-design edges (permissive, not paternalistic — invisible accent-on-accent, redundant identical solid styles) are recorded in design doc §10.

Suite: **597 passed** (excl. the known `nl.msg` env flake).

### Next
- **PR 3** — roll the mechanism out to the remaining consuming families (check/radio/toggle/scale/progressbar/scrollbar/label), add the `_SURFACE_FAMILIES` graceful-degrade net, and update `gallery/collapsing_frame.py` as the live proof + light↔dark visual spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)