### PR TITLE
validation: Validation namespace + author Typography/Localization/Validation guides

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -21,6 +21,7 @@
 | **Deferred-config seam + `ttk.set_default_button()` pre-root setter** | New | this doc, below (Slice 5) |
 | **Localization: msgcat bug fixes + `L()` / `LocaleVar` / `set_locale`** | Fix/New | this doc, below (Slice 3) |
 | **Typography: `ttk.Fonts` + `ttk.set_global_family()` over the Tk named fonts** | New | this doc, below (Slice 4) |
+| **Validation rules grouped under a `Validation` namespace** | API | this doc, below |
 | **Light/dark theme mode (settable `theme_mode`/`toggle_theme()`)** | New | this doc, below |
 | **Theme-aware custom styles (`on_theme_change` / `@theme_aware`)** | New | this doc, below |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
@@ -1492,3 +1493,36 @@ Inputs are unchanged (they signal focus with a border-color highlight, not a
 ring — see "Inputs: focus color on focus only").
 
 **Migration.** None (appearance only).
+
+## Validation rules grouped under a `Validation` namespace  *(API — deprecated aliases, not a hard break)*
+
+The input-validation helpers moved from flat `add_*_validation` free functions to
+a `Validation` namespace (mirroring `Fonts` / `MessageCatalog`), re-exported at the
+top level as `ttk.Validation`:
+
+| Pre-2.0 (deprecated) | 2.0 |
+|---|---|
+| `add_text_validation(w)` | `Validation.text(w)` |
+| `add_numeric_validation(w)` | `Validation.numeric(w)` |
+| `add_range_validation(w, start, end)` | `Validation.range(w, start, end)` |
+| `add_regex_validation(w, pattern)` | `Validation.regex(w, pattern)` |
+| `add_option_validation(w, options)` | `Validation.options(w, options)` |
+| `add_phonenumber_validation(w)` | `Validation.phonenumber(w)` |
+| `add_validation(w, func)` | `Validation.add(w, func)` |
+
+**Why.** The `add_X_validation` names bracketed the one varying word (`text`/
+`numeric`/`range`) with a redundant verb+noun repeated across all seven. The
+namespace drops the `_validation` suffix, groups the rules for discovery
+(`Validation.<tab>`), and — unlike a flat `validate_range()` — reads as
+*attaching a rule* rather than colliding with tkinter's existing
+`widget.validate()` (which runs a check now and returns a bool). `@validator` and
+`ValidationEvent` are unchanged (also re-exported at top level).
+
+**Migration.** The seven `add_*` functions (public through v1.9.0) stay as thin
+deprecated aliases that warn-and-forward, removed in 3.0. First-party callers
+(the built-in `ColorChooser`) are already migrated so the shipped dialogs don't
+trip the warning. `when=` semantics are identical; only the call name changes.
+
+**Scope.** `validation.py` (new `Validation` namespace + deprecated aliases),
+`__init__.py` (top-level `Validation`/`validator`/`ValidationEvent` re-export),
+`dialogs/colorchooser.py` (4 call sites migrated).

--- a/docs/user-guide/feature-guides/localization.rst
+++ b/docs/user-guide/feature-guides/localization.rst
@@ -1,21 +1,134 @@
 Localization
 ============
 
+**Localization** is showing your interface in the user's language. ttkbootstrap
+wraps Tcl/Tk's built-in message catalog (``::msgcat``) so you can register
+translations, wrap the strings your app displays, and switch languages at
+runtime — no restart. This guide covers the everyday idiom (``L``), changing the
+locale (``set_locale``), live-switching widgets (``LocaleVar``), and managing the
+catalog directly (``MessageCatalog``).
+
+The message catalog
+-------------------
+
+A **message catalog** maps a source string to its translation for a given
+locale. You write your app in one language — the *source* strings — and register
+translations for the others. At runtime, looking a source string up in the
+catalog returns the translation for the active locale, or the source string
+itself if there is no entry (so an untranslated string still shows something
+sensible).
+
+ttkbootstrap already ships catalog entries for its own dialog text (the button
+labels in :doc:`Messagebox and Querybox </user-guide/feature-guides/windows>`,
+and so on) in a range of locales. You add entries for your app's strings.
+
+Translating a string with ``L``
+-------------------------------
+
+:func:`~ttkbootstrap.L` is the everyday idiom — the equivalent of the ``_()``
+function in other toolkits. It looks ``src`` up in the catalog for the current
+locale and then applies Python ``str.format``:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   ttk.Label(app, text=ttk.L("Welcome")).pack()
+   ttk.Label(app, text=ttk.L("Hello, {}", "Ada")).pack()   # {}/{0}/{name} fields
+
+Wrap every user-facing string in ``L`` and your app is ready to translate; the
+lookup happens at call time, which is exactly right for the common "pick the
+language at startup" case.
+
 .. note::
 
-   This guide is being written for 2.0.
+   ``L`` uses Python ``str.format`` (``{}`` / ``{0}`` / ``{name}`` fields). If
+   you need the Tcl ``%``-style specifiers that ``msgcat`` uses natively, call
+   ``MessageCatalog.translate(src, *args)`` instead.
 
-ttkbootstrap wraps Tcl/Tk's ``::msgcat`` so you can translate interface strings
-and switch languages at runtime.
+Registering translations
+-------------------------
 
