### PR TITLE
docs: User Guide Concepts band (bootstyle grammar, delivery, theming, color, custom style/theme)

### DIFF
--- a/docs/user-guide/concepts/bootstyle-grammar.rst
+++ b/docs/user-guide/concepts/bootstyle-grammar.rst
@@ -12,9 +12,9 @@ value. This guide covers everything that string can express.
 
    app = ttk.App()
 
-   ttk.Button(app, text="Save",   bootstyle="success").pack(padx=8, pady=4)
-   ttk.Button(app, text="Cancel", bootstyle="secondary outline").pack(padx=8, pady=4)
-   ttk.Button(app, text="Delete", bootstyle="danger ghost").pack(padx=8, pady=4)
+   ttk.Button(app, text="Save",   bootstyle="success").pack()
+   ttk.Button(app, text="Cancel", bootstyle="secondary outline").pack()
+   ttk.Button(app, text="Delete", bootstyle="danger ghost").pack()
 
    app.mainloop()
 
@@ -77,7 +77,7 @@ accent bar instead of the window background:
 .. code-block:: python
 
    card = ttk.Frame(app, bootstyle="card", padding=12)
-   ttk.Button(card, text="More", bootstyle="@card primary ghost").pack()
+   ttk.Button(card, text="More", bootstyle="@card primary ghost")
 
 Chameleon base-types
 --------------------

--- a/docs/user-guide/concepts/bootstyle-grammar.rst
+++ b/docs/user-guide/concepts/bootstyle-grammar.rst
@@ -40,8 +40,10 @@ slot order::
 - **orient** — ``horizontal`` / ``vertical``, inferred from the widget where it
   applies.
 
-Every slot is optional. A bare widget with no ``bootstyle`` gets the theme's
-default look; each token you add refines it.
+Every slot is optional. A bare widget with no ``bootstyle`` takes the theme's
+default look — for the **button family** (``Button``, ``Menubutton``, and the
+``toolbutton`` variant) that default is ``neutral``, a quiet no-accent fill;
+other widgets use their standard theme style. Each token you add refines it.
 
 Building up a style
 -------------------
@@ -63,11 +65,11 @@ Add a **variant** to change visual weight. The color still leads:
    ttk.Button(app, text="Link",    bootstyle="primary link")
    ttk.Button(app, text="Ghost",   bootstyle="primary ghost")
 
-A variant with no color falls back to the family default (``primary`` for most):
+You can drop the color as well — a bare ``outline`` button uses ``primary``:
 
 .. code-block:: python
 
-   ttk.Button(app, text="Outline", bootstyle="outline")   # == "primary outline"
+   ttk.Button(app, text="Outline", bootstyle="outline")   # primary outline
 
 Point a control at a **surface** with an ``@`` token so it blends on a card or an
 accent bar instead of the window background:

--- a/docs/user-guide/concepts/bootstyle-grammar.rst
+++ b/docs/user-guide/concepts/bootstyle-grammar.rst
@@ -24,7 +24,7 @@ The slots
 A ``bootstyle`` value is a single string of space-separated tokens in a fixed
 slot order::
 
-   [@surface] [color] [modifier] <base-type> [orient]
+   [@surface] [color] [variant] <base-type> [orient]
 
 - **@surface** — the surface the control sits on: ``@card`` (a neutral raised
   panel) or an accent (``@primary`` …), so a ghost, outline, or link control
@@ -32,7 +32,7 @@ slot order::
   Optional and position-free.
 - **color** — the semantic intent: ``primary``, ``secondary``, ``success``,
   ``info``, ``warning``, ``danger``, ``light``, ``dark``, ``neutral``.
-- **modifier** — a variant such as ``outline``, ``link``, ``ghost``, ``round``,
+- **variant** — a look such as ``outline``, ``link``, ``ghost``, ``round``,
   ``striped``.
 - **base-type** — the widget family. Usually inferred from the widget, so you
   leave it out; you spell it only for the chameleon families ``toggle`` /
@@ -54,7 +54,7 @@ Start with a **color** — the widget picks the right shape from its own class:
    ttk.Label(app, text="Heads up", bootstyle="warning")
    ttk.Progressbar(app, bootstyle="success")   # orient inferred → horizontal
 
-Add a **modifier** to change visual weight. The color still leads:
+Add a **variant** to change visual weight. The color still leads:
 
 .. code-block:: python
 
@@ -63,7 +63,7 @@ Add a **modifier** to change visual weight. The color still leads:
    ttk.Button(app, text="Link",    bootstyle="primary link")
    ttk.Button(app, text="Ghost",   bootstyle="primary ghost")
 
-A modifier with no color falls back to the family default (``primary`` for most):
+A variant with no color falls back to the family default (``primary`` for most):
 
 .. code-block:: python
 

--- a/docs/user-guide/concepts/bootstyle-grammar.rst
+++ b/docs/user-guide/concepts/bootstyle-grammar.rst
@@ -1,8 +1,25 @@
 The bootstyle grammar
 =====================
 
-Every ttkbootstrap widget is styled through one keyword: ``bootstyle``. This
-guide is the canonical reference for its grammar.
+Every ttkbootstrap widget is styled through one keyword: ``bootstyle``. You give
+it a short string that names *intent* — a color, a variant, a surface — and the
+theme renders it correctly in light and dark without hard-coding a single hex
+value. This guide covers everything that string can express.
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   ttk.Button(app, text="Save",   bootstyle="success").pack(padx=8, pady=4)
+   ttk.Button(app, text="Cancel", bootstyle="secondary outline").pack(padx=8, pady=4)
+   ttk.Button(app, text="Delete", bootstyle="danger ghost").pack(padx=8, pady=4)
+
+   app.mainloop()
+
+The slots
+---------
 
 A ``bootstyle`` value is a single string of space-separated tokens in a fixed
 slot order::
@@ -17,20 +34,122 @@ slot order::
   ``info``, ``warning``, ``danger``, ``light``, ``dark``, ``neutral``.
 - **modifier** — a variant such as ``outline``, ``link``, ``ghost``, ``round``,
   ``striped``.
