### PR TITLE
Surface color PR 4: bar families (scale/progressbar/scrollbar)

### DIFF
--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -4,8 +4,9 @@
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
 _Last updated: 2026-07-10 (**Surface-color workstream — PRs 1/2/3 MERGED into `2.0`
-(#1149 / #1150 / #1152, branches deleted); NEXT = PR 4 (bar families), then RESUME
-docs Workstream H below**).
+(#1149 / #1150 / #1152); PR 4 (bar families) IMPLEMENTED on
+`feat/2.0-surface-color-pr4` (committed, not yet pushed/merged) — this COMPLETES the
+family rollout; then RESUME docs Workstream H below**).
 A mid-stream initiative that interrupted the docs work (next entry). Fixes a real
 theming gap: every built style assumed widget bg == app bg (`colors.bg`), so a
 ghost/link/outline control on a non-default surface (a card, an accent toolbar)
@@ -45,16 +46,22 @@ contrasting `light` accents.
 reversal that review drove out), PR 3 #1152 (checkbutton/radiobutton/toggle/label +
 degrade net + `examples/surface_preview.py` visual proof + a gate↔recipe
 correspondence test). Each PR had 1–2 high-effort `/code-review` passes.
-**>>> NEXT — PR 4 = the bar families (scale / progressbar / scrollbar):** the last
-rollout piece, split out (lower value on a distinct surface, more complex: H/V ×
-glyph assets). Same template. Recipe map already produced (design doc §6): each pulls
-`border(colors.bg)` for the trough + bakes `colors.bg` in the slider/handle glyphs
-(`recolor(... white=colors.bg ...)`); add each to `_SURFACE_FAMILIES`, resolve the
-surface, prefix names (`StyleName(surface=)` for scale — it builds H+V via StyleName;
-inline `surface_prefix` for progressbar/scrollbar — they build H+V f-string names),
-swap the `colors.bg` sites, and ADD the three to
-`tests/test_surface_families.py::test_every_gated_family_honors_surface` (that test
-asserts the gate == the wired families, so it will fail until PR 4 is done — expected).
+**PR 4 = the bar families (scale / progressbar / scrollbar) — DONE (committed on
+`feat/2.0-surface-color-pr4`, not yet pushed/PR'd).** The last rollout piece,
+following the same template. Added all three to `_SURFACE_FAMILIES` (now 8); swapped
+the `border(colors.bg)` trough sites → `border(resolve_surface(_surface))`, the
+`white=colors.bg` slider-handle glyph bake → `white=surface`, and the widget
+`background`/scrollbar trough → the resolved surface; prefixed names via
+`StyleName(surface=)` (scale) and inline `builder.surface_prefix(...)`
+(progressbar/scrollbar — incl. striped/thin/round). Extended
+`test_every_gated_family_honors_surface` with the three cases + added
+`test_scale_tracks_surface` / `test_progressbar_trough_tracks_surface` /
+`test_scrollbar_trough_tracks_surface`; `examples/surface_preview.py` now shows a
+scale/progressbar/scrollbar per surface. Additive — surfaceless names/appearance are
+byte-for-byte unchanged (no `2_0_breaking_changes.md` entry needed, design §8). Suite
+618 (+3). **This COMPLETES the surface-color family rollout** (frames stay out —
+producers). **>>> NEXT: push `feat/2.0-surface-color-pr4` + open the PR against `2.0`
+(1–2 `/code-review` passes per the prior PRs), then RESUME docs Workstream H.**
 **Still pending before the docs finalize:** the **deferred "spaces sweep"** —
 regenerate the dash-joined `BootStyle` Literal + reference to the space form and touch
 up docstrings so autocomplete/docs match the recommended spelling

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -4,8 +4,8 @@
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
 _Last updated: 2026-07-10 (**Surface-color workstream — PRs 1/2/3 MERGED into `2.0`
-(#1149 / #1150 / #1152); PR 4 (bar families) IMPLEMENTED on
-`feat/2.0-surface-color-pr4` (committed, not yet pushed/merged) — this COMPLETES the
+(#1149 / #1150 / #1152); PR 4 (bar families) = **PR #1154, OPEN against `2.0`**
+(branch `feat/2.0-surface-color-pr4`, `/code-review` clean) — this COMPLETES the
 family rollout; then RESUME docs Workstream H below**).
 A mid-stream initiative that interrupted the docs work (next entry). Fixes a real
 theming gap: every built style assumed widget bg == app bg (`colors.bg`), so a
@@ -60,8 +60,9 @@ the `border(colors.bg)` trough sites → `border(resolve_surface(_surface))`, th
 scale/progressbar/scrollbar per surface. Additive — surfaceless names/appearance are
 byte-for-byte unchanged (no `2_0_breaking_changes.md` entry needed, design §8). Suite
 618 (+3). **This COMPLETES the surface-color family rollout** (frames stay out —
-producers). **>>> NEXT: push `feat/2.0-surface-color-pr4` + open the PR against `2.0`
-(1–2 `/code-review` passes per the prior PRs), then RESUME docs Workstream H.**
+producers). Opened as **PR #1154** against `2.0` (high-effort `/code-review` came
+back clean — surfaceless path proven byte-for-byte unchanged; no hardcoded
+consumers break). **>>> NEXT: merge PR #1154, then RESUME docs Workstream H.**
 **Still pending before the docs finalize:** the **deferred "spaces sweep"** —
 regenerate the dash-joined `BootStyle` Literal + reference to the space form and touch
 up docstrings so autocomplete/docs match the recommended spelling

--- a/development/2_0_surface_color_design.md
+++ b/development/2_0_surface_color_design.md
@@ -279,11 +279,21 @@ working feature.
   light↔dark visual proof (accent producing-frames + matching `@<accent>`
   controls). `gallery/collapsing_frame.py` left untouched (author WIP). Frames
   stay out (producers, §4e).
-- **PR 4 — bar families (deferred).** scale / progressbar / scrollbar — lower
-  value on a distinct surface and more complex (H/V × glyph assets); same
-  mechanism, split out for reviewability. Map already produced (each pulls
-  `border(colors.bg)` for the trough + bakes `colors.bg` in the slider/handle
-  glyphs).
+- **PR 4 — bar families. [DONE — pending PR/merge]** scale / progressbar /
+  scrollbar wired onto the same mechanism. Each family added to
+  `_SURFACE_FAMILIES`; the `border(colors.bg)` trough sites → `border(resolve_
+  surface(_surface))`, the `white=colors.bg` slider-handle glyph bake → `white=
+  surface`, and the widget `background`/scrollbar trough → the resolved surface.
+  Names prefixed via `StyleName(surface=)` (scale — it builds H+V through
+  StyleName) and inline `builder.surface_prefix(...)` (progressbar/scrollbar —
+  they hand-build H+V f-string names, incl. the striped/thin/round variants).
+  Covered by the three new `_SURFACE_FAMILIES` cases in
+  `test_every_gated_family_honors_surface` + per-family behavior tests
+  (`test_scale_tracks_surface`, `test_progressbar_trough_tracks_surface`,
+  `test_scrollbar_trough_tracks_surface`) in `tests/test_surface_families.py`;
+  `examples/surface_preview.py` extended with a scale/progressbar/scrollbar on
+  each surface. Headless suite 618 (+3). **This completes the surface-color
+  family rollout** (frames stay out — producers, §4e).
 
 ## 7. Phase 2 (deferred, not this pass)
 

--- a/examples/surface_preview.py
+++ b/examples/surface_preview.py
@@ -36,6 +36,16 @@ def build_controls(parent, surface):
                     ).pack(anchor=W, pady=2)
     ttk.Button(parent, text="Ghost button", bootstyle=f"{at}{color}ghost".strip()
                ).pack(anchor=W, pady=(2, 0))