-This guide will cover:
+Add entries with :class:`~ttkbootstrap.localization.MessageCatalog` (import it
+from ``ttkbootstrap.localization`` — it is not a top-level name). Register one
+pair with ``set(locale, src, translated)``, or many at once with
+``set_many(locale, src1, trans1, src2, trans2, …)``:
 
-- ``L(src, *args, **kwargs)`` — the universal translate-and-format idiom:
-  looks ``src`` up in the message catalog and applies ``str.format``.
-- ``set_locale(locale)`` — set the active locale; queues before the root
-  exists and applies live afterward, firing ``<<LocaleChanged>>``.
-- ``LocaleVar`` — a ``StringVar`` that re-translates itself on
-  ``<<LocaleChanged>>``, so a widget bound with ``textvariable=`` switches
-  language without a restart.
-- ``MessageCatalog`` — loading translation bundles, setting entries, and
-  querying preferences.
+.. code-block:: python
+
+   from ttkbootstrap.localization import MessageCatalog
+
+   MessageCatalog.set_many(
+       "es",
+       "Welcome", "Bienvenido",
+       "Hello, {}", "Hola, {}",
+       "Save", "Guardar",
+   )
+
+For a real app you keep translations in ``.msg`` files (one per locale) and load
+a whole directory of them with ``MessageCatalog.load(dirname)``, which sources
+every file matching the user's preferred locales and returns how many it loaded:
+
+.. code-block:: python
+
+   MessageCatalog.load("locales")     # sources locales/es.msg, locales/fr.msg, …
+
+Switching the locale
+--------------------
+
+:func:`~ttkbootstrap.set_locale` sets the active locale. Like the typography
+helpers it rides the **deferred-config seam**: call it at the top of a file
+before the root exists and it is queued until ``App()`` comes up; call it
+against a live root and it applies immediately, firing a ``<<LocaleChanged>>``
+event:
+
+.. code-block:: python
+
+   ttk.set_locale("es")               # everything wrapped in L() now resolves to Spanish
+
+Strings already rendered do not re-resolve on their own — ``L`` runs once, when
+you build the widget. To make widgets *follow* a live locale change, bind them to
+a ``LocaleVar`` (next section).
+
+.. note::
+
+   The initial locale defaults to the user's environment. Query the ordered list
+   of the user's preferred locales with ``MessageCatalog.preferences()`` (most
+   specific first), and read the current locale with ``MessageCatalog.locale()``.
+
+Live language switching with ``LocaleVar``
+------------------------------------------
+
+:class:`~ttkbootstrap.LocaleVar` is a ``StringVar`` whose value is a *source
+string*: it holds the source, shows its translation, and re-translates itself
+whenever the locale changes. Bind a widget to it with ``textvariable=`` and the
+widget follows the language live — no rebuild:
+
+.. code-block:: python
+
+   greeting = ttk.LocaleVar(app, "Welcome")          # (master, source string)
+   ttk.Label(app, textvariable=greeting).pack()
+
+   ttk.Button(app, text="Español",
+              command=lambda: ttk.set_locale("es")).pack()   # label switches instantly
+
+Under the hood it is the observer pattern: every ``LocaleVar`` listens for the
+``<<LocaleChanged>>`` event that ``set_locale`` fires and re-runs its own
+translation. Replace the source string (and any format args) with
+``set_source(src, *args)``; call ``stop_tracking()`` to freeze one at its current
+text while keeping it alive.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A small window with a label and buttons, shown once in English and once after
+   pressing a language button, the bound text switched live.
+
+.. seealso::
+
+   :doc:`Variables </user-guide/feature-guides/variables>` for how variable
+   objects bind to widgets — ``LocaleVar`` is a specialized ``StringVar`` — and
+   :doc:`Events </user-guide/feature-guides/events>` for the ``<<LocaleChanged>>``
+   virtual event that drives it.

--- a/docs/user-guide/feature-guides/typography.rst
+++ b/docs/user-guide/feature-guides/typography.rst
@@ -1,22 +1,149 @@
 Typography
 ==========
 
+Text in a tkinter app is styled through the **standard Tk named fonts** — a
+handful of fonts (``TkDefaultFont``, ``TkTextFont``, ``TkFixedFont``, …) that
+every interpreter ships and every widget reads by default. There is no separate
+ttkbootstrap font vocabulary: change a named font and every widget that uses it
+restyles at once. This guide covers the one-liner for the whole app, per-font
+tweaks, and registering your own named fonts.
+
+The named fonts
+---------------
+
+A **named font** is a font registered under a name in the interpreter. Widgets
+reference it by that name rather than carrying their own copy, so reconfiguring
+the name updates every widget that uses it — no interception, no per-widget
+loop. These are the fonts ttkbootstrap manages:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 18 48
+
+   * - Named font
+     - Kind
+     - Used by
+   * - ``TkDefaultFont``
+     - proportional
+     - Most widgets — buttons, labels, entries; the general UI font.
+   * - ``TkTextFont``
+     - proportional
+     - Text-entry widgets (``Entry``, ``Text``, ``Spinbox``).
+   * - ``TkHeadingFont``
+     - proportional
+     - Column headings and other emphasis.
+   * - ``TkMenuFont``
+     - proportional
+     - Menu items.
+   * - ``TkCaptionFont`` / ``TkSmallCaptionFont``
+     - proportional
+     - Window and dialog captions.
+   * - ``TkIconFont`` / ``TkTooltipFont``
+     - proportional
+     - Icon labels and tooltips.
+   * - ``TkFixedFont``
+     - monospace
+     - Code and console-style text.
+
+You can hand any of these to a widget's ``font=`` option directly — it works on
+stock tkinter widgets too:
+
+.. code-block:: python
+
+   ttk.Label(app, text="Section", font="TkHeadingFont").pack()
+
 .. note::
 
