### PR TITLE
docs: Foundations band + tkinter event reference and images how-to

### DIFF
--- a/development/2_0_docs_design.md
+++ b/development/2_0_docs_design.md
@@ -411,7 +411,54 @@ Churn is asymmetric, so mitigate by page type:
 Track the pending API-normalization pass as its own future workstream (not H);
 when it lands, re-sweep the catalog/How-To examples for those widgets.
 
-## 12. Open / deferred
+## 12. "tkinter essentials" reference/guide strand (added 2026-07-11)
+
+Filling the *modern-tkinter-docs* gap (§1) is a first-class goal, and much of Tk's
+own material lives only in C-oriented man pages. This strand restates that material
+in Python terms — **ttkbootstrap-flavored, always linking out** to python.org /
+Tk for exhaustive detail (a welcoming reference, NOT a tkinter fork). The split,
+locked with the author, mirrors Diátaxis:
+
+- **Reference = the names / catalog** (tables of tokens, attributes, options).
+- **Guide = the usage** (how to bind, generate, keep a reference, etc.).
+
+**Landed (uncommitted):** the **Event reference** (`reference/events/`: index +
+event-types, modifiers-and-keys, event-object, event-generate-options,
+virtual-events) + the expanded **Events & callbacks** guide
+(`foundations/events-and-callbacks.rst`) + the **Working with images** How-To.
+
+**Roadmap (author-requested; recommended order winfo → cursors → usage guides):**
+
+| Topic | Home | Notes |
+|---|---|---|
+| `winfo_*` widget & screen info | **Reference** (new table page) | Highest-value next; undocumented-in-friendly-form |
+| Cursors + `bell`/`busy` | cursor-names **Reference** table; feedback **guide** | Cursor list is another "exists nowhere" table |
+| Focus, modality & lifecycle (`focus`/`grab`/`lift`/`lower`/`destroy`/`WM_DELETE_WINDOW`) | **Guide** — extend *Windows, icons & DPI* | Mostly usage |
+| Clipboard & selection (`clipboard_*`/`selection_*`) | **How-To** | Small recipe |
+| Error handling (`report_callback_exception`, `TclError`) | **How-To** | Pairs with the threading recipe; documents the swallowed-exception gotcha |
+| `bindtags` | **Done** (events guide) | Ref stub optional |
+
+### 12a. Image handling decision (2026-07-11)
+
+- **`ttk.PhotoImage` stays `tkinter.PhotoImage`.** Re-pointing it to
+  `ImageTk.PhotoImage` was considered and **rejected**: empirically not a drop-in
+  — base64 `data=` raises `UnidentifiedImageError`, it is not a subclass (breaks
+  `isinstance`), it drops ~18 methods (`put`/`get`/`zoom`/`subsample`/`copy`/
+  `configure`/`cget`/…), and it does **not** fix GC anyway (it wraps a
+  `tk.PhotoImage` whose `__del__` frees it; the Python wrapper must still be held).
+- **Docs approach (now):** the *Working with images* How-To documents the GC
+  keep-a-reference gotcha (applies to both classes) and **recommends Pillow**
+  (`ImageTk.PhotoImage`) for real image work — the "use the PIL version" guidance
+  delivered as a recommendation, not a class swap.
+- **2.1 candidate (design pass required):** a bootstack-style **`Image` handle**
+  (`D:/Development/bootstack/src/bootstack/images.py`) — a PIL-based handle that
+  owns its `PhotoImage`; the blessed widgets keep the handle, so GC-safety is
+  structural (widget → handle → photo). A NEW, distinctly named export (not a
+  reused `PhotoImage`); must NOT duplicate the font-glyph `Icon`/`icon_element`/
+  `apply_icon` engine. Auto-ref-keeping needs our widget classes to own `image=`,
+  so it brushes the utilities-not-widgets boundary — a conscious call, deferred.
+
+## 13. Open / deferred
 
 - Style Reference: one page per widget family vs. one big generated table (lean:
   per-family, browsable).

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,6 +3,82 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
+_Last updated: 2026-07-11 (**Docs Workstream H — Foundations band + a NEW
+"tkinter essentials" reference/guide strand (events + images). ALL UNCOMMITTED on
+the working tree — no branch cut yet.**
+**What was authored this session (all `-W` clean, every code example verified
+headlessly against a live root):**
+**(1) Foundations band** (design §3, five-band IA) — three User Guide pages under
+`docs/user-guide/foundations/`: *Arranging widgets* (pack/grid/place + fluent
+geometry; per-section python.org links to `#tkinter.Pack`/`Grid`/`Place` — the
+geometry-manager mixin classes; caught 2 broken anchors I'd first guessed), *State
+& variables* (StringVar/IntVar/BooleanVar + textvariable binding + `trace_add`/
+`trace_remove` cleanup + `LocaleVar`; fixed a copy-paste crash — `LocaleVar`'s 1st
+positional is `master`, so `ttk.LocaleVar(app, "Hello")`), *Events & callbacks*
+(see below). Wired into `user-guide/index.rst` (cards + toctree).
+**(2) Event reference — a NEW Reference sub-area** `docs/reference/events/` (index +
+`event-types` + `modifiers-and-keys` + `event-object` + `event-generate-options` +
+`virtual-events`). This restates Tk's `bind`/`event` man-page material (which only
+exists in C-oriented Tk docs) in Python terms — the first slice of a broader
+**"tkinter essentials" strand** filling the modern-tkinter-docs gap (design §1).
+Added as a 3rd card in `reference/index.rst`. Content is ground-truthed:
+`event_info()` for the virtual-event catalog, `tk.Misc._substitute` for the exact
+Event-attribute↔Tk-field map (documented the fields tkinter OMITS — `%d`/user_data
+et al.), empirical checks for `event.type` (EventType enum), `'??'` placeholders,
+and `return "break"`.
+**(3) Events & callbacks guide** (`foundations/events-and-callbacks.rst`) — the
+USAGE, expanded well past the on-ramp: `command`/`bind`, **Binding scope**
+(instance/class/toplevel/all, `winfo_class`, **bindtags** with real output, and
+**`add="+"` vs replace** — the footgun, with `unbind`), **Stopping an event**
+(`return "break"`), Virtual events, and a prominent **Generating events** section
+(`event_generate` incl. your own virtual events + `event_add` key aliases). Every
+non-obvious claim was verified: `event_generate` does NOT broadcast (a child
+doesn't hear an app-level generate → bind consumers on the same widget/root or use
+`bind_all`), a 2nd `bind` replaces without `add="+"`, and `data=` is NOT readable
+on the Python event.
+**(4) Working with images How-To** `docs/user-guide/how-to/working-with-images.rst`
+— headline is the **GC "image vanishes" gotcha** (keep a ref: `label.image =
+photo`), which class to use (`ttk.PhotoImage` = GIF/PNG/base64 vs Pillow
+`ImageTk.PhotoImage` = all formats + resize), `compound=`, base64 embed, and a
+cross-ref to `apply_icon`/the glyph engine for themed icons. Wired into
+`how-to/index.rst`.
+**DECISIONS locked with the author this session:**
+- **Reference = the NAMES/catalog; Guide = the USAGE** (Diátaxis split, author
+  call). And the events USAGE lives in the **expanded Foundations page** (author
+  call via AskUserQuestion), not a separate How-To.
+- **`ttk.PhotoImage` STAYS `tkinter.PhotoImage`** — do NOT re-point it to
+  `ImageTk.PhotoImage`. Empirically it is NOT a drop-in: base64 `data=` raises
+  `UnidentifiedImageError`, it is not a subclass (breaks `isinstance`), it drops
+  ~18 methods (`put`/`get`/`zoom`/`subsample`/`copy`/`configure`/`cget`/…), and it
+  does NOT fix GC anyway (it wraps a `tk.PhotoImage` and its `__del__` frees it, so
+  the Python wrapper must still be held). So: keep the class, document GC, and
+  *recommend* Pillow in the docs. See [[image-photoimage-decision]].
+- **2.1 candidate (needs a design pass):** a bootstack-style **`Image` handle**
+  (`bootstack/images.py` model — a PIL-based handle that owns its `PhotoImage`;
+  blessed widgets keep the handle → GC-safe by construction). A NEW, distinctly
+  named export (NOT a reused `PhotoImage`); do NOT duplicate the existing font-glyph
+  `Icon`/`icon_element`/`apply_icon` engine. Brushes [[boundary-utilities-not-widgets]]
+  (auto-ref needs our widget classes to own `image=`), so a conscious call, not now.
+**NEXT (author-requested "document the rest so it's not lost") — the "tkinter
+essentials" roadmap** (each ttkbootstrap-flavored, link-out for exhaustive detail;
+Reference=names, Guide=usage), recorded in design doc §12 + [[project-tkinter-essentials-docs]]:
+  - **Widget & screen info (`winfo_*`)** → Reference (new table page). *Highest-value
+    next* — another "exists nowhere readable" table.
+  - **Cursors & feedback** — cursor-names table → Reference; `bell`/`busy` → guide.
+  - **Focus, modality & lifecycle** — `focus`/`grab`/`lift`/`lower`/`destroy`/
+    `WM_DELETE_WINDOW` → extend the Windows feature guide.
+  - **Clipboard & selection** (`clipboard_*`/`selection_*`) → How-To.
+  - **Error handling** (`report_callback_exception`, `TclError`) → How-To.
+  Recommended order: winfo → cursors → the usage guides.
+**Build/verify:** `sphinx -b html -W --keep-going` → **zero warnings** (~31 pages).
+All examples run headlessly (`PYTHONPATH=src`, `.update()`/`.destroy()` for the
+mainloop demos). **NOTHING committed** — cut e.g. `docs/2.0-foundations-and-events`
+off `2.0` when ready; PR + this handoff. **Env:** docsenv lives at scratchpad
+`dd055ae5-…/docsenv` (build with `PYTHONPATH=src <docsenv>/Scripts/python.exe -m
+sphinx …`); repo `.venv` exits 127 → suite via `PYTHONPATH=src python -m pytest`.
+User WIP `gallery/collapsing_frame.py` + the dialog WIP LEFT UNTOUCHED. Prior entry
+follows.**)_
+
 _Last updated: 2026-07-11 (**Docs Workstream H — Concepts band authored + a
 cluster of API refinements the docs surfaced. FIVE PRs MERGED into `2.0` this
 session (all clean, high-effort `/code-review` on the code PRs):**

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -4,8 +4,8 @@
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
 _Last updated: 2026-07-11 (**Docs Workstream H — Foundations band + a NEW
-"tkinter essentials" reference/guide strand (events + images). ALL UNCOMMITTED on
-the working tree — no branch cut yet.**
+"tkinter essentials" reference/guide strand (events + images). OPEN as PR #1166
+against `2.0` (branch `docs/2.0-foundations-and-events`); docs-only, `-W` clean.**
 **What was authored this session (all `-W` clean, every code example verified
 headlessly against a live root):**
 **(1) Foundations band** (design §3, five-band IA) — three User Guide pages under
@@ -72,8 +72,10 @@ Reference=names, Guide=usage), recorded in design doc §12 + [[project-tkinter-e
   Recommended order: winfo → cursors → the usage guides.
 **Build/verify:** `sphinx -b html -W --keep-going` → **zero warnings** (~31 pages).
 All examples run headlessly (`PYTHONPATH=src`, `.update()`/`.destroy()` for the
-mainloop demos). **NOTHING committed** — cut e.g. `docs/2.0-foundations-and-events`
-off `2.0` when ready; PR + this handoff. **Env:** docsenv lives at scratchpad
+mainloop demos). **Committed + PR #1166** open against `2.0`
+(`docs/2.0-foundations-and-events`). **NEXT SESSION: start the `winfo_*` widget/
+screen-info Reference table** (design §12 roadmap — highest-value next), then
+cursors. **Env:** docsenv lives at scratchpad
 `dd055ae5-…/docsenv` (build with `PYTHONPATH=src <docsenv>/Scripts/python.exe -m
 sphinx …`); repo `.venv` exits 127 → suite via `PYTHONPATH=src python -m pytest`.
 User WIP `gallery/collapsing_frame.py` + the dialog WIP LEFT UNTOUCHED. Prior entry

--- a/docs/reference/events/event-generate-options.rst
+++ b/docs/reference/events/event-generate-options.rst
@@ -1,0 +1,85 @@
+event_generate options
+=======================
+
+``widget.event_generate(sequence, **options)`` synthesizes an event and
+dispatches it to ``widget``. The options fill in the fields the event would
+normally carry; each mirrors a Tk ``-option`` with the **leading dash dropped**
+(Tk ``-rootx`` → ``rootx=``). See
+:doc:`Events & callbacks </user-guide/foundations/events-and-callbacks>` for how
+to use it.
+
+.. code-block:: python
+
+   widget.event_generate("<Button-1>", x=10, y=20, when="now")
+   widget.event_generate("<<DataLoaded>>")
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 34 46
+
+   * - Keyword
+     - Applies to
+     - Sets
+   * - ``x``, ``y``
+     - pointer & key events
+     - Position relative to the target widget.
+   * - ``rootx``, ``rooty``
+     - pointer & key events
+     - Position relative to the screen.
+   * - ``button``
+     - Button events
+     - The button number.
+   * - ``keysym``
+     - key events
+     - The :doc:`key symbol <modifiers-and-keys>` (overrides the detail).
+   * - ``keycode``
+     - key events
+     - The hardware key code.
+   * - ``delta``
+     - MouseWheel
+     - The wheel rotation amount.
+   * - ``state``
+     - pointer, key events
+     - The modifier/button bitmask.
+   * - ``width``, ``height``
+     - Configure
+     - The reported size.
+   * - ``warp``
+     - pointer & key events
+     - If true, actually move the mouse pointer to the given position.
+   * - ``data``
+     - virtual events
+     - User data. Accepted, but **not** readable on tkinter's event object —
+       see :doc:`The event object <event-object>`.
+   * - ``when``
+     - all
+     - When the event is processed (see below).
+
+``when``
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 84
+
+   * - Value
+     - Effect
+   * - ``now``
+     - Process immediately, before ``event_generate`` returns (the default).
+   * - ``tail``
+     - Queue behind the events already waiting.
+   * - ``head``
+     - Queue ahead of all waiting events.
+   * - ``mark``
+     - Queue ahead of normal events but behind earlier ``mark`` events —
+       preserves order across a burst of generated events.
+
+.. note::
+
+   The full Tk option set (``-above``, ``-borderwidth``, ``-count``,
+   ``-detail``, ``-focus``, ``-mode``, ``-override``, ``-place``, ``-root``,
+   ``-sendevent``, ``-serial``, ``-subwindow``, ``-time``) is also accepted with
+   the dash dropped, for filling in fields of the more specialized event types.

--- a/docs/reference/events/event-object.rst
+++ b/docs/reference/events/event-object.rst
@@ -1,0 +1,117 @@
+The event object
+================
+
+A callback bound with ``bind`` receives one argument: an ``event`` object whose
+attributes describe what happened. tkinter fills these from the underlying Tk
+event; **an attribute that does not apply to the event type holds the string
+``"??"``** (or a meaningless value), so read only the ones relevant to the event
+you bound.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 44 24
+
+   * - Attribute
+     - Tk field
+     - Meaning
+     - Populated for
+   * - ``widget``
+     - ``%W``
+     - The widget instance the event fired on.
+     - all events
+   * - ``x``, ``y``
+     - ``%x`` ``%y``
+     - Pointer position relative to the widget's top-left.
+     - pointer & key events
+   * - ``x_root``, ``y_root``
+     - ``%X`` ``%Y``
+     - Pointer position relative to the whole screen.
+     - pointer & key events
+   * - ``num``
+     - ``%b``
+     - Button number (1–5).
+     - Button events
+   * - ``delta``
+     - ``%D``
+     - Wheel rotation amount and direction.
+     - MouseWheel
+   * - ``char``
+     - ``%A``
+     - The character produced (``""`` for non-printing keys).
+     - key events
+   * - ``keysym``
+     - ``%K``
+     - The :doc:`key symbol <modifiers-and-keys>` name (``"Left"``, ``"a"``).
+     - key events
+   * - ``keysym_num``
+     - ``%N``
+     - The key symbol as a number.
+     - key events
+   * - ``keycode``
+     - ``%k``
+     - The hardware key code.
+     - key events
+   * - ``state``
+     - ``%s``
+     - Modifier/button state as a bitmask integer (see below).
+     - pointer, key & other events
+   * - ``time``
+     - ``%t``
+     - Server timestamp in milliseconds.
+     - most events
+   * - ``width``, ``height``
+     - ``%w`` ``%h``
+     - New size of the widget.
+     - Configure, Expose
+   * - ``type``
+     - ``%T``
+     - The event type as an ``EventType`` enum (see below).
+     - all events
+   * - ``focus``
+     - ``%f``
+     - Whether the pointer's window has focus.
+     - Enter, Leave
+   * - ``send_event``
+     - ``%E``
+     - ``True`` if the event was synthesized.
+     - all events
+   * - ``serial``
+     - ``%#``
+     - The event's serial number.
+     - all events
+
+``event.type``
+--------------
+
+``event.type`` is an ``EventType`` enum member, not a bare string. Read its name
+or compare against the enum:
+
+.. code-block:: python
+
+   import tkinter as tk
+
+   def handler(event):
+       print(event.type.name)              # -> "ButtonPress"
+       if event.type == tk.EventType.KeyPress:
+           ...
+
+``event.state``
+---------------
+
+``state`` is a bitmask of the modifiers and buttons held when the event fired
+(``Shift`` = ``0x0001``, ``Lock`` = ``0x0002``, ``Control`` = ``0x0004``,
+``Button1`` = ``0x0100``, …). Decoding it by hand is rarely worth it — prefer
+naming the modifier in the pattern (``<Shift-Button-1>``) so tkinter matches it
+for you.
+
+Fields tkinter does not expose
+------------------------------
+
+Tk defines several event fields that tkinter's ``event`` object omits — notably
+the *detail / user-data* field (``%d``) of a virtual event. This means a value
+passed to ``event_generate(..., data="…")`` is **not** readable on the Python
+event; to pass information alongside a
+:doc:`virtual event <virtual-events>`, keep it somewhere both sides can see (an
+attribute, a variable) rather than on the event. The X11-internal fields (``%a``,
+``%c``, ``%m``, ``%o``, ``%p``, ``%B``, ``%P``, ``%R``, ``%S``, ``%i``) are
+likewise not exposed.

--- a/docs/reference/events/event-types.rst
+++ b/docs/reference/events/event-types.rst
@@ -1,0 +1,104 @@
+Event types
+===========
+
+The **type** is the core of an event pattern — the kind of thing that happened.
+Use it in a :doc:`pattern <index>` as ``<Type>`` or ``<Type-detail>``, e.g.
+``<KeyPress-Return>`` or ``<Button-1>``.
+
+Commonly used types
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 64
+
+   * - Type
+     - Alias
+     - Fires when
+   * - ``KeyPress``
+     - ``Key``
+     - A key is pressed. The detail is a :doc:`key symbol <modifiers-and-keys>`
+       (``<KeyPress-a>``, ``<Return>``).
+   * - ``KeyRelease``
+     -
+     - A key is released.
+   * - ``ButtonPress``
+     - ``Button``
+     - A mouse button is pressed. The detail is the button number
+       (``<Button-1>`` = left, ``2`` = middle, ``3`` = right).
+   * - ``ButtonRelease``
+     -
+     - A mouse button is released.
+   * - ``Motion``
+     -
+     - The pointer moves. Combine with a button modifier for drags:
+       ``<B1-Motion>``.
+   * - ``MouseWheel``
+     -
+     - The mouse wheel turns; the rotation is in ``event.delta`` (see the note
+       below).
+   * - ``Enter``
+     -
+     - The pointer enters the widget.
+   * - ``Leave``
+     -
+     - The pointer leaves the widget.
+   * - ``FocusIn``
+     -
+     - The widget (or a descendant) gains keyboard focus.
+   * - ``FocusOut``
+     -
+     - The widget (or a descendant) loses keyboard focus.
+   * - ``Configure``
+     -
+     - The widget changes size or position; new size is ``event.width`` /
+       ``event.height``.
+   * - ``Map``
+     -
+     - The widget becomes visible (mapped).
+   * - ``Unmap``
+     -
+     - The widget becomes hidden (unmapped).
+   * - ``Visibility``
+     -
+     - The widget's visible/obscured state changes.
+   * - ``Expose``
+     -
+     - All or part of the widget needs redrawing.
+   * - ``Destroy``
+     -
+     - The widget is being destroyed.
+   * - ``Activate``
+     -
+     - The toplevel becomes the active window.
+   * - ``Deactivate``
+     -
+     - The toplevel stops being the active window.
+   * - ``Property``
+     -
+     - An X property on the window changes (X11).
+   * - ``Colormap``
+     -
+     - The window's colormap changes (X11).
+
+.. note::
+
+   **MouseWheel is platform-split.** On Windows and macOS, bind ``<MouseWheel>``
+   and read ``event.delta`` (multiples of 120 on Windows, ±1 on macOS). On X11
+   (Linux) the wheel arrives as ``<Button-4>`` (up) and ``<Button-5>`` (down)
+   instead. Cross-platform code binds all three.
+
+Rarely used types
+-----------------
+
+``Circulate``, ``Gravity``, and ``Reparent`` report low-level X11 window changes
+and are seldom useful in applications. The ``CirculateRequest``,
+``ConfigureRequest``, ``MapRequest``, ``ResizeRequest``, and ``Create`` types are
+**only** delivered to an X11 window manager, never to an ordinary application.
+
+Virtual event types
+-------------------
+
+A type written in double brackets — ``<<Paste>>``, ``<<ThemeChanged>>`` — is a
+:doc:`virtual event <virtual-events>`, a named notification decoupled from any
+one physical event.

--- a/docs/reference/events/index.rst
+++ b/docs/reference/events/index.rst
@@ -1,0 +1,85 @@
+Event reference
+===============
+
+The catalog of tkinter's event system: every event **type**, **modifier**, and
+**key symbol** you can name in a pattern, every attribute of the event object a
+callback receives, the options for synthesizing events, and the built-in
+``<<virtual>>`` event names.
+
+.. note::
+
+   This is standard tkinter — it comes from Tk's ``bind`` and ``event``
+   commands, which Tk documents only in C-oriented manual pages. This reference
+   restates the names in Python terms. For **how to use** them — binding
+   callbacks, stopping propagation, and generating your own events — see
+   :doc:`Events & callbacks </user-guide/foundations/events-and-callbacks>` in
+   the User Guide.
+
+Pattern grammar
+---------------
+
+An event pattern names *which* event fires a callback. Its full form is one or
+more **modifiers**, a **type**, and an optional **detail**, inside angle
+brackets:
+
+.. code-block:: text
+
+   <Control-Shift-KeyPress-Q>
+    │       │     │        └─ detail     which key or button
+    │       │     └───────── type        the kind of event
+    └───────┴─────────────── modifiers   keys/buttons held down
+
+- The **type** is required unless it can be inferred: a bare detail like
+  ``<1>`` means ``<Button-1>`` and ``<q>`` means ``<KeyPress-q>``.
+- **Detail** is a button number for button events or a
+  :doc:`key symbol <modifiers-and-keys>` for key events; omit it to match any
+  button or key.
+- A ``<<Name>>`` pattern (double brackets) is a
+  :doc:`virtual event <virtual-events>`; modifiers may not be combined
+  with one.
+
+.. toctree::
+   :hidden:
+
+   event-types
+   modifiers-and-keys
+   event-object
+   event-generate-options
+   virtual-events
+
+.. grid:: 1 2 2 2
+   :gutter: 3
+
+   .. grid-item-card:: Event types
+      :link: event-types
+      :link-type: doc
+
+      Every event type token — ``KeyPress``, ``Button``, ``Motion``,
+      ``Configure``, ``<<virtual>>`` — and when each fires.
+
+   .. grid-item-card:: Modifiers & keys
+      :link: modifiers-and-keys
+      :link-type: doc
+
+      The modifier tokens (``Control``, ``Shift``, ``Double``, …) and the
+      common key symbols used as the detail of a key event.
+
+   .. grid-item-card:: The event object
+      :link: event-object
+      :link-type: doc
+
+      Every attribute of the ``event`` passed to a callback, the Tk field it
+      maps to, and which event types populate it.
+
+   .. grid-item-card:: event_generate options
+      :link: event-generate-options
+      :link-type: doc
+
+      The keyword options accepted by ``event_generate`` and the ``when``
+      scheduling values.
+
+   .. grid-item-card:: Built-in virtual events
+      :link: virtual-events
+      :link-type: doc
+
+      The predefined ``<<virtual>>`` events Tk, ttk, and ttkbootstrap emit.

--- a/docs/reference/events/modifiers-and-keys.rst
+++ b/docs/reference/events/modifiers-and-keys.rst
@@ -1,0 +1,97 @@
+Modifiers & keys
+================
+
+Modifiers
+---------
+
+A **modifier** requires a key or button to be held for the pattern to match.
+Prefix it to the type: ``<Control-c>``, ``<Shift-Button-1>``,
+``<Control-Alt-Delete>``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 74
+
+   * - Modifier
+     - Requires
+   * - ``Control``
+     - The Control key.
+   * - ``Shift``
+     - The Shift key.
+   * - ``Alt``
+     - The Alt key. On some Linux keymaps Alt is a ``Mod`` modifier; if
+       ``<Alt-…>`` does not match, try ``<Mod1-…>``.
+   * - ``Lock``
+     - Caps Lock to be on.
+   * - ``Command``
+     - The ⌘ Command key (macOS).
+   * - ``Option``
+     - The ⌥ Option key (macOS).
+   * - ``Meta`` / ``M``
+     - The Meta key (whichever ``Mod`` maps to it).
+   * - ``Mod1`` … ``Mod5`` / ``M1`` … ``M5``
+     - A numbered X modifier. Which physical key maps to which number is
+       platform-dependent.
+   * - ``Button1`` … ``Button5`` / ``B1`` … ``B5``
+     - A mouse button held down — used with ``Motion`` for drags
+       (``<B1-Motion>``).
+   * - ``Double`` / ``Triple`` / ``Quadruple``
+     - The pattern to repeat 2 / 3 / 4 times in quick succession, close in time
+       and space — ``<Double-Button-1>`` is a double-click.
+   * - ``Extended``
+     - The event to come from an extended key — numeric keypad, cursor cluster,
+       right-hand Alt/Control (Windows).
+
+Key symbols
+-----------
+
+For a key event, the **detail** is a *key symbol* (keysym) — a name for the key.
+A printable key is its own symbol (``a``, ``A``, ``1``, ``space`` for the space
+bar). Non-printing keys have names:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Key
+     - Symbol
+     - Pattern
+   * - Enter / Return
+     - ``Return``
+     - ``<Return>``
+   * - Escape
+     - ``Escape``
+     - ``<Escape>``
+   * - Tab
+     - ``Tab``
+     - ``<Tab>``
+   * - Backspace
+     - ``BackSpace``
+     - ``<BackSpace>``
+   * - Delete
+     - ``Delete``
+     - ``<Delete>``
+   * - Insert
+     - ``Insert``
+     - ``<Insert>``
+   * - Space
+     - ``space``
+     - ``<space>``
+   * - Arrows
+     - ``Up`` ``Down`` ``Left`` ``Right``
+     - ``<Up>``
+   * - Home / End
+     - ``Home`` ``End``
+     - ``<Home>``
+   * - Page Up / Down
+     - ``Prior`` ``Next``
+     - ``<Prior>``
+   * - Function keys
+     - ``F1`` … ``F12``
+     - ``<F1>``
+
+.. tip::
+
+   To discover any key's symbol, bind ``<KeyPress>`` and print ``event.keysym``
+   (the key name) or ``event.char`` (the character it produced). See
+   :doc:`The event object <event-object>`.

--- a/docs/reference/events/virtual-events.rst
+++ b/docs/reference/events/virtual-events.rst
@@ -1,0 +1,144 @@
+Built-in virtual events
+=======================
+
+A **virtual event** is a named notification in double brackets — ``<<Copy>>``,
+``<<ThemeChanged>>`` — decoupled from any one physical event. Bind them exactly
+like physical events. This page catalogs the ones Tk, ttk, and ttkbootstrap
+define; to define or fire your *own*, see
+:doc:`Events & callbacks </user-guide/foundations/events-and-callbacks>`.
+
+Editing & clipboard
+-------------------
+
+Defined by default with the key sequences shown; emitted by ``Text`` and
+``Entry`` widgets and safe to bind or generate yourself.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 40 30
+
+   * - Virtual event
+     - Default sequence
+     - Meaning
+   * - ``<<Cut>>``
+     - ``Control-x``, ``Shift-Delete``
+     - Cut the selection.
+   * - ``<<Copy>>``
+     - ``Control-c``, ``Control-Insert``
+     - Copy the selection.
+   * - ``<<Paste>>``
+     - ``Control-v``, ``Shift-Insert``
+     - Paste the clipboard.
+   * - ``<<PasteSelection>>``
+     - ``ButtonRelease-2``
+     - Paste the X selection (middle-click).
+   * - ``<<Undo>>``
+     - ``Control-z``
+     - Undo.
+   * - ``<<Redo>>``
+     - ``Control-y``
+     - Redo.
+   * - ``<<SelectAll>>``
+     - ``Control-a``, ``Control-/``
+     - Select everything.
+   * - ``<<SelectNone>>``
+     - ``Control-\``
+     - Clear the selection.
+   * - ``<<ToggleSelection>>``
+     - ``Control-Button-1``
+     - Toggle selection of the item under the pointer.
+   * - ``<<ContextMenu>>``
+     - ``Button-3``
+     - Request a context menu (right-click).
+
+Caret navigation
+----------------
+
+Text-editing motion events, each mapped to an arrow/navigation key. Every one
+below has a ``<<Select…>>`` counterpart (e.g. ``<<SelectNextWord>>``) that the
+``Shift``-modified key fires to *extend* the selection.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 30 36
+
+   * - Virtual event
+     - Default key
+     - Moves the caret
+   * - ``<<PrevChar>>`` / ``<<NextChar>>``
+     - ``Left`` / ``Right``
+     - one character
+   * - ``<<PrevWord>>`` / ``<<NextWord>>``
+     - ``Control-Left`` / ``Control-Right``
+     - one word
+   * - ``<<PrevLine>>`` / ``<<NextLine>>``
+     - ``Up`` / ``Down``
+     - one line
+   * - ``<<PrevPara>>`` / ``<<NextPara>>``
+     - ``Control-Up`` / ``Control-Down``
+     - one paragraph
+   * - ``<<LineStart>>`` / ``<<LineEnd>>``
+     - ``Home`` / ``End``
+     - to the line edge
+
+Focus traversal
+---------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Virtual event
+     - Default key
+     - Meaning
+   * - ``<<NextWindow>>``
+     - ``Tab``
+     - Move focus to the next widget.
+   * - ``<<PrevWindow>>``
+     - ``Shift-Tab``
+     - Move focus to the previous widget.
+
+Widget notifications
+--------------------
+
+Emitted by specific widgets when their selection or state changes — no default
+key sequence; you bind them to react to the widget. Read the current value from
+the widget in the handler.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Virtual event
+     - Emitted by
+   * - ``<<ComboboxSelected>>``
+     - ``Combobox`` — a value was chosen.
+   * - ``<<NotebookTabChanged>>``
+     - ``Notebook`` — the active tab changed.
+   * - ``<<TreeviewSelect>>``
+     - ``Treeview`` — the selection changed.
+   * - ``<<TreeviewOpen>>`` / ``<<TreeviewClose>>``
+     - ``Treeview`` — a node was expanded / collapsed.
+   * - ``<<ListboxSelect>>``
+     - ``Listbox`` — the selection changed.
+   * - ``<<MenuSelect>>``
+     - ``Menu`` — the highlighted item changed.
+   * - ``<<Modified>>``
+     - ``Text`` — the contents changed.
+
+Theme & locale (ttkbootstrap)
+-----------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 66
+
+   * - Virtual event
+     - Fires when
+   * - ``<<ThemeChanged>>``
+     - The theme is switched (delivered to every widget). Bind it to recolor
+       anything you drew yourself; for rebuilding a custom *style* prefer
+       :func:`~ttkbootstrap.on_theme_change`.
+   * - ``<<LocaleChanged>>``
+     - The locale is switched via ``set_locale`` — what drives
+       :class:`~ttkbootstrap.LocaleVar`.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,8 +1,7 @@
 Reference
 =========
 
-The lookup layer. Two references sit here, mirroring the native/shipped split in
-the :doc:`Widgets catalog </widgets/index>`:
+The lookup layer:
 
 .. grid:: 1 2 2 2
    :gutter: 3
@@ -22,8 +21,16 @@ the :doc:`Widgets catalog </widgets/index>`:
       The complete public API ttkbootstrap authors — shipped widgets, dialogs,
       the style engine, and the toolkit.
 
+   .. grid-item-card:: Event reference
+      :link: events/index
+      :link-type: doc
+
+      tkinter's event system in Python terms — event types, modifiers, key
+      symbols, the event object, and the built-in virtual events.
+
 .. toctree::
    :hidden:
 
    style-reference/index
    api/index
+   events/index

--- a/docs/user-guide/foundations/arranging-widgets.rst
+++ b/docs/user-guide/foundations/arranging-widgets.rst
@@ -1,0 +1,126 @@
+Arranging widgets
+=================
+
+Creating a widget does not make it appear. A widget only shows up once a
+**geometry manager** places it inside its parent. tkinter has three, and you
+pick one per container based on the shape of the layout:
+
+- **pack** — stack widgets in a row or a column. Best for simple, one-direction
+  layouts (a toolbar, a vertical stack of controls).
+- **grid** — arrange widgets in rows and columns, like a table. Best for forms
+  and anything that should line up in two dimensions.
+- **place** — position a widget at exact coordinates. Best for overlays and the
+  rare pixel-perfect case; you rarely need it.
+
+Each manager is a method on the widget: ``.pack()``, ``.grid()``, ``.place()``.
+
+.. admonition:: One manager per container
+
+   Do not mix ``pack`` and ``grid`` on children of the *same* parent — the two
+   negotiate size differently and tkinter will hang trying to reconcile them.
+   Different containers can use different managers freely; nesting frames is the
+   normal way to combine layouts.
+
+pack
+----
+
+``pack`` places each widget against one side of the remaining space. The default
+side is ``"top"``, so successive ``pack`` calls stack downward:
+
+.. code-block:: python
+
+   ttk.Button(app, text="One").pack()
+   ttk.Button(app, text="Two").pack()
+
+Common options: ``side`` (``"top"``/``"bottom"``/``"left"``/``"right"``),
+``fill`` (``"x"``/``"y"``/``"both"`` — grow to fill its allotted space),
+``expand`` (claim leftover space), and ``padx``/``pady`` (outer spacing):
+
+.. code-block:: python
+
+   ttk.Entry(app).pack(side="left", fill="x", expand=True, padx=5)
+   ttk.Button(app, text="Go").pack(side="left", padx=5)
+
+See the tkinter `Pack geometry manager
+<https://docs.python.org/3/library/tkinter.html#tkinter.Pack>`__ reference for
+the complete list of options.
+
+grid
+----
+
+``grid`` assigns each widget a ``row`` and ``column``. Widgets snap into a table
+that sizes itself to its contents:
+
+.. code-block:: python
+
+   ttk.Label(app, text="Name").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+   ttk.Entry(app).grid(row=0, column=1, padx=5, pady=5)
+
+Useful options: ``sticky`` (which edges the widget clings to — combine
+``"n"``/``"s"``/``"e"``/``"w"``, e.g. ``"ew"`` to stretch horizontally),
+``columnspan``/``rowspan``, and ``padx``/``pady``. To let a column or row absorb
+extra space when the window resizes, give it weight:
+
+.. code-block:: python
+
+   app.columnconfigure(1, weight=1)   # column 1 grows with the window
+
+See the tkinter `Grid geometry manager
+<https://docs.python.org/3/library/tkinter.html#tkinter.Grid>`__ reference for
+the complete list of options.
+
+place
+-----
+
+``place`` positions a widget by coordinate or by relative fraction of its
+parent. Reach for it only when the other two cannot express the layout:
+
+.. code-block:: python
+
+   badge.place(relx=1.0, rely=0.0, anchor="ne")   # pin to the top-right corner
+
+See the tkinter `Place geometry manager
+<https://docs.python.org/3/library/tkinter.html#tkinter.Place>`__ reference for
+the complete list of options.
+
+Fluent geometry
+---------------
+
+In ttkbootstrap, ``pack``, ``grid``, and ``place`` (and their ``*_configure``
+spellings) **return the widget**, so you can create and place it in one
+expression:
+
+.. code-block:: python
+
+   save = ttk.Button(app, text="Save", bootstyle="success").pack(side="left")
+
+``save`` is the button. With stock tkinter these methods return ``None``, so you
+would have to create the widget on one line and place it on the next whenever you
+need to keep a reference.
+
+A small form
+------------
+
+pack and grid together — an outer frame packed to fill the window, a form laid
+out inside it with grid:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(title="Sign in")
+
+   form = ttk.Frame(app, padding=20)
+   form.pack(fill="both", expand=True)
+   form.columnconfigure(1, weight=1)
+
+   ttk.Label(form, text="Email").grid(row=0, column=0, sticky="w", pady=5)
+   ttk.Entry(form).grid(row=0, column=1, sticky="ew", padx=(10, 0), pady=5)
+
+   ttk.Label(form, text="Password").grid(row=1, column=0, sticky="w", pady=5)
+   ttk.Entry(form, show="•").grid(row=1, column=1, sticky="ew", padx=(10, 0), pady=5)
+
+   ttk.Button(form, text="Sign in", bootstyle="primary").grid(
+       row=2, column=1, sticky="e", pady=(10, 0))
+
+   app.mainloop()

--- a/docs/user-guide/foundations/events-and-callbacks.rst
+++ b/docs/user-guide/foundations/events-and-callbacks.rst
@@ -1,0 +1,279 @@
+Events & callbacks
+==================
+
+A tkinter app spends almost all its time idle inside ``mainloop()``, waiting.
+Your code runs in response to **events** — a button click, a keypress, a window
+resize, a theme change. You connect an event to a **callback** (a function to
+run) in one of three ways, from most to least specific: the ``command`` option,
+``bind``, and virtual events.
+
+``command`` — the built-in action
+---------------------------------
+
+Buttons, checkbuttons, and similar controls take a ``command`` option: a
+callable to run when the widget is activated. This is the common case:
+
+.. code-block:: python
+
+   def save():
+       print("saved")
+
+   ttk.Button(app, text="Save", command=save, bootstyle="primary").pack()
+
+``command`` takes the function itself — ``command=save``, not ``command=save()``
+(the second calls it immediately and passes the result). To pass arguments, wrap
+it in a ``lambda``:
+
+.. code-block:: python
+
+   ttk.Button(app, text="Delete", command=lambda: delete(item_id)).pack()
+
+``bind`` — any event, any widget
+--------------------------------
+
+For events without a ``command`` option — mouse motion, individual keystrokes,
+focus changes — use ``bind``. You give it an **event pattern** and a callback
+that receives an **event object** describing what happened:
+
+.. code-block:: python
+
+   entry = ttk.Entry(app)
+   entry.pack()
+
+   def on_return(event):
+       print("submitted:", event.widget.get())
+
+   entry.bind("<Return>", on_return)
+
+The callback takes one argument, the event. Its most useful attributes are
+``event.widget`` (the widget the event fired on), ``event.x``/``event.y`` (cursor
+position), and ``event.keysym`` (the key name). Common patterns include
+``"<Button-1>"`` (left click), ``"<Double-Button-1>"``, ``"<KeyPress>"``, and
+``"<Motion>"``.
+
+Binding scope
+-------------
+
+``widget.bind`` attaches a callback to *one widget*. But every event actually
+consults **four levels** of bindings in turn, and understanding them is what lets
+you write shortcuts and shared behavior instead of wiring every widget by hand:
+
+- **Instance** — ``widget.bind(pattern, callback)`` — this one widget only.
+- **Class** — ``widget.bind_class("TEntry", pattern, callback)`` — every widget
+  of that Tk class at once. This is the level a widget's *default* behavior lives
+  at (what makes an ``Entry`` insert the character you type).
+- **Toplevel** — bindings on the containing window, seen by any widget in it.
+- **Application** — ``widget.bind_all(pattern, callback)`` — every widget in the
+  program. The right tool for a global shortcut like ``<F1>`` or ``<Control-q>``.
+
+A widget's class name for ``bind_class`` is ``widget.winfo_class()`` —
+``"TEntry"``, ``"TButton"``, ``"Text"``, and so on.
+
+The order events travel
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When an event fires, tkinter walks those four levels **in order** and runs
+*every* matching binding it finds. That order is the widget's **bindtags**:
+
+.. code-block:: python
+
+   entry.bindtags()
+   # ('.!entry', 'TEntry', '.', 'all')
+   #   instance    class   toplevel  application
+
+Two consequences worth internalizing:
+
+- Your **instance** binding runs *before* the **class** binding — which is why
+  returning ``"break"`` from it can pre-empt the widget's default behavior (see
+  `Stopping an event`_).
+- A matching binding at *any* level fires, so one ``bind_all("<F1>", …)`` covers
+  the whole application.
+
+You can reorder or insert tags with ``widget.bindtags((...))`` for advanced
+cases, but the default order serves almost everything.
+
+Adding vs replacing
+~~~~~~~~~~~~~~~~~~~~~
+
+Within a single tag, binding a pattern **replaces** whatever callback was already
+bound to that same pattern — a real footgun when two parts of your code each
+assume they own the event:
+
+.. code-block:: python
+
+   widget.bind("<Button-1>", first)
+   widget.bind("<Button-1>", second)             # first is silently gone
+   widget.bind("<Button-1>", third, add="+")     # third runs alongside second
+
+Pass ``add="+"`` to **add** a callback instead of replacing it; every bound
+callback then fires, in the order added. Reach for it whenever a handler should
+coexist with others — especially the app-wide events under `Generating events`_,
+where each consumer must add its own handler without clobbering the rest.
+
+``bind`` returns an id that ``unbind`` uses to remove a single callback again:
+
+.. code-block:: python
+
+   handler_id = widget.bind("<Motion>", track)
+   widget.unbind("<Motion>", handler_id)
+
+Stopping an event
+-----------------
+
+A widget's *class* binding implements its default behavior — a ``Text`` widget
+inserting the character you typed, for instance. Because the instance binding
+runs first, returning the string ``"break"`` from your callback halts the chain,
+so the class binding never runs and the default is suppressed:
+
+.. code-block:: python
+
+   def tab_moves_focus(event):
+       event.widget.tk_focusNext().focus()
+       return "break"        # stop Text from inserting a literal tab
+
+   text.bind("<Tab>", tab_moves_focus)
+
+Virtual events
+--------------
+
+**Virtual events** are named, higher-level notifications written in double angle
+brackets, ``<<Like this>>``. They fire when something meaningful happens rather
+than for a raw input, and you bind them exactly like physical events.
+ttkbootstrap emits two you will use:
+
+- ``<<ThemeChanged>>`` — fires on every widget after the theme is switched. Bind
+  it to recolor anything you drew yourself (a ``Canvas``, a custom asset):
+
+  .. code-block:: python
+
+     canvas.bind("<<ThemeChanged>>", lambda e: repaint(canvas))
+
+- ``<<LocaleChanged>>`` — fires when the app's locale changes; this is what
+  drives :class:`~ttkbootstrap.LocaleVar` (see
+  :doc:`State & variables <state-and-variables>`).
+
+.. admonition:: Prefer the callback helpers for theme changes
+
+   For rebuilding a **custom style** after a theme switch, ttkbootstrap offers
+   :func:`~ttkbootstrap.on_theme_change` and the ``@theme_aware`` decorator,
+   which are easier than a raw ``<<ThemeChanged>>`` binding. See
+   :doc:`Make your own style </user-guide/concepts/make-your-own-style>`.
+
+Generating events
+-----------------
+
+You can fire an event yourself with ``event_generate`` — most usefully your own
+**virtual events**. A virtual event lets one part of an app announce that
+something happened without knowing who cares: a producer generates it, and any
+number of consumers bind to it. That decouples components cleanly.
+
+.. code-block:: python
+
+   # a producer announces on the root — it calls no one directly
+   def load_data():
+       ...  # do the work
+       app.event_generate("<<DataLoaded>>")
+
+   # consumers register on the SAME widget, each with add="+" so they stack
+   app.bind("<<DataLoaded>>", lambda e: status.configure(text="Loaded"), add="+")
+   app.bind("<<DataLoaded>>", lambda e: table.refresh(), add="+")
+
+The name in double brackets is all you need — a ``<<virtual>>`` event works the
+moment you bind and generate it.
+
+.. important::
+
+   ``event_generate`` dispatches to **one** widget (and its ``bindtags``); it
+   does not broadcast. Bind consumers on the same widget you generate on — the
+   root makes a natural app-wide bus — or use ``bind_all`` for a truly global
+   signal. Use ``add="+"`` so each consumer adds a handler rather than replacing
+   the previous one.
+
+To make a virtual event fire from the keyboard too, alias it to physical key
+sequences with ``event_add``:
+
+.. code-block:: python
+
+   app.event_add("<<Save>>", "<Control-s>", "<Control-S>")
+   app.bind("<<Save>>", lambda e: save())   # Ctrl-S now fires <<Save>>
+
+.. note::
+
+   ``event_generate`` accepts ``data="…"``, but tkinter does not surface it on
+   the event the callback receives, so it cannot be read back. To pass
+   information with a virtual event, store it where both sides can reach it. See
+   :doc:`the event object </reference/events/event-object>`.
+
+``after`` — run code later
+--------------------------
+
+Never call ``time.sleep`` in a GUI — it blocks ``mainloop()`` and freezes the
+window. To do something after a delay, or to poll on a timer, use ``after``,
+which schedules a callback to run in *n* milliseconds without blocking:
+
+.. code-block:: python
+
+   app.after(2000, lambda: status.configure(text="Ready"))   # in 2 seconds
+
+Re-scheduling from inside the callback makes a repeating timer — the basis for
+clocks, progress polling, and animation:
+
+.. code-block:: python
+
+   def tick():
+       clock.configure(text=now())
+       app.after(1000, tick)   # again in 1 second
+
+   tick()
+
+``after`` returns a **job id**, and ``after_cancel`` stops a scheduled callback
+before it fires:
+
+.. code-block:: python
+
+   job = app.after(1000, tick)
+   app.after_cancel(job)        # tick will not run
+
+This matters most for a repeating timer: it keeps firing even after the widget it
+updates is destroyed, and the callback then errors on the dead widget. Keep the
+job id and cancel it when you tear the widget down (a ``<Destroy>`` binding is a
+natural place).
+
+For work that should happen only once the interface has caught up — after the
+pending events and redraws are processed — use ``after_idle``, which runs the
+callback the next time the event loop goes idle:
+
+.. code-block:: python
+
+   app.after_idle(finish_setup)   # runs after the UI settles
+
+A worked example
+----------------
+
+A ``command`` starts a countdown that drives itself with ``after`` and updates a
+label — no blocking, the window stays responsive throughout:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(title="Countdown")
+
+   label = ttk.Label(app, text="10", font=("", 48), bootstyle="primary")
+   label.pack(padx=40, pady=(20, 10))
+
+   def countdown(n):
+       label.configure(text=str(n))
+       if n > 0:
+           app.after(1000, countdown, n - 1)   # extra args are passed to the callback
+
+   ttk.Button(app, text="Start", bootstyle="success",
+              command=lambda: countdown(10)).pack(pady=(0, 20))
+
+   app.mainloop()
+
+.. seealso::
+
+   For the complete catalog — every event type, modifier, key symbol, event
+   attribute, and ``event_generate`` option — see the
+   :doc:`Event reference </reference/events/index>`.

--- a/docs/user-guide/foundations/state-and-variables.rst
+++ b/docs/user-guide/foundations/state-and-variables.rst
@@ -1,0 +1,123 @@
+State & variables
+=================
+
+Widgets that hold a value — entries, checkbuttons, radiobuttons, scales — can be
+bound to a **variable object** instead of you reading and writing the widget
+directly. A variable is the single source of truth for that value: set the
+variable and the widget updates; the user edits the widget and the variable
+updates. This two-way link is how tkinter keeps your data and your UI in sync.
+
+The variable classes are re-exported from ttkbootstrap, so you can reach them as
+``ttk.StringVar``, ``ttk.IntVar``, ``ttk.BooleanVar``, and ``ttk.DoubleVar``
+(they are the tkinter classes — import them from ``tkinter`` if you prefer).
+
+Binding a widget to a variable
+------------------------------
+
+Create a variable, then hand it to the widget through the option that fits:
+``textvariable`` for text-bearing widgets (Entry, Label), ``variable`` for
+selection controls (Checkbutton, Radiobutton, Scale):
+
+.. code-block:: python
+
+   name = ttk.StringVar(value="Ada")
+
+   ttk.Entry(app, textvariable=name).pack()
+   ttk.Label(app, textvariable=name).pack()   # mirrors the entry live
+
+Read and write the value with ``.get()`` and ``.set()``:
+
+.. code-block:: python
+
+   name.get()          # -> "Ada"
+   name.set("Grace")   # entry and label both update
+
+Choose the class by value type
+------------------------------
+
+The class you pick determines what ``.get()`` returns:
+
+- ``StringVar`` — text (entries, labels).
+- ``IntVar`` — whole numbers; also the on/off value of a Checkbutton or the
+  chosen value of a Radiobutton group.
+- ``BooleanVar`` — ``True``/``False`` (a Checkbutton's checked state).
+- ``DoubleVar`` — floating-point numbers (a Scale's position).
+
+.. code-block:: python
+
+   agree = ttk.BooleanVar()
+   ttk.Checkbutton(app, text="I agree", variable=agree,
+                   bootstyle="success-round-toggle").pack()
+
+   agree.get()   # -> True once the box is checked
+
+Reacting to changes
+-------------------
+
+To run code whenever a variable changes, attach a trace. The callback fires on
+every write — useful for live validation, enabling a button, or updating a
+summary:
+
+.. code-block:: python
+
+   def on_change(*_):
+       print("value is now", name.get())
+
+   trace_id = name.trace_add("write", on_change)
+
+Most traces live for the life of the app and need no cleanup. When you do need to
+stop reacting — say the callback closes over a widget you are about to destroy —
+``trace_add`` returns an id you pass to ``trace_remove``:
+
+.. code-block:: python
+
+   name.trace_remove("write", trace_id)
+
+A worked example
+----------------
+
+A checkbutton drives a boolean, and a trace enables the submit button only when
+the box is checked:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(title="Terms")
+
+   agree = ttk.BooleanVar()
+   submit = ttk.Button(app, text="Continue", bootstyle="primary", state="disabled")
+
+   def refresh(*_):
+       submit.configure(state="normal" if agree.get() else "disabled")
+
+   agree.trace_add("write", refresh)
+
+   ttk.Checkbutton(app, text="I accept the terms", variable=agree,
+                   bootstyle="round-toggle").pack(padx=20, pady=(20, 10))
+   submit.pack(padx=20, pady=(0, 20))
+
+   app.mainloop()
+
+``LocaleVar`` — a variable that re-translates
+---------------------------------------------
+
+ttkbootstrap ships one specialized variable, :class:`~ttkbootstrap.LocaleVar`. It
+is a ``StringVar`` whose text is a translation key: bind a widget to it, and the
+text re-translates itself automatically whenever the app's locale changes. It is
+a concrete example of the same observer pattern — the variable listens for the
+``<<LocaleChanged>>`` event and updates every widget bound to it:
+
+.. code-block:: python
+
+   greeting = ttk.LocaleVar(app, "Hello")
+   ttk.Label(app, textvariable=greeting).pack()   # follows the locale
+
+See :doc:`Localization </user-guide/feature-guides/localization>` for the full
+localization subsystem.
+
+.. seealso::
+
+   The variable classes are standard tkinter. For the complete API, see
+   `Variable classes <https://docs.python.org/3/library/tkinter.html#coupling-widget-variables>`__
+   on python.org.

--- a/docs/user-guide/how-to/index.rst
+++ b/docs/user-guide/how-to/index.rst
@@ -20,8 +20,8 @@ Building interfaces
 - **Wire events and variables** — ``bind``, ``command=``, and the tk variable
   classes (``StringVar``/``IntVar``/…).
 - **Menus and context menus** — a menu bar and a right-click popup.
-- **Images and icons** — ``PhotoImage``, and rendering themed glyphs with
-  ``apply_icon``.
+- :doc:`Working with images <working-with-images>` — ``PhotoImage`` and Pillow,
+  the keep-a-reference gotcha, and themed glyphs with ``apply_icon``.
 - **Scrollable content** — ``ScrolledFrame``/``ScrolledText`` for content that
   outgrows the window.
 
@@ -42,3 +42,8 @@ Presentation
   with ``PhotoImage``.
 - **Splash screen** — a borderless startup window with ``window_type``.
 - **Application icon** — set the window/taskbar icon.
+
+.. toctree::
+   :hidden:
+
+   working-with-images

--- a/docs/user-guide/how-to/working-with-images.rst
+++ b/docs/user-guide/how-to/working-with-images.rst
@@ -1,0 +1,136 @@
+Working with images
+====================
+
+To show a picture in tkinter you wrap it in an *image object* and hand that to a
+widget's ``image=`` option. There are two image classes, and one notorious
+gotcha to know before anything else.
+
+Which image class
+-----------------
+
+- ``ttk.PhotoImage`` — tkinter's built-in image, re-exported for convenience. It
+  reads **GIF, PNG, PGM, and PPM** files (and base64-encoded GIF/PNG data), and
+  needs no extra library.
+- Pillow's ``ImageTk.PhotoImage`` — reads **every common format** (JPEG, BMP,
+  TIFF, WebP, …) and lets you resize, crop, and filter first. Pillow is already a
+  dependency of ttkbootstrap, so it is always available.
+
+Reach for Pillow for anything beyond a simple GIF/PNG — which is most real work:
+
+.. code-block:: python
+
+   from PIL import Image, ImageTk
+
+.. _images-keep-a-reference:
+
+Keep a reference (the image that vanishes)
+------------------------------------------
+
+.. important::
+
+   **An image object must be kept alive by your own code, or it disappears.**
+   Tk stores the image by *name*, and a widget's ``image=`` option does not hold
+   the Python object — so if the only reference is a local variable, the garbage
+   collector reclaims the image the moment the function returns and the widget
+   goes blank.
+
+This is the single most common tkinter image bug. It applies to **both** image
+classes. The fix is to keep a reference somewhere that outlives the function —
+conventionally on the widget itself, or on ``self``:
+
+.. code-block:: python
+
+   def add_logo(parent):
+       photo = ttk.PhotoImage(file="logo.png")
+       label = ttk.Label(parent, image=photo)
+       label.image = photo          # <- keeps the image alive with the label
+       label.pack()
+
+Without the ``label.image = photo`` line, the label shows nothing. When you store
+images on ``self`` (say in a class-based app), the same rule holds — just make
+sure the attribute lives as long as the widget does.
+
+Displaying an image
+-------------------
+
+Pass the image as ``image=``. To show it *alongside* text, add ``compound=`` to
+say where the image sits relative to the label:
+
+.. code-block:: python
+
+   ttk.Button(app, text="Open", image=photo, compound="left")
+
+``compound`` takes ``"left"``, ``"right"``, ``"top"``, ``"bottom"``, ``"center"``
+(text over image), or ``"none"`` (image only).
+
+Loading and resizing with Pillow
+--------------------------------
+
+Open with Pillow, transform, then wrap the result. Keep a reference as always:
+
+.. code-block:: python
+
+   from PIL import Image, ImageTk
+
+   pil = Image.open("photo.jpg")
+   pil = pil.resize((120, 120))
+   thumb = ImageTk.PhotoImage(pil)
+
+   card = ttk.Label(app, image=thumb)
+   card.image = thumb
+   card.pack()
+
+Embedding an image in your code
+-------------------------------
+
+To ship an image inside a ``.py`` file with no separate asset, base64-encode it
+and pass it as ``data=`` to ``ttk.PhotoImage`` (GIF/PNG only):
+
+.. code-block:: python
+
+   LOGO = "iVBORw0KGgo..."          # base64 string of a PNG
+   photo = ttk.PhotoImage(data=LOGO)
+
+Themed glyph icons
+------------------
+
+For *icons* — the small symbols on buttons and menu items — you usually want a
+crisp, theme-following glyph rather than a raster file. ttkbootstrap renders
+those from a built-in Bootstrap Icons font, so they recolor with the theme
+automatically:
+
+.. code-block:: python
+
+   btn = ttk.Button(app, text="Settings")
+   ttk.apply_icon(btn, "gear-fill")     # glyph follows the theme + widget state
+
+See :doc:`Make your own style </user-guide/concepts/make-your-own-style>` for the
+icon toolkit, and :doc:`Windows, icons & high-DPI
+</user-guide/feature-guides/windows>` for setting the *application* icon.
+
+A worked example
+----------------
+
+Loads a Pillow image, scales it, and displays it — with the reference kept so it
+stays on screen:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from PIL import Image, ImageTk
+
+   app = ttk.App(title="Image")
+
+   pil = Image.open("photo.jpg").resize((200, 200))
+   photo = ImageTk.PhotoImage(pil)
+
+   label = ttk.Label(app, image=photo, padding=10)
+   label.image = photo          # keep the reference
+   label.pack()
+
+   app.mainloop()
+
+.. seealso::
+
+   For the raster-image formats and manipulation, see the `Pillow
+   <https://pillow.readthedocs.io/>`__ documentation.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -39,6 +39,35 @@ Getting Started
 
       bootstyle strings, theme names, removed shims, and icons.
 
+Foundations
+-----------
+
+New to tkinter? These pages cover the mental models everything else builds on —
+how widgets are arranged, how they bind to your data, and how they respond to
+input.
+
+.. grid:: 1 2 2 2
+   :gutter: 3
+
+   .. grid-item-card:: Arranging widgets
+      :link: foundations/arranging-widgets
+      :link-type: doc
+
+      ``pack``, ``grid``, and ``place`` — the layout model and when to use each.
+
+   .. grid-item-card:: State & variables
+      :link: foundations/state-and-variables
+      :link-type: doc
+
+      Binding widgets to ``StringVar``/``IntVar``/``BooleanVar`` and reacting to
+      changes.
+
+   .. grid-item-card:: Events & callbacks
+      :link: foundations/events-and-callbacks
+      :link-type: doc
+
+      ``command``, ``bind`` and event objects, virtual events, and ``after``.
+
 Concepts
 --------
 
@@ -133,6 +162,14 @@ Task-focused recipes — common tkinter jobs done the ttkbootstrap way. See the
    getting-started/quickstart
    getting-started/app-structures
    getting-started/migrating
+
+.. toctree::
+   :hidden:
+   :caption: Foundations
+
+   foundations/arranging-widgets
+   foundations/state-and-variables
+   foundations/events-and-callbacks
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Continues Docs Workstream H. Authors the User Guide **Foundations** band and opens a **"tkinter essentials"** reference/guide strand that restates Tk's `bind`/`event` material in Python terms — filling the modern-tkinter-docs gap (design §1). Docs-only.

## What's here

**Foundations band** (`docs/user-guide/foundations/`) — three pages:
- *Arranging widgets* — pack/grid/place + fluent geometry; per-manager python.org links.
- *State & variables* — `StringVar`/`IntVar`/`BooleanVar`, `textvariable` binding, `trace_add`/`trace_remove`, `LocaleVar`.
- *Events & callbacks* — the usage guide (see below).

**Event reference** (`docs/reference/events/`, new Reference sub-area — the *names/catalog*):
event types · modifiers & keys · the event object (attribute↔Tk-field map, incl. the fields tkinter omits) · `event_generate` options · built-in virtual events. Wired in as a 3rd card on the Reference landing.

**Events & callbacks guide** (the *usage*): binding scope (instance/class/toplevel/all, `bindtags`), `add="+"` vs replace, `return "break"`, **generating events** (incl. your own virtual events + `event_add`), and the `after`/`after_idle`/`after_cancel` family.

**Working with images How-To** (`how-to/working-with-images.rst`): the keep-a-reference **GC gotcha**, `ttk.PhotoImage` vs Pillow `ImageTk.PhotoImage`, `compound=`, base64 embed, and `apply_icon` for themed glyphs.

## Decisions recorded (design doc §12 + handoff)
- **Reference = names, Guide = usage** (Diátaxis split); events usage lives in the expanded Foundations page.
- **Keep `ttk.PhotoImage = tkinter.PhotoImage`** — the swap to Pillow was rejected on evidence (base64 breaks, not a subclass, ~18 methods dropped, doesn't fix GC). A bootstack-style `Image` handle is logged as a **2.1 candidate**.
- Remaining **tkinter-essentials roadmap** (winfo → cursors → focus/grab/lifecycle → clipboard → error handling) captured in the design doc.

## Verification
- `sphinx -b html -W --keep-going` → **zero warnings**.
- Every code example run headlessly against a live root (bindings, `event_generate`/`add=`, `after_cancel`/`after_idle`, image GC pattern, base64, `apply_icon`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)