+    # bar families: trough/track derives from the surface (2.0 PR 4)
+    ttk.Scale(parent, value=40, from_=0, to=100,
+              bootstyle=f"{at}{color}".strip()).pack(anchor=W, fill=X, pady=(8, 2))
+    ttk.Progressbar(parent, value=60, bootstyle=f"{at}{color}".strip()
+                    ).pack(anchor=W, fill=X, pady=2)
+    bar = ttk.Frame(parent)
+    bar.pack(anchor=W, fill=X, pady=2)
+    sb = ttk.Scrollbar(bar, orient=HORIZONTAL, bootstyle=f"{at}{color}".strip())
+    sb.set(0.2, 0.6)  # partial thumb so both track and thumb show
+    sb.pack(fill=X)
 
 
 def main():

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -102,7 +102,8 @@ _TOKEN_SPLIT = re.compile(r"[-\s]+")
 # once in constants (`BOOTSTYLE_SURFACE_TOKENS`).
 _SURFACE_TOKENS = frozenset(BOOTSTYLE_SURFACE_TOKENS)
 _SURFACE_FAMILIES = frozenset(
-    {"button", "checkbutton", "radiobutton", "toggle", "label"}
+    {"button", "checkbutton", "radiobutton", "toggle", "label",
+     "scale", "progressbar", "scrollbar"}
 )
 
 