-   This guide is being written for 2.0.
+   Some named fonts (``TkTooltipFont``, ``TkIconFont``, ``TkSmallCaptionFont``)
+   are absent on some platforms. The helpers below skip any that the current
+   interpreter does not define, so you never have to guard for them yourself.
 
-ttkbootstrap styles text through the **standard Tk named fonts**
-(``TkDefaultFont``, ``TkTextFont``, ``TkFixedFont``, ``TkHeadingFont``, …) — there
-is no separate font DSL. Retint a named font and every widget that uses it
-updates at once.
+Setting the global family
+-------------------------
 
-This guide will cover:
+The headline one-liner retints every proportional named font in a single call.
+Because widgets read those fonts, it restyles the whole app:
 
-- ``set_global_family(family, *, mono_family=None)`` — the one-liner: set the
-  proportional (and optionally monospace) family for the whole app. It rides the
-  deferred-config seam, so you can call it at the top of a file *before* the root
-  exists, or live afterward.
-- The ``Fonts`` namespace (call after the root exists): ``Fonts.configure``
-  to tweak one named font, ``Fonts.create_alias`` to register your own
-  (``font="Body"``), ``Fonts.names``/``Fonts.describe`` to introspect, and
-  ``Fonts.reset``.
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   ttk.set_global_family("Segoe UI")
+
+   app = ttk.App()
+   ttk.Button(app, text="Save", bootstyle="primary").pack(padx=20, pady=20)
+   app.mainloop()
+
+:func:`~ttkbootstrap.set_global_family` rides the **deferred-config seam**: call
+it at the top of a file *before* the root exists — as above — and the setting is
+queued and applied when ``App()`` comes up. If a root already exists, it applies
+live.
+
+The monospace font (``TkFixedFont``) is left alone unless you ask for it with
+``mono_family``:
+
+.. code-block:: python
+
+   ttk.set_global_family("Inter", mono_family="Cascadia Code")
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   The same small window rendered with the default family and with a custom
+   ``set_global_family`` family side by side, showing the whole UI restyled.
+
+The ``Fonts`` namespace
+-----------------------
+
+For finer control against a **live** root, use the :class:`~ttkbootstrap.Fonts`
+namespace. Its methods operate on the running application, so call them once
+``App()`` exists — a pre-root call raises a clear "too early" error rather than
+spawning a stray root. (For the top-of-file case, use the module-level
+``set_global_family`` above.)
+
+**Tweak one named font** with ``Fonts.configure`` — pass any font option
+(``family``, ``size``, ``weight``, ``slant``, ``underline``). Every widget
+reading that font updates live:
+
+.. code-block:: python
+
+   ttk.Fonts.configure("TkDefaultFont", size=11)
+   ttk.Fonts.configure("TkHeadingFont", weight="bold", size=13)
+
+``Fonts.set_global_family`` is the live sibling of the module-level function —
+retint every proportional font now, against the existing root:
+
+.. code-block:: python
+
+   ttk.Fonts.set_global_family("Segoe UI", mono_family="Consolas")
+
+**Register your own named font** with ``Fonts.create_alias``. Define it once and
+refer to it by name everywhere — the same mechanism the ``Tk*Font`` names use.
+It returns the ``font.Font`` wrapper for further tweaking, and re-registering a
+name reconfigures it instead of erroring:
+
+.. code-block:: python
+
+   ttk.Fonts.create_alias("Body", family="Georgia", size=12)
+
+   ttk.Label(app, text="Chapter one", font="Body").pack()
+
+**Introspect** with ``Fonts.names`` (the managed named fonts) and
+``Fonts.describe`` (their resolved family/size/weight/…):
+
+.. code-block:: python
+
+   ttk.Fonts.names()               # ('TkDefaultFont', 'TkTextFont', …)
+   ttk.Fonts.describe("TkDefaultFont")
+   # {'family': 'Segoe UI', 'size': 9, 'weight': 'normal', …}
+   ttk.Fonts.describe()            # every managed font, as a mapping
+
+``Fonts.reset`` drops ttkbootstrap's cached font wrappers; it runs automatically
+when the app is destroyed, so you rarely call it yourself.
+
+.. seealso::
+
+   The named-font families are the standard tkinter fonts; for the underlying
+   options and the ``font.Font`` object, see
+   `tkinter.font <https://docs.python.org/3/library/tkinter.font.html>`__ on
+   python.org.

--- a/docs/user-guide/feature-guides/validation.rst
+++ b/docs/user-guide/feature-guides/validation.rst
@@ -1,19 +1,147 @@
 Input validation
 ================
 