-- **base-type** — the widget family, usually inferred from the widget and
-  spelled only for the chameleon families ``toggle`` / ``toolbutton``.
-- **orient** — ``horizontal`` / ``vertical`` where applicable.
+- **base-type** — the widget family. Usually inferred from the widget, so you
+  leave it out; you spell it only for the chameleon families ``toggle`` /
+  ``toolbutton`` (see below).
+- **orient** — ``horizontal`` / ``vertical``, inferred from the widget where it
+  applies.
 
-**Spaces are the recommended separator** —
-``ttk.Button(bootstyle="@primary success ghost")``. Dashes
-(``primary-success-ghost``) and any token order still parse, but spaces read
-best and are what editor autocomplete suggests.
+Every slot is optional. A bare widget with no ``bootstyle`` gets the theme's
+default look; each token you add refines it.
 
-The parser is a tokenizer over a closed vocabulary: unknown tokens fail loudly
-(a warning by default; ``set_bootstyle_strict(True)`` or
-``TTKBOOTSTRAP_STRICT=1`` raises).
+Building up a style
+-------------------
 
-The full vocabulary and every registered widget family follow, generated from
-the closed vocabulary and the builder registry.
+Start with a **color** — the widget picks the right shape from its own class:
+
+.. code-block:: python
+
+   ttk.Button(app, text="Go", bootstyle="primary")
+   ttk.Label(app, text="Heads up", bootstyle="warning")
+   ttk.Progressbar(app, bootstyle="success")   # orient inferred → horizontal
+
+Add a **modifier** to change visual weight. The color still leads:
+
+.. code-block:: python
+
+   ttk.Button(app, text="Solid",   bootstyle="primary")
+   ttk.Button(app, text="Outline", bootstyle="primary outline")
+   ttk.Button(app, text="Link",    bootstyle="primary link")
+   ttk.Button(app, text="Ghost",   bootstyle="primary ghost")
+
+A modifier with no color falls back to the family default (``primary`` for most):
+
+.. code-block:: python
+
+   ttk.Button(app, text="Outline", bootstyle="outline")   # == "primary outline"
+
+Point a control at a **surface** with an ``@`` token so it blends on a card or an
+accent bar instead of the window background:
+
+.. code-block:: python
+
+   card = ttk.Frame(app, bootstyle="card", padding=12)
+   ttk.Button(card, text="More", bootstyle="@card primary ghost").pack()
+
+Chameleon base-types
+--------------------
+
+Two variants aren't tied to one widget class, so you name the **base-type**
+explicitly. ``toggle`` turns a ``Checkbutton`` into a switch; ``toolbutton``
+turns a ``Button`` (or ``Checkbutton``) into a pressed-state toolbar button:
+
+.. code-block:: python
+
+   ttk.Checkbutton(app, text="Wi-Fi", bootstyle="success round toggle")
+   ttk.Checkbutton(app, text="Bold",  bootstyle="toolbutton")
+
+How it resolves
+---------------
+
+``bootstyle`` is a compact spelling of the underlying **ttk style name**. The
+tokens map onto the dotted name ttk actually uses:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - ``bootstyle``
+     - ttk style name
+   * - ``primary outline``
+     - ``primary.Outline.TButton``
+   * - ``success round toggle``
+     - ``success.Round.Toggle``
+   * - ``info striped``
+     - ``info.Striped.Horizontal.TProgressbar``
+
+Because of that, ``bootstyle="primary outline"`` and the raw
+``style="primary.Outline.TButton"`` are interchangeable — ``bootstyle`` just
+saves you from spelling the base-type, orientation, and casing. The full mapping
+per widget is in the :doc:`Style Reference </reference/style-reference/index>`.
+
+Tokens are **order-free** and **separator-flexible**: ``"outline primary"`` and
+``"primary-outline"`` resolve the same as ``"primary outline"``. Spaces are the
+recommended spelling — they read best and are what editor autocomplete suggests.
+
+When a token is wrong
+---------------------
+
+The parser is a tokenizer over a **closed vocabulary**, so a typo doesn't
+silently produce the wrong style — it fails loudly. By default an unknown token
+warns (and suggests the nearest match) and the widget falls back to a valid
+style:
+
+.. code-block:: python
+
+   ttk.Button(app, bootstyle="primatry")   # UserWarning: did you mean 'primary'?
+
+To make unknown tokens raise instead — useful in tests and CI — turn on strict
+mode, globally or per environment:
+
+.. code-block:: python
+
+   from ttkbootstrap import set_bootstyle_strict
+
+   set_bootstyle_strict(True)               # or set TTKBOOTSTRAP_STRICT=1
+
+Note that ttkbootstrap is permissive about *valid* choices: a control on its own
+matching accent surface may render low-contrast, but that is a real style, so it
+is allowed — only misspelled or unknown tokens fail.
+
+Beyond the grammar
+------------------
+
+When you need a look the grammar can't name — a bespoke color, a custom element
+layout — you register your own ttk style and apply it with ``style=``. See
+:doc:`Make your own style <make-your-own-style>`.
+
+The rest of this page is the full vocabulary and every registered widget family,
+generated from the closed vocabulary and the builder registry.
 
 .. include:: /_generated/bootstyle_reference.rst

--- a/docs/user-guide/concepts/delivery-model.rst
+++ b/docs/user-guide/concepts/delivery-model.rst
@@ -1,21 +1,27 @@
 How styling is delivered
 ========================
 
-In 1.x, ``import ttkbootstrap`` **monkey-patched tkinter** at import time, so
-every ``ttk`` widget grew a ``bootstyle`` keyword — even widgets you created
-through plain ``tkinter.ttk``. 2.0 stops doing that. The styling API is delivered
-through **concrete widget subclasses** instead, so importing the library mutates
-nothing, and the widgets keep real signatures and docstrings your editor can see.
+ttkbootstrap delivers its styling API through **concrete widget subclasses**.
+``ttk.Button``, ``ttk.Entry``, ``ttk.Combobox``, … are real classes that carry
+the ``bootstyle`` keyword (via :class:`~ttkbootstrap.BootMixin`), so you build
+widgets from ``ttkbootstrap`` and style them inline. Importing the library
+changes nothing about tkinter — the widgets keep real signatures and docstrings
+your editor can see.
 