--- a/src/ttkbootstrap/style/builders/progressbar.py
+++ b/src/ttkbootstrap/style/builders/progressbar.py
@@ -70,15 +70,15 @@ def build_striped_progressbar_style(builder: StyleBuilderTTK, colorname=DEFAULT)
     thickness = builder.scale_size(12)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        h_ttk_style = h_ttk_class
-        v_ttk_style = v_ttk_class
+        h_ttk_style = builder.surface_prefix(h_ttk_class)
+        v_ttk_style = builder.surface_prefix(v_ttk_class)
     else:
-        h_ttk_style = f"{colorname}.{h_ttk_class}"
-        v_ttk_style = f"{colorname}.{v_ttk_class}"
+        h_ttk_style = builder.surface_prefix(f"{colorname}.{h_ttk_class}")
+        v_ttk_style = builder.surface_prefix(f"{colorname}.{v_ttk_class}")
 
     # Recessed neutral trough = border(surface) (bootstack parity), subtle in
-    # both modes.
-    trough_color = builder.border(builder.colors.bg)
+    # both modes. The surface (2.0 surface-color) defaults to the theme bg.
+    trough_color = builder.border(builder.resolve_surface(builder._surface))
     border_color = trough_color
 
     # ( horizontal, vertical )
@@ -160,15 +160,19 @@ def _create_recolored_progressbar_style(
     """Build horizontal and vertical progressbars from one source asset."""
     h_base = f"{type_name}Horizontal.TProgressbar"
     v_base = f"{type_name}Vertical.TProgressbar"
-    trough_color = builder.border(builder.colors.bg)
+    # The surface the bar sits on (2.0 surface-color); default == theme bg. The
+    # recessed trough and the widget background both derive from it.
+    surface = builder.resolve_surface(builder._surface)
+    trough_color = builder.border(surface)
 
     if colorname in (DEFAULT, ""):
         bar_color = builder.colors.primary
-        h_ttk_style, v_ttk_style = h_base, v_base
+        h_ttk_style = builder.surface_prefix(h_base)
+        v_ttk_style = builder.surface_prefix(v_base)
     else:
         bar_color = builder.colors.get(colorname)
-        h_ttk_style = f"{colorname}.{h_base}"
-        v_ttk_style = f"{colorname}.{v_base}"
+        h_ttk_style = builder.surface_prefix(f"{colorname}.{h_base}")
+        v_ttk_style = builder.surface_prefix(f"{colorname}.{v_base}")
 
     a = builder.assets
     h_trough = a.recolor(
@@ -210,10 +214,10 @@ def _create_recolored_progressbar_style(
                El(v_bar_name, side=tk.BOTTOM, sticky=tk.NS)]))
 
     builder.configure(
-        h_ttk_style, background=builder.colors.bg, troughcolor=trough_color,
+        h_ttk_style, background=surface, troughcolor=trough_color,
         thickness=h_trough.meta.height, borderwidth=0)
     builder.configure(
-        v_ttk_style, background=builder.colors.bg, troughcolor=trough_color,
+        v_ttk_style, background=surface, troughcolor=trough_color,
         thickness=v_trough.meta.width, borderwidth=0)
 
     # register styles

