### PR TITLE
feat: theme-aware custom styles (on_theme_change / @theme_aware)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -21,6 +21,7 @@
 | **Localization: msgcat bug fixes + `L()` / `LocaleVar` / `set_locale`** | Fix/New | this doc, below (Slice 3) |
 | **Typography: `ttk.Fonts` + `ttk.set_global_family()` over the Tk named fonts** | New | this doc, below (Slice 4) |
 | **Light/dark theme mode (settable `theme_mode`/`toggle_theme()`)** | New | this doc, below |
+| **Theme-aware custom styles (`on_theme_change` / `@theme_aware`)** | New | this doc, below |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -83,6 +84,37 @@ toggle emits `<<ThemeChanged>>` like any `theme_use`.
 
 **Scope note.** This is a *utility*, not a widget — it fits the 2.0 "no new
 *widgets*" rule. No migration required; purely additive.
+
+---
+
+## Theme-aware custom styles: `on_theme_change` / `@theme_aware`  *(New)*
+
+**What.** A hook that re-runs a style-building callback after every theme change,
+so a hand-built ttk style tracks the active theme instead of going stale on
+switch. Serves the 2.0 goal of making user-defined custom styles easy.
+
+- `Style.on_theme_change(callback, *, call_now=True)` → register `callback(style)`
+  to run after each `theme_use`/`toggle_theme` (and once immediately by default).
+  Returns the callback, so it doubles as a decorator.
+  `Style.remove_theme_change_callback(callback)` unregisters it.
+- `ttk.on_theme_change(...)` (top level) → same, but works **before the root
+  exists**: the registration queues on the deferred-config seam and applies when
+  the app is created.
+- `ttk.theme_aware` → decorator sugar:
+
+  ```python
+  @theme_aware
+  def build_styles(style):
+      style.configure("Pill.TButton", background=style.colors.primary)
+  ```
+
+**Why.** Custom styles are configured against the *active* theme's Tcl style DB;
+a theme switch repaints built-in widgets but not styles you built by hand. This
+gives those styles a place to rebuild. A callback that raises warns and is
+skipped — one bad callback never breaks theming. Rides the existing theme walk.
+
+**Scope note.** A *utility* over the existing theme walk, not new widget
+behavior. Purely additive; no migration required.
 
 ---
 

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -89,6 +89,9 @@ from ttkbootstrap.utils import (
     contrast_color,
     conform_color_model,
     set_default_button,
+    on_theme_change,
+    theme_aware,
+    remove_theme_change_callback,
     Fonts,
     set_global_family,
 )