-This changes one thing in practice: to get ``bootstyle``, use ttkbootstrap's
-widget classes rather than ``tkinter.ttk``'s.
+The one rule to internalize: to get ``bootstyle``, use ttkbootstrap's widget
+classes rather than ``tkinter.ttk``'s.
+
+.. admonition:: Coming from 1.x
+   :class: note
+
+   1.x monkey-patched tkinter at import so *every* ttk widget grew ``bootstyle``,
+   even ones built through plain ``tkinter.ttk``. 2.0 patches nothing at import.
+   To opt back into that global behavior, see `The global API (opt-in)`_.
 
 Use ttkbootstrap's widgets
 --------------------------
 
-``ttk.Button``, ``ttk.Entry``, ``ttk.Combobox``, … are real subclasses that carry
-the ``bootstyle`` keyword (via :class:`~ttkbootstrap.BootMixin`). Import
-``ttkbootstrap as ttk`` and build widgets from it:
+Import ``ttkbootstrap as ttk`` and build widgets from it:
 
 .. code-block:: python
 
@@ -87,10 +93,9 @@ there are two escape hatches:
 The global API (opt-in)
 -----------------------
 
-If you are migrating a 1.x app and don't want to reroute every import,
-``enable_global_api()`` restores the old behavior: *vanilla* ``tkinter`` and
-``tkinter.ttk`` widgets accept ``bootstyle``, and everything gains fluent
-geometry. Call it once, before creating widgets:
+``enable_global_api()`` makes *vanilla* ``tkinter`` and ``tkinter.ttk`` widgets
+accept ``bootstyle`` and gain fluent geometry, without subclassing. Call it once,
+before creating widgets:
 
 .. code-block:: python
 

--- a/docs/user-guide/concepts/delivery-model.rst
+++ b/docs/user-guide/concepts/delivery-model.rst
@@ -1,28 +1,106 @@
 How styling is delivered
 ========================
 
-.. note::
+In 1.x, ``import ttkbootstrap`` **monkey-patched tkinter** at import time, so
+every ``ttk`` widget grew a ``bootstyle`` keyword — even widgets you created
+through plain ``tkinter.ttk``. 2.0 stops doing that. The styling API is delivered
+through **concrete widget subclasses** instead, so importing the library mutates
+nothing, and the widgets keep real signatures and docstrings your editor can see.
 
-   This guide is being written for 2.0. It documents the single biggest change
-   from 1.x.
+This changes one thing in practice: to get ``bootstyle``, use ttkbootstrap's
+widget classes rather than ``tkinter.ttk``'s.
 
-In 1.x, ``import ttkbootstrap`` **monkey-patched tkinter** at import time so that
-every ``ttk`` widget grew a ``bootstyle`` keyword. 2.0 stops doing that. The
-styling API is now delivered through concrete subclasses, so widgets keep real
-signatures and docstrings and importing the library mutates nothing.
+Use ttkbootstrap's widgets
+--------------------------
 
-This guide will cover:
+``ttk.Button``, ``ttk.Entry``, ``ttk.Combobox``, … are real subclasses that carry
+the ``bootstyle`` keyword (via :class:`~ttkbootstrap.BootMixin`). Import
+``ttkbootstrap as ttk`` and build widgets from it:
 
-- **Blessed widget subclasses.** ``ttk.Button``, ``ttk.Entry``, … are real
-  subclasses that carry ``bootstyle=`` via
-  :class:`~ttkbootstrap.BootMixin`; the legacy ``tk`` set
-  (``Tk``/``Menu``/``Text``/``Canvas``/``TkFrame``/``TkLabel``/``LabelFrame``)
-  auto-themes via :class:`~ttkbootstrap.AutoStyleMixin`.
-- **Fluent geometry.** ``pack``/``grid``/``place`` return the widget, so
-  ``ttk.Button(root, text="Save").pack()`` is one expression.
-- **Styling widgets you didn't subclass.** ``bootify(cls)`` returns a
-  bootstyle-enabled subclass of any third-party ttk class; ``apply_bootstyle
-  (widget, style)`` styles one already-created vanilla widget.
-- **Opting back into the global API.** ``enable_global_api()`` restores the 1.x
-  behavior so *vanilla* ``tkinter``/``tkinter.ttk`` widgets accept ``bootstyle``
-  and everything gains fluent geometry.
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   ttk.Button(app, text="Save", bootstyle="success").pack()
+   ttk.Entry(app, bootstyle="primary").pack()
+
+   app.mainloop()
+
+That is the whole delivery model for everyday use — the sections below are for the
+edges: legacy ``tk`` widgets, widgets ttkbootstrap doesn't ship, and opting back
+into the old global behavior.
+
+Fluent geometry
+---------------
+
+``pack``, ``grid``, and ``place`` (and their ``*_configure`` spellings) return the
+widget, so you can construct and place in one expression:
+
+.. code-block:: python
+
+   save = ttk.Button(app, text="Save", bootstyle="success").pack(side="left")
+
+``save`` is the button, not ``None`` as it would be with stock tkinter.
+
+Blessed tk widgets
+------------------
+
+A few widgets have no ttk equivalent — the toplevels and the classic ``tk``
+controls. ttkbootstrap ships themed versions that pick up the theme's colors
+automatically (via :class:`~ttkbootstrap.AutoStyleMixin`): ``ttk.Tk``,
+``ttk.Toplevel``, ``ttk.Menu``, ``ttk.Text``, ``ttk.Canvas``, ``ttk.TkFrame``,
+``ttk.TkLabel``, and ``ttk.LabelFrame``. Use them in place of the ``tkinter``
+originals and they theme themselves:
+
+.. code-block:: python
+
+   ttk.Text(app, height=4).pack()   # background/foreground follow the theme
+
+Widgets you didn't subclass
+---------------------------
+
+For a third-party ttk widget, or a plain ``tkinter.ttk`` one you already created,
+there are two escape hatches:
+
+- **A reusable class** — ``bootify(cls)`` returns a ``bootstyle``-enabled subclass
+  of any ttk widget class:
+
+  .. code-block:: python
+
+     from third_party import FancyWidget
+
+     FancyBoot = ttk.bootify(FancyWidget)
+     FancyBoot(app, bootstyle="info").pack()
+
+- **One instance** — ``apply_bootstyle(widget, style)`` styles a single
+  already-created vanilla widget and returns the resolved style name:
+
+  .. code-block:: python
+
+     import tkinter.ttk as tkttk
+
+     legacy = tkttk.Button(app, text="Legacy")
+     ttk.apply_bootstyle(legacy, "primary")
+
+The global API (opt-in)
+-----------------------
+
+If you are migrating a 1.x app and don't want to reroute every import,
+``enable_global_api()`` restores the old behavior: *vanilla* ``tkinter`` and
+``tkinter.ttk`` widgets accept ``bootstyle``, and everything gains fluent
+geometry. Call it once, before creating widgets:
+
+.. code-block:: python
+
+   import tkinter.ttk as tkttk
+   import ttkbootstrap as ttk
+
+   ttk.enable_global_api()
+
+   app = ttk.App()
+   tkttk.Button(app, text="Vanilla", bootstyle="success").pack()
+
+This is opt-in and global — the escape hatch for gradual migration, not the
+recommended default. New code should prefer ttkbootstrap's own widget classes.