--- a/src/ttkbootstrap/style/builders/scale.py
+++ b/src/ttkbootstrap/style/builders/scale.py
@@ -24,10 +24,13 @@ def _create_scale_assets(builder, colorname=DEFAULT):
     """
     a = builder.assets
     disabled_color = builder.disabled("text")
+    # The surface the scale sits on (2.0 surface-color); default == theme bg. The
+    # handle's transparent halo is baked against it, and the track derives from it.
+    surface = builder.resolve_surface(builder._surface)
     # The track is a recessed neutral: bootstack derives it as border(surface),
     # so it reads as a subtle groove in both modes (shading the now-light
     # selectbg made it too strong on dark backgrounds).
-    track_color = builder.border(builder.colors.bg)
+    track_color = builder.border(surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
         normal_color = builder.colors.primary
@@ -38,13 +41,13 @@ def _create_scale_assets(builder, colorname=DEFAULT):
 
     # ( normal, pressed, hover, disabled thumbs; horizontal, vertical track )
     return (
-        a.recolor("slider_handle", white=builder.colors.bg,
+        a.recolor("slider_handle", white=surface,
                   black=disabled_color, magenta=normal_color),
-        a.recolor("slider_handle", white=builder.colors.bg,
+        a.recolor("slider_handle", white=surface,
                   black=disabled_color, magenta=pressed_color),
-        a.recolor("slider_handle", white=builder.colors.bg,
+        a.recolor("slider_handle", white=surface,
                   black=disabled_color, magenta=hover_color),
-        a.recolor("slider_handle", white=builder.colors.bg,
+        a.recolor("slider_handle", white=surface,
                   black=disabled_color, magenta=disabled_color),
         a.recolor("slider_track", white=track_color, black=track_color),
         a.recolor("slider_track", white=track_color, black=track_color,
@@ -63,8 +66,8 @@ def build_scale_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         colorname (str):
             The color label used to style the widget.
     """
-    h = StyleName("TScale", colorname, orient="Horizontal")
-    v = StyleName("TScale", colorname, orient="Vertical")
+    h = StyleName("TScale", colorname, orient="Horizontal", surface=builder._surface)
+    v = StyleName("TScale", colorname, orient="Vertical", surface=builder._surface)
 
     # ( normal, pressed, hover, disabled, htrack, vtrack )
     images = _create_scale_assets(builder, colorname)

--- a/src/ttkbootstrap/style/builders/scrollbar.py
+++ b/src/ttkbootstrap/style/builders/scrollbar.py
@@ -17,8 +17,9 @@ _SCROLLBAR_THICKNESS = 8
 
 def _scrollbar_trough(builder):
     """The scrollbar track color: the surface, so the thumb floats with no
-    visible channel around it."""
-    return builder.colors.bg
+    visible channel around it. Honors the 2.0 surface-color token (default ==
+    theme bg)."""
+    return builder.resolve_surface(builder._surface)
 
 
 def _scrollbar_thumb_color(builder, colorname):
@@ -105,7 +106,7 @@ def _build_scrollbar(builder: StyleBuilderTTK, colorname, rounded):
         ("vertical", "ns", "Vertical.Scrollbar.trough"),
     ):
         axis = "Horizontal" if orient == "horizontal" else "Vertical"
-        ttk_style = f"{base}{axis}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{base}{axis}.{ttk_class}")
         builder.configure(
             ttk_style,
             troughcolor=trough,
@@ -149,14 +150,15 @@ def build_thin_scrollbar_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             The color label used to style the widget.
     """
     ttk_class = "TScrollbar"
