### PR TITLE
Add public Dialog.close() method

### DIFF
--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -139,7 +139,7 @@ class Dialog(BaseWidget):
         self._toplevel.withdraw()  # reset the iconify state
 
         # bind <Escape> event to window close
-        self._toplevel.bind("<Escape>", lambda _: self._toplevel.destroy())
+        self._toplevel.bind("<Escape>", lambda _: self.close())
 
         # create widgets
         self.create_body(self._toplevel)
@@ -153,6 +153,18 @@ class Dialog(BaseWidget):
         height = self._toplevel.winfo_reqheight()
         if width > 0 and height > 0:
             self._toplevel.geometry(f"{width}x{height}")        
+
+    def close(self) -> None:
+        """Close (destroy) the dialog window.
+
+        The public way to dismiss a dialog. Safe to call more than once and
+        before `show()` (a no-op if the window was never built or is already
+        gone). Subclasses that draw their own close button should route its
+        `command` here rather than reaching into `self._toplevel`.
+        """
+        toplevel = self._toplevel
+        if toplevel is not None and toplevel.winfo_exists():
+            toplevel.destroy()
 
     @property
     def result(self) -> Any:

--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -163,8 +163,15 @@ class Dialog(BaseWidget):
         `command` here rather than reaching into `self._toplevel`.
         """
         toplevel = self._toplevel
-        if toplevel is not None and toplevel.winfo_exists():
-            toplevel.destroy()
+        if toplevel is None:
+            return
+        try:
+            if toplevel.winfo_exists():
+                toplevel.destroy()
+        except tkinter.TclError:
+            # The interpreter was already torn down (winfo_exists raises once
+            # the application is destroyed); nothing left to close.
+            pass
 
     @property
     def result(self) -> Any:

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -69,6 +69,35 @@ def test_base_result_is_safe_without_a_toplevel(root):
     assert dialog.result is None
 
 
+def test_close_before_show_is_a_safe_noop(root):
+    # close() on a dialog that was never shown has no toplevel; it must be a
+    # no-op rather than raising on None.
+    dialog = MessageDialog(message="hi", parent=root)
+    assert dialog._toplevel is None
+    dialog.close()  # must not raise
+
+
+def test_close_destroys_the_toplevel_and_is_idempotent(root):
+    dialog = MessageDialog(message="hi", parent=root, buttons=["OK:primary"])
+    dialog.build()
+    dialog._toplevel.withdraw()
+    assert dialog._toplevel.winfo_exists()
+    dialog.close()
+    assert not dialog._toplevel.winfo_exists()
+    dialog.close()  # second call is a no-op (winfo_exists guard), must not raise
+
+
+def test_escape_binding_is_installed_for_dismissal(root):
+    # The base class wires <Escape> to dismiss the dialog (it routes through the
+    # public close()). Synthesizing the keypress needs a mapped window + running
+    # loop the headless fixture can't guarantee, so assert the binding exists;
+    # close()'s destroy behavior is covered above.
+    dialog = MessageDialog(message="hi", parent=root, buttons=["OK:primary"])
+    dialog.build()
+    dialog._toplevel.withdraw()
+    assert dialog._toplevel.bind("<Escape>"), "an <Escape> binding should be installed"
+
+
 def test_querybox_get_string_returns_via_result_property():
     # Every get_* now returns dialog.result, not the private ._result.
     src = inspect.getsource(Querybox.get_string)

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -87,6 +87,26 @@ def test_close_destroys_the_toplevel_and_is_idempotent(root):
     dialog.close()  # second call is a no-op (winfo_exists guard), must not raise
 
 
+def test_close_is_safe_after_interpreter_teardown(root):
+    # winfo_exists() raises TclError once the application is destroyed; close()
+    # must swallow that and stay a no-op (matching the result property's guard),
+    # not propagate the error out of a cleanup path. Simulate the torn-down
+    # state with a stub rather than destroying a real root -- destroying a second
+    # root would corrupt the process-wide Style singleton for other tests.
+    import tkinter
+
+    class _DeadToplevel:
+        def winfo_exists(self):
+            raise tkinter.TclError("application has been destroyed")
+
+        def destroy(self):  # pragma: no cover - must never be reached
+            raise AssertionError("destroy() should not run when the app is gone")
+
+    dialog = MessageDialog(message="hi", parent=root)
+    dialog._toplevel = _DeadToplevel()
+    dialog.close()  # must not raise
+
+
 def test_escape_binding_is_installed_for_dismissal(root):
     # The base class wires <Escape> to dismiss the dialog (it routes through the
     # public close()). Synthesizing the keypress needs a mapped window + running


### PR DESCRIPTION
## Summary

`ttkbootstrap.dialogs.Dialog` is a `BaseWidget` wrapper whose actual window is built as `self._toplevel` in `build()`/`show()`. To dismiss a `Dialog` subclass, callers had to reach into the private `self._toplevel` and call `self._toplevel.destroy()` — `self.quit()` (exits the mainloop) and `self.destroy()` (destroys the wrapper, not the window) don't close the visible dialog. This is a recurring source of confusion (see discussion #358).

This adds a public **`close()`** method to `Dialog`:

```python
def close(self) -> None:
    toplevel = self._toplevel
    if toplevel is not None and toplevel.winfo_exists():
        toplevel.destroy()
```

- No-op before `show()` (no toplevel yet) and after the window is already gone.
- Idempotent (`winfo_exists()` guard).
- The base `<Escape>` binding now routes through `self.close()` so there's a single close path.
- Subclasses that draw their own close button can point its `command` at `self.close()` instead of the private attribute.

Additive and non-breaking — `self._toplevel.destroy()` continues to work.

## Tests

Added to `tests/test_dialogs_api.py`:
- `close()` before `show()` is a safe no-op
- `close()` destroys the toplevel and is idempotent
- the `<Escape>` binding is installed for dismissal

Full headless suite: **621 passed**.

## Related

- Fixes #1155
- Discussion #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)