--- a/docs/user-guide/concepts/make-your-own-style.rst
+++ b/docs/user-guide/concepts/make-your-own-style.rst
@@ -91,4 +91,4 @@ the ``icon=`` keyword instead of building the image yourself:
 
    Custom styles are registered against the **active** theme and are not rebuilt
    automatically when you switch themes. Re-apply them after a
-   ``theme_use``/``toggle_theme_mode`` if you need them to survive a switch.
+   ``theme_use``/``toggle_theme`` if you need them to survive a switch.

--- a/docs/user-guide/concepts/make-your-own-style.rst
+++ b/docs/user-guide/concepts/make-your-own-style.rst
@@ -2,8 +2,8 @@ Make your own style
 ===================
 
 ``bootstyle`` covers the looks the themes ship. When you need something it can't
-name — a bespoke shape, your own element tree, a one-off tweak — 2.0 gives you a
-public toolkit to build a ttk style yourself and apply it with ``style=``.
+name — a bespoke shape, your own element tree, a one-off tweak — a public toolkit
+lets you build a ttk style yourself and apply it with ``style=``.
 
 Tweak an existing style
 -----------------------

--- a/docs/user-guide/concepts/make-your-own-style.rst
+++ b/docs/user-guide/concepts/make-your-own-style.rst
@@ -109,8 +109,8 @@ the ``icon=`` keyword instead of building the image yourself:
 
    ttk.Button(app, text="Save", icon="save", bootstyle="success").pack()
 
-Keeping a style across theme switches
--------------------------------------
+Creating theme-aware styles
+---------------------------
 
 A custom style is built against the **active** theme, so a theme switch repaints
 the built-in widgets but leaves your style untouched — its colors go stale. Wrap

--- a/docs/user-guide/concepts/make-your-own-style.rst
+++ b/docs/user-guide/concepts/make-your-own-style.rst
@@ -26,6 +26,16 @@ its base class (``my.TButton`` → ``TButton``), so you only set what changes:
 Build a style from scratch
 --------------------------
 
+.. admonition:: Advanced
+   :class: caution
+
+   This is an advanced feature. It works directly with ttk's own element and
+   layout model — element trees, element options, and state specs — which this
+   guide does not teach. The toolkit below makes that model easier to drive, but
+   assumes you're comfortable with how ttk styling works. For the underlying
+   concepts, see the `tkinter.ttk styling
+   <https://docs.python.org/3/library/tkinter.ttk.html#ttk-styling>`__ reference.
+
 For a genuinely new look, compose one from **assets**, **elements**, a **state
 map**, and a **layout**. Each piece is a small toolkit call:
 

--- a/docs/user-guide/concepts/make-your-own-style.rst
+++ b/docs/user-guide/concepts/make-your-own-style.rst
@@ -125,11 +125,18 @@ against the new theme's ``style.colors``:
    def build_pill(style):
        fill = style.colors.primary
        pill = Assets(style).rounded_rect(fill, size=(80, 28), radius=14)
-       image_element(style, "Pill.TButton.background", default=pill, border=14, sticky="nsew")
-       layout(style, "Pill.TButton", El(
-           "Pill.TButton.background", sticky="nsew",
-           children=[El("Button.label", side="left", expand=True)],
-       ))
+       image_element(
+            style,
+            "Pill.TButton.background",
+            default=pill,
+            border=14,
+            sticky="nsew"
+       )
+
+       layout(style, "Pill.TButton",
+            El("Pill.TButton.background", sticky="nsew", children=[
+                El("Button.label", side="left", expand=True)])
+       )
 
 Now ``ttk.Button(app, style="Pill.TButton")`` stays correct through
 ``theme_use`` and ``toggle_theme``. ``theme_aware`` even works at module top

--- a/docs/user-guide/concepts/make-your-own-style.rst
+++ b/docs/user-guide/concepts/make-your-own-style.rst
@@ -60,14 +60,26 @@ map**, and a **layout**. Each piece is a small toolkit call:
 
    pill = assets.rounded_rect(style.colors.primary, size=(80, 28), radius=14)
 
