### PR TITLE
Fix stale MessageDialog command type hint

### DIFF
--- a/src/ttkbootstrap/dialogs/message.py
+++ b/src/ttkbootstrap/dialogs/message.py
@@ -28,7 +28,7 @@ class MessageDialog(Dialog):
             message: str,
             title: str = " ",
             buttons: Optional[List[str]] = None,
-            command: Optional[Tuple[Callable[..., Any], str]] = None,
+            command: Optional[Callable[[], Any]] = None,
             width: int = 50,
             parent: Optional[tkinter.Misc] = None,
             alert: bool = False,
@@ -86,7 +86,7 @@ class MessageDialog(Dialog):
         """
         super().__init__(parent, title, alert)
         self._message = message
-        self._command: Optional[Tuple[Callable[..., Any], str]] = command
+        self._command: Optional[Callable[[], Any]] = command
         self._width = width
         self._alert = alert
         self._default = default


### PR DESCRIPTION
## Summary

`MessageDialog.command` is invoked as a plain zero-argument callable — `on_button_press` calls `command()` with no arguments — but the type annotation still advertised the legacy `Optional[Tuple[Callable[..., Any], str]]` form. The docstring was already corrected to describe a single callback, but the annotation lagged, and it actively misled users into passing a `(callable, label)` tuple (see discussion #413).

This corrects the annotation on both the `command` parameter and the `self._command` attribute to `Optional[Callable[[], Any]]`, matching the docstring and the `2.0` branch (which additionally deprecates the tuple form with a runtime warning).

No behavior change — annotation only.

## Related

- Discussion #413