### PR TITLE
docs: revise User Guide IA to four-band structure (Workstream H)

### DIFF
--- a/development/2_0_docs_design.md
+++ b/development/2_0_docs_design.md
@@ -100,34 +100,78 @@ Themes · Gallery · Cookbook).
 | Destination | Diátaxis role | Contains |
 |---|---|---|
 | **Landing** | — | marketing hero (light+dark hero shot), "why" cards, a glimpse (minimal code + screenshot), install |
-| **User Guide** | tutorial + how-to + explanation | Getting Started · Concepts (guides) · How-To |
+| **User Guide** | tutorial + how-to + explanation | Getting Started · Concepts (styling core) · Feature guides (2.0 subsystems) · How-To |
 | **Widgets** | (task/reference hybrid) | the visual catalog — grouped native vs. shipped |
 | **Reference** | reference | **Style Reference** (generated) + **API Reference** (mkdocstrings) |
 | *(supporting)* | — | Release Notes (link to GH releases), optional Roadmap |
 
-### User Guide internal structure
+### User Guide internal structure — FOUR BANDS (revised 2026-07-10)
+
+Revised after the compat-and-utilities pass (Slices 0–5) and the other 2.0
+non-widget additions landed — the original two-band plan (5 Concepts + a vague
+How-To) had nowhere to teach the delivery model, fonts, localization,
+validation, or windowing. Adopts bootstack's proven **four-band** shape (Getting
+Started · Concepts · Feature guides · How-To), scoped down to a *styling
+extension* (its framework-only bands — signals/store/streams/CLI/hot-reload —
+are dropped). Two author decisions locked the shape (2026-07-10): **adopt the
+four-band structure**, and **teach generic tkinter tasks "ttkbootstrap-flavored"**
+in How-To (every example uses ttkbootstrap idioms and links out to python.org for
+the raw tk API) — this is the concrete fill for the "modern tkinter docs" gap.
 
 ```
 User Guide
-├─ Getting Started
-│   ├─ Quickstart              first window; Window vs Tk; choosing a theme
+├─ Getting Started              ← the tutorial path
+│   ├─ Installation            pip, requires-python >=3.10
+│   ├─ Quickstart              first themed window; Window vs Tk; choosing a theme
+│   ├─ Structuring an app      Window vs Tk, the single-root rule, an app skeleton
 │   └─ Migrating to 2.0        bootstyle strings, theme names, removed shims, icons
-├─ Concepts (the guides)       ← the "modern tkinter docs" gap-fill
+├─ Concepts — the styling core (the FLAGSHIP band)
 │   ├─ The bootstyle grammar   ★ FLAGSHIP — canonical grammar + reference table
+│   ├─ How styling is delivered ★ NEW — no monkey-patch: blessed subclasses,
+│   │                             BootMixin/AutoStyleMixin, enable_global_api,
+│   │                             bootify, apply_bootstyle, fluent geometry
 │   ├─ Theming                 semantic-anchor model + 2-column light/dark gallery
-│   ├─ Make your own style     ☆ second act — the custom-style toolkit
-│   ├─ Make your own theme     Theme() API + ttkcreator
-│   └─ Working with color      style.colors, ramp addressing (c.primary[300])
-└─ How-To (tasks)              validate input, animate a gif, … (absorbs Cookbook)
+│   ├─ Working with color      style.colors, ramp addressing (c.primary[300])
+│   ├─ Make your own style     ☆ the custom-style toolkit + icon engine
+│   └─ Make your own theme     Theme() API + ttkcreator
+├─ Feature guides — 2.0 subsystems (each a utility we shipped)
+│   ├─ Typography              Fonts, set_global_family over the named fonts
+│   ├─ Localization            L(), LocaleVar, set_locale, <<LocaleChanged>>
+│   ├─ Input validation        add_*_validation, @validator
+│   └─ Windows, icons & DPI    App/Toplevel, positioning, apply_icon,
+│                                enable_high_dpi_awareness, window_type; the
+│                                deferred-config seam as a sidebar
+└─ How-To — short task recipes (absorbs Cookbook; ttkbootstrap-flavored tkinter)
+    layout (pack/grid/place) · events & variables · menus & context menus ·
+    images & PhotoImage · scrollable content · message boxes & dialogs ·
+    multiple windows · background work without freezing the UI (after + threads) ·
+    splash screen · app icon · validate a form · animate a GIF (salvaged)
 ```
 
 - **Flagship = the bootstyle grammar** — leads the Landing hero and the User