-   image_element(style, "Pill.TButton.background", default=pill, border=14, sticky="nsew")
-   state_map(style, "Pill.TButton", foreground={"disabled": style.colors.border})
-   layout(style, "Pill.TButton", El(
-       "Pill.TButton.background", sticky="nsew",
-       children=[El("Button.label", side="left", expand=True)],
-   ))
+   image_element(
+        style,
+        "Pill.TButton.background",
+        default=pill,
+        border=14,
+        sticky="nsew"
+   )
 
-   ttk.Button(app, text="Go", style="Pill.TButton").pack(padx=20, pady=20)
+   state_map(
+        style,
+        "Pill.TButton",
+        foreground={"disabled": style.colors.border}
+   )
+
+   layout(style, "Pill.TButton",
+            El("Pill.TButton.background", sticky="nsew", children=[
+                El("Button.label", side="left", expand=True)])
+   )
+
+   ttk.Button(app, text="Go", style="Pill.TButton").pack()
 
    app.mainloop()
 
@@ -86,8 +98,9 @@ returns a cached image name you can drop into any ``image=`` option:
 
    from ttkbootstrap import Icon
 
-   ttk.Button(app, text="Save", image=Icon("save", size=16, color="light"),
-              compound="left").pack()
+   save_icon = Icon("save", size=16, color="light")
+
+   ttk.Button(app, text="Save", image=save_icon, compound="left").pack()
 
 For an icon that follows the widget's foreground and state automatically, pass
 the ``icon=`` keyword instead of building the image yourself:

--- a/docs/user-guide/concepts/make-your-own-style.rst
+++ b/docs/user-guide/concepts/make-your-own-style.rst
@@ -109,9 +109,30 @@ the ``icon=`` keyword instead of building the image yourself:
 
    ttk.Button(app, text="Save", icon="save", bootstyle="success").pack()
 
-.. admonition:: Theme switches
-   :class: note
+Keeping a style across theme switches
+-------------------------------------
 
-   Custom styles are registered against the **active** theme and are not rebuilt
-   automatically when you switch themes. Re-apply them after a
-   ``theme_use``/``toggle_theme`` if you need them to survive a switch.
+A custom style is built against the **active** theme, so a theme switch repaints
+the built-in widgets but leaves your style untouched — its colors go stale. Wrap
+the build in ``@theme_aware`` and it re-runs after every switch, rebuilding
+against the new theme's ``style.colors``:
+
+.. code-block:: python
+
+   from ttkbootstrap import theme_aware
+
+   @theme_aware        # runs once now, and again after every theme change
+   def build_pill(style):
+       fill = style.colors.primary
+       pill = Assets(style).rounded_rect(fill, size=(80, 28), radius=14)
+       image_element(style, "Pill.TButton.background", default=pill, border=14, sticky="nsew")
+       layout(style, "Pill.TButton", El(
+           "Pill.TButton.background", sticky="nsew",
+           children=[El("Button.label", side="left", expand=True)],
+       ))
+
+Now ``ttk.Button(app, style="Pill.TButton")`` stays correct through
+``theme_use`` and ``toggle_theme``. ``theme_aware`` even works at module top
+level, before the app exists — the build is queued and runs when the app is
+created. Use ``on_theme_change(fn)`` for the plain-function form, and
+``remove_theme_change_callback(fn)`` to unregister.

--- a/docs/user-guide/concepts/make-your-own-style.rst
+++ b/docs/user-guide/concepts/make-your-own-style.rst
@@ -1,12 +1,94 @@
 Make your own style
 ===================
 
-.. note::
+``bootstyle`` covers the looks the themes ship. When you need something it can't
+name — a bespoke shape, your own element tree, a one-off tweak — 2.0 gives you a
+public toolkit to build a ttk style yourself and apply it with ``style=``.
 
-   This guide is being written for 2.0.
+Tweak an existing style
+-----------------------
 
-The biggest new capability in 2.0 is a public toolkit for building custom ttk
-styles. This guide will cover the toolkit surface — ``Assets`` (image recipes
-and the icon font engine), ``El``/``layout`` for composing element trees,
-``register_style``, and the ``statespec``/``state_map`` state helpers — with
-worked examples.
+The simplest custom style is a named variant of a base one. ``style.configure``
+a dotted name, then hand it to a widget with ``style=``; the name inherits from
+its base class (``my.TButton`` → ``TButton``), so you only set what changes:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   app.style.configure("big.TButton", font=("Helvetica", 16), padding=12)
+   ttk.Button(app, text="Big", style="big.TButton").pack()
+
+   app.mainloop()
+
+Build a style from scratch
+--------------------------
+
+For a genuinely new look, compose one from **assets**, **elements**, a **state
+map**, and a **layout**. Each piece is a small toolkit call:
+
+- :class:`~ttkbootstrap.Assets` renders cached images from recipes
+  (``circle``, ``rounded_rect``, ``rect``, ``icon``) or an ``image`` draw
+  callback. Sizes are logical UI units — DPI scaling is handled for you.
+- ``image_element`` turns an image into a named ttk element (optionally
+  state-keyed).
+- ``state_map`` is a validated ``style.map`` — a typo in a state string raises
+  instead of silently doing nothing.
+- ``layout`` arranges elements into the widget's element tree with ``El`` nodes,
+  and registers the style for you.
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap import Assets, El, layout, image_element, state_map
+
+   app = ttk.App()
+   style = app.style
+   assets = Assets(style)
+
+   pill = assets.rounded_rect(style.colors.primary, size=(80, 28), radius=14)
+
+   image_element(style, "Pill.TButton.background", default=pill, border=14, sticky="nsew")
+   state_map(style, "Pill.TButton", foreground={"disabled": style.colors.border})
+   layout(style, "Pill.TButton", El(
+       "Pill.TButton.background", sticky="nsew",
+       children=[El("Button.label", side="left", expand=True)],
+   ))
+
+   ttk.Button(app, text="Go", style="Pill.TButton").pack(padx=20, pady=20)
+
+   app.mainloop()
+
+Because ``layout`` registers the name, ``style="Pill.TButton"`` resolves to what
+you built. If you configure a style but never call ``layout`` on it, register it
+yourself with ``register_style`` so ttkbootstrap doesn't re-resolve the name back
+to the base.
+
+Icons
+-----
+
+The same asset pipeline renders Bootstrap Icons glyphs. :class:`~ttkbootstrap.Icon`
+returns a cached image name you can drop into any ``image=`` option:
+
+.. code-block:: python
+
+   from ttkbootstrap import Icon
+
+   ttk.Button(app, text="Save", image=Icon("save", size=16, color="light"),
+              compound="left").pack()
+
+For an icon that follows the widget's foreground and state automatically, pass
+the ``icon=`` keyword instead of building the image yourself:
+
+.. code-block:: python
+
+   ttk.Button(app, text="Save", icon="save", bootstyle="success").pack()
+
+.. admonition:: Theme switches
+   :class: note
+
+   Custom styles are registered against the **active** theme and are not rebuilt
+   automatically when you switch themes. Re-apply them after a
+   ``theme_use``/``toggle_theme_mode`` if you need them to survive a switch.