+ttkbootstrap ships a small validation framework for the text-entry widgets —
+``Entry``, ``Spinbox``, and ``Combobox``. Attach a rule to a widget and a value
+that fails it flags the widget with a ``danger``-colored border until the
+contents become valid again. This guide covers the ready-made rules, when they
+fire, and writing your own.
+
+Import the helpers from ``ttkbootstrap.validation``:
+
+.. code-block:: python
+
+   from ttkbootstrap.validation import add_numeric_validation, add_range_validation
+
+The ready-made rules
+--------------------
+
+Each helper takes the widget as its first argument and wires up a rule in one
+call:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 46 54
+
+   * - Helper
+     - Passes when the contents are…
+   * - ``add_text_validation(widget)``
+     - alphabetic (or empty).
+   * - ``add_numeric_validation(widget)``
+     - numeric (or empty).
+   * - ``add_range_validation(widget, start, end)``
+     - a number within ``start``–``end`` inclusive (or empty).
+   * - ``add_regex_validation(widget, pattern)``
+     - a match for the regular expression ``pattern``.
+   * - ``add_option_validation(widget, options)``
+     - one of the values in ``options``.
+   * - ``add_phonenumber_validation(widget)``
+     - a match for a common phone-number pattern.
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.validation import add_range_validation
+
+   app = ttk.App()
+
+   age = ttk.Entry(app)
+   age.pack(padx=20, pady=20)
+   add_range_validation(age, 0, 120)      # 0–120 accepted; anything else flags danger
+
+   app.mainloop()
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   An entry with a valid value (normal border) beside the same entry holding an
+   out-of-range value (``danger``-red border).
+
 .. note::
 
-   This guide is being written for 2.0.
+   The text, numeric, and range rules treat an **empty** field as valid, so an
+   untouched entry is not flagged before the user types anything. Combine a rule
+   with a "required field" check of your own if empty should fail.
 
-ttkbootstrap ships a small validation framework for ``Entry``, ``Spinbox``, and
-``Combobox``: attach a rule and a failing value paints the widget with a
-``danger`` border until it is corrected.
+When validation fires
+---------------------
 
-This guide will cover:
+Every helper takes a ``when=`` argument that controls *when* the rule runs.
+The default is ``"focusout"`` — validate when the widget loses focus, the least
+intrusive choice:
 
-- **Ready-made rules** — ``add_text_validation``, ``add_numeric_validation``,
-  ``add_range_validation(start, end)``, ``add_regex_validation(pattern)``,
-  ``add_option_validation(options)``, ``add_phonenumber_validation``.
-- **When they fire** — the ``when=`` argument (``"focusout"``, ``"key"``, …).
-- **Custom rules** — the ``@validator`` decorator over ``add_validation`` and the
-  ``ValidationEvent`` passed to your function.
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - ``when``
+     - Validates…
+   * - ``"focusout"``
+     - when the widget loses focus (the default).
+   * - ``"focusin"``
+     - when the widget gains focus.
+   * - ``"focus"``
+     - on both focus in and focus out.
+   * - ``"key"``
+     - on every keystroke — live, as the user types.
+   * - ``"all"``
+     - in all of the above situations.
+
+.. code-block:: python
+
+   add_numeric_validation(entry, when="key")     # reject non-digits as they are typed
+
+With ``when="key"`` the rule runs on each edit, so a rejected change keeps a bad
+character from ever landing in the field; with ``"focusout"`` the value is
+accepted into the widget but the widget is flagged until corrected.
+
+.. note::
+
+   The ``danger`` border is the ttk ``invalid`` widget state, toggled
+   automatically from the rule's result — so a validated widget reports
+   ``"invalid"`` in ``widget.state()`` while it holds a bad value. You can force
+   a check at any time (for example, before submitting a form) by calling
+   ``widget.validate()``, which returns ``True`` or ``False``.
+
+Custom rules
+------------
+
+When no ready-made rule fits, write your own. A **rule** is a function that
+receives a :class:`~ttkbootstrap.validation.ValidationEvent` and returns
+``True`` (valid) or ``False`` (invalid). Decorate it with ``@validator`` so it
+receives the event object, then attach it with ``add_validation``:
+
+.. code-block:: python
+
+   from ttkbootstrap.validation import validator, add_validation
+
+   @validator
+   def is_even(event):
+       text = event.postchangetext
+       return text.isdigit() and int(text) % 2 == 0
+
+   add_validation(entry, is_even, when="focusout")
+
+The event's most useful attribute is ``postchangetext`` — the value the widget
+*will* hold if the change is allowed — along with ``widget`` (the widget being
+validated). The full set (``actioncode``, ``insertdeletetext``,
+``validationreason``, …) is documented on
+:class:`~ttkbootstrap.validation.ValidationEvent`.
+
+Pass extra keyword arguments through ``add_validation`` and they arrive at your
+rule — the same mechanism the built-in ``add_range_validation`` uses:
+
+.. code-block:: python
+
+   @validator
+   def max_length(event, limit):
+       return len(event.postchangetext) <= limit
+
+   add_validation(entry, max_length, when="key", limit=10)
+
+.. seealso::
+
+   :doc:`Variables </user-guide/feature-guides/variables>` for reacting to input
+   changes generally with traces, and
+   :doc:`Events </user-guide/feature-guides/events>` for the binding system these
+   validation callbacks are built on.

--- a/docs/user-guide/feature-guides/validation.rst
+++ b/docs/user-guide/feature-guides/validation.rst
@@ -7,47 +7,48 @@ that fails it flags the widget with a ``danger``-colored border until the
 contents become valid again. This guide covers the ready-made rules, when they
 fire, and writing your own.
 
-Import the helpers from ``ttkbootstrap.validation``:
+The rules live on the :class:`~ttkbootstrap.Validation` namespace, re-exported
+at the top level — import it directly, or reach it as ``ttk.Validation``:
 
 .. code-block:: python
 
