### PR TITLE
feat: consolidate the theme API (settable theme_mode, toggle_theme, app delegates)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -20,7 +20,7 @@
 | **Deferred-config seam + `ttk.set_default_button()` pre-root setter** | New | this doc, below (Slice 5) |
 | **Localization: msgcat bug fixes + `L()` / `LocaleVar` / `set_locale`** | Fix/New | this doc, below (Slice 3) |
 | **Typography: `ttk.Fonts` + `ttk.set_global_family()` over the Tk named fonts** | New | this doc, below (Slice 4) |
-| **Light/dark theme mode toggle (`theme_mode`/`toggle_theme_mode`)** | New | this doc, below |
+| **Light/dark theme mode (settable `theme_mode`/`toggle_theme()`)** | New | this doc, below |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -58,15 +58,17 @@ but there was no first-class way to flip between them. Named `theme_mode` (not
 bare `mode`) so it does not collide with the widget `mode` option
 (`Progressbar`/`Floodgauge` determinate/indeterminate). Now:
 
-- `style.theme_mode` → `"light"` or `"dark"` (the active theme's type).
-- `style.toggle_theme_mode()` → switch to the counterpart, returns the new mode.
-- `style.use_theme_mode("light" | "dark")` → set a specific mode (e.g. to follow
-  an OS preference).
+- `style.theme_mode` → `"light"` or `"dark"` (the active theme's type); it is
+  **settable** — assign `"light"`/`"dark"` to switch (e.g. to follow an OS
+  preference).
+- `style.toggle_theme()` → switch to the counterpart, returns the new mode.
 - `style.set_theme_modes(light=..., dark=...)` and `App(light_theme=...,
   dark_theme=...)` → optionally *designate* the pair.
-- `App`/`Toplevel` expose `theme_mode` / `toggle_theme_mode()` /
-  `use_theme_mode()` / `set_theme_modes()` as convenience delegates to the
-  singleton `Style`.
+- `App`/`Toplevel` expose the **full common theming surface** as convenience
+  delegates to the singleton `Style`: `theme_use()` / `theme_names()` /
+  `theme_mode` (get+set) / `toggle_theme()` / `set_theme_modes()`. Drop to
+  `app.style` for the engine (colors, `configure`, `register_theme`, the
+  custom-style toolkit).
 
 **Counterpart resolution.** If a pair is designated, toggling switches between
 exactly those two themes (they may cross families, e.g. `bootstrap-light` ↔

--- a/docs/user-guide/feature-guides/windows.rst
+++ b/docs/user-guide/feature-guides/windows.rst
@@ -16,8 +16,8 @@ This guide will cover:
   ``iconphoto``, plus the renamed ``high_dpi``/``override_redirect``.
 - **Positioning** — ``place_window_center()`` (monitor-aware when ``screeninfo``
   is installed, clamped on-screen).
-- **Light/dark mode** — the ``theme_mode`` property, ``set_theme_modes(light=,
-  dark=)``, ``use_theme_mode``, and ``toggle_theme_mode``.
+- **Light/dark mode** — the settable ``theme_mode`` property, ``toggle_theme()``,
+  and ``set_theme_modes(light=, dark=)``.
 - **Toplevels** — ``window_type``, ``topmost``, ``tool_window``, and inherited
   app icons.
 - **High-DPI** — ``enable_high_dpi_awareness()`` and ``scale_size()``.

--- a/examples/prerelease_visual_review.py
+++ b/examples/prerelease_visual_review.py
@@ -237,7 +237,7 @@ def build_controls(parent, app):
                 lambda e: style.theme_use(picker.get()))
 
     def on_toggle():
-        app.toggle_theme_mode()  # switches the current family's -light/-dark sibling
+        app.toggle_theme()  # switches the current family's -light/-dark sibling
         picker.set(style.theme.name)
 
     ttk.Button(bar, text="Toggle light/dark", command=on_toggle,

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -75,8 +75,8 @@ class Style(ttk.Style):
                 the same purpose (pre-2.0 spelling); pass either.
 
             light_theme, dark_theme (str):
-                Optionally designate the themes that `toggle_theme_mode()` /
-                `use_theme_mode()` switch between. If omitted, the counterpart
+                Optionally designate the themes that `toggle_theme()` /
+                `theme_mode` switch between. If omitted, the counterpart
                 is derived from the `<family>-light` / `<family>-dark` naming
                 convention, so designation is only needed to pin a specific
                 pair (e.g. a light theme from one family with a dark theme from
@@ -106,8 +106,8 @@ class Style(ttk.Style):
         self._style_registry = set()  # all styles used
         self._theme_styles = {}  # styles used in theme
         self._theme_names = set()
-        # Optional designated light/dark theme pair for use_theme_mode()/
-        # toggle_theme_mode(); None means "derive from the -light/-dark naming".
+        # Optional designated light/dark theme pair for the theme_mode setter /
+        # toggle_theme(); None means "derive from the -light/-dark naming".
         self._light_theme = None
         self._dark_theme = None
         # Monotonic counter bumped on every theme switch. The theme walk
@@ -308,14 +308,24 @@ class Style(ttk.Style):
     def theme_mode(self) -> Optional[str]:
         """The active theme mode (`"light"` or `"dark"`).
 
+        Read it, or assign `"light"`/`"dark"` to switch the current family to
+        that mode (the designated theme, else the `-light`/`-dark` sibling)::
+
+            style.theme_mode           # -> "light"
+            style.theme_mode = "dark"  # switch
+
         Reads the active theme's type; `None` before a theme is applied.
         """
         theme = getattr(self, "theme", None)
         return theme.type if theme is not None else None
 
+    @theme_mode.setter
+    def theme_mode(self, mode: str) -> None:
+        self._apply_theme_mode(mode)
+
     def set_theme_modes(self, light: str = None, dark: str = None) -> None:
-        """Designate the light and/or dark theme that `use_theme_mode()` /
-        `toggle_theme_mode()` switch between.
+        """Designate the light and/or dark theme that `theme_mode` /
+        `toggle_theme()` switch between.
 
         By default the counterpart is derived from the `<family>-light` /
         `<family>-dark` naming convention, so this is only needed to pin a
@@ -363,17 +373,12 @@ class Style(ttk.Style):
         candidate = f"{family}-{mode}"
         return candidate if candidate in self._theme_names else None
 
-    def use_theme_mode(self, mode: str) -> Optional[str]:
+    def _apply_theme_mode(self, mode: str) -> Optional[str]:
         """Switch to the light or dark theme (the designated one, else the
-        current family's `-light`/`-dark` sibling).
+        current family's `-light`/`-dark` sibling); returns the resulting mode.
 
-        Returns the resulting mode. No-ops with a warning if no counterpart
-        exists (e.g. a single legacy theme with no sibling).
-
-        Parameters:
-
-            mode (str):
-                `"light"` or `"dark"`.
+        Backs the `theme_mode` setter and `toggle_theme()`. No-ops with a
+        warning if no counterpart exists (e.g. a single legacy theme).
         """
         mode = str(mode).lower()
         if mode not in ("light", "dark"):
@@ -392,10 +397,10 @@ class Style(ttk.Style):
             self.theme_use(target)
         return self.theme_mode
 
-    def toggle_theme_mode(self) -> Optional[str]:
+    def toggle_theme(self) -> Optional[str]:
         """Toggle between the light and dark theme, returning the new mode."""
         other = "dark" if self.theme_mode == "light" else "light"
-        return self.use_theme_mode(other)
+        return self._apply_theme_mode(other)
 
     def theme_create(self, themename: str, parent: str = None, settings: dict = None) -> None:
         """

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -200,25 +200,35 @@ class _BaseWindow:
         """Return a reference to the `ttkbootstrap.style.Style` object."""
         return Style.get_instance()
 
-    # -- light/dark theme mode (convenience delegates to Style) ------------
+    # -- theme (convenience delegates to Style) ----------------------------
+    # The common theming surface lives on the window; drop to `self.style` for
+    # the engine (colors, configure, register_theme, custom-style toolkit).
+
+    def theme_use(self, themename: Optional[str] = None) -> Optional[str]:
+        """Switch to `themename`, or return the current theme name."""
+        return self.style.theme_use(themename)
+
+    def theme_names(self) -> list:
+        """Return every registered theme name."""
+        return self.style.theme_names()
 
     @property
     def theme_mode(self) -> Optional[str]:
-        """The active theme mode (`"light"` or `"dark"`)."""
+        """The active theme mode; assign `"light"`/`"dark"` to switch."""
         return self.style.theme_mode
+
+    @theme_mode.setter
+    def theme_mode(self, mode: str) -> None:
+        self.style.theme_mode = mode
 
     def set_theme_modes(self, light: Optional[str] = None,
                         dark: Optional[str] = None) -> None:
         """Designate the light/dark theme pair the toggle switches between."""
         self.style.set_theme_modes(light=light, dark=dark)
 
-    def use_theme_mode(self, mode: str) -> Optional[str]:
-        """Switch to the light or dark theme; returns the resulting mode."""
-        return self.style.use_theme_mode(mode)
-
-    def toggle_theme_mode(self) -> Optional[str]:
+    def toggle_theme(self) -> Optional[str]:
         """Toggle between the light and dark theme; returns the new mode."""
-        return self.style.toggle_theme_mode()
+        return self.style.toggle_theme()
 
     # -- setup helpers -----------------------------------------------------
 

--- a/tests/widget_styles/test_theme_anchor.py
+++ b/tests/widget_styles/test_theme_anchor.py
@@ -249,8 +249,7 @@ def test_legacy_theme_use_lazy_registers_then_bulk_opt_in(root):
 
 
 # --------------------------------------------------------------------------- #
-# Light/dark theme mode (theme_mode / toggle_theme_mode / use_theme_mode /
-# set_theme_modes)
+# Light/dark theme mode (theme_mode get/set / toggle_theme / set_theme_modes)
 # --------------------------------------------------------------------------- #
 def test_mode_reflects_active_theme_type(root):
     style = root.style
@@ -263,35 +262,47 @@ def test_mode_reflects_active_theme_type(root):
 def test_toggle_mode_swaps_family_sibling(root):
     style = root.style
     style.theme_use("bootstrap-light")
-    assert style.toggle_theme_mode() == "dark"
+    assert style.toggle_theme() == "dark"
     assert style.theme.name == "bootstrap-dark"
-    assert style.toggle_theme_mode() == "light"
+    assert style.toggle_theme() == "light"
     assert style.theme.name == "bootstrap-light"
 
 
-def test_use_mode_is_explicit_and_idempotent(root):
+def test_setting_mode_is_explicit_and_idempotent(root):
     style = root.style
     style.theme_use("bootstrap-light")
-    assert style.use_theme_mode("dark") == "dark"
+    style.theme_mode = "dark"
+    assert style.theme_mode == "dark"
     assert style.theme.name == "bootstrap-dark"
     # already dark -> no-op, stays put
-    assert style.use_theme_mode("dark") == "dark"
+    style.theme_mode = "dark"
     assert style.theme.name == "bootstrap-dark"
     with pytest.raises(ValueError):
-        style.use_theme_mode("sepia")
+        style.theme_mode = "sepia"
 
 
 def test_designated_pair_can_cross_families(root):
     style = root.style
     try:
         style.set_theme_modes(light="bootstrap-light", dark="dracula-dark")
-        style.use_theme_mode("light")
+        style.theme_mode = "light"
         assert style.theme.name == "bootstrap-light"
-        assert style.toggle_theme_mode() == "dark"
+        assert style.toggle_theme() == "dark"
         assert style.theme.name == "dracula-dark"
     finally:
         style._light_theme = style._dark_theme = None
         style.theme_use("bootstrap-light")
+
+
+def test_app_delegates_common_theme_surface(root):
+    # the window exposes the full common theming API without reaching into .style
+    root.theme_use("bootstrap-light")
+    assert root.theme_use() == "bootstrap-light"
+    assert {"bootstrap-light", "bootstrap-dark"} <= set(root.theme_names())
+    root.theme_mode = "dark"
+    assert root.theme_mode == "dark" == root.style.theme_mode
+    assert root.toggle_theme() == "light"
+    assert root.theme_use() == "bootstrap-light"
 
 
 def test_set_mode_themes_rejects_unregistered_and_warns_on_type_mismatch(root):
@@ -314,7 +325,7 @@ def test_toggle_without_sibling_warns_and_noops(root):
             ttk.install_legacy_themes()
         style.theme_use("darkly")  # a single legacy theme, no -light sibling
         with pytest.warns(UserWarning, match="no light theme"):
-            assert style.toggle_theme_mode() == "dark"  # unchanged
+            assert style.toggle_theme() == "dark"  # unchanged
         assert style.theme.name == "darkly"
     finally:
         for name in list(style._theme_names):


### PR DESCRIPTION
Refines the **unreleased-in-2.0** light/dark theme surface for ergonomics and consistency — surfaced while authoring the Theming user guide (the value of docs-before-release).

## What changed
- **`theme_mode` is now settable** — `app.theme_mode = "dark"` switches the current family to that mode. Replaces `use_theme_mode(mode)`.
- **`toggle_theme()`** replaces `toggle_theme_mode()` — matches the universal "toggle theme" idiom, and since it takes no argument, "toggle" keeps its flip semantics (no `toggle('dark')` set-via-toggle contradiction).
- **`App`/`Toplevel` delegate the full common theming surface** — `theme_use()`, `theme_names()`, `theme_mode` (get+set), `toggle_theme()`, `set_theme_modes()`. Previously only the mode helpers were on the window while `theme_use`/`theme_names` required reaching into `app.style`. Now everyday theming lives on `app`; **`app.style` is reserved for the engine** (colors, `configure`, `register_theme`, the custom-style toolkit).

```python
app.theme_use("nord-dark")   # switch theme
app.theme_names()            # list
app.theme_mode = "dark"      # switch mode
app.toggle_theme()           # flip
```

## Notes
- These are new-in-2.0, unreleased methods, so renamed **cleanly with no deprecation shims**.
- `engine.py` keeps a private `_apply_theme_mode` backing the setter + toggle.
- Tests updated + a new `test_app_delegates_common_theme_surface`; `2_0_breaking_changes.md` entry updated.

## Verification
- Full suite **625 passed** (excl. the known `nl.msg` env flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)