--- a/docs/user-guide/concepts/make-your-own-theme.rst
+++ b/docs/user-guide/concepts/make-your-own-theme.rst
@@ -1,9 +1,61 @@
 Make your own theme
 ===================
 
-.. note::
+A theme is a handful of **semantic anchors** — the accent colors and a neutral
+gray — plus a light and/or dark surface. Declare those, and ttkbootstrap derives
+the full color set (borders, inputs, selections, hovers) for each mode.
 
-   This guide is being written for 2.0.
+Defining a theme
+----------------
 
-Define a theme from semantic colors with the ``Theme`` API, or build one
-visually with the ttkcreator editor. This guide will walk through both.
+Build a :class:`~ttkbootstrap.Theme` from its anchors and register it. The five
+accents are the mid-tone of each color; ``light``/``dark`` each give a background
+and foreground. Registration needs a running app (a style must exist first):
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   ttk.Theme(
+       name="pulse",
+       primary="#593196", success="#13b955", info="#009cdc",
+       warning="#efa31d", danger="#fc3939",
+       light=dict(background="#ffffff", foreground="#17141f"),
+       dark=dict(background="#17141f", foreground="#e9ecef"),
+   ).register()
+
+   app.style.theme_use("pulse-light")   # registered as pulse-light and pulse-dark
+   app.mainloop()
+
+Registering a theme generates a ``<name>-light`` and ``<name>-dark`` variant for
+whichever surfaces you declared, so it drops straight into
+:doc:`light/dark switching <theming>` — ``app.toggle_theme_mode()`` flips
+``pulse-light`` ↔ ``pulse-dark``.
+
+Re-branding a built-in
+----------------------
+
+To change just a color or two on an existing theme, derive from it with
+``Theme.from_existing`` and override the anchors you care about:
+
+.. code-block:: python
+
+   from ttkbootstrap.themes.builtin import BOOTSTRAP
+
+   ttk.Theme.from_existing(BOOTSTRAP, name="brand", primary="#ff6600").register()
+   app.style.theme_use("brand-light")
+
+The visual editor
+-----------------
+
+To design a theme interactively rather than by hand, run the bundled editor:
+
+.. code-block:: bash
+
+   python -m ttkcreator
+
+Edit the accent anchors and the light/dark surfaces, preview against live
+widgets, and save. Saved themes persist as anchor specs and are registered
+automatically the next time you create an app.

--- a/docs/user-guide/concepts/make-your-own-theme.rst
+++ b/docs/user-guide/concepts/make-your-own-theme.rst
@@ -26,12 +26,12 @@ and foreground. Registration needs a running app (a style must exist first):
        dark=dict(background="#17141f", foreground="#e9ecef"),
    ).register()
 
-   app.style.theme_use("pulse-light")   # registered as pulse-light and pulse-dark
+   app.theme_use("pulse-light")   # registered as pulse-light and pulse-dark
    app.mainloop()
 
 Registering a theme generates a ``<name>-light`` and ``<name>-dark`` variant for
 whichever surfaces you declared, so it drops straight into
-:doc:`light/dark switching <theming>` — ``app.toggle_theme_mode()`` flips
+:doc:`light/dark switching <theming>` — ``app.toggle_theme()`` flips
 ``pulse-light`` ↔ ``pulse-dark``.
 
 Re-branding a built-in
@@ -45,7 +45,7 @@ To change just a color or two on an existing theme, derive from it with
    from ttkbootstrap.themes.builtin import BOOTSTRAP
 
    ttk.Theme.from_existing(BOOTSTRAP, name="brand", primary="#ff6600").register()
-   app.style.theme_use("brand-light")
+   app.theme_use("brand-light")
 
 The visual editor
 -----------------

--- a/docs/user-guide/concepts/make-your-own-theme.rst
+++ b/docs/user-guide/concepts/make-your-own-theme.rst
@@ -57,5 +57,6 @@ To design a theme interactively rather than by hand, run the bundled editor:
    python -m ttkcreator
 
 Edit the accent anchors and the light/dark surfaces, preview against live
-widgets, and save. Saved themes persist as anchor specs and are registered
-automatically the next time you create an app.
+widgets, then **Export theme (.py)** -- you get a ``Theme(...).register()``
+snippet (the same shape as above) to drop into your app. The editor doesn't
+save into the library; your theme lives in your own code.

--- a/docs/user-guide/concepts/theming.rst
+++ b/docs/user-guide/concepts/theming.rst
@@ -30,14 +30,13 @@ Pass ``theme=`` to the app. The default is ``bootstrap-light``:
 Switching at runtime
 --------------------
 
-Switch themes on a live app through the style engine — every mounted widget
-repaints:
+Switch themes on a live app — every mounted widget repaints:
 
 .. code-block:: python
 
-   app.style.theme_use("solarized-dark")   # switch
-   app.style.theme_use()                    # -> the current theme name
-   app.style.theme_names()                  # -> every registered theme name
+   app.theme_use("solarized-dark")   # switch
+   app.theme_use()                   # -> the current theme name
+   app.theme_names()                 # -> every registered theme name
 
 Light and dark
 --------------
