### PR TITLE
Surface color PR 3: indicator + label families + degrade net

### DIFF
--- a/development/2_0_surface_color_design.md
+++ b/development/2_0_surface_color_design.md
@@ -268,12 +268,22 @@ working feature.
   surfaces flip to `on_color`, near-bg `card`/`neutral` keep the soft theme fg) —
   as the `collapsing_frame` acceptance proof. **No `surface=` param** (§5.1). A
   high-effort `/code-review` on the param version drove the reversal + these fixes.
-- **PR 3 — roll out to remaining consuming families.** Extend the same mechanism
-  (add each to `_SURFACE_FAMILIES`, point their `colors.bg` sites at
-  `resolve_surface`) to check/radio/toggle/scale/progressbar/scrollbar/label; the
-  recolor-glyph asset half falls out for free (§3). Update
-  `gallery/collapsing_frame.py`; visual spot-check light↔dark. Frames stay out
-  (surface *producers*, §4e).
+- **PR 3 — indicator + label families.** Extended the mechanism to the common
+  "on a surface" controls: **checkbutton, radiobutton, toggle** (round + square),
+  **label** (added to `_SURFACE_FAMILIES`; `colors.bg`/glyph-bg/`colors.fg` sites
+  → `resolve_surface`/`on_surface_fg`; `StyleName` gained a `surface=` param so
+  check/radio/scale names prefix cleanly). Added the **`_SURFACE_FAMILIES`
+  graceful-degrade net** (deferred from PR 2 review): if a listed family's recipe
+  did not emit `surface_prefix`, the resolver falls back to the plain style rather
+  than a bare-clam unregistered `@` name. `examples/surface_preview.py` is the
+  light↔dark visual proof (accent producing-frames + matching `@<accent>`
+  controls). `gallery/collapsing_frame.py` left untouched (author WIP). Frames
+  stay out (producers, §4e).
+- **PR 4 — bar families (deferred).** scale / progressbar / scrollbar — lower
+  value on a distinct surface and more complex (H/V × glyph assets); same
+  mechanism, split out for reviewability. Map already produced (each pulls
+  `border(colors.bg)` for the trough + bakes `colors.bg` in the slider/handle
+  glyphs).
 
 ## 7. Phase 2 (deferred, not this pass)
 