-  Guide (the universal "how do I style anything" front door). *Make your own
-  style/theme* is the prominent second act (the biggest *new* 2.0 capability).
+  Guide (the universal "how do I style anything" front door). **How styling is
+  delivered** sits second: it is the single biggest 2.0 conceptual shift
+  (`import ttkbootstrap` no longer monkey-patches tkinter). *Make your own
+  style/theme* remains a prominent act (the biggest *new* 2.0 capability).
+- **Feature guides** is the NEW band that homes the shipped non-widget utilities
+  end-to-end (typography, localization, validation, windowing); keeping them out
+  of Concepts leaves the styling band uncluttered.
 - **Themes** is folded here as the *Theming* guide; its gallery renders the 30
   themes as **light/dark pairs in a 2-column layout**.
-- **Cookbook** is removed; its pages become **How-To** entries.
+- **Cookbook** is removed; its pages become **How-To** entries. The How-To band
+  also gap-fills the common *generic-tkinter* tasks newcomers arrive needing
+  (layout, events, threading, menus, images), each written ttkbootstrap-flavored.
 - **Gallery** (real-app demos) is removed for 2.0; can return later.
+
+**Authoring conventions (locked 2026-07-10, apply to every page):**
+- **Lead with ``App``, not ``Window``.** ``App`` is the actual class; ``Window``
+  is a permanent alias (``window.py`` `Window = App`). Prose and code examples
+  teach ``ttk.App(...)`` as canonical and mention ``ttk.Window`` once as the
+  alias. (Existing skeleton pages were swept to match.)
+- **Use fluent geometry in examples where appropriate.** ``pack``/``grid``/
+  ``place`` return the widget (2.0 `FluentGeometryMixin`), so construct-and-place
+  in one expression — ``ttk.Button(app, text="Save").pack(...)`` — whenever the
+  example does not need to keep a reference. Showcases a real 2.0 ergonomic.
 
 ## 4. The native / shipped dichotomy (the core design idea)
 
@@ -306,9 +350,12 @@ Docs work is continuous but breaks into reviewable slices:
 2. **Reference generators** — `tools/generate_style_reference.py` (offline, emits
    committed rST); retarget `tools/generate_bootstyle_reference.py` md→rST and wire
    it in; sync tests.