@@ -49,8 +48,8 @@ counterpart:
 .. code-block:: python
 
    app.theme_mode          # "light" or "dark"
-   app.toggle_theme_mode() # light <-> dark within the family, returns the new mode
-   app.use_theme_mode("dark")
+   app.toggle_theme()      # flip light <-> dark within the family, returns the new mode
+   app.theme_mode = "dark" # or switch explicitly
 
 A toggle button is the common case:
 
@@ -61,7 +60,7 @@ A toggle button is the common case:
    app = ttk.App(theme="nord-light")
 
    ttk.Button(app, text="Toggle theme",
-              command=app.toggle_theme_mode, bootstyle="primary").pack()
+              command=app.toggle_theme, bootstyle="primary").pack()
 
    app.mainloop()
 
@@ -76,7 +75,7 @@ ttkbootstrap ships **15 theme families** — ``bootstrap``, ``pydata``, ``nord``
 ``solarized``, ``catppuccin``, ``gruvbox``, ``dracula``, ``tokyo-night``, ``one``,
 ``everforest``, ``vapor``, ``minty``, ``pulse``, ``united``, ``sandstone`` — each
 with a light and dark variant, for **30 built-in themes**. List them live with
-``app.style.theme_names()``.
+``app.theme_names()``.
 
 .. admonition:: Coming from 1.x
    :class: note

--- a/docs/user-guide/concepts/theming.rst
+++ b/docs/user-guide/concepts/theming.rst
@@ -1,13 +1,95 @@
 Theming
 =======
 
+A **theme** decides what every ``bootstyle`` color actually renders as. Each
+theme is built from a small set of **semantic anchors** — the accent colors
+(``primary``, ``success``, ``info``, ``warning``, ``danger``) plus a neutral gray
+— resolved against a light or dark surface. Pick a theme and the whole interface,
+including your ``bootstyle`` widgets, recolors coherently.
+
+Choosing a theme
+----------------
+
+Pass ``theme=`` to the app. The default is ``bootstrap-light``:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(theme="nord-light")
+
+   ttk.Button(app, text="Primary", bootstyle="primary").pack()
+
+   app.mainloop()
+
 .. note::
 
-   This guide is being written for 2.0. It will fold in the theme material
-   staged in ``development/2_0_theme_migration.md`` and render the 30 built-in
-   themes as a two-column light/dark gallery.
+   ``themename=`` is an accepted alias for ``theme=`` (the pre-2.0 spelling); use
+   whichever you prefer.
 
-ttkbootstrap themes are built from a small set of **semantic anchors** — the
-same nine ``bootstyle`` colors — resolved against a light or dark surface. This
-guide will cover the ``Theme`` model, the built-in catalog, and switching
-themes at runtime.
+Switching at runtime
+--------------------
+
+Switch themes on a live app through the style engine — every mounted widget
+repaints:
+
+.. code-block:: python
+
+   app.style.theme_use("solarized-dark")   # switch
+   app.style.theme_use()                    # -> the current theme name
+   app.style.theme_names()                  # -> every registered theme name
+
+Light and dark
+--------------
+
+Built-in themes come in ``<family>-light`` / ``<family>-dark`` pairs, so a family
+has a matched light and dark surface. Flip between them without naming the
+counterpart:
+
+.. code-block:: python
+
+   app.theme_mode          # "light" or "dark"
+   app.toggle_theme_mode() # light <-> dark within the family, returns the new mode
+   app.use_theme_mode("dark")
+
+A toggle button is the common case:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(theme="nord-light")
+
+   ttk.Button(app, text="Toggle theme",
+              command=app.toggle_theme_mode, bootstyle="primary").pack()
+
+   app.mainloop()
+
+To pair themes from different families (say a light theme with an unrelated dark
+one), set the pair explicitly with ``app.set_theme_modes(light=..., dark=...)`` or
+``App(light_theme=..., dark_theme=...)``.
+
+The built-in catalog
+--------------------
+
+ttkbootstrap ships **15 theme families** — ``bootstrap``, ``pydata``, ``nord``,
+``solarized``, ``catppuccin``, ``gruvbox``, ``dracula``, ``tokyo-night``, ``one``,
+``everforest``, ``vapor``, ``minty``, ``pulse``, ``united``, ``sandstone`` — each
+with a light and dark variant, for **30 built-in themes**. List them live with
+``app.style.theme_names()``.
+
+.. admonition:: Coming from 1.x
+   :class: note
+
+   The pre-2.0 Bootswatch theme names (``"darkly"``, ``"cosmo"``, …) are no longer
+   registered by default. Call :func:`~ttkbootstrap.install_legacy_themes` to
+   register them all (it warns, and they are removed in 3.0), or just name one —
+   ``App(themename="darkly")`` lazily registers that single theme with a warning.
+
+The Theme model
+---------------
+
+Each theme is a semantic-anchor :class:`~ttkbootstrap.Theme` — a family described
+by its accent anchors and its light/dark surfaces, from which ttkbootstrap
+derives the full color set for each mode. To build your own, see
+:doc:`Make your own theme <make-your-own-theme>`.

--- a/docs/user-guide/concepts/working-with-color.rst
+++ b/docs/user-guide/concepts/working-with-color.rst
@@ -1,10 +1,77 @@
 Working with color
 ===================
 
-.. note::
+The active theme resolves its palette to concrete hex values, and exposes them
+through ``app.style.colors``. Read those colors whenever you draw your own
+content — a ``Canvas``, a custom style, a chart — so it tracks the theme instead
+of hard-coding hex.
 
-   This guide is being written for 2.0.
+Reading semantic colors
+-----------------------
 