@@ -317,6 +320,9 @@ __all__ = [
     "contrast_color",
     "conform_color_model",
     "set_default_button",
+    "on_theme_change",
+    "theme_aware",
+    "remove_theme_change_callback",
     "Fonts",
     "set_global_family",
 

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -121,6 +121,10 @@ class Style(ttk.Style):
         # dedupe and are rendered once. Replaces the per-builder theme_images
         # dicts that pinned a fresh PhotoImage per theme (the image leak).
         self._image_cache = {}
+        # Callbacks run after every theme change (register via on_theme_change),
+        # so a custom style can rebuild itself against the new theme's colors.
+        self._theme_change_callbacks = []
+        self._running_theme_callbacks = False
         self._load_themes()
         self._dynamic_foreground = False
         super().__init__()
@@ -301,6 +305,18 @@ class Style(ttk.Style):
         self._theme_version += 1
         self._theme_walk()
 
+        # Let theme-aware custom styles rebuild against the new theme. Run after
+        # the walk so the new theme's colors/styles are fully live. The guard
+        # keeps a callback that itself calls theme_use from recursing forever --
+        # a nested switch still repaints, it just doesn't re-enter this loop.
+        if not self._running_theme_callbacks:
+            self._running_theme_callbacks = True
+            try:
+                for callback in list(self._theme_change_callbacks):
+                    self._run_theme_change_callback(callback)
+            finally:
+                self._running_theme_callbacks = False
+
     # ------------------------------------------------------------------ #
     # Light/dark theme mode toggling
     # ------------------------------------------------------------------ #
@@ -401,6 +417,58 @@ class Style(ttk.Style):
         """Toggle between the light and dark theme, returning the new mode."""
         other = "dark" if self.theme_mode == "light" else "light"
         return self._apply_theme_mode(other)
+
+    # ------------------------------------------------------------------ #
+    # Theme-change callbacks (theme-aware custom styles)
+    # ------------------------------------------------------------------ #
+    def on_theme_change(self, callback, *, call_now: bool = True):
+        """Register ``callback(style)`` to run after every theme change.
+
+        Use it to (re)build a custom style so it tracks the active theme: the
+        callback re-runs on each ``theme_use`` / ``toggle_theme``. When
+        ``call_now`` (the default), it also runs once immediately if a theme is
+        already active, so the style exists before the first switch.
+
+        Returns ``callback``, so it doubles as a decorator.
+
+        Parameters:
+
+            callback (Callable[[Style], None]):
+                Called with this `Style`; typically rebuilds a style from
+                `style.colors`.
+
+            call_now (bool):
+                Also run it once now (if a theme is active).
+        """
+        newly_added = callback not in self._theme_change_callbacks
+        if newly_added:
+            self._theme_change_callbacks.append(callback)
+        # Only fire on first registration, so a duplicate register is a no-op
+        # (idempotent) rather than re-running the callback's side effects.
+        if call_now and newly_added and getattr(self, "theme", None) is not None:
+            self._run_theme_change_callback(callback)
+        return callback
+
+    def remove_theme_change_callback(self, callback) -> None:
+        """Unregister a callback previously passed to `on_theme_change`."""
+        try:
+            self._theme_change_callbacks.remove(callback)
+        except ValueError:
+            pass
+
+    def _run_theme_change_callback(self, callback) -> None:
+        """Run one theme-change callback; a failure warns but never breaks
+        theming for the rest of the app."""
+        try:
+            callback(self)
+        except Exception as exc:
+            warnings.warn(
+                f"theme-change callback "
+                f"{getattr(callback, '__name__', callback)!r} raised {exc!r}; "
+                "skipping it.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     def theme_create(self, themename: str, parent: str = None, settings: dict = None) -> None:
         """

--- a/src/ttkbootstrap/utils/__init__.py
+++ b/src/ttkbootstrap/utils/__init__.py
@@ -40,7 +40,12 @@ from ttkbootstrap.utils.scaling import (
     scale_size,
 )
 from ttkbootstrap.utils.platform import windowing_system
-from ttkbootstrap.utils.config import set_default_button
+from ttkbootstrap.utils.config import (
+    set_default_button,
+    on_theme_change,
+    theme_aware,
+    remove_theme_change_callback,
+)
 from ttkbootstrap.utils.fonts import Fonts, set_global_family
 
 # Localization helpers live in the `localization` package (the i18n engine stays
@@ -77,6 +82,9 @@ __all__ = [
     "set_global_family",
     # deferred config (pre-root setters)
     "set_default_button",
+    "on_theme_change",
+    "theme_aware",
+    "remove_theme_change_callback",
     # localization (surfaced lazily from the localization package)
     "L",
     "LocaleVar",

--- a/src/ttkbootstrap/utils/config.py
+++ b/src/ttkbootstrap/utils/config.py
@@ -79,3 +79,50 @@ def set_default_button(color: str) -> None:
         # Capture `color` in the closure so the queued applier carries its own
         # value -- no shared module-level state to keep in sync.
         defer("default_button", lambda: setattr(_style(), "default_button", color))
+
+
+def on_theme_change(callback, *, call_now: bool = True):
+    """Register ``callback(style)`` to run after every theme change.
+
+    Use it to keep a custom style in sync with the active theme -- the callback
+    re-runs on each ``theme_use`` / ``toggle_theme``. Works before the root
+    exists: if no ``App``/``Style`` has been created yet, the registration is
+    queued and applied when the root comes up. See ``Style.on_theme_change`` for
+    the full semantics. Returns ``callback``, so it can be used as a decorator.
+    """
+    style = _style()
+    if style is not None:
+        return style.on_theme_change(callback, call_now=call_now)
+    # unique key per callback so multiple registrations all survive the queue
+    defer(
+        f"on_theme_change:{id(callback)}",
+        lambda: _style().on_theme_change(callback, call_now=call_now),
+    )
+    return callback
+
+
+def theme_aware(callback):
+    """Decorator marking ``callback(style)`` as a theme-aware style builder.
+
+    Runs it once when a theme is active -- immediately if the app already
+    exists, otherwise at app creation -- and again after every theme change, so
+    the style tracks the theme::
+
+        @theme_aware
+        def build_styles(style):
+            style.configure("Pill.TButton", background=style.colors.primary)
+    """
+    return on_theme_change(callback, call_now=True)
+
+
+def remove_theme_change_callback(callback) -> None:
+    """Unregister a callback previously passed to ``on_theme_change`` /
+    ``theme_aware``.
+
+    Removes it whether it is already live on the ``Style`` or still queued from a
+    pre-root registration.
+    """
+    _pending.pop(f"on_theme_change:{id(callback)}", None)
+    style = _style()
+    if style is not None:
+        style.remove_theme_change_callback(callback)

--- a/tests/widget_styles/test_theme_anchor.py
+++ b/tests/widget_styles/test_theme_anchor.py
@@ -336,3 +336,157 @@ def test_toggle_without_sibling_warns_and_noops(root):
                 style._theme_objects.pop(name, None)
         style._light_theme = style._dark_theme = None
         style.theme_use("bootstrap-light")
+
+
+# --------------------------------------------------------------------------- #
+# Theme-aware custom styles (on_theme_change / theme_aware)
+# --------------------------------------------------------------------------- #
+def test_on_theme_change_runs_now_and_on_switch(root):
+    style = root.style
+    style.theme_use("bootstrap-light")
+    seen = []
+    cb = lambda s: seen.append(s.theme_use())
+    try:
+        style.on_theme_change(cb)
+        assert seen == ["bootstrap-light"]                    # call_now
+        style.theme_use("bootstrap-dark")
+        assert seen == ["bootstrap-light", "bootstrap-dark"]  # re-ran on switch
+    finally:
+        style.remove_theme_change_callback(cb)
+
+
+def test_on_theme_change_call_now_false_skips_initial(root):
+    style = root.style
+    style.theme_use("bootstrap-light")
+    seen = []
+    cb = lambda s: seen.append(1)
+    try:
+        style.on_theme_change(cb, call_now=False)
+        assert seen == []                                     # not called now
+        style.theme_use("bootstrap-dark")
+        assert seen == [1]                                    # only on switch
+    finally:
+        style.remove_theme_change_callback(cb)
+
+
+def test_theme_use_query_does_not_fire_callbacks(root):
+    style = root.style
+    seen = []
+    cb = lambda s: seen.append(1)
+    try:
+        style.on_theme_change(cb, call_now=False)
+        style.theme_use()                                     # no-arg query
+        assert seen == []
+    finally:
+        style.remove_theme_change_callback(cb)
+
+
+def test_on_theme_change_dedups_same_callback(root):
+    style = root.style
+    cb = lambda s: None
+    try:
+        style.on_theme_change(cb, call_now=False)
+        style.on_theme_change(cb, call_now=False)
+        assert style._theme_change_callbacks.count(cb) == 1
+    finally:
+        style.remove_theme_change_callback(cb)
+
+
+def test_bad_callback_warns_but_does_not_break_theming(root):
+    style = root.style
+    style.theme_use("bootstrap-light")
+    good = []
+    boom = lambda s: (_ for _ in ()).throw(RuntimeError("boom"))
+    keep = lambda s: good.append(s.theme_use())
+    try:
+        style.on_theme_change(boom, call_now=False)
+        style.on_theme_change(keep, call_now=False)
+        with pytest.warns(UserWarning, match="boom"):
+            style.theme_use("bootstrap-dark")
+        assert style.theme_use() == "bootstrap-dark"          # switch still happened
+        assert good == ["bootstrap-dark"]                     # other callback still ran
+    finally:
+        style.remove_theme_change_callback(boom)
+        style.remove_theme_change_callback(keep)
+
+
+def test_theme_aware_decorator_returns_and_registers(root):
+    root.theme_use("bootstrap-light")
+    seen = []
+
+    @ttk.theme_aware
+    def build(style):
+        seen.append(style.theme_use())
+
+    try:
+        assert build.__name__ == "build"                      # returns the function
+        assert seen == ["bootstrap-light"]                    # ran once now
+        root.theme_use("bootstrap-dark")
+        assert seen[-1] == "bootstrap-dark"
+    finally:
+        root.style.remove_theme_change_callback(build)
+
+
+def test_call_now_does_not_double_fire_on_reregister(root):
+    style = root.style
+    style.theme_use("bootstrap-light")
+    calls = []
+    cb = lambda s: calls.append(1)
+    try:
+        style.on_theme_change(cb, call_now=True)   # runs once
+        style.on_theme_change(cb, call_now=True)   # duplicate -> must NOT run again
+        assert calls == [1]
+    finally:
+        style.remove_theme_change_callback(cb)
+
+
+def test_callback_calling_theme_use_does_not_recurse(root):
+    style = root.style
+    style.theme_use("bootstrap-light")
+    ran = []
+
+    def cb(s):
+        ran.append(1)
+        s.theme_use("nord-dark")   # nested switch inside the callback
+
+    try:
+        style.on_theme_change(cb, call_now=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")   # a recursion-in-callback would warn -> error here
+            style.theme_use("nord-light")    # fires cb, which re-enters theme_use
+        assert ran == [1]                     # guard blocks re-entry: callback ran once
+        assert style.theme_use() == "nord-dark"   # the nested switch still took effect
+    finally:
+        style.remove_theme_change_callback(cb)
+        style.theme_use("bootstrap-light")
+
+
+def test_top_level_remove_theme_change_callback(root):
+    style = root.style
+    calls = []
+    cb = lambda s: calls.append(1)
+    ttk.on_theme_change(cb, call_now=False)
+    ttk.remove_theme_change_callback(cb)
+    style.theme_use("nord-dark")
+    assert calls == []                        # removed -> never fires
+    style.theme_use("bootstrap-light")
+
+
+def test_pre_root_registration_defers_then_applies(root, monkeypatch):
+    # the trickiest branch: registering before a root exists queues on the
+    # deferred-config seam and applies when the app is created.
+    from ttkbootstrap.utils import config
+    style = root.style
+    cb = lambda s: None
+    key = f"on_theme_change:{id(cb)}"
+    try:
+        monkeypatch.setattr(config, "_style", lambda: None)   # pretend no root yet
+        config.on_theme_change(cb, call_now=True)
+        assert key in config._pending                          # queued, not applied
+        assert cb not in style._theme_change_callbacks
+        monkeypatch.undo()                                     # root now exists
+        config.flush_pending_config()                          # the App-create flush
+        assert cb in style._theme_change_callbacks             # now live
+    finally:
+        style.remove_theme_change_callback(cb)
+        config._pending.pop(key, None)


### PR DESCRIPTION
Makes a hand-built ttk style track the active theme — surfaced from the docs discussion of "how do I make a custom style that survives theme switches?" Serves the 2.0 goal of making user-defined custom styles easy; a **utility over the existing theme walk**, not new widget behavior.

## API
```python
from ttkbootstrap import theme_aware

@theme_aware                     # runs once now, and after every theme change
def build_styles(style):
    style.configure("Pill.TButton", background=style.colors.primary)
```
- `Style.on_theme_change(callback, *, call_now=True)` → register `callback(style)`; re-runs after each `theme_use`/`toggle_theme`. Returns the callback (so it doubles as a decorator). `Style.remove_theme_change_callback(cb)` unregisters.
- Top-level `ttk.on_theme_change` / `ttk.theme_aware` / `ttk.remove_theme_change_callback` — the top-level forms also work **before the root exists** (queued on the deferred-config seam, applied at app creation).

## Robustness
- A callback that raises **warns and is skipped** — one bad callback never breaks theming.
- A **re-entrancy guard** stops a callback that itself calls `theme_use` from recursing (the nested switch still repaints).
- Duplicate registration is **idempotent** (no double-fire).

## Why not a custom builder?
The builder registry (`register_builder`) is internal, frozen after startup, and — crucially — the closed-vocabulary `bootstyle` tokenizer can't *address* a custom variant token, so a custom builder would be registered-but-unreachable. `<<ThemeChanged>>`-style rebuild is the right layer, and this wraps it ergonomically.

## Review & tests
A high-effort `/code-review` (8 angles) ran on the diff; fixes folded in: recursion guard, no-double-fire on re-register, symmetric top-level `remove_*`, accurate pre-root docstring, and tests for the deferred/recursion/double-fire/remove paths. Suite **636 passed**. New-feature entry added to `2_0_breaking_changes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)