-   from ttkbootstrap.validation import add_numeric_validation, add_range_validation
+   from ttkbootstrap import Validation
 
 The ready-made rules
 --------------------
 
-Each helper takes the widget as its first argument and wires up a rule in one
+Each method takes the widget as its first argument and wires up a rule in one
 call:
 
 .. list-table::
    :header-rows: 1
    :widths: 46 54
 
-   * - Helper
+   * - Rule
      - Passes when the contents are…
-   * - ``add_text_validation(widget)``
+   * - ``Validation.text(widget)``
      - alphabetic (or empty).
-   * - ``add_numeric_validation(widget)``
+   * - ``Validation.numeric(widget)``
      - numeric (or empty).
-   * - ``add_range_validation(widget, start, end)``
+   * - ``Validation.range(widget, start, end)``
      - a number within ``start``–``end`` inclusive (or empty).
-   * - ``add_regex_validation(widget, pattern)``
+   * - ``Validation.regex(widget, pattern)``
      - a match for the regular expression ``pattern``.
-   * - ``add_option_validation(widget, options)``
+   * - ``Validation.options(widget, options)``
      - one of the values in ``options``.
-   * - ``add_phonenumber_validation(widget)``
+   * - ``Validation.phonenumber(widget)``
      - a match for a common phone-number pattern.
 
 .. code-block:: python
 
    import ttkbootstrap as ttk
-   from ttkbootstrap.validation import add_range_validation
+   from ttkbootstrap import Validation
 
    app = ttk.App()
 
    age = ttk.Entry(app)
    age.pack(padx=20, pady=20)
-   add_range_validation(age, 0, 120)      # 0–120 accepted; anything else flags danger
+   Validation.range(age, 0, 120)      # 0–120 accepted; anything else flags danger
 
    app.mainloop()
 
@@ -89,7 +90,7 @@ intrusive choice:
 
 .. code-block:: python
 
-   add_numeric_validation(entry, when="key")     # reject non-digits as they are typed
+   Validation.numeric(entry, when="key")     # reject non-digits as they are typed
 
 With ``when="key"`` the rule runs on each edit, so a rejected change keeps a bad
 character from ever landing in the field; with ``"focusout"`` the value is
@@ -109,18 +110,18 @@ Custom rules
 When no ready-made rule fits, write your own. A **rule** is a function that
 receives a :class:`~ttkbootstrap.validation.ValidationEvent` and returns
 ``True`` (valid) or ``False`` (invalid). Decorate it with ``@validator`` so it
-receives the event object, then attach it with ``add_validation``:
+receives the event object, then attach it with ``Validation.add``:
 
 .. code-block:: python
 
-   from ttkbootstrap.validation import validator, add_validation
+   from ttkbootstrap import Validation, validator
 
    @validator
    def is_even(event):
        text = event.postchangetext
        return text.isdigit() and int(text) % 2 == 0
 
-   add_validation(entry, is_even, when="focusout")
+   Validation.add(entry, is_even, when="focusout")
 
 The event's most useful attribute is ``postchangetext`` — the value the widget
 *will* hold if the change is allowed — along with ``widget`` (the widget being
@@ -128,8 +129,8 @@ validated). The full set (``actioncode``, ``insertdeletetext``,
 ``validationreason``, …) is documented on
 :class:`~ttkbootstrap.validation.ValidationEvent`.
 
-Pass extra keyword arguments through ``add_validation`` and they arrive at your
-rule — the same mechanism the built-in ``add_range_validation`` uses:
+Pass extra keyword arguments through ``Validation.add`` and they arrive at your
+rule — the same mechanism the built-in ``Validation.range`` uses:
 
 .. code-block:: python
 
@@ -137,7 +138,7 @@ rule — the same mechanism the built-in ``add_range_validation`` uses:
    def max_length(event, limit):
        return len(event.postchangetext) <= limit
 