-    surface = builder.colors.bg
+    # The surface the bar sits on (2.0 surface-color); default == theme bg.
+    surface = builder.resolve_surface(builder._surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        h_ttk_style = f"Thin.Horizontal.{ttk_class}"
-        v_ttk_style = f"Thin.Vertical.{ttk_class}"
+        h_ttk_style = builder.surface_prefix(f"Thin.Horizontal.{ttk_class}")
+        v_ttk_style = builder.surface_prefix(f"Thin.Vertical.{ttk_class}")
     else:
-        h_ttk_style = f"{colorname}.Thin.Horizontal.{ttk_class}"
-        v_ttk_style = f"{colorname}.Thin.Vertical.{ttk_class}"
+        h_ttk_style = builder.surface_prefix(f"{colorname}.Thin.Horizontal.{ttk_class}")
+        v_ttk_style = builder.surface_prefix(f"{colorname}.Thin.Vertical.{ttk_class}")
     # share the darker, clearly-visible thumb color with the default/round bars
     thumb = _scrollbar_thumb_color(builder, colorname)
 

--- a/tests/test_surface_families.py
+++ b/tests/test_surface_families.py
@@ -96,6 +96,33 @@ def test_square_toggle_tracks_surface(root):
     assert mapped == style.colors.primary
 
 
+# --- bar families (scale / progressbar / scrollbar) ----------------------- #
+
+def test_scale_tracks_surface(root):
+    style = Style.get_instance()
+    sc = ttk.Scale(root, bootstyle="@primary")
+    assert sc.cget("style") == "@primary.Horizontal.TScale"
+    assert style.style_exists_in_theme(sc.cget("style"))
+
+
+def test_progressbar_trough_tracks_surface(root):
+    b = StyleBuilderTTK(build=False)
+    pb = ttk.Progressbar(root, bootstyle="@card")
+    assert pb.cget("style") == "@card.Horizontal.TProgressbar"
+    # recessed trough = border(surface); widget bg = the surface itself
+    assert _lookup(root, pb.cget("style"), "troughcolor") == b.border(b.card_surface())
+    assert _lookup(root, pb.cget("style"), "background") == b.card_surface()
+
+
+def test_scrollbar_trough_tracks_surface(root):
+    b = StyleBuilderTTK(build=False)
+    sb = ttk.Scrollbar(root, bootstyle="@primary")
+    # scrollbar default orient is vertical
+    assert sb.cget("style") == "@primary.Vertical.TScrollbar"
+    # the track floats the thumb on the (accent) surface, no visible channel
+    assert _lookup(root, sb.cget("style"), "troughcolor") == b.colors.primary
+
+
 # --- theme reactivity ----------------------------------------------------- #
 
 def test_surfaced_family_is_theme_reactive(root):
@@ -122,6 +149,9 @@ def test_every_gated_family_honors_surface(root):
         "radiobutton": ttk.Radiobutton(root, bootstyle="@card"),
         "toggle": ttk.Checkbutton(root, bootstyle="@card toggle"),
         "label": ttk.Label(root, bootstyle="@card"),
+        "scale": ttk.Scale(root, bootstyle="@card"),
+        "progressbar": ttk.Progressbar(root, bootstyle="@card"),
+        "scrollbar": ttk.Scrollbar(root, bootstyle="@card"),
     }
     # the test must cover exactly the gate (update both together)
     assert set(cases) == set(bs._SURFACE_FAMILIES)


### PR DESCRIPTION
Completes the 2.0 surface-color family rollout (PRs 1/2/3 = #1149/#1150/#1152) by wiring the last three families onto the existing `@<surface>` bootstyle-token mechanism: **scale, progressbar, and scrollbar** now honor the surface a widget sits on, so a bar on a card or an accent panel styles/renders against that panel instead of the app background.

## What changed

Same template as PR 3 — no new mechanism:

- **`bootstyle.py`** — added `scale`, `progressbar`, `scrollbar` to `_SURFACE_FAMILIES` (now 8).
- **`scale.py`** — recessed track → `border(resolve_surface(_surface))`; slider-handle transparent halo baked against the resolved surface (`white=surface`); H/V names via `StyleName(surface=builder._surface)`.
- **`progressbar.py`** — trough → `border(surface)`, widget `background` → surface; names prefixed via `builder.surface_prefix(...)` across the solid, `striped`, and `thin` variants.
- **`scrollbar.py`** — track → resolved surface (thumb floats on the panel with no visible channel); names prefixed across `default`, `round`, and `thin`.

## Additive — no breaking change

With no `@surface` token, `_surface == ""`: `surface_segment("")` → `""` and `resolve_surface("")` → `colors.bg`, so every rewritten site collapses to its exact pre-PR expression. Surfaceless style **names and appearance are byte-for-byte unchanged** (design §8) — no `2_0_breaking_changes.md` entry needed.

## Tests / proof

- Extended `test_every_gated_family_honors_surface` with the three new gate cases (the gate↔recipe correspondence test).
- Added `test_scale_tracks_surface`, `test_progressbar_trough_tracks_surface`, `test_scrollbar_trough_tracks_surface`.
- `examples/surface_preview.py` now shows a scale/progressbar/scrollbar on each surface (light↔dark visual proof).
- Headless suite **618 passed** (+3). Verified all variants × surfaces × colors build and survive a light↔dark theme toggle with no exceptions/warnings.

A high-effort `/code-review` (cross-file tracer + line-by-line correctness + removed-behavior/test audit) came back clean.

**This completes the surface-color family rollout** (frames stay out — they are surface producers, not consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)