-The active theme exposes its resolved colors through ``style.colors``. This
-guide will cover reading semantic colors and addressing the 50–950 ramps
-(``c.primary[300]``) for your own drawing and custom styles.
+``style.colors`` gives attribute access to the theme's colors: the accents
+(``primary``, ``secondary``, ``success``, ``info``, ``warning``, ``danger``,
+``light``, ``dark``) and the interface roles (``bg``, ``fg``, ``selectbg``,
+``selectfg``, ``border``, ``inputbg``, ``inputfg``, ``active``):
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+   c = app.style.colors
+
+   canvas = ttk.Canvas(app, width=200, height=80, highlightthickness=0)
+   canvas.create_rectangle(10, 10, 190, 70, fill=c.success, outline=c.border)
+   canvas.pack()
+
+   app.mainloop()
+
+Each value is an ordinary hex string, so it drops into any tkinter color option.
+``c.get(name)`` looks a color up by name and returns ``None`` if it isn't one —
+handy when the name is dynamic.
+
+Color ramps
+-----------
+
+Every color is also a **ramp**: index it with a stop from ``50`` (lightest) to
+``950`` (darkest) to get a tint or shade, with the color itself as the ``500``
+anchor. This is how you get an on-theme lighter or darker variant without color
+math:
+
+.. code-block:: python
+
+   c.primary            # the theme's primary accent (also c.primary[500])
+   c.primary[300]       # a lighter tint
+   c.primary[700]       # a darker shade
+   c.ramp("primary")    # the whole 50–950 ramp as a mapping
+
+Because a ramp color is just a string, ``c.primary`` still behaves exactly like
+its hex value everywhere else.
+
+Deriving colors
+---------------
+
+For adjustments the ramp doesn't cover, the color utilities are exported at the
+top level:
+
+.. code-block:: python
+
+   from ttkbootstrap import contrast_color, update_hsl_value, color_to_rgb
+
+   contrast_color(c.primary, model="hex")          # "#000"/"#fff" — readable text over a fill
+   update_hsl_value(c.primary, lum=70, inmodel="hex", outmodel="hex")  # lighten
+   color_to_rgb(c.primary, "hex")                  # the primary as an (r, g, b) tuple
+
+To simulate a translucent fill over a known background, blend it with
+``make_transparent``:
+
+.. code-block:: python
+
+   c.make_transparent(0.2, c.primary, c.bg)   # 20% primary over the window bg
+
+.. admonition:: Coming from 1.x
+   :class: note
+
+   The color helpers moved to ``ttkbootstrap.utils`` (and the top level). The old
+   ``ttkbootstrap.colorutils`` import still works but warns and is removed in 3.0.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -59,7 +59,7 @@ any order.
       :link: concepts/delivery-model
       :link-type: doc
 
-      Why 2.0 stopped monkey-patching tkinter — the blessed subclasses,
+      How the ``bootstyle`` API reaches your widgets — the blessed subclasses,
       ``enable_global_api``, ``bootify``, and ``apply_bootstyle``.
 
    .. grid-item-card:: Theming
@@ -89,8 +89,8 @@ any order.
 Feature guides
 --------------
 
-Each 2.0 subsystem, end to end — the utilities that work on plain tkinter, not
-just ttkbootstrap widgets.
+Each subsystem, end to end — the utilities that work on plain tkinter, not just
+ttkbootstrap widgets.
 
 .. grid:: 1 2 2 2
    :gutter: 3

--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -39,7 +39,7 @@ without hard-coding a color.
 Variants
 --------
 
-Combine a color with a modifier to change visual weight — ``outline``, ``link``,
+Combine a color with a variant to change visual weight — ``outline``, ``link``,
 or ``ghost``:
 
 .. code-block:: python

--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -54,7 +54,16 @@ Colors
 
 The nine semantic colors — ``primary``, ``secondary``, ``success``, ``info``,
 ``warning``, ``danger``, ``light``, ``dark``, and ``neutral`` — combine with any
-variant. A bare ``Button`` with no ``bootstyle`` uses the ``neutral`` default.
+variant. A bare ``Button`` with no ``bootstyle`` uses the ``neutral`` default (as
+does ``Menubutton``). To restore the pre-2.0 accented default, set it **before**
+the app is created — the setting is consumed when a button's style is first
+built:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(default_button="primary")   # or ttk.set_default_button("primary")
 
 States
 ------


### PR DESCRIPTION
Authors the full **Concepts band** of the 2.0 User Guide — the styling core — teach-first, with every code example run against a live root and the whole site building clean under `-W`.

## Pages
- **The bootstyle grammar** (flagship) — the slot grammar, worked build-up examples, `bootstyle`→ttk-style-name resolution, loud-failure/strict mode, and the generated reference table.
- **How styling is delivered** — concrete subclasses, fluent geometry, blessed tk widgets, `bootify`/`apply_bootstyle`, the opt-in global API.
- **Theming** — choose/switch themes, the light/dark `toggle_theme`, the 30-theme catalog.
- **Working with color** — `style.colors`, the 50–950 ramps, `colorutils` derivations.
- **Make your own style** — the `configure` path, the `Assets`/element/`layout` toolkit (flagged **Advanced** with a `tkinter.ttk` cross-reference), icons, and a **`@theme_aware`** recipe for styles that survive theme switches.
- **Make your own theme** — the `Theme` anchor model, `from_existing`, `ttkcreator`.

## Conventions established (applied throughout)
- **"variant"** (not "modifier") for the bootstyle slot.
- **Teach-first**: describe how 2.0 works; 1.x comparisons live only in **"Coming from 1.x"** admonitions and the Migrating page (no "new in 2.0" framing in body prose).
- One runnable example per page + focused fragments; **no geometry noise**.
- Features that drop into ttk internals get an **Advanced** admonition + a ttk cross-reference.

## Notes
- Reflects the consolidated theme API (`app.theme_use`/`theme_mode`/`toggle_theme`) from #1162 and the `@theme_aware` hook from #1163 — both merged to `2.0` and merged in here.
- Also: dropped the "Section Navigation" sidebar heading and added the favicon + navbar wordmark logo (earlier in the branch).
- Builds clean under `sphinx -W` (48 pages, zero warnings).

Remaining User Guide bands (Getting Started, Feature guides, How-To) are a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)