-   add_validation(entry, max_length, when="key", limit=10)
+   Validation.add(entry, max_length, when="key", limit=10)
 
 .. seealso::
 

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -271,6 +271,11 @@ from ttkbootstrap.dialogs import (
 # the canonical home / import path.
 from ttkbootstrap.localization import L, LocaleVar, set_locale
 
+# Input-validation namespace re-exported at the top level (`ttk.Validation`).
+# Imported last so the `validation -> ttkbootstrap` chain sees a fully built
+# package; `ttkbootstrap.validation` remains the canonical home / import path.
+from ttkbootstrap.validation import Validation, validator, ValidationEvent
+
 __all__ = [
     # Tk exports
     "Tk", "Menu", "Text", "Canvas", "TkFrame", "TkLabel", "LabelFrame", "Variable", "StringVar", "IntVar", "BooleanVar",
@@ -330,6 +335,11 @@ __all__ = [
     "L",
     "LocaleVar",
     "set_locale",
+
+    # Input validation
+    "Validation",
+    "validator",
+    "ValidationEvent",
 
     # Application root + windows
     "App",

--- a/src/ttkbootstrap/dialogs/colorchooser.py
+++ b/src/ttkbootstrap/dialogs/colorchooser.py
@@ -16,7 +16,7 @@ from ttkbootstrap.utils import HEX, HSL, HUE, LUM, RGB, SAT
 from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
 from ttkbootstrap.widgets.tooltip import ToolTip
-from ttkbootstrap.validation import add_range_validation, add_validation, validator
+from ttkbootstrap.validation import Validation, validator
 from .colordropper import ColorChoice, ColorDropperDialog
 
 STD_SHADES: List[float] = [0.9, 0.8, 0.7, 0.4, 0.3]
@@ -290,12 +290,12 @@ class ColorChooser(ttk.Frame):
         ent_hex = ttk.Entry(container, textvariable=self.hex).grid(row=3, column=1, padx=4, columnspan=3, pady=2, sticky=EW)
 
         # add input validation
-        add_validation(ent_hex, validate_color)
-        add_range_validation(sb_hue, 0, 360)
+        Validation.add(ent_hex, validate_color)
+        Validation.range(sb_hue, 0, 360)
         for sb in [sb_sat, sb_lum]:
-            add_range_validation(sb, 0, 100)
+            Validation.range(sb, 0, 100)
         for sb in [sb_red, sb_grn, sb_blu]:
-            add_range_validation(sb, 0, 255)
+            Validation.range(sb, 0, 255)
 
         # event binding for updating colors on value change
         for sb in [sb_hue, sb_sat, sb_lum]:

--- a/src/ttkbootstrap/validation.py
+++ b/src/ttkbootstrap/validation.py
@@ -1,16 +1,21 @@
 r"""Validation framework for ttkbootstrap entry widgets.
 
 Adds input validation to Entry, Spinbox, and Combobox widgets: a failing value
-flags the widget with a 'danger'-colored border that clears once the contents
-become valid. Provides the `@validator` decorator, the core `add_validation`,
-and a family of `add_*` helpers for common cases (text, numeric, phone number,
-regex, range, options).
+flags the widget with the ttk ``invalid`` state (a 'danger'-colored border) that
+clears once the contents become valid. The public surface is the `Validation`
+namespace (`Validation.numeric`, `Validation.range`, ..., and `Validation.add`
+for a custom rule) plus the `@validator` decorator and the `ValidationEvent`
+passed to a rule.
+
+The pre-2.0 module-level `add_*_validation` functions remain as thin deprecated
+aliases (removed in 3.0); new code should call the `Validation` namespace.
 """
 import re
 from tkinter import Misc
 from typing import Any, Callable, Union
 
 import ttkbootstrap as ttk
+from ttkbootstrap.style._compat import warn_deprecated
 
 
 class ValidationEvent:
@@ -85,38 +90,6 @@ def validator(func: Callable[[ValidationEvent], bool]) -> Callable[..., bool]:
     return inner
 
 
-def add_validation(widget: Misc, func: Callable[..., bool], when: str = "focusout", **kwargs: Any) -> None:
-    """Adds validation to the widget of type `Entry`, `Combobox`, or
-    `Spinbox`. The func should accept a parameter of type
-    `ValidationEvent` and should return a boolean value.
-
-    Parameters:
-
-        widget (Widget):
-            The widget on which validation will be applied.
-
-        func (Callable):
-            The function that will be called when a validation event
-            occurs.
-
-        when (str):
-            Indicates when the validation event should occur. Possible
-            values include:
-
-            * focus - whenever the widget gets or loses focus
-            * focusin - whenever the widget gets focus
-            * focusout - whenever the widget loses focus
-            * key - whenever a key is pressed
-            * all - validate in all of the above situations
-
-        kwargs (Dict):
-            Optional arguments passed to the callback.
-    """
-    f = widget.register(lambda *e: func(*e, **kwargs))
-    subs = (r"%d", r"%i", r"%P", r"%s", r"%S", r"%v", r"%V", r"%W")
-    widget.configure(validate=when, validatecommand=(f, *subs))
-
-
 @validator
 def _validate_text(event: ValidationEvent) -> bool:
     """Contents is text."""
@@ -163,71 +136,141 @@ def _validate_regex(event: ValidationEvent, pattern: str) -> bool:
     return match is not None
 
 
-# helper methods
+# A common phone-number shape, shared by Validation.phonenumber.
+_PHONE_PATTERN = r"^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$"
+
+
+class Validation:
+    """Namespace of input-validation rules for ``Entry``, ``Spinbox``, and
+    ``Combobox``.
+
+    Each method attaches a rule to a widget; a value that fails the rule flags
+    the widget with the ttk ``invalid`` state (a ``danger``-colored border) until
+    the contents become valid again. Call them like ``Validation.numeric(entry)``.
+
+    The ``when`` argument on every method controls *when* the rule runs:
+
+    * ``"focusout"`` — when the widget loses focus (the default)
+    * ``"focusin"`` — when the widget gains focus
+    * ``"focus"`` — on both focus in and focus out
+    * ``"key"`` — on every keystroke, as the user types
+    * ``"all"`` — in all of the above situations
+
+    Use ``Validation.add`` for a custom rule (a function decorated with
+    ``@validator``).
+    """
+
+    @staticmethod
+    def add(widget: Misc, func: Callable[..., bool], when: str = "focusout", **kwargs: Any) -> None:
+        """Attach a custom rule to `widget`.
+
+        The rule `func` receives a `ValidationEvent` and returns a boolean; it is
+        usually written with the `@validator` decorator. Extra keyword arguments
+        are forwarded to the rule on each call (as `add_range_validation` forwards
+        its bounds).
+
+        Parameters:
+
+            widget (Widget):
+                The `Entry`, `Combobox`, or `Spinbox` to validate.
+
+            func (Callable):
+                The validation function, called on each validation event.
+
+            when (str):
+                When the rule runs. See the class docstring for the options.
+
+            kwargs (Dict):
+                Optional arguments forwarded to `func`.
+        """
+        f = widget.register(lambda *e: func(*e, **kwargs))
+        subs = (r"%d", r"%i", r"%P", r"%s", r"%S", r"%v", r"%V", r"%W")
+        widget.configure(validate=when, validatecommand=(f, *subs))
+
+    @staticmethod
+    def text(widget: Misc, when: str = "focusout") -> None:
+        """Require the contents to be alphabetic (an empty field passes)."""
+        Validation.add(widget, _validate_text, when=when)
+
+    @staticmethod
+    def numeric(widget: Misc, when: str = "focusout") -> None:
+        """Require the contents to be numeric (an empty field passes)."""
+        Validation.add(widget, _validate_number, when=when)
+
+    @staticmethod
+    def range(
+        widget: Misc,
+        start: Union[int, float],
+        end: Union[int, float],
+        when: str = "focusout",
+    ) -> None:
+        """Require a number within `start`–`end` inclusive (an empty field passes).
+
+        Parameters:
+
+            widget (Widget):
+                The widget on which to add validation.
+
+            start (int or float):
+                The lower bound of the accepted range, inclusive.
+
+            end (int or float):
+                The upper bound of the accepted range, inclusive.
+
+            when (str):
+                When the rule runs. See the class docstring for the options.
+        """
+        Validation.add(widget, _validate_range, startrange=start, endrange=end, when=when)
+
+    @staticmethod
+    def regex(widget: Misc, pattern: str, when: str = "focusout") -> None:
+        """Require the contents to match the regular expression `pattern`."""
+        Validation.add(widget, _validate_regex, pattern=pattern, when=when)
+
+    @staticmethod
+    def options(widget: Misc, options: list[Any], when: str = "focusout") -> None:
+        """Require the contents to be one of the values in `options`."""
+        Validation.add(widget, _validate_options, options=options, when=when)
+
+    @staticmethod
+    def phonenumber(widget: Misc, when: str = "focusout") -> None:
+        """Require the contents to match a common phone-number pattern."""
+        Validation.add(widget, _validate_regex, pattern=_PHONE_PATTERN, when=when)
+
+
+# ---------------------------------------------------------------------------
+# Deprecated pre-2.0 free functions -> Validation namespace (removed in 3.0).
+# ---------------------------------------------------------------------------
+
+
+def add_validation(widget: Misc, func: Callable[..., bool], when: str = "focusout", **kwargs: Any) -> None:
+    """Deprecated alias for `Validation.add` (removed in 3.0)."""
+    warn_deprecated("add_validation()", "Validation.add()")
+    Validation.add(widget, func, when=when, **kwargs)
 
 
 def add_text_validation(widget: Misc, when: str = "focusout") -> None:
-    """Check if widget contents is alpha. Sets the state to 'Invalid'
-    if not text.
-
-    Parameters:
-
-        widget (Widget):
-            The widget on which to add validation.
-
-        when (str):
-            Specifies when to apply validation. See the `add_validation`
-            method docstring for a full list of options.
-    """
-    add_validation(widget, _validate_text, when=when)
+    """Deprecated alias for `Validation.text` (removed in 3.0)."""
+    warn_deprecated("add_text_validation()", "Validation.text()")
+    Validation.text(widget, when=when)
 
 
 def add_numeric_validation(widget: Misc, when: str = "focusout") -> None:
-    """Check if widget contents is numeric. Sets the state to 'Invalid'
-    if not a number.
-
-    Parameters:
-
-        widget (Widget):
-            The widget on which to add validation.
-
-        when (str):
-            Specifies when to apply validation. See the `add_validation`
-            method docstring for a full list of options.
-    """
-    add_validation(widget, _validate_number, when=when)
+    """Deprecated alias for `Validation.numeric` (removed in 3.0)."""
+    warn_deprecated("add_numeric_validation()", "Validation.numeric()")
+    Validation.numeric(widget, when=when)
 
 
 def add_phonenumber_validation(widget: Misc, when: str = "focusout") -> None:
-    """Check if the widget contents matches a phone number pattern.
-
-    Parameters:
-
-        widget (Widget):
-            The widget on which to add validation.
-
-        when (str):
-            Specifies when to apply validation. See the `add_validation`
-            method docstring for a full list of options.
-    """
-    pattern = r"^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$"
-    add_validation(widget, _validate_regex, pattern=pattern, when=when)
+    """Deprecated alias for `Validation.phonenumber` (removed in 3.0)."""
+    warn_deprecated("add_phonenumber_validation()", "Validation.phonenumber()")
+    Validation.phonenumber(widget, when=when)
 
 
 def add_regex_validation(widget: Misc, pattern: str, when: str = "focusout") -> None:
-    """Check if widget contents matches regular expresssion. Sets the
-    state to 'Invalid' if no match is found.
-
-    Parameters:
-
-        widget (Widget):
-            The widget on which to add validation.
-
-        when (str):
-            Specifies when to apply validation. See the `add_validation`
-            method docstring for a full list of options.
-    """
-    add_validation(widget, _validate_regex, pattern=pattern, when=when)
+    """Deprecated alias for `Validation.regex` (removed in 3.0)."""
+    warn_deprecated("add_regex_validation()", "Validation.regex()")
+    Validation.regex(widget, pattern, when=when)
 
 
 def add_range_validation(
@@ -236,68 +279,28 @@ def add_range_validation(
     endrange: Union[int, float],
     when: str = "focusout",
 ) -> None:
-    """Check if widget contents is within a range of numbers, inclusive.
-    Sets the state to 'Invalid' if the number is outside of the range.
-
-    Parameters:
-
-        widget (Widget):
-            The widget on which to add validation.
-
-        startrange (Union[int, float]):
-            The lower bound of the accepted range, inclusive.
-
-        endrange (Union[int, float]):
-            The upper bound of the accepted range, inclusive.
-
-        when (str):
-            Specifies when to apply validation. See the `add_validation`
-            method docstring for a full list of options.
-    """
-    add_validation(
-        widget,
-        _validate_range,
-        startrange=startrange,
-        endrange=endrange,
-        when=when,
-    )
+    """Deprecated alias for `Validation.range` (removed in 3.0)."""
+    warn_deprecated("add_range_validation()", "Validation.range()")
+    Validation.range(widget, startrange, endrange, when=when)
 
 
 def add_option_validation(widget: Misc, options: list[Any], when: str = "focusout") -> None:
-    """Check if the widget contents is in a list of options.
-
-    Parameters:
-
-        widget (Widget):
-            The widget on which to add validation.
-
-        options (list):
-            The list of acceptable values.
-
-        when (str):
-            Specifies when to apply validation. See the `add_validation`
-            method docstring for a full list of options.
-    """
-    add_validation(widget, _validate_options, options=options, when=when)
+    """Deprecated alias for `Validation.options` (removed in 3.0)."""
+    warn_deprecated("add_option_validation()", "Validation.options()")
+    Validation.options(widget, options, when=when)
 
 
 if __name__ == "__main__":
     app = ttk.App()
-
 
     @validator
     def my_validation(event: ValidationEvent) -> bool:
         print(event.postchangetext)
         return True
 
-
     entry = ttk.Entry().pack(padx=10, pady=10)
     entry2 = ttk.Entry().pack(padx=10, pady=10)
-    # add_validation(entry, validate_range, startrange=5, endrange=10)
-    # add_validation(entry, validate_regex, pattern="israel")
-    add_text_validation(entry, when="key")  # prevents from using any numbers
-    add_text_validation(entry2, when="key")
-    # add_option_validation(entry, ['red', 'blue', 'green'], 'focusout')
-    # add_regex_validation(entry, r'\d{4}-\d{2}-\d{2}')
+    Validation.text(entry, when="key")  # prevents from using any numbers
+    Validation.text(entry2, when="key")
     ttk.Button(text="Other").pack(padx=10, pady=10)
     app.mainloop()


### PR DESCRIPTION
## Summary

Two related pieces of 2.0 work, starting from the docs Workstream H feature-guide stubs and turning up an API-normalization opportunity along the way.

### 1. `Validation` namespace *(API — deprecated aliases, not a hard break)*

The input-validation helpers move from flat `add_*_validation` free functions to a `Validation` namespace (mirroring `Fonts` / `MessageCatalog`), re-exported at the top level as `ttk.Validation`:

| Pre-2.0 (deprecated) | 2.0 |
|---|---|
| `add_text_validation(w)` | `Validation.text(w)` |
| `add_numeric_validation(w)` | `Validation.numeric(w)` |
| `add_range_validation(w, start, end)` | `Validation.range(w, start, end)` |
| `add_regex_validation(w, pattern)` | `Validation.regex(w, pattern)` |
| `add_option_validation(w, options)` | `Validation.options(w, options)` |
| `add_phonenumber_validation(w)` | `Validation.phonenumber(w)` |
| `add_validation(w, func)` | `Validation.add(w, func)` |

**Why the namespace** (vs a flat `ttk.validate_range(...)`): it houses the custom-rule core cleanly as `Validation.add`, reads as *attaching a rule* rather than colliding with tkinter's existing `widget.validate()` (which runs a check now and returns a bool), and groups the rules for discovery. `@validator` and `ValidationEvent` are unchanged (also top-level now).

The seven `add_*` functions were public through **v1.9.0** (released, documented, with a cookbook example), so they stay as thin **warn-and-forward deprecated aliases** (removed in 3.0) — same migration pattern as the window-kwarg / Tableview-verb renames. First-party caller `ColorChooser` is migrated so shipped dialogs don't trip their own deprecation warnings (cf. #1132).

Logged in `development/2_0_breaking_changes.md`.

### 2. Feature guides authored

Fleshed the three "being written for 2.0" stubs into full guides, modeled on the Variables/Events guides (teach-by-example, list-tables, screenshot placeholders, `seealso` cross-refs):

- **Typography** — the standard Tk named fonts, `set_global_family` (deferred-config seam), and the `Fonts` namespace.
- **Localization** — the message-catalog model, `L()`, registering translations (`MessageCatalog`), `set_locale`, and live switching with `LocaleVar`.
- **Input validation** — authored against the new `Validation` namespace: the ready-made rules, the `when=` modes, the danger border as the ttk `invalid` state, and custom rules via `@validator` + `Validation.add`.

## Verification

- Headless suite: **636 passed** (incl. the normally-flaky `nl.msg` test this run); colorchooser no longer emits deprecation warnings.
- All six deprecated aliases confirmed to warn and forward; `ColorChooser` builds warning-free under `-W error::DeprecationWarning`.
- Every guide code example verified headlessly; `LocaleVar` live re-translate confirmed.
- Full-site `sphinx -b html -W --keep-going` clean, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)