--- a/examples/surface_preview.py
+++ b/examples/surface_preview.py
@@ -1,0 +1,77 @@
+"""Surface-color preview (2.0 surface-color).
+
+A visual spot-check for the `@<surface>` bootstyle token: the same controls on
+the application background vs. on accent-colored surfaces. Each accent panel is a
+producing frame (`bootstyle="<accent>"`); the controls on it carry the matching
+`@<accent>` surface token so their flat backgrounds, off-indicators, and text
+read against the panel instead of the app background.
+
+Toggle light/dark (top-right) to confirm every surfaced style repaints.
+
+Run:  python examples/surface_preview.py
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+
+
+ACCENTS = ("primary", "success", "danger", "dark")
+
+
+def build_controls(parent, surface):
+    """Fill `parent` with one of each family. `surface` is "" or an accent token.
+
+    On an accent panel the controls use a *light* accent so the indicator glyphs
+    and ghost fill stay legible against the panel (a `@primary primary` control
+    would render accent-on-accent -- the user's call, but not a useful preview).
+    """
+    at = f"@{surface} " if surface else ""       # surface prefix
+    color = "light " if surface else ""          # legible-on-accent accent
+    ttk.Label(parent, text=f"surface: {surface or 'background'}",
+              bootstyle=f"{at}{color}".strip() or None).pack(anchor=W, pady=(0, 8))
+    ttk.Checkbutton(parent, text="Checkbutton", bootstyle=f"{at}{color}".strip()
+                    ).pack(anchor=W, pady=2)
+    ttk.Radiobutton(parent, text="Radiobutton", value=1,
+                    bootstyle=f"{at}{color}".strip()).pack(anchor=W, pady=2)
+    ttk.Checkbutton(parent, text="Toggle", bootstyle=f"{at}{color}toggle".strip()
+                    ).pack(anchor=W, pady=2)
+    ttk.Button(parent, text="Ghost button", bootstyle=f"{at}{color}ghost".strip()
+               ).pack(anchor=W, pady=(2, 0))
+
+
+def main():
+    app = ttk.Window(title="Surface color preview", themename="bootstrap-light",
+                     size=(720, 340))
+
+    top = ttk.Frame(app, padding=10)
+    top.pack(fill=X)
+    ttk.Label(top, text="@<surface> bootstyle token", font="-size 13 -weight bold"
+              ).pack(side=LEFT)
+
+    def toggle_theme():
+        name = app.style.theme.name
+        app.style.theme_use(
+            "bootstrap-dark" if name == "bootstrap-light" else "bootstrap-light"
+        )
+
+    ttk.Button(top, text="Toggle light/dark", bootstyle="secondary-outline",
+               command=toggle_theme).pack(side=RIGHT)
+
+    row = ttk.Frame(app, padding=10)
+    row.pack(fill=BOTH, expand=YES)
+
+    # baseline: the app background (no surface token)
+    base = ttk.Frame(row, padding=15)
+    base.pack(side=LEFT, fill=BOTH, expand=YES, padx=5)
+    build_controls(base, "")
+
+    # one producing accent panel per accent
+    for accent in ACCENTS:
+        panel = ttk.Frame(row, bootstyle=accent, padding=15)
+        panel.pack(side=LEFT, fill=BOTH, expand=YES, padx=5)
+        build_controls(panel, accent)
+
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -101,7 +101,9 @@ _TOKEN_SPLIT = re.compile(r"[-\s]+")
 # never in it -- they are surface producers, not consumers). The token vocab lives
 # once in constants (`BOOTSTYLE_SURFACE_TOKENS`).
 _SURFACE_TOKENS = frozenset(BOOTSTYLE_SURFACE_TOKENS)
-_SURFACE_FAMILIES = frozenset({"button"})
+_SURFACE_FAMILIES = frozenset(
+    {"button", "checkbutton", "radiobutton", "toggle", "label"}
+)
 
 
 def _normalize_surface(surface, family, source, warn):
@@ -729,6 +731,18 @@ class Bootstyle:
                     # A third-party widget whose class maps to no ttkbootstrap
                     # builder: pass its style through untouched.
                     return style_string
+
+        # Graceful degrade (2.0 surface-color): if a surface was requested but the
+        # surfaced style still isn't registered after the build -- a family listed
+        # in `_SURFACE_FAMILIES` whose recipe did not emit `surface_prefix` -- fall
+        # back to the plain style so the widget renders normally, not bare clam.
+        if surface and not style.style_exists_in_theme(ttkstyle):
+            builder = style._get_builder()
+            plain = _build_ttkstyle_name(color, modifier, orient, family)
+            if not style.style_exists_in_theme(plain):
+                builder.build_style(variant, family, color)
+            if style.style_exists_in_theme(plain):
+                ttkstyle = plain
 
         # Repaint the combobox popdown. It is a Tcl-level toplevel that the
         # theme walk's winfo_children() DFS cannot reach, so it is refreshed

--- a/src/ttkbootstrap/style/builders/checkbutton.py
+++ b/src/ttkbootstrap/style/builders/checkbutton.py
@@ -21,10 +21,11 @@ def build_checkbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     sn = StyleName("TCheckbutton", colorname, surface=builder._surface)
     # Label/focus text reads against the surface (2.0 surface-color); the
     # indicator glyph is self-contained (its paper is `on_accent`, not the bg).
+    surface = builder.resolve_surface(builder._surface)
     fg = builder.on_surface_fg()
 
-    disabled = builder.disabled("text")
-    fg_muted = builder.mute(fg)
+    disabled = builder.disabled("text", surface)
+    fg_muted = builder.mute(fg, surface)
 
     accent = builder.colors.get(colorname or 'primary')
     on_accent = builder.on_color(accent)

--- a/src/ttkbootstrap/style/builders/checkbutton.py
+++ b/src/ttkbootstrap/style/builders/checkbutton.py
@@ -18,8 +18,10 @@ def build_checkbutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    sn = StyleName("TCheckbutton", colorname)
-    fg = builder.colors.fg
+    sn = StyleName("TCheckbutton", colorname, surface=builder._surface)
+    # Label/focus text reads against the surface (2.0 surface-color); the
+    # indicator glyph is self-contained (its paper is `on_accent`, not the bg).
+    fg = builder.on_surface_fg()
 
     disabled = builder.disabled("text")
     fg_muted = builder.mute(fg)

--- a/src/ttkbootstrap/style/builders/label.py
+++ b/src/ttkbootstrap/style/builders/label.py
@@ -18,18 +18,19 @@ def build_meter_subtxt_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             The color label used to style the widget.
     """
     ttk_class = "Metersubtxt.TLabel"
+    surface = builder.resolve_surface(builder._surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
+        ttk_style = builder.surface_prefix(ttk_class)
         if builder.is_light_theme:
             foreground = builder.colors.secondary
         else:
             foreground = builder.colors.light
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
         foreground = builder.colors.get(colorname)
 
-    background = builder.colors.bg
+    background = surface
 
     builder.configure(
         ttk_style, foreground=foreground, background=background
@@ -58,17 +59,18 @@ def build_meter_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     # text color = `foreground`
     # trough color = `space`
 
+    surface = builder.resolve_surface(builder._surface)
     # Recessed neutral trough = border(surface) (bootstack parity).
-    trough_color = builder.border(builder.colors.bg)
+    trough_color = builder.border(surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
-        background = builder.colors.bg
+        ttk_style = builder.surface_prefix(ttk_class)
+        background = surface
         textcolor = builder.colors.primary
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
         textcolor = builder.colors.get(colorname)
-        background = builder.colors.bg
+        background = surface
 
     builder.configure(
         ttk_style,
@@ -130,12 +132,15 @@ def build_inverse_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Inverse.TLabel"
 
+    # An inverse label is a deliberate high-contrast chip; it does not blend into
+    # a surface, but its name is still prefixed so an `@surface inverse` resolves
+    # to a real (if identical) style rather than degrading (2.0 surface-color).
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
+        ttk_style = builder.surface_prefix(ttk_class)
         background = builder.colors.fg
         foreground = builder.colors.bg
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
         background = builder.colors.get(colorname)
         foreground = builder.on_color(background)
 

--- a/src/ttkbootstrap/style/builders/label.py
+++ b/src/ttkbootstrap/style/builders/label.py
@@ -92,15 +92,17 @@ def build_label_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             The color label used to style the widget.
     """
     ttk_class = "TLabel"
+    # The surface the label sits on (2.0 surface-color); default == theme bg.
+    surface = builder.resolve_surface(builder._surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
-        foreground = builder.colors.fg
-        background = builder.colors.bg
+        ttk_style = builder.surface_prefix(ttk_class)
+        foreground = builder.on_surface_fg()
+        background = surface
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
         foreground = builder.colors.get(colorname)
-        background = builder.colors.bg
+        background = surface
 
     # standard label
     builder.configure(

--- a/src/ttkbootstrap/style/builders/radiobutton.py
+++ b/src/ttkbootstrap/style/builders/radiobutton.py
@@ -18,8 +18,11 @@ def build_radiobutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    sn = StyleName("TRadiobutton", colorname)
-    fg = builder.colors.fg
+    sn = StyleName("TRadiobutton", colorname, surface=builder._surface)
+    # The unselected radio's knockout interior shows the surface (2.0
+    # surface-color); the label text reads against it too.
+    surface = builder.resolve_surface(builder._surface)
+    fg = builder.on_surface_fg()
     disabled = builder.disabled("text")
     fg_muted = builder.mute(fg)
 
@@ -48,9 +51,9 @@ def build_radiobutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 
     a = builder.assets
     selected = a.recolor("radiobutton", white=accent, black=accent)
-    unselected = a.recolor("radiobutton", white=builder.colors.bg, black=fg_muted)
+    unselected = a.recolor("radiobutton", white=surface, black=fg_muted)
     disabled_selected = a.recolor("radiobutton", white=disabled, black=disabled)
-    disabled_unselected = a.recolor("radiobutton", white=builder.colors.bg, black=disabled)
+    disabled_unselected = a.recolor("radiobutton", white=surface, black=disabled)
     image_element(
         builder.style, f"{sn.ttk_style}.indicator", default=selected.image,
         states={

--- a/src/ttkbootstrap/style/builders/radiobutton.py
+++ b/src/ttkbootstrap/style/builders/radiobutton.py
@@ -23,8 +23,8 @@ def build_radiobutton_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     # surface-color); the label text reads against it too.
     surface = builder.resolve_surface(builder._surface)
     fg = builder.on_surface_fg()
-    disabled = builder.disabled("text")
-    fg_muted = builder.mute(fg)
+    disabled = builder.disabled("text", surface)
+    fg_muted = builder.mute(fg, surface)
 
     # Resolve the "on" accent; LIGHT/DARK on their own background need a
     # contrasting indicator so the knockout interior stays readable

--- a/src/ttkbootstrap/style/builders/toggle.py
+++ b/src/ttkbootstrap/style/builders/toggle.py
@@ -46,13 +46,17 @@ def build_round_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 def _build_round_toggle_style(builder: StyleBuilderTTK, colorname, ttk_class):
     """Build a round toggle under `ttk_class` (`Toggle` or `Round.Toggle`)."""
     disabled_fg = builder.disabled("text")
-    off_track = builder.border(builder.colors.bg)  # bootstack: off track = border(surface)
+    # The surface the toggle sits on (2.0 surface-color): the off track, the
+    # background, and the switch glyph's knockout (black channel) all track it.
+    surface = builder.resolve_surface(builder._surface)
+    fg = builder.on_surface_fg()
+    off_track = builder.border(surface)  # bootstack: off track = border(surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
+        ttk_style = builder.surface_prefix(ttk_class)
         colorname = PRIMARY
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
 
 
     # Resolve the "on" accent; LIGHT/DARK on their own background need a
@@ -70,24 +74,24 @@ def _build_round_toggle_style(builder: StyleBuilderTTK, colorname, ttk_class):
         relief=tk.FLAT,
         borderwidth=0,
         padding=0,
-        foreground=builder.colors.fg,
-        background=builder.colors.bg,
+        foreground=fg,
+        background=surface,
         # 1px keyboard-focus ring around the label (via the `Toolbutton.focus`
         # element in the layout below), matching the rest of the button family.
-        focuscolor=builder.colors.fg,
+        focuscolor=fg,
         focusthickness=builder.scale_size(1),
     )
     builder.style.map(
         ttk_style,
         foreground=[("disabled", disabled_fg)],
         focuscolor=[("disabled", disabled_fg)],
-        background=[("selected", builder.colors.bg)],
+        background=[("selected", surface)],
     )
     a = builder.assets
-    on = a.recolor("switch_round", white=accent, black=builder.colors.bg)
-    off = a.recolor("switch_round", white=off_track, black=builder.colors.bg, transform="flip-x")
-    disabled_on = a.recolor("switch_round", white=disabled_fg, black=builder.colors.bg)
-    disabled_off = a.recolor("switch_round", white=disabled_fg, black=builder.colors.bg, transform="flip-x")
+    on = a.recolor("switch_round", white=accent, black=surface)
+    off = a.recolor("switch_round", white=off_track, black=surface, transform="flip-x")
+    disabled_on = a.recolor("switch_round", white=disabled_fg, black=surface)
+    disabled_off = a.recolor("switch_round", white=disabled_fg, black=surface, transform="flip-x")
     spacer_name = f"{ttk_style}.spacer"
     try:
         image_element(
@@ -133,13 +137,16 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Square.Toggle"
     disabled_fg = builder.disabled("text")
-    off_track = builder.border(builder.colors.bg)  # bootstack: off track = border(surface)
+    # The surface the toggle sits on (2.0 surface-color).
+    surface = builder.resolve_surface(builder._surface)
+    fg = builder.on_surface_fg()
+    off_track = builder.border(surface)  # bootstack: off track = border(surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
+        ttk_style = builder.surface_prefix(ttk_class)
         colorname = PRIMARY
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
 
     # Resolve the "on" accent (same logic as round-toggle).
     if colorname == LIGHT:
@@ -150,25 +157,25 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         accent = builder.colors.get(colorname)
 
     builder.configure(
-        ttk_style, relief=tk.FLAT, borderwidth=0, foreground=builder.colors.fg,
+        ttk_style, relief=tk.FLAT, borderwidth=0, foreground=fg,
         # 1px keyboard-focus ring around the label (via the `Toolbutton.focus`
         # element in the layout below), matching the rest of the button family.
-        focuscolor=builder.colors.fg, focusthickness=builder.scale_size(1),
+        focuscolor=fg, focusthickness=builder.scale_size(1),
     )
     builder.style.map(
         ttk_style,
         foreground=[("disabled", disabled_fg)],
         focuscolor=[("disabled", disabled_fg)],
         background=[
-            ("selected", builder.colors.bg),
-            ("!selected", builder.colors.bg),
+            ("selected", surface),
+            ("!selected", surface),
         ],
     )
     a = builder.assets
-    on = a.recolor("switch_square", white=accent, black=builder.colors.bg)
-    off = a.recolor("switch_square", white=off_track, black=builder.colors.bg, transform="flip-x")
-    disabled_on = a.recolor("switch_square", white=disabled_fg, black=builder.colors.bg)
-    disabled_off = a.recolor("switch_square", white=disabled_fg, black=builder.colors.bg, transform="flip-x")
+    on = a.recolor("switch_square", white=accent, black=surface)
+    off = a.recolor("switch_square", white=off_track, black=surface, transform="flip-x")
+    disabled_on = a.recolor("switch_square", white=disabled_fg, black=surface)
+    disabled_off = a.recolor("switch_square", white=disabled_fg, black=surface, transform="flip-x")
     spacer_name = f"{ttk_style}.spacer"
     image_element(
         builder.style, f"{ttk_style}.indicator", default=on.image,

--- a/src/ttkbootstrap/style/builders/toggle.py
+++ b/src/ttkbootstrap/style/builders/toggle.py
@@ -45,10 +45,10 @@ def build_round_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
 
 def _build_round_toggle_style(builder: StyleBuilderTTK, colorname, ttk_class):
     """Build a round toggle under `ttk_class` (`Toggle` or `Round.Toggle`)."""
-    disabled_fg = builder.disabled("text")
     # The surface the toggle sits on (2.0 surface-color): the off track, the
     # background, and the switch glyph's knockout (black channel) all track it.
     surface = builder.resolve_surface(builder._surface)
+    disabled_fg = builder.disabled("text", surface)
     fg = builder.on_surface_fg()
     off_track = builder.border(surface)  # bootstack: off track = border(surface)
 
@@ -136,9 +136,9 @@ def build_square_toggle_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             The color label used to style the widget.
     """
     ttk_class = "Square.Toggle"
-    disabled_fg = builder.disabled("text")
     # The surface the toggle sits on (2.0 surface-color).
     surface = builder.resolve_surface(builder._surface)
+    disabled_fg = builder.disabled("text", surface)
     fg = builder.on_surface_fg()
     off_track = builder.border(surface)  # bootstack: off track = border(surface)
 

--- a/src/ttkbootstrap/style/layout.py
+++ b/src/ttkbootstrap/style/layout.py
@@ -12,7 +12,7 @@ with raw `style.element_create`/`style.layout`/`style.map` calls. Top-level
 imports are tkinter constants only -- no engine edge, so these stay leaves in
 the package layering.
 """
-from ttkbootstrap.constants import DEFAULT, PRIMARY
+from ttkbootstrap.constants import DEFAULT, PRIMARY, surface_segment
 
 
 # The canonical ttk widget state tokens. `statespec`/`state_map` validate against
@@ -201,15 +201,16 @@ class StyleName:
 
     __slots__ = ("colorname", "ttk_style", "element")
 
-    def __init__(self, ttk_class, colorname=DEFAULT, orient=None):
+    def __init__(self, ttk_class, colorname=DEFAULT, orient=None, surface=""):
         is_default = colorname in (DEFAULT, "")
         self.colorname = PRIMARY if is_default else colorname
 
+        prefix = surface_segment(surface)
         orient_prefix = f"{orient}." if orient else ""
         if is_default:
-            self.ttk_style = f"{orient_prefix}{ttk_class}"
+            self.ttk_style = f"{prefix}{orient_prefix}{ttk_class}"
         else:
-            self.ttk_style = f"{colorname}.{orient_prefix}{ttk_class}"
+            self.ttk_style = f"{prefix}{colorname}.{orient_prefix}{ttk_class}"
 
         element_class = ttk_class[1:] if ttk_class.startswith("T") else ttk_class
         self.element = self.ttk_style.replace(ttk_class, element_class)

--- a/tests/test_surface_families.py
+++ b/tests/test_surface_families.py
@@ -109,6 +109,34 @@ def test_surfaced_family_is_theme_reactive(root):
     assert light != dark
 
 
+# --- gate <-> recipe correspondence --------------------------------------- #
+
+def test_every_gated_family_honors_surface(root):
+    """Every family in `_SURFACE_FAMILIES` must actually emit the `@surface`
+    prefix -- guards the hand-maintained gate against drifting from the recipes
+    (a listed-but-unwired family would silently degrade instead)."""
+    import ttkbootstrap.style.bootstyle as bs
+    cases = {
+        "button": ttk.Button(root, bootstyle="@card"),
+        "checkbutton": ttk.Checkbutton(root, bootstyle="@card"),
+        "radiobutton": ttk.Radiobutton(root, bootstyle="@card"),
+        "toggle": ttk.Checkbutton(root, bootstyle="@card toggle"),
+        "label": ttk.Label(root, bootstyle="@card"),
+    }
+    # the test must cover exactly the gate (update both together)
+    assert set(cases) == set(bs._SURFACE_FAMILIES)
+    for family, w in cases.items():
+        assert w.cget("style").startswith("@card."), f"{family} dropped its surface"
+
+
+def test_inverse_label_prefixes_not_degrades(root):
+    """Every label variant honors the surface in its name (no degrade churn)."""
+    assert (
+        ttk.Label(root, bootstyle="@card inverse").cget("style")
+        == "@card.Inverse.TLabel"
+    )
+
+
 # --- graceful-degrade net ------------------------------------------------- #
 
 def test_surface_degrades_when_family_recipe_unwired(root, monkeypatch):

--- a/tests/test_surface_families.py
+++ b/tests/test_surface_families.py
@@ -1,0 +1,124 @@
+"""Surface-color family rollout tests (2.0 surface-color, PR 3).
+
+Extends the `@<surface>` bootstyle token to the indicator + label families
+(checkbutton, radiobutton, toggle, label), and covers the `_SURFACE_FAMILIES`
+graceful-degrade net (a listed family whose recipe does not emit surface_prefix
+falls back to the plain style, not a bare-clam unregistered name).
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.style import Style
+from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
+
+
+def _lookup(app, style_name, option):
+    return app.tk.call("ttk::style", "lookup", style_name, f"-{option}")
+
+
+# --- default (surfaceless) names unchanged -------------------------------- #
+
+def test_family_default_names_unchanged(root):
+    assert ttk.Label(root).cget("style") == "TLabel"
+    assert ttk.Checkbutton(root).cget("style") == "TCheckbutton"
+    assert ttk.Radiobutton(root).cget("style") == "TRadiobutton"
+    assert ttk.Checkbutton(root, bootstyle="toggle").cget("style") == "Toggle"
+    assert (
+        ttk.Checkbutton(root, bootstyle="round-toggle").cget("style")
+        == "Round.Toggle"
+    )
+
+
+# --- label ---------------------------------------------------------------- #
+
+def test_label_tracks_surface(root):
+    b = StyleBuilderTTK(build=False)
+    lbl = ttk.Label(root, bootstyle="@card")
+    assert lbl.cget("style") == "@card.TLabel"
+    assert _lookup(root, lbl.cget("style"), "background") == b.card_surface()
+    # near-bg card keeps the soft theme fg
+    assert _lookup(root, lbl.cget("style"), "foreground") == str(b.colors.fg)
+
+
+def test_label_on_accent_surface_flips_fg(root):
+    b = StyleBuilderTTK(build=False)
+    style = Style.get_instance()
+    lbl = ttk.Label(root, bootstyle="@primary")
+    assert lbl.cget("style") == "@primary.TLabel"
+    assert _lookup(root, lbl.cget("style"), "background") == style.colors.primary
+    assert _lookup(root, lbl.cget("style"), "foreground") == b.on_color(
+        style.colors.primary
+    )
+
+
+def test_colored_label_keeps_accent_text_on_surface(root):
+    """A colored label on a surface: accent text, surface background."""
+    style = Style.get_instance()
+    lbl = ttk.Label(root, bootstyle="@card info")
+    assert lbl.cget("style") == "@card.info.TLabel"
+    assert _lookup(root, lbl.cget("style"), "foreground") == style.colors.info
+
+
+# --- checkbutton / radiobutton -------------------------------------------- #
+
+def test_checkbutton_on_surface(root):
+    b = StyleBuilderTTK(build=False)
+    cb = ttk.Checkbutton(root, bootstyle="@primary")
+    assert cb.cget("style") == "@primary.TCheckbutton"
+    # label text reads against the accent surface
+    assert _lookup(root, cb.cget("style"), "foreground") == b.on_color(
+        b.colors.primary
+    )
+
+
+def test_radiobutton_on_surface_builds(root):
+    b = StyleBuilderTTK(build=False)
+    rb = ttk.Radiobutton(root, bootstyle="@card")
+    assert rb.cget("style") == "@card.TRadiobutton"
+    assert _lookup(root, rb.cget("style"), "foreground") == str(b.colors.fg)
+
+
+# --- toggle --------------------------------------------------------------- #
+
+def test_toggle_tracks_surface(root):
+    style = Style.get_instance()
+    tg = ttk.Checkbutton(root, bootstyle="@primary toggle")
+    assert tg.cget("style") == "@primary.Toggle"
+    assert _lookup(root, tg.cget("style"), "background") == style.colors.primary
+
+
+def test_square_toggle_tracks_surface(root):
+    style = Style.get_instance()
+    tg = ttk.Checkbutton(root, bootstyle="@primary square-toggle")
+    assert tg.cget("style") == "@primary.Square.Toggle"
+    # square toggle sets background via the state map -> query the mapped state
+    mapped = root.tk.call(
+        "ttk::style", "lookup", tg.cget("style"), "-background", "selected"
+    )
+    assert mapped == style.colors.primary
+
+
+# --- theme reactivity ----------------------------------------------------- #
+
+def test_surfaced_family_is_theme_reactive(root):
+    style = Style.get_instance()
+    style.theme_use("bootstrap-light")
+    tg = ttk.Checkbutton(root, bootstyle="@primary toggle")
+    light = _lookup(root, tg.cget("style"), "background")
+    style.theme_use("bootstrap-dark")
+    dark = _lookup(root, tg.cget("style"), "background")
+    assert tg.cget("style") == "@primary.Toggle"
+    assert light != dark
+
+
+# --- graceful-degrade net ------------------------------------------------- #
+
+def test_surface_degrades_when_family_recipe_unwired(root, monkeypatch):
+    """A family listed in the gate whose recipe ignores surface must degrade to
+    the plain style (not an unregistered '@' name -> bare clam)."""
+    import ttkbootstrap.style.bootstyle as bs
+    style = Style.get_instance()
+    monkeypatch.setattr(
+        bs, "_SURFACE_FAMILIES", frozenset(bs._SURFACE_FAMILIES | {"entry"})
+    )
+    e = ttk.Entry(root, bootstyle="@card")
+    assert "@" not in e.cget("style")
+    assert style.style_exists_in_theme(e.cget("style"))


### PR DESCRIPTION
## Surface color — PR 3 of the workstream (indicator + label families)

Rolls the `@<surface>` bootstyle-token mechanism (PR 1 #1149, PR 2 #1150) out to the common "on a surface" controls — **checkbutton, radiobutton, toggle** (round + square), and **label** — following the button-family template. **Additive:** with no `@surface` token every existing style name and appearance is byte-for-byte unchanged.

### What's here
- **`style/bootstyle.py`** — the four families added to `_SURFACE_FAMILIES`; a **graceful-degrade net** (deferred from the PR 2 review): if a gated family's recipe doesn't emit `surface_prefix`, the resolver falls back to the plain style rather than an unregistered `@` name (bare clam).
- **`style/layout.py`** — `StyleName` gains a `surface=` param (prefixes both `ttk_style` and `element`) so the check/radio recipes prefix cleanly and their sub-element names inherit it.
- **`builders/{checkbutton,radiobutton,toggle,label}.py`** — `colors.bg`/glyph-bg/`colors.fg`/`mute`/`disabled` sites → `resolve_surface`/`on_surface_fg`/surface-threaded; every label variant honors the surface in its name.
- **`examples/surface_preview.py`** — light↔dark visual proof (accent producing-frames + matching `@<accent>` controls, using `light` accents for legibility).
- **`tests/`** — `test_surface_families.py` (+12): per-family surfaced + default-unchanged, on-surface fg, theme-reactivity, the degrade net (monkeypatched mismatch), and a **gate↔recipe correspondence** test.

### Review
A high-effort `/code-review` gated this PR. Core came back clean (byte-identical default path, toggle family inference, robust degrade net). It caught a **half-migration** (indicator `mute`/`disabled` still blending toward `colors.bg`) and **label-variant completeness** (`inverse`/`meter`/`metersubtxt` gated but unwired) — both fixed. Accent-on-accent low-contrast (a solid indicator on its own matching accent surface) is accepted by-design (permissive, not paternalistic; the example uses contrasting `light` accents).

### Scope
The bar families (**scale / progressbar / scrollbar**) are split out to **PR 4** — lower value on a distinct surface, more complex (H/V × glyph assets), smaller PR reviews better. Their recipe map is captured in the design doc §6. Frames stay out (surface *producers*). `gallery/collapsing_frame.py` left untouched (author WIP).

Suite: **609 passed** (excl. the known `nl.msg` env flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)