-3. **User Guide** — Quickstart (rewrite the tutorial), the 5 Concept guides
-   (flagship first), How-To (salvage cookbook), Migrating to 2.0 (fold theme +
-   icon migration).
+3. **User Guide** — the four-band IA (revised §3): Getting Started (Installation,
+   Quickstart rewrite, Structuring an app, Migrating), Concepts (6 styling guides,
+   flagship + delivery-model first), Feature guides (typography, localization,
+   validation, windowing), How-To (salvage cookbook + ttkbootstrap-flavored
+   generic-tkinter recipes). The IA skeleton (index + honest stubs) lands as a
+   fast-follow to sub-PR 1; prose fills in per band.
 4. **Widgets catalog** — the shared template across all widgets, grouped native/
    shipped, cross-linked to the deep reference.
 5. **Landing + screenshots** — marketing hero; light+dark screenshots (author,

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -4,8 +4,10 @@
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
 _Last updated: 2026-07-10 (**Docs Workstream H — User Guide IA revised to a
-FOUR-BAND structure + skeleton re-scaffolded. On branch `docs/2.0-user-guide-ia`
-(NOT yet committed/pushed — author go-ahead pending).**
+FOUR-BAND structure + skeleton re-scaffolded. Committed on `docs/2.0-user-guide-ia`
+and OPENED as PR #1156 against `2.0` (docs-only; no `/code-review` — the diff is
+all rST/markdown prose, nothing for a correctness pass to bite; clean `-W` build is
+the gate). Awaiting review/merge.**
 This is the "iterate the skeleton" fast-follow to sub-PR 1 the prior entry
 anticipated, driven by the author's steer: **plan the User Guide topics around the
 2.0 utilities/non-widget features + common tkinter concerns** (and mine bootstack's

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,6 +3,51 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
+_Last updated: 2026-07-10 (**Docs Workstream H — User Guide IA revised to a
+FOUR-BAND structure + skeleton re-scaffolded. On branch `docs/2.0-user-guide-ia`
+(NOT yet committed/pushed — author go-ahead pending).**
+This is the "iterate the skeleton" fast-follow to sub-PR 1 the prior entry
+anticipated, driven by the author's steer: **plan the User Guide topics around the
+2.0 utilities/non-widget features + common tkinter concerns** (and mine bootstack's
+IA for ideas). **What changed:** the design doc's original two-band User Guide
+(5 Concepts + a vague How-To, written pre-utilities-pass) had nowhere to teach the
+delivery model, fonts, localization, validation, or windowing. Revised
+`development/2_0_docs_design.md` §3 to bootstack's proven **four-band** shape,
+scoped to a styling extension (its framework-only bands dropped):
+**Getting Started** (Installation · Quickstart · Structuring an app · Migrating) ·
+**Concepts — styling core** (bootstyle grammar ★ · **How styling is delivered** ★NEW ·
+Theming · Working with color · Make your own style · Make your own theme) ·
+**Feature guides — 2.0 subsystems** (Typography · Localization · Input validation ·
+Windows/icons/DPI) · **How-To** (common tkinter tasks, ttkbootstrap-flavored;
+absorbs cookbook). **Two author decisions locked (both via AskUserQuestion):**
+(1) *teach generic tkinter "ttkbootstrap-flavored"* in How-To (fills the "modern
+tkinter docs" gap; examples use ttkb idioms + link out to python.org); (2) *adopt
+the four-band shape* (splits styling-concepts from subsystem feature-guides).
+**Two authoring conventions LOCKED in design §3** (apply to every page): **lead with
+`App`, not `Window`** (`App` is the real class, `Window = App` alias — corrected
+mid-session by the author; swept all existing skeleton pages incl. landing glimpse +
+button/meter catalog), and **use fluent geometry in examples** (`pack`/`grid`/`place`
+return the widget — construct-and-place in one expression). **Files:** rebuilt
+`docs/user-guide/index.rst` (4 grid-card bands + 4 hidden toctrees); new stubs
+`getting-started/{installation,app-structures}.rst`, `concepts/delivery-model.rst`,
+`feature-guides/{typography,localization,validation,windows}.rst`; expanded
+`how-to/index.rst` into a grouped recipe list (no per-recipe toctree yet — recipes
+become files in sub-PR 3). Each stub is an honest "being written for 2.0" note +
+seeded intro naming the real APIs. **Build gate:** 29 pages, **zero warnings** with
+`-W --keep-going` (warnings-as-errors). **ENV GOTCHA (important):** `.venv-home`'s
+base Python lives under a different user profile (`C:\Users\Israel Dryer\...`) that
+this account (`Logistiview`) gets **Access is denied** on — `.venv-home` python/
+sphinx-build all fail with "did not find executable". Workaround used: built a fresh
+docs venv from `py -3.13` (Python 3.13.7, under `Logistiview`) in the **scratchpad**
+(`.../scratchpad/docsenv`), `pip install -r docs/requirements.txt`, then
+`PYTHONPATH=src .../docsenv/Scripts/python.exe -m sphinx -b html -W ...`. (The
+scratchpad venv is outside the repo so it can't be committed; note `.gitignore`'s
+bare `venv`/`pyvenv` rules would NOT catch a repo-local `.venv-docs`.) **User WIP
+`gallery/collapsing_frame.py`** still modified — LEFT UNTOUCHED. **>>> NEXT:** author
+reviews the IA/stubs; then commit + PR this slice, and proceed down §11 — **sub-PR 2
+= reference generators**, or continue authoring User Guide prose per band. Prior
+entry (surface-color complete) follows._
+
 _Last updated: 2026-07-10 (**Surface-color workstream COMPLETE — ALL PRs MERGED into
 `2.0`: PR 1 #1149 / PR 2 #1150 / PR 3 #1152 / PR 4 (bar families) #1154 (merge
 `7953d2de`, branch deleted). PR 4 COMPLETES the family rollout, so the whole

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,7 @@ A themed window is a handful of lines — every widget takes ``bootstyle``:
 
    import ttkbootstrap as ttk
 
-   app = ttk.Window(title="Hello", themename="bootstrap-light")
+   app = ttk.App(title="Hello", themename="bootstrap-light")
 
    ttk.Label(app, text="Hello from ttkbootstrap!").pack(padx=16, pady=(16, 8))
    ttk.Button(app, text="Primary", bootstyle="primary").pack(padx=16, pady=4)

--- a/docs/user-guide/concepts/delivery-model.rst
+++ b/docs/user-guide/concepts/delivery-model.rst
@@ -1,0 +1,28 @@
+How styling is delivered
+========================
+
+.. note::
+
+   This guide is being written for 2.0. It documents the single biggest change
+   from 1.x.
+
+In 1.x, ``import ttkbootstrap`` **monkey-patched tkinter** at import time so that
+every ``ttk`` widget grew a ``bootstyle`` keyword. 2.0 stops doing that. The
+styling API is now delivered through concrete subclasses, so widgets keep real
+signatures and docstrings and importing the library mutates nothing.
+
+This guide will cover:
+
+- **Blessed widget subclasses.** ``ttk.Button``, ``ttk.Entry``, … are real
+  subclasses that carry ``bootstyle=`` via
+  :class:`~ttkbootstrap.BootMixin`; the legacy ``tk`` set
+  (``Tk``/``Menu``/``Text``/``Canvas``/``TkFrame``/``TkLabel``/``LabelFrame``)
+  auto-themes via :class:`~ttkbootstrap.AutoStyleMixin`.
+- **Fluent geometry.** ``pack``/``grid``/``place`` return the widget, so
+  ``ttk.Button(root, text="Save").pack()`` is one expression.
+- **Styling widgets you didn't subclass.** ``bootify(cls)`` returns a
+  bootstyle-enabled subclass of any third-party ttk class; ``apply_bootstyle
+  (widget, style)`` styles one already-created vanilla widget.
+- **Opting back into the global API.** ``enable_global_api()`` restores the 1.x
+  behavior so *vanilla* ``tkinter``/``tkinter.ttk`` widgets accept ``bootstyle``
+  and everything gains fluent geometry.

--- a/docs/user-guide/feature-guides/localization.rst
+++ b/docs/user-guide/feature-guides/localization.rst
@@ -1,0 +1,21 @@
+Localization
+============
+
+.. note::
+
+   This guide is being written for 2.0.
+
+ttkbootstrap wraps Tcl/Tk's ``::msgcat`` so you can translate interface strings
+and switch languages at runtime.
+
+This guide will cover:
+
+- **``L(src, *args, **kwargs)``** — the universal translate-and-format idiom:
+  looks ``src`` up in the message catalog and applies ``str.format``.
+- **``set_locale(locale)``** — set the active locale; queues before the root
+  exists and applies live afterward, firing ``<<LocaleChanged>>``.
+- **``LocaleVar``** — a ``StringVar`` that re-translates itself on
+  ``<<LocaleChanged>>``, so a widget bound with ``textvariable=`` switches
+  language without a restart.
+- **``MessageCatalog``** — loading translation bundles, setting entries, and
+  querying preferences.

--- a/docs/user-guide/feature-guides/typography.rst
+++ b/docs/user-guide/feature-guides/typography.rst
@@ -1,0 +1,22 @@
+Typography
+==========
+
+.. note::
+
+   This guide is being written for 2.0.
+
+ttkbootstrap styles text through the **standard Tk named fonts**
+(``TkDefaultFont``, ``TkTextFont``, ``TkFixedFont``, ``TkHeadingFont``, …) — there
+is no separate font DSL. Retint a named font and every widget that uses it
+updates at once.
+
+This guide will cover:
+
+- **``set_global_family(family, *, mono_family=None)``** — the one-liner: set the
+  proportional (and optionally monospace) family for the whole app. It rides the
+  deferred-config seam, so you can call it at the top of a file *before* the root
+  exists, or live afterward.
+- **The ``Fonts`` namespace** (call after the root exists): ``Fonts.configure``
+  to tweak one named font, ``Fonts.create_alias`` to register your own
+  (``font="Body"``), ``Fonts.names``/``Fonts.describe`` to introspect, and
+  ``Fonts.reset``.

--- a/docs/user-guide/feature-guides/validation.rst
+++ b/docs/user-guide/feature-guides/validation.rst
@@ -1,0 +1,19 @@
+Input validation
+================
+
+.. note::
+
+   This guide is being written for 2.0.
+
+ttkbootstrap ships a small validation framework for ``Entry``, ``Spinbox``, and
+``Combobox``: attach a rule and a failing value paints the widget with a
+``danger`` border until it is corrected.
+
+This guide will cover:
+
+- **Ready-made rules** — ``add_text_validation``, ``add_numeric_validation``,
+  ``add_range_validation(start, end)``, ``add_regex_validation(pattern)``,
+  ``add_option_validation(options)``, ``add_phonenumber_validation``.
+- **When they fire** — the ``when=`` argument (``"focusout"``, ``"key"``, …).
+- **Custom rules** — the ``@validator`` decorator over ``add_validation`` and the
+  ``ValidationEvent`` passed to your function.

--- a/docs/user-guide/feature-guides/windows.rst
+++ b/docs/user-guide/feature-guides/windows.rst
@@ -1,0 +1,26 @@
+Windows, icons & high-DPI
+=========================
+
+.. note::
+
+   This guide is being written for 2.0.
+
+``App`` (also exported as ``ttk.Window``) and ``ttk.Toplevel`` are enhanced
+replacements for ``tk.Tk``/``tk.Toplevel`` that fold window setup into the
+constructor and add ttkbootstrap-specific conveniences.
+
+This guide will cover:
+
+- **The constructor surface** — ``title``, ``size``, ``position`` (signed and
+  edge-relative), ``minsize``/``maxsize``, ``resizable``, ``alpha``,
+  ``iconphoto``, plus the renamed ``high_dpi``/``override_redirect``.
+- **Positioning** — ``place_window_center()`` (monitor-aware when ``screeninfo``
+  is installed, clamped on-screen).
+- **Light/dark mode** — the ``theme_mode`` property, ``set_theme_modes(light=,
+  dark=)``, ``use_theme_mode``, and ``toggle_theme_mode``.
+- **Toplevels** — ``window_type``, ``topmost``, ``tool_window``, and inherited
+  app icons.
+- **High-DPI** — ``enable_high_dpi_awareness()`` and ``scale_size()``.
+- **Sidebar: the deferred-config seam** — how ``set_locale``,
+  ``set_global_family``, and ``set_default_button`` can be called before the root
+  exists and flush when it comes up.

--- a/docs/user-guide/getting-started/app-structures.rst
+++ b/docs/user-guide/getting-started/app-structures.rst
@@ -1,0 +1,25 @@
+Structuring an app
+==================
+
+.. note::
+
+   This guide is being written for 2.0.
+
+Where :doc:`Quickstart <quickstart>` shows the smallest possible window, this
+guide covers how to structure a real application:
+
+- **``App`` vs ``Tk``.** ``App`` (also exported as ``ttk.Window``) is the enhanced
+  root — it owns the theme and sets title, geometry, icon, alpha, and DPI in one
+  constructor. Use it for new code; a bare ``tk.Tk`` still works if you attach a
+  :class:`~ttkbootstrap.style.Style` yourself.
+- **The single-root rule.** ttkbootstrap enforces one application root per
+  process (the ``Style`` engine is a singleton bound to it). Extra windows are
+  ``ttk.Toplevel``, not a second ``App``.
+- **An app skeleton.** Subclassing ``ttk.App`` (or a ``ttk.Frame``) into a
+  class-based layout, wiring ``mainloop``, and cleaning up on ``destroy``.
+
+.. seealso::
+
+   :doc:`Windows, icons & high-DPI </user-guide/feature-guides/windows>` for the
+   full ``App``/``Toplevel`` surface (positioning, icons, ``window_type``,
+   light/dark mode).

--- a/docs/user-guide/getting-started/installation.rst
+++ b/docs/user-guide/getting-started/installation.rst
@@ -1,0 +1,18 @@
+Installation
+============
+
+Install ttkbootstrap from PyPI:
+
+.. code-block:: bash
+
+   pip install ttkbootstrap
+
+ttkbootstrap requires **Python 3.10 or newer**. Its only runtime dependency is
+`Pillow <https://python-pillow.org/>`_, used to render image-based widget
+assets; ``pip`` installs it automatically.
+
+.. note::
+
+   This page is being written for 2.0. It will cover optional extras
+   (``screeninfo`` for multi-monitor window positioning), virtual-environment
+   setup, and verifying the install with ``python -m ttkbootstrap``.

--- a/docs/user-guide/getting-started/quickstart.rst
+++ b/docs/user-guide/getting-started/quickstart.rst
@@ -10,7 +10,7 @@ Hello ttkbootstrap
 
    import ttkbootstrap as ttk
 
-   app = ttk.Window(title="Hello", themename="bootstrap-light")
+   app = ttk.App(title="Hello", themename="bootstrap-light")
 
    ttk.Label(app, text="Hello from ttkbootstrap!").pack(padx=16, pady=(16, 8))
    ttk.Button(app, text="Primary", bootstyle="primary").pack(padx=16, pady=4)
@@ -21,20 +21,24 @@ Hello ttkbootstrap
 
 A few things to notice:
 
-- ``ttk.Window`` creates the root window and installs a theme in one step. Pass
+- ``ttk.App`` creates the root window and installs a theme in one step. Pass
   ``themename=`` to choose one; it defaults to ``bootstrap-light``.
 - Every ttkbootstrap widget accepts ``bootstyle=``. The value describes intent
   — a color (``"primary"``), a variant (``"outline"``), or both
   (``"danger-outline"``) — not a literal color.
+- ``pack`` (and ``grid``/``place``) **return the widget**, so you can construct
+  and place in one expression — no separate variable needed unless you keep a
+  reference.
 - ``app.mainloop()`` starts the event loop, exactly as in stock tkinter.
 
-Window vs Tk
-------------
+App vs Tk
+---------
 
-``ttk.Window`` is a drop-in replacement for ``tkinter.Tk`` that also owns the
-theme. If you already have a ``Tk`` root, create a :class:`~ttkbootstrap.style.Style`
-instead — the styling engine attaches to whichever root exists. Prefer
-``ttk.Window`` for new code.
+``ttk.App`` is a drop-in replacement for ``tkinter.Tk`` that also owns the theme.
+(It is also exported under its longtime alias ``ttk.Window`` — both name the same
+class.) If you already have a ``Tk`` root, create a
+:class:`~ttkbootstrap.style.Style` instead — the styling engine attaches to
+whichever root exists. Prefer ``ttk.App`` for new code.
 
 Choosing a theme
 ----------------

--- a/docs/user-guide/how-to/index.rst
+++ b/docs/user-guide/how-to/index.rst
@@ -3,7 +3,42 @@ How-To
 
 .. note::
 
-   The How-To section is being written for 2.0. It absorbs the recipes from the
-   old cookbook — validating input, animating a GIF, and similar focused tasks.
+   The How-To section is being written for 2.0. Each recipe below will become
+   its own page as it is authored; this page lists the planned set.
 
-Task-focused recipes will be listed here.
+Short, task-focused recipes for common jobs — the everyday tkinter tasks a
+newcomer arrives needing, written the ttkbootstrap way (ttkbootstrap widgets and
+idioms throughout, with links out to the `tkinter reference
+<https://docs.python.org/3/library/tkinter.html>`_ for the raw API). This band
+absorbs the recipes from the old cookbook.
+
+Building interfaces
+-------------------
+
+- **Lay out widgets** — ``pack``, ``grid``, and ``place``, and when to reach for
+  each (uses the fluent geometry helpers).
+- **Wire events and variables** — ``bind``, ``command=``, and the tk variable
+  classes (``StringVar``/``IntVar``/…).
+- **Menus and context menus** — a menu bar and a right-click popup.
+- **Images and icons** — ``PhotoImage``, and rendering themed glyphs with
+  ``apply_icon``.
+- **Scrollable content** — ``ScrolledFrame``/``ScrolledText`` for content that
+  outgrows the window.
+
+Interaction and data
+---------------------
+
+- **Message boxes and dialogs** — ``Messagebox``/``Querybox`` and the shipped
+  dialogs.
+- **Validate a form** — attach validation rules and read the result.
+- **Multiple windows** — ``Toplevel``, modality, and returning a value.
+- **Background work without freezing the UI** — ``after`` and worker threads,
+  updating widgets safely from the main loop.
+
+Presentation
+------------
+
+- **Animate a GIF** *(salvaged from the cookbook)* — frame-by-frame animation
+  with ``PhotoImage``.
+- **Splash screen** — a borderless startup window with ``window_type``.
+- **Application icon** — set the window/taskbar icon.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -1,10 +1,13 @@
 User Guide
 ==========
 
-Learn ttkbootstrap by concept: how the ``bootstyle`` grammar works, how themes
-are built from semantic colors, and how to make your own styles and themes.
-Start with the :doc:`Quickstart <getting-started/quickstart>`, then read the
-guides in any order.
+Learn ttkbootstrap by working through it: set up and build your first window,
+grasp the core styling concepts (the ``bootstyle`` grammar and how styling is
+delivered), reach for a feature guide when you need a whole subsystem — fonts,
+localization, validation, windowing — or grab a how-to when you have a specific
+task in mind. For the complete lookup of every public name see the
+:doc:`API Reference </reference/api/index>`; for the visual widget catalog see
+:doc:`Widgets </widgets/index>`.
 
 Getting Started
 ---------------
@@ -12,11 +15,23 @@ Getting Started
 .. grid:: 1 2 2 2
    :gutter: 3
 
+   .. grid-item-card:: Installation
+      :link: getting-started/installation
+      :link-type: doc
+
+      Install from PyPI; supported Python versions.
+
    .. grid-item-card:: Quickstart
       :link: getting-started/quickstart
       :link-type: doc
 
-      Your first themed window; ``Window`` vs ``Tk``; choosing a theme.
+      Your first themed window; ``App`` vs ``Tk``; choosing a theme.
+
+   .. grid-item-card:: Structuring an app
+      :link: getting-started/app-structures
+      :link-type: doc
+
+      ``App`` vs ``Tk``, the single-root rule, and a real app skeleton.
 
    .. grid-item-card:: Migrating to 2.0
       :link: getting-started/migrating
@@ -26,6 +41,9 @@ Getting Started
 
 Concepts
 --------
+
+The styling core. **Start with the bootstyle grammar**, then read the rest in
+any order.
 
 .. grid:: 1 2 2 2
    :gutter: 3
@@ -37,11 +55,24 @@ Concepts
       **Start here.** The canonical grammar for styling any widget, with the
       full reference table.
 
+   .. grid-item-card:: How styling is delivered
+      :link: concepts/delivery-model
+      :link-type: doc
+
+      Why 2.0 stopped monkey-patching tkinter — the blessed subclasses,
+      ``enable_global_api``, ``bootify``, and ``apply_bootstyle``.
+
    .. grid-item-card:: Theming
       :link: concepts/theming
       :link-type: doc
 
       The semantic-anchor color model and the built-in light/dark themes.
+
+   .. grid-item-card:: Working with color
+      :link: concepts/working-with-color
+      :link-type: doc
+
+      ``style.colors`` and ramp addressing (``c.primary[300]``).
 
    .. grid-item-card:: Make your own style
       :link: concepts/make-your-own-style
@@ -55,22 +86,52 @@ Concepts
 
       The ``Theme`` API and the ttkcreator editor.
 
-   .. grid-item-card:: Working with color
-      :link: concepts/working-with-color
+Feature guides
+--------------
+
+Each 2.0 subsystem, end to end — the utilities that work on plain tkinter, not
+just ttkbootstrap widgets.
+
+.. grid:: 1 2 2 2
+   :gutter: 3
+
+   .. grid-item-card:: Typography
+      :link: feature-guides/typography
       :link-type: doc
 
-      ``style.colors`` and ramp addressing (``c.primary[300]``).
+      ``Fonts`` and ``set_global_family`` over the standard named fonts.
+
+   .. grid-item-card:: Localization
+      :link: feature-guides/localization
+      :link-type: doc
+
+      ``L()``, ``LocaleVar``, ``set_locale``, and live language switching.
+
+   .. grid-item-card:: Input validation
+      :link: feature-guides/validation
+      :link-type: doc
+
+      ``add_*_validation`` helpers and the ``@validator`` decorator.
+
+   .. grid-item-card:: Windows, icons & high-DPI
+      :link: feature-guides/windows
+      :link-type: doc
+
+      ``App``/``Toplevel``, positioning, application icons, and DPI scaling.
 
 How-To
 ------
 
-Task-focused recipes — see the :doc:`How-To index <how-to/index>`.
+Task-focused recipes — common tkinter jobs done the ttkbootstrap way. See the
+:doc:`How-To index <how-to/index>`.
 
 .. toctree::
    :hidden:
    :caption: Getting Started
 
+   getting-started/installation
    getting-started/quickstart
+   getting-started/app-structures
    getting-started/migrating
 
 .. toctree::
@@ -78,10 +139,20 @@ Task-focused recipes — see the :doc:`How-To index <how-to/index>`.
    :caption: Concepts
 
    concepts/bootstyle-grammar
+   concepts/delivery-model
    concepts/theming
+   concepts/working-with-color
    concepts/make-your-own-style
    concepts/make-your-own-theme
-   concepts/working-with-color
+
+.. toctree::
+   :hidden:
+   :caption: Feature guides
+
+   feature-guides/typography
+   feature-guides/localization
+   feature-guides/validation
+   feature-guides/windows
 
 .. toctree::
    :hidden:

--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -25,7 +25,7 @@ without hard-coding a color.
 
    import ttkbootstrap as ttk
 
-   app = ttk.Window()
+   app = ttk.App()
 
    ttk.Button(app, text="Primary",   bootstyle="primary").pack(padx=8, pady=4)
    ttk.Button(app, text="Secondary", bootstyle="secondary").pack(padx=8, pady=4)

--- a/docs/widgets/meter.rst
+++ b/docs/widgets/meter.rst
@@ -16,7 +16,7 @@ Set the indicator color with ``bootstyle=``:
 
    import ttkbootstrap as ttk
 
-   app = ttk.Window()
+   app = ttk.App()
 
    meter = ttk.Meter(
        app,


### PR DESCRIPTION
Iterate the merged Sphinx skeleton (#1148). The original two-band User Guide plan predated the compat-and-utilities pass, so it had nowhere to teach the 2.0 non-widget surface (delivery model, fonts, localization, validation, windowing). This reworks the IA around the shipped utilities + common tkinter concerns, modeled on bootstack's structure but scoped to a styling extension.

## What changed

**Design** — `development/2_0_docs_design.md` §3 rewritten to a **four-band** shape:
- **Getting Started** — Installation · Quickstart · *Structuring an app* (new) · Migrating
- **Concepts (styling core)** — bootstyle grammar ★ · **How styling is delivered** ★ (new) · Theming · Working with color · Make your own style · Make your own theme
- **Feature guides (2.0 subsystems)** — Typography · Localization · Input validation · Windows/icons/DPI
- **How-To** — common tkinter tasks, ttkbootstrap-flavored; absorbs the cookbook

**Author decisions locked** (design §3): teach generic tkinter *ttkbootstrap-flavored* in How-To; adopt the four-band split.

**Authoring conventions locked** (design §3, swept across existing pages): lead with **`App`** (the real class) over the `Window` alias; **use fluent geometry** (`.pack()`/`.grid()`/`.place()` return the widget) in examples.

**Files** — rebuilt `docs/user-guide/index.rst` (4 grid-card bands + toctrees); 7 seeded stubs (`installation`, `app-structures`, `delivery-model`, and the 4 feature guides); expanded `how-to/index.rst` into a grouped recipe list. Each stub is an honest "being written for 2.0" note + intro naming the real APIs.

## Scope

Skeleton/IA only — no prose authoring yet (that's sub-PR 3 / generators). Every stub is a placeholder; every toctree entry resolves.

## Build gate

**29 pages, zero warnings** with `-W --keep-going` (warnings-as-errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)