### PR TITLE
docs: Dialogs guide + file-dialog Querybox methods + feature-guide robustness pass

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -36,6 +36,7 @@
 | **Button-family visual restyle (flat + hairline border)** | Visual | this doc, below |
 | **Bare buttons default to `neutral`** | Visual/API | this doc, below |
 | **Dialog API normalization (Messagebox/Querybox)** | API | `development/2_0_shipped_widget_api_design.md` (PR A) |
+| **File dialogs surfaced: `Querybox.get_open_filename`/… + `ttk.filedialog`** | New | this doc, below |
 | **Meter: snake_case options, DoubleVar, `value`** | Breaking/additive | this doc, below (PR 2 / #1110) |
 | **DateEntry: snake_case (cross-layer), live-text read, string `state`** | Breaking/additive | this doc, below (PR 3 / #1111) |
 | **Floodgauge: DoubleVar value, `start(interval)`, live mode/orient** | Breaking/additive | this doc, below (PR 4) |
@@ -1526,3 +1527,32 @@ trip the warning. `when=` semantics are identical; only the call name changes.
 **Scope.** `validation.py` (new `Validation` namespace + deprecated aliases),
 `__init__.py` (top-level `Validation`/`validator`/`ValidationEvent` re-export),
 `dialogs/colorchooser.py` (4 call sites migrated).
+
+## File dialogs surfaced through `Querybox` + `ttk.filedialog`  *(New — additive)*
+
+The native file dialog was the one standard dialog with **no** ttkbootstrap
+entry point — callers had to drop to `from tkinter import filedialog` while every
+other dialog was `ttk.Messagebox` / `ttk.Querybox`. That inconsistency is closed:
+
+- **`Querybox.get_open_filename` / `get_open_filenames` / `get_save_filename` /
+  `get_directory`** — thin static-method wrappers over `tkinter.filedialog`
+  (`askopenfilename` / `askopenfilenames` / `asksaveasfilename` / `askdirectory`),
+  so a file path is fetched through the same `Querybox.get_*` facade as every
+  other value. They **normalize the stdlib `""`/`()`-on-cancel to `None`** to
+  match the rest of the facade's contract; all other keyword args (`title`,
+  `filetypes`, `initialdir`, `defaultextension`, …) forward to the underlying
+  function.
+- **`ttk.filedialog`** — the stdlib `tkinter.filedialog` module, re-exported at
+  the top level for the variants the four wrappers don't cover (e.g.
+  `askopenfile`, which returns an open file object).
+
+**Why.** filedialog is *not superseded* (the OS draws the native picker, so
+ttkbootstrap can't restyle it) — but "not restyled" is no reason to make it the
+one dialog you can't reach through the library. This surfaces it for API
+consistency without pretending to theme it. Consistent with the static-method
+facade the rest of `Querybox`/`Messagebox` already use (not new free functions).
+This is additive — no existing call changes; `tkinter.filedialog` still works.
+
+**Scope.** `dialogs/query.py` (four `Querybox` methods + `filedialog` import),
+`__init__.py` (`ttk.filedialog` re-export), `tests/test_dialogs_api.py` (+3), the
+Dialogs feature guide.

--- a/docs/user-guide/feature-guides/dialogs.rst
+++ b/docs/user-guide/feature-guides/dialogs.rst
@@ -1,0 +1,207 @@
+Dialogs
+=======
+
+A **dialog** is a small pop-up window for a single interaction — telling the user
+something, asking a yes/no question, or collecting one value. ttkbootstrap ships
+themed dialogs that replace tkinter's plain stdlib ones, reached through two
+facades:
+
+- **Messagebox** — *tell* the user something, or *ask* a fixed question (OK,
+  yes/no, retry/cancel).
+- **Querybox** — *get a value* back: a string, a number, a date, a font, a color.
+
+Every dialog is **modal** (it blocks the rest of the app until dismissed) and
+**returns its result directly** from the call — no callbacks to wire up. All the
+names below are re-exported at the top level, so ``ttk.Messagebox`` and
+``from ttkbootstrap import Messagebox`` both work.
+
+Messagebox — tell and ask
+-------------------------
+
+Each method is a one-line call that pops the dialog, blocks until the user
+answers, and **returns the label of the button they pressed** — or ``None`` if
+they dismissed it with *Escape* or the window's ✕:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap import Messagebox
+
+   app = ttk.App()
+
+   answer = Messagebox.yesno("Save changes before closing?", "Confirm")
+   if answer == "Yes":
+       save()
+
+The two families:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Method
+     - Shows
+   * - ``show_info`` / ``show_warning`` / ``show_error`` / ``show_question``
+     - A message with the matching icon and an **OK** button.
+   * - ``ok`` / ``okcancel`` / ``yesno`` / ``yesnocancel`` / ``retrycancel``
+     - The named choice buttons; the return value is the one pressed.
+
+The first positional argument is the ``message``; the second is the ``title``.
+Everything else is **keyword-only** — most importantly ``parent``, which centers
+the dialog over a window and ties its modality to it:
+
+.. code-block:: python
+
+   Messagebox.show_error("The file could not be opened.", "Error", parent=app)
+
+Pass your own ``buttons`` to a Messagebox as ``"label:bootstyle"`` strings; the
+returned value is still whichever label was clicked:
+
+.. code-block:: python
+
+   choice = Messagebox.show_question(
+       "Apply changes to all items?", "Apply",
+       buttons=["Cancel:secondary", "This one:primary", "All:success"],
+   )
+
+.. note::
+
+   The return value is the button's **displayed** text. With localization active
+   the labels are translated, so a bare ``== "Yes"`` can miss — compare against
+   the same source string you passed, or drive off the button *position*. See
+   :doc:`Localization </user-guide/feature-guides/localization>`.
+
+Querybox — get a value
+----------------------
+
+Where a Messagebox returns a button, a **Querybox** returns a **typed value** —
+or ``None`` if the user cancels:
+
+.. code-block:: python
+
+   from ttkbootstrap import Querybox
+
+   name = Querybox.get_string("What is your name?", "Name")
+   if name is not None:                 # None means they cancelled
+       greet(name)
+
+.. list-table::
+   :header-rows: 1
+   :widths: 46 54
+
+   * - Method
+     - Returns (or ``None`` on cancel)
+   * - ``get_string(prompt, title)``
+     - the entered ``str`` (an empty submit is ``""``, *not* ``None``).
+   * - ``get_integer(prompt, title, minvalue=, maxvalue=)``
+     - an ``int``, range-checked.
+   * - ``get_float(prompt, title, minvalue=, maxvalue=)``
+     - a ``float``, range-checked.
+   * - ``get_item(prompt, title, items=[...])``
+     - the chosen ``str`` from ``items``.
+   * - ``get_date(parent, ...)``
+     - a ``datetime.date`` from a calendar popup.
+   * - ``get_font(parent)``
+     - a ``tkinter.font.Font``.
+   * - ``get_color(parent, initialcolor=)``
+     - a ``ColorChoice`` (see below).
+
+The number pickers validate for you — a value outside ``minvalue``/``maxvalue``
+keeps the dialog open until it is corrected or cancelled:
+
+.. code-block:: python
+
+   age = Querybox.get_integer("Age?", "Sign up", minvalue=0, maxvalue=130)
+
+.. note::
+
+   ``None`` unambiguously means *cancelled*. Always check for it before using the
+   result — the value pickers never raise on cancel, they return ``None``.
+
+The pickers
+~~~~~~~~~~~
+
+``get_date``, ``get_font``, and ``get_color`` open richer choosers. Note their
+first argument is the ``parent`` window (the dialog centers on it):
+
+.. code-block:: python
+
+   from datetime import date
+
+   d = Querybox.get_date(app, title="Pick a date", start_date=date.today())
+
+   font = Querybox.get_font(app)         # a tkinter.font.Font, usable as font=font
+
+``get_color`` returns a ``ColorChoice`` — a named tuple with the same color in
+three models, so you can take whichever you need:
+
+.. code-block:: python
+
+   c = Querybox.get_color(app, initialcolor="#3498db")
+   if c is not None:
+       print(c.hex)      # '#RRGGBB'
+       print(c.rgb)      # (r, g, b), each 0–255
+       print(c.hsl)      # (h 0–360, s 0–100, l 0–100)
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A Messagebox yes/no and a Querybox color picker side by side, both in the
+   active theme.
+
+``filedialog`` — the one you still reach for stdlib
+---------------------------------------------------
+
+The **one** standard dialog ttkbootstrap does *not* replace is the file dialog:
+open, save, and choose-directory use the **native OS** dialog, which you want —
+so call tkinter's :mod:`tkinter.filedialog` directly. Each returns the chosen
+path as a string, or an empty string ``""`` if cancelled:
+
+.. code-block:: python
+
+   from tkinter import filedialog
+
+   path = filedialog.askopenfilename(
+       title="Open",
+       filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
+   )
+   if path:                              # "" means cancelled
+       open(path).read()
+
+   save_to = filedialog.asksaveasfilename(defaultextension=".txt")
+   folder = filedialog.askdirectory()
+
+The other stdlib dialogs (``messagebox``, ``simpledialog``, ``colorchooser``,
+the font chooser) *are* superseded — reach for ``Messagebox`` / ``Querybox``
+above instead, so they match your theme.
+
+Building your own dialog
+------------------------
+
+The facades are built on the ``MessageDialog`` and ``QueryDialog`` classes, which
+you can use directly when you need more control — for instance to place the
+dialog yourself or run it **without blocking**. Construct one, then call
+``show(position=...)`` and read ``.result``:
+
+.. code-block:: python
+
+   dialog = ttk.MessageDialog("Delete this record?", buttons=["Cancel", "Delete:danger"])
+   dialog.show()                # modal; blocks until a button is pressed
+   if dialog.result == "Delete":
+       delete()
+
+``MessageDialog`` also accepts a ``command`` — a plain zero-argument callable run
+when a button is pressed — for a fire-and-forget dialog you do not block on.
+
+For a fully bespoke dialog (your own widgets and layout), build a ``Toplevel``
+and make it modal yourself; the :doc:`Multiple windows how-to
+</user-guide/how-to/multiple-windows>` walks through a reusable modal that
+returns a value.
+
+.. seealso::
+
+   :doc:`Windows & high-DPI </user-guide/feature-guides/windows>` for the focus,
+   modality, and lifecycle mechanics the dialogs are built on;
+   :doc:`Input validation </user-guide/feature-guides/validation>` for validating
+   fields in a form dialog; and the :doc:`Multiple windows how-to
+   </user-guide/how-to/multiple-windows>` for rolling your own.

--- a/docs/user-guide/feature-guides/dialogs.rst
+++ b/docs/user-guide/feature-guides/dialogs.rst
@@ -105,6 +105,12 @@ or ``None`` if the user cancels:
      - a ``tkinter.font.Font``.
    * - ``get_color(parent, initialcolor=)``
      - a ``ColorChoice`` (see below).
+   * - ``get_open_filename(parent)`` / ``get_open_filenames(parent)``
+     - a file path ``str`` / a ``tuple`` of paths (native file dialog).
+   * - ``get_save_filename(parent)``
+     - a file path ``str`` (native *save as* dialog).
+   * - ``get_directory(parent)``
+     - a directory path ``str`` (native folder dialog).
 
 The number pickers validate for you — a value outside ``minvalue``/``maxvalue``
 keeps the dialog open until it is corrected or cancelled:
@@ -149,31 +155,43 @@ three models, so you can take whichever you need:
    A Messagebox yes/no and a Querybox color picker side by side, both in the
    active theme.
 
-``filedialog`` — the one you still reach for stdlib
----------------------------------------------------
+File dialogs
+~~~~~~~~~~~~
 
-The **one** standard dialog ttkbootstrap does *not* replace is the file dialog:
-open, save, and choose-directory use the **native OS** dialog, which you want —
-so call tkinter's :mod:`tkinter.filedialog` directly. Each returns the chosen
-path as a string, or an empty string ``""`` if cancelled:
+Opening and saving files use the **native OS** dialog — the one standard dialog
+ttkbootstrap deliberately does *not* restyle, because the OS draws it and users
+expect their platform's file picker. They are still reached through ``Querybox``,
+so a path is fetched the same way as any other value, and — like the rest of the
+facade — they return ``None`` on cancel:
 
 .. code-block:: python
 
-   from tkinter import filedialog
-
-   path = filedialog.askopenfilename(
-       title="Open",
+   path = Querybox.get_open_filename(
+       parent=app,
        filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
    )
-   if path:                              # "" means cancelled
+   if path is not None:                  # None means cancelled
        open(path).read()
 
-   save_to = filedialog.asksaveasfilename(defaultextension=".txt")
-   folder = filedialog.askdirectory()
+   save_to = Querybox.get_save_filename(parent=app, defaultextension=".txt")
+   folder  = Querybox.get_directory(parent=app)
+   many    = Querybox.get_open_filenames(parent=app)   # a tuple of paths
 
-The other stdlib dialogs (``messagebox``, ``simpledialog``, ``colorchooser``,
-the font chooser) *are* superseded — reach for ``Messagebox`` / ``Querybox``
-above instead, so they match your theme.
+Each forwards its keyword arguments (``title``, ``filetypes``, ``initialdir``,
+``defaultextension``, …) to the underlying ``tkinter.filedialog`` function. That
+module is also re-exported as ``ttk.filedialog`` if you need a variant these four
+don't cover (for example ``askopenfile``, which returns an open file object):
+
+.. code-block:: python
+
+   ttk.filedialog.askopenfile(parent=app)     # the stdlib module, surfaced
+
+.. note::
+
+   File dialogs are the **only** stdlib dialog ttkbootstrap keeps. The others —
+   ``messagebox``, ``simpledialog``, ``colorchooser``, the font chooser — are
+   superseded by ``Messagebox`` / ``Querybox`` above, so reach for those to get
+   themed, consistent dialogs.
 
 Building your own dialog
 ------------------------

--- a/docs/user-guide/feature-guides/dialogs.rst
+++ b/docs/user-guide/feature-guides/dialogs.rst
@@ -2,25 +2,30 @@ Dialogs
 =======
 
 A **dialog** is a small pop-up window for a single interaction — telling the user
-something, asking a yes/no question, or collecting one value. ttkbootstrap ships
-themed dialogs that replace tkinter's plain stdlib ones, reached through two
-facades:
+something, asking a question, or collecting one value. Working with a dialog is
+always the same three-step shape: **show it, read what it returns, act on that.**
+Every ttkbootstrap dialog is **modal** (it blocks the rest of the app until the
+user answers) and hands its result straight back from the call — there are no
+callbacks to wire up.
 
-- **Messagebox** — *tell* the user something, or *ask* a fixed question (OK,
-  yes/no, retry/cancel).
-- **Querybox** — *get a value* back: a string, a number, a date, a font, a color.
+ttkbootstrap ships themed dialogs that replace tkinter's plain stdlib ones,
+reached through two facades:
 
-Every dialog is **modal** (it blocks the rest of the app until dismissed) and
-**returns its result directly** from the call — no callbacks to wire up. All the
-names below are re-exported at the top level, so ``ttk.Messagebox`` and
+- **Messagebox** — *tell* the user something, or *ask* a question with fixed
+  buttons (OK, yes/no, retry/cancel).
+- **Querybox** — *get a value* back: a string, a number, a date, a font, a color,
+  or a file path.
+
+Both are re-exported at the top level, so ``ttk.Messagebox`` and
 ``from ttkbootstrap import Messagebox`` both work.
 
-Messagebox — tell and ask
--------------------------
+Asking a question — Messagebox
+------------------------------
 
-Each method is a one-line call that pops the dialog, blocks until the user
-answers, and **returns the label of the button they pressed** — or ``None`` if
-they dismissed it with *Escape* or the window's ✕:
+A ``Messagebox`` call pops the dialog, blocks until the user answers, and
+**returns the label of the button they pressed** — or ``None`` if they dismiss it
+with *Escape* or the window's ✕. You branch on that label. A "close with unsaved
+changes" prompt is the archetypal example — three buttons, three paths:
 
 .. code-block:: python
 
@@ -29,40 +34,75 @@ they dismissed it with *Escape* or the window's ✕:
 
    app = ttk.App()
 
-   answer = Messagebox.yesno("Save changes before closing?", "Confirm")
-   if answer == "Yes":
-       save()
+   def on_quit():
+       answer = Messagebox.yesnocancel(
+           "Save changes before closing?", "Unsaved changes", parent=app)
+       if answer == "Yes":
+           save()
+           app.destroy()
+       elif answer == "No":
+           app.destroy()          # discard and close
+       # "Cancel" or None → fall through: stay open, do nothing
 
-The two families:
+Reading it back: ``yesnocancel`` gives you ``"Yes"`` / ``"No"`` / ``"Cancel"``,
+and — crucially — ``None`` if the window is simply closed, which you handle the
+same as Cancel.
+
+Pick the method for the buttons your question needs:
 
 .. list-table::
    :header-rows: 1
-   :widths: 40 60
+   :widths: 42 58
 
    * - Method
-     - Shows
+     - Buttons / use
    * - ``show_info`` / ``show_warning`` / ``show_error`` / ``show_question``
-     - A message with the matching icon and an **OK** button.
-   * - ``ok`` / ``okcancel`` / ``yesno`` / ``yesnocancel`` / ``retrycancel``
-     - The named choice buttons; the return value is the one pressed.
+     - A message with the matching icon and a single **OK** button — a
+       notification, not a real question.
+   * - ``ok`` / ``okcancel``
+     - Confirm an action (returns ``"OK"`` / ``"Cancel"``).
+   * - ``yesno`` / ``yesnocancel``
+     - A yes/no decision, optionally with a third *Cancel* out.
+   * - ``retrycancel``
+     - Offer a retry after a failure.
 
-The first positional argument is the ``message``; the second is the ``title``.
-Everything else is **keyword-only** — most importantly ``parent``, which centers
-the dialog over a window and ties its modality to it:
+The first two arguments are the ``message`` and ``title``; **everything else is
+keyword-only.** The most important keyword is ``parent`` — pass it and the dialog
+centers over that window and scopes its modality to it (without it, the dialog
+centers on screen and grabs the whole application):
 
 .. code-block:: python
 
    Messagebox.show_error("The file could not be opened.", "Error", parent=app)
 
-Pass your own ``buttons`` to a Messagebox as ``"label:bootstyle"`` strings; the
-returned value is still whichever label was clicked:
+``show_warning`` and ``show_error`` also ring the system bell by default; pass
+``alert=False`` to silence it.
+
+Custom buttons
+~~~~~~~~~~~~~~
+
+When the fixed sets don't fit, pass your own ``buttons`` as ``"label:bootstyle"``
+strings — the color after the colon is any :doc:`bootstyle
+</user-guide/foundations/bootstyle-grammar>` color. The return value is still
+whichever label was clicked, so name them for how you'll test them:
 
 .. code-block:: python
 
    choice = Messagebox.show_question(
-       "Apply changes to all items?", "Apply",
+       "Apply changes to all items, or just this one?", "Apply changes",
        buttons=["Cancel:secondary", "This one:primary", "All:success"],
+       parent=app,
    )
+   if choice == "All":
+       apply_to_all()
+   elif choice == "This one":
+       apply_to_current()
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   The "Apply changes" dialog with three custom buttons — a secondary *Cancel*, a
+   primary *This one*, and a success-green *All* — in the active theme.
 
 .. note::
 
@@ -71,19 +111,22 @@ returned value is still whichever label was clicked:
    the same source string you passed, or drive off the button *position*. See
    :doc:`Localization </user-guide/feature-guides/localization>`.
 
-Querybox — get a value
-----------------------
+Collecting a value — Querybox
+-----------------------------
 
-Where a Messagebox returns a button, a **Querybox** returns a **typed value** —
-or ``None`` if the user cancels:
+Where a Messagebox returns a button, a ``Querybox`` returns a **typed value** — or
+``None`` if the user cancels. The pattern is *get, check for* ``None``\ *, use*:
 
 .. code-block:: python
 
    from ttkbootstrap import Querybox
 
-   name = Querybox.get_string("What is your name?", "Name")
-   if name is not None:                 # None means they cancelled
-       greet(name)
+   new_name = Querybox.get_string(
+       "Rename to:", "Rename", initialvalue=item.name, parent=app)
+   if new_name:                          # None = cancelled, "" = empty submit
+       item.rename(new_name)
+
+The full set — every method returns its value or ``None`` on cancel:
 
 .. list-table::
    :header-rows: 1
@@ -105,54 +148,64 @@ or ``None`` if the user cancels:
      - a ``tkinter.font.Font``.
    * - ``get_color(parent, initialcolor=)``
      - a ``ColorChoice`` (see below).
-   * - ``get_open_filename(parent)`` / ``get_open_filenames(parent)``
-     - a file path ``str`` / a ``tuple`` of paths (native file dialog).
-   * - ``get_save_filename(parent)``
-     - a file path ``str`` (native *save as* dialog).
-   * - ``get_directory(parent)``
-     - a directory path ``str`` (native folder dialog).
+   * - ``get_open_filename`` / ``get_open_filenames`` / ``get_save_filename`` /
+       ``get_directory``
+     - a file path / paths (see *File dialogs*).
 
-The number pickers validate for you — a value outside ``minvalue``/``maxvalue``
-keeps the dialog open until it is corrected or cancelled:
+The number pickers **validate for you** — a value outside ``minvalue`` /
+``maxvalue`` keeps the dialog open until it's corrected or cancelled, so a
+returned number is always in range:
 
 .. code-block:: python
 
-   age = Querybox.get_integer("Age?", "Sign up", minvalue=0, maxvalue=130)
+   qty = Querybox.get_integer(
+       "Quantity:", "Order", initialvalue=1, minvalue=1, maxvalue=99, parent=app)
+   if qty is not None:
+       add_to_cart(item, qty)
 
 .. note::
 
-   ``None`` unambiguously means *cancelled*. Always check for it before using the
-   result — the value pickers never raise on cancel, they return ``None``.
+   ``get_string`` distinguishes an **empty submit** (``""``) from a **cancel**
+   (``None``); the ``if new_name:`` test above treats both as "nothing to do,"
+   which is usually what you want. When you need to tell them apart — an empty
+   value is meaningful — test ``is not None`` explicitly. Every other picker
+   returns only its value or ``None``.
 
 The pickers
 ~~~~~~~~~~~
 
-``get_date``, ``get_font``, and ``get_color`` open richer choosers. Note their
-first argument is the ``parent`` window (the dialog centers on it):
+``get_date``, ``get_font``, and ``get_color`` open richer choosers. Their **first
+argument is the** ``parent`` **window** (the dialog centers on it), and the value
+they return is ready to use directly:
 
 .. code-block:: python
 
    from datetime import date
 
-   d = Querybox.get_date(app, title="Pick a date", start_date=date.today())
+   due = Querybox.get_date(app, title="Due date", start_date=date.today())
+   if due is not None:
+       due_entry.delete(0, "end")
+       due_entry.insert(0, due.isoformat())
 
-   font = Querybox.get_font(app)         # a tkinter.font.Font, usable as font=font
+   font = Querybox.get_font(app)
+   if font is not None:
+       heading.configure(font=font)      # the Font object drops straight in
 
-``get_color`` returns a ``ColorChoice`` — a named tuple with the same color in
-three models, so you can take whichever you need:
+``get_color`` returns a ``ColorChoice`` — a named tuple carrying the same color in
+three models, so you take whichever the calling code needs:
 
 .. code-block:: python
 
-   c = Querybox.get_color(app, initialcolor="#3498db")
-   if c is not None:
-       print(c.hex)      # '#RRGGBB'
-       print(c.rgb)      # (r, g, b), each 0–255
-       print(c.hsl)      # (h 0–360, s 0–100, l 0–100)
+   picked = Querybox.get_color(app, initialcolor="#3498db")
+   if picked is not None:
+       swatch.configure(background=picked.hex)   # '#RRGGBB'
+       r, g, b = picked.rgb                       # each 0–255
+       h, s, l = picked.hsl                       # h 0–360, s/l 0–100
 
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder
 
-   A Messagebox yes/no and a Querybox color picker side by side, both in the
+   The date picker (a themed calendar popup) beside the color chooser, both in the
    active theme.
 
 File dialogs
@@ -160,9 +213,9 @@ File dialogs
 
 Opening and saving files use the **native OS** dialog — the one standard dialog
 ttkbootstrap deliberately does *not* restyle, because the OS draws it and users
-expect their platform's file picker. They are still reached through ``Querybox``,
-so a path is fetched the same way as any other value, and — like the rest of the
-facade — they return ``None`` on cancel:
+expect their platform's file picker. They're still reached through ``Querybox``,
+so a path is fetched like any other value, and — like the rest of the facade —
+they return ``None`` on cancel:
 
 .. code-block:: python
 
@@ -171,7 +224,8 @@ facade — they return ``None`` on cancel:
        filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
    )
    if path is not None:                  # None means cancelled
-       open(path).read()
+       with open(path) as f:
+           load(f.read())
 
    save_to = Querybox.get_save_filename(parent=app, defaultextension=".txt")
    folder  = Querybox.get_directory(parent=app)
@@ -179,8 +233,8 @@ facade — they return ``None`` on cancel:
 
 Each forwards its keyword arguments (``title``, ``filetypes``, ``initialdir``,
 ``defaultextension``, …) to the underlying ``tkinter.filedialog`` function. That
-module is also re-exported as ``ttk.filedialog`` if you need a variant these four
-don't cover (for example ``askopenfile``, which returns an open file object):
+module is also re-exported as ``ttk.filedialog`` for a variant these four don't
+cover — for example ``askopenfile``, which returns an open file object:
 
 .. code-block:: python
 
@@ -190,31 +244,70 @@ don't cover (for example ``askopenfile``, which returns an open file object):
 
    File dialogs are the **only** stdlib dialog ttkbootstrap keeps. The others —
    ``messagebox``, ``simpledialog``, ``colorchooser``, the font chooser — are
-   superseded by ``Messagebox`` / ``Querybox`` above, so reach for those to get
+   superseded by ``Messagebox`` / ``Querybox`` above; reach for those to get
    themed, consistent dialogs.
 
-Building your own dialog
-------------------------
+Driving the dialog classes directly
+-----------------------------------
 
-The facades are built on the ``MessageDialog`` and ``QueryDialog`` classes, which
-you can use directly when you need more control — for instance to place the
-dialog yourself or run it **without blocking**. Construct one, then call
-``show(position=...)`` and read ``.result``:
+The facades are thin conveniences over two classes — ``MessageDialog`` and
+``QueryDialog`` — that you can use directly when you need more than a one-line
+call: to set a **default button**, **place** the dialog yourself, or run it
+**without blocking**. The three-step shape becomes explicit: construct, ``show``,
+read ``.result``.
 
 .. code-block:: python
 
-   dialog = ttk.MessageDialog("Delete this record?", buttons=["Cancel", "Delete:danger"])
-   dialog.show()                # modal; blocks until a button is pressed
+   dialog = ttk.MessageDialog(
+       "Delete this record? This cannot be undone.",
+       title="Delete",
+       buttons=["Cancel:secondary", "Delete:danger"],
+       default="Cancel",              # focused button; Return activates it
+       parent=app,
+   )
+   dialog.show()                      # modal — blocks until a button is pressed
    if dialog.result == "Delete":
        delete()
 
-``MessageDialog`` also accepts a ``command`` — a plain zero-argument callable run
-when a button is pressed — for a fire-and-forget dialog you do not block on.
+**Place it yourself.** ``show`` centers on the parent by default; pass
+``position=(x, y)`` to pin the top-left corner instead — handy for a dialog that
+should appear next to the widget that opened it:
 
-For a fully bespoke dialog (your own widgets and layout), build a ``Toplevel``
-and make it modal yourself; the :doc:`Multiple windows how-to
-</user-guide/how-to/multiple-windows>` walks through a reusable modal that
-returns a value.
+.. code-block:: python
+
+   dialog.show(position=(event.x_root, event.y_root))
+
+**Run it without blocking.** Pass a ``command`` — a plain zero-argument callable
+run when a button is pressed — and show it with ``wait_for_result=False``. The
+call returns immediately and your callback fires when the user answers, which
+suits an event-driven flow where you don't want to stop the world:
+
+.. code-block:: python
+
+   def on_dismissed():
+       status.configure(text="Reminder dismissed")
+
+   note = ttk.MessageDialog("Don't forget to save.", buttons=["OK:primary"],
+                            command=on_dismissed, parent=app)
+   note.show(wait_for_result=False)   # non-modal; on_dismissed runs on OK
+
+Building a fully custom dialog
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you need your own widgets and layout, build the dialog from a ``Toplevel``:
+add your widgets, ``grab_set()`` to make it modal, ``wait_window()`` to block
+until it closes, and leave the result on an attribute for the caller to read.
+That is the same modal mechanism the facades use, applied to a window you own —
+the :doc:`Multiple windows how-to </user-guide/how-to/multiple-windows>` walks
+through a reusable version, and :doc:`Input validation
+</user-guide/feature-guides/validation>` covers checking the fields before you
+accept them.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A custom modal dialog built from a ``Toplevel`` — a titled form with two fields
+   and *Cancel* / *OK* buttons — centered over its parent.
 
 .. seealso::
 

--- a/docs/user-guide/feature-guides/localization.rst
+++ b/docs/user-guide/feature-guides/localization.rst
@@ -19,7 +19,7 @@ itself if there is no entry (so an untranslated string still shows something
 sensible).
 
 ttkbootstrap already ships catalog entries for its own dialog text (the button
-labels in :doc:`Messagebox and Querybox </user-guide/feature-guides/windows>`,
+labels in :doc:`Messagebox and Querybox </user-guide/feature-guides/dialogs>`,
 and so on) in a range of locales. You add entries for your app's strings.
 
 Translating a string with ``L``
@@ -120,11 +120,41 @@ translation. Replace the source string (and any format args) with
 ``set_source(src, *args)``; call ``stop_tracking()`` to freeze one at its current
 text while keeping it alive.
 
+Putting it together
+-------------------
+
+The full loop is small: register the translations, use ``LocaleVar`` for text
+that must follow the locale live (and plain ``L`` where a one-time lookup is
+enough), then a control that calls ``set_locale``:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.localization import MessageCatalog
+
+   MessageCatalog.set_many("es", "Welcome", "Bienvenido", "Language", "Idioma")
+
+   app = ttk.App()
+
+   greeting = ttk.LocaleVar(app, "Welcome")
+   ttk.Label(app, textvariable=greeting, font="TkHeadingFont").pack(padx=20, pady=10)
+
+   ttk.Label(app, text=ttk.L("Language")).pack()      # one-time; set before this runs
+   for code, label in [("en", "English"), ("es", "Español")]:
+       ttk.Button(app, text=label,
+                  command=lambda c=code: ttk.set_locale(c)).pack(pady=2)
+
+   app.mainloop()
+
+Pressing a language button re-translates every ``LocaleVar`` at once; the plain
+``L("Language")`` label, resolved when it was built, stays put — which is why
+anything that must switch live is bound to a ``LocaleVar``.
+
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder
 
-   A small window with a label and buttons, shown once in English and once after
-   pressing a language button, the bound text switched live.
+   The window shown once in English and once after pressing *Español*, the bound
+   heading switched live while the layout is unchanged.
 
 .. seealso::
 

--- a/docs/user-guide/feature-guides/typography.rst
+++ b/docs/user-guide/feature-guides/typography.rst
@@ -92,51 +92,62 @@ The monospace font (``TkFixedFont``) is left alone unless you ask for it with
    The same small window rendered with the default family and with a custom
    ``set_global_family`` family side by side, showing the whole UI restyled.
 
-The ``Fonts`` namespace
------------------------
+Building a type system
+----------------------
 
-For finer control against a **live** root, use the :class:`~ttkbootstrap.Fonts`
-namespace. Its methods operate on the running application, so call them once
-``App()`` exists — a pre-root call raises a clear "too early" error rather than
-spawning a stray root. (For the top-of-file case, use the module-level
-``set_global_family`` above.)
+Past the global family, most apps want a few deliberate **roles** — a larger
+heading, a smaller caption — and the named fonts are where you set them, once, at
+startup. Use the :class:`~ttkbootstrap.Fonts` namespace, whose methods operate on
+the live root, so call them after ``App()`` exists (a pre-root call raises a clear
+"too early" error rather than spawning a stray root — for the top-of-file case use
+the module-level ``set_global_family`` above).
 
-**Tweak one named font** with ``Fonts.configure`` — pass any font option
-(``family``, ``size``, ``weight``, ``slant``, ``underline``). Every widget
-reading that font updates live:
+**Adjust a built-in role.** ``Fonts.configure`` changes one named font in place —
+``family``, ``size``, ``weight``, ``slant``, ``underline`` — and every widget
+that reads it updates live. Bump the base size a point and make headings larger
+and bold:
 
 .. code-block:: python
 
    ttk.Fonts.configure("TkDefaultFont", size=11)
-   ttk.Fonts.configure("TkHeadingFont", weight="bold", size=13)
+   ttk.Fonts.configure("TkHeadingFont", size=14, weight="bold")
 
-``Fonts.set_global_family`` is the live sibling of the module-level function —
-retint every proportional font now, against the existing root:
+   ttk.Label(app, text="Quarterly report", font="TkHeadingFont").pack()
 
-.. code-block:: python
+Because widgets already read these names, that is a working type scale without
+touching a single widget's ``font=``. (To retint the whole family live against an
+existing root, ``Fonts.set_global_family(...)`` is the sibling of the
+module-level call.)
 
-   ttk.Fonts.set_global_family("Segoe UI", mono_family="Consolas")
-
-**Register your own named font** with ``Fonts.create_alias``. Define it once and
-refer to it by name everywhere — the same mechanism the ``Tk*Font`` names use.
-It returns the ``font.Font`` wrapper for further tweaking, and re-registering a
-name reconfigures it instead of erroring:
-
-.. code-block:: python
-
-   ttk.Fonts.create_alias("Body", family="Georgia", size=12)
-
-   ttk.Label(app, text="Chapter one", font="Body").pack()
-
-**Introspect** with ``Fonts.names`` (the managed named fonts) and
-``Fonts.describe`` (their resolved family/size/weight/…):
+**Define your own role.** When no built-in name maps to a role you need, register
+one with ``Fonts.create_alias`` and refer to it by name everywhere — the same
+mechanism the ``Tk*Font`` names use. Re-registering a name reconfigures it rather
+than erroring, so it is safe to call at startup:
 
 .. code-block:: python
 
-   ttk.Fonts.names()               # ('TkDefaultFont', 'TkTextFont', …)
+   ttk.Fonts.create_alias("Caption", family="Georgia", size=9, slant="italic")
+
+   ttk.Label(app, text="figure 1 — quarterly revenue", font="Caption").pack()
+
+Define your fonts once and the rest of the code just names the role; restyle a
+role later — a bigger caption, a different heading family — in that one place and
+the whole app follows.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A small card using three roles — bold ``TkHeadingFont`` title, default body
+   text, and the italic ``Caption`` alias — showing the type scale in one view.
+
+**Seeing what the fonts are.** ``Fonts.names()`` lists the managed named fonts and
+``Fonts.describe(name)`` returns a font's resolved family/size/weight (omit the
+name for the whole mapping) — useful when a value isn't what you expect:
+
+.. code-block:: python
+
    ttk.Fonts.describe("TkDefaultFont")
-   # {'family': 'Segoe UI', 'size': 9, 'weight': 'normal', …}
-   ttk.Fonts.describe()            # every managed font, as a mapping
+   # {'family': 'Segoe UI', 'size': 11, 'weight': 'normal', …}
 
 ``Fonts.reset`` drops ttkbootstrap's cached font wrappers; it runs automatically
 when the app is destroyed, so you rarely call it yourself.

--- a/docs/user-guide/feature-guides/validation.rst
+++ b/docs/user-guide/feature-guides/validation.rst
@@ -140,9 +140,55 @@ rule — the same mechanism the built-in ``Validation.range`` uses:
 
    Validation.add(entry, max_length, when="key", limit=10)
 
+Validating a form
+-----------------
+
+Rules flag fields as the user goes, but before you **accept** a form you want a
+final check — including on fields the user never touched. ``widget.validate()``
+runs a widget's rule on demand and returns ``True`` / ``False``. Validate every
+field first (so *all* bad ones light up, not just the first), then proceed only if
+they all pass:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap import Validation, Messagebox
+
+   app = ttk.App()
+
+   name = ttk.Entry(app)
+   age = ttk.Entry(app)
+   for field in (name, age):
+       field.pack(padx=20, pady=5)
+   Validation.text(name)
+   Validation.range(age, 0, 120)
+
+   def submit():
+       results = [field.validate() for field in (name, age)]   # check all, flag all
+       if all(results):
+           save(name.get(), age.get())
+       else:
+           Messagebox.show_warning("Please fix the highlighted fields.", parent=app)
+
+   ttk.Button(app, text="Submit", command=submit, bootstyle="success").pack(pady=10)
+
+   app.mainloop()
+
+Building the list *before* the ``all`` check matters: ``all(field.validate() …)``
+as a generator would short-circuit at the first failure and leave later invalid
+fields unflagged.
+
+.. note::
+
+   The ready-made rules pass on an **empty** field, so ``validate()`` returns
+   ``True`` for a required field the user left blank. Add your own emptiness check
+   in ``submit`` (``if not name.get(): …``) when a field is mandatory.
+
 .. seealso::
 
    :doc:`Variables </user-guide/feature-guides/variables>` for reacting to input
-   changes generally with traces, and
+   changes generally with traces,
    :doc:`Events </user-guide/feature-guides/events>` for the binding system these
-   validation callbacks are built on.
+   validation callbacks are built on, and
+   :doc:`Dialogs </user-guide/feature-guides/dialogs>` for the ``Messagebox`` used
+   above.

--- a/docs/user-guide/how-to/clipboard.rst
+++ b/docs/user-guide/how-to/clipboard.rst
@@ -1,0 +1,82 @@
+Clipboard & selection
+=====================
+
+Copy text to the system clipboard, read it back, and work with the current
+selection — all through methods every widget already has (they live on
+``Misc``, the common base), so you can call them on ``app`` or any widget.
+
+Copy and paste text
+-------------------
+
+Three methods cover the clipboard. Clear it, append your text, then it is
+available to other applications:
+
+.. code-block:: python
+
+   app.clipboard_clear()
+   app.clipboard_append("copied text")
+
+Read what is on the clipboard with ``clipboard_get``:
+
+.. code-block:: python
+
+   text = app.clipboard_get()
+
+.. note::
+
+   ``clipboard_append`` **adds** to the clipboard; it does not replace. Call
+   ``clipboard_clear()`` first (as above) so you don't concatenate onto whatever
+   was there. ``clipboard_get`` raises ``TclError`` when the clipboard is empty or
+   holds non-text data — guard it if that's possible:
+
+   .. code-block:: python
+
+      from tkinter import TclError
+
+      try:
+          text = app.clipboard_get()
+      except TclError:
+          text = ""
+
+A copy action, wired to a button or a shortcut, is just those two calls:
+
+.. code-block:: python
+
+   def copy_result():
+       app.clipboard_clear()
+       app.clipboard_append(result_var.get())
+
+   ttk.Button(app, text="Copy", command=copy_result, bootstyle="secondary").pack()
+   app.bind_all("<Control-c>", lambda e: copy_result())
+
+The current selection
+---------------------
+
+Entry, Text, and Listbox widgets track a **selection** — the highlighted range.
+Read the selected text with ``selection_get``:
+
+.. code-block:: python
+
+   entry.select_range(0, "end")          # select all (Entry)
+   selected = entry.selection_get()      # the highlighted text
+
+By default ``selection_get`` reads the **PRIMARY** selection (the X11
+"highlight" selection). Pass ``selection="CLIPBOARD"`` to read the clipboard
+through the same call instead:
+
+.. code-block:: python
+
+   entry.selection_get(selection="CLIPBOARD")   # same as clipboard_get()
+
+.. note::
+
+   The **PRIMARY** selection is an X11 (Linux) convention — highlighting text
+   makes it available to paste with the middle mouse button. On Windows and macOS
+   there is no persistent PRIMARY selection, so for portable copy/paste use the
+   **clipboard** methods above; keep PRIMARY for Linux-specific niceties.
+
+.. seealso::
+
+   The :doc:`Events guide </user-guide/feature-guides/events>` for binding the
+   copy/paste shortcuts, and the ``<<Copy>>`` / ``<<Paste>>`` / ``<<Cut>>``
+   virtual events that Entry and Text already handle for you.

--- a/docs/user-guide/how-to/error-handling.rst
+++ b/docs/user-guide/how-to/error-handling.rst
@@ -1,0 +1,71 @@
+Handle callback errors
+======================
+
+When an exception escapes a callback — a ``command=`` handler, a ``bind``
+callback, an ``after`` job — tkinter does **not** crash the app. It catches the
+exception, prints a traceback to the console, and keeps the event loop running.
+That default keeps a typo from killing the whole UI, but it also means errors
+pass silently for anyone not watching the terminal. This page shows how to take
+over that handling, and how to deal with the one tkinter-specific exception,
+``TclError``.
+
+Catching every uncaught callback error
+--------------------------------------
+
+The root routes every uncaught callback exception through one method,
+``report_callback_exception(exc, val, tb)``. Override it to log the error or show
+the user a dialog instead of printing to a console they may never see:
+
+.. code-block:: python
+
+   import traceback
+   import ttkbootstrap as ttk
+   from ttkbootstrap import Messagebox
+
+   app = ttk.App()
+
+   def report_callback_exception(exc, val, tb):
+       traceback.print_exception(exc, val, tb)          # still log it
+       Messagebox.show_error(f"Something went wrong:\n{val}", "Error", parent=app)
+
+   app.report_callback_exception = report_callback_exception
+
+The three arguments are the standard ``sys.exc_info`` triple — exception type,
+value, and traceback. This is your **safety net**, not a substitute for handling
+expected failures where they happen; use it to make sure nothing fails
+*invisibly*.
+
+.. note::
+
+   This handler only sees exceptions raised **inside** the event loop — callbacks
+   and ``after`` jobs. An exception raised during setup, before ``mainloop()``,
+   propagates normally; wrap that code in your own ``try``/``except``.
+
+``TclError``
+------------
+
+``TclError`` (from ``tkinter``) is the exception raised when the underlying Tcl
+interpreter rejects an operation — a bad option value, an invalid widget path, a
+color name it doesn't recognize, reading an empty clipboard. Catch it where such
+a call is expected to fail:
+
+.. code-block:: python
+
+   from tkinter import TclError
+
+   try:
+       widget.configure(bootstyle="not-a-real-style")
+   except TclError as err:
+       ...
+
+A common source is a numeric variable holding in-progress text: ``IntVar.get()``
+raises ``TclError`` when the bound entry is empty or half-typed. Guard the read,
+or validate the field instead — see
+:doc:`Input validation </user-guide/feature-guides/validation>`.
+
+.. seealso::
+
+   The :doc:`Variables guide </user-guide/feature-guides/variables>` for the
+   numeric-variable coercion gotcha, and
+   :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
+   for the event loop that these callbacks run inside.

--- a/docs/user-guide/how-to/index.rst
+++ b/docs/user-guide/how-to/index.rst
@@ -28,13 +28,17 @@ Building interfaces
 Interaction and data
 ---------------------
 
-- **Message boxes and dialogs** — ``Messagebox``/``Querybox`` and the shipped
-  dialogs.
+- **Message boxes and dialogs** — for ``Messagebox``/``Querybox`` and the shipped
+  pickers, see the :doc:`Dialogs guide </user-guide/feature-guides/dialogs>`.
 - **Validate a form** — attach validation rules and read the result.
 - :doc:`Multiple windows & modal dialogs <multiple-windows>` — a second
   ``Toplevel``, a modal dialog that returns a value, and the close button.
 - **Background work without freezing the UI** — ``after`` and worker threads,
   updating widgets safely from the main loop.
+- :doc:`Clipboard & selection <clipboard>` — copy and paste text, and read the
+  current selection.
+- :doc:`Handle callback errors <error-handling>` — take over
+  ``report_callback_exception`` and deal with ``TclError``.
 - :doc:`Feedback: bell & busy <feedback>` — a system beep and a busy overlay that
   blocks a window while it works.
 

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -149,6 +149,13 @@ Each subsystem, end to end — its concepts and its usage in one place.
       ``App``/``Toplevel``, focus & modality, positioning, application icons, and
       DPI scaling.
 
+   .. grid-item-card:: Dialogs
+      :link: feature-guides/dialogs
+      :link-type: doc
+
+      ``Messagebox`` and ``Querybox``, the date/font/color pickers, ``filedialog``,
+      and what each returns.
+
    .. grid-item-card:: Theming
       :link: feature-guides/theming
       :link-type: doc
@@ -213,6 +220,7 @@ Task-focused recipes — common tkinter jobs done the ttkbootstrap way. See the
    feature-guides/events
    feature-guides/icons
    feature-guides/windows
+   feature-guides/dialogs
    feature-guides/theming
    feature-guides/working-with-color
    feature-guides/make-your-own-style
@@ -225,4 +233,6 @@ Task-focused recipes — common tkinter jobs done the ttkbootstrap way. See the
    how-to/index
    how-to/working-with-images
    how-to/feedback
+   how-to/clipboard
+   how-to/error-handling
    how-to/multiple-windows

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -276,6 +276,12 @@ from ttkbootstrap.localization import L, LocaleVar, set_locale
 # package; `ttkbootstrap.validation` remains the canonical home / import path.
 from ttkbootstrap.validation import Validation, validator, ValidationEvent
 
+# Re-export the stdlib file dialog as `ttk.filedialog`. It is the one standard
+# dialog ttkbootstrap does not supersede (native OS chrome), so surfacing the
+# module here spares callers a bare `from tkinter import filedialog`; the themed
+# wrappers live on `Querybox.get_open_filename`/etc.
+from tkinter import filedialog
+
 __all__ = [
     # Tk exports
     "Tk", "Menu", "Text", "Canvas", "TkFrame", "TkLabel", "LabelFrame", "Variable", "StringVar", "IntVar", "BooleanVar",
@@ -340,6 +346,9 @@ __all__ = [
     "Validation",
     "validator",
     "ValidationEvent",
+
+    # Stdlib file dialog (native; not superseded)
+    "filedialog",
 
     # Application root + windows
     "App",

--- a/src/ttkbootstrap/dialogs/query.py
+++ b/src/ttkbootstrap/dialogs/query.py
@@ -2,6 +2,7 @@
 
 import textwrap
 import tkinter
+from tkinter import filedialog
 from datetime import date
 from typing import Any, List, Optional, Tuple
 
@@ -380,3 +381,58 @@ class Querybox:
         dialog = FontDialog(parent=parent, **kwargs)
         dialog.show(position)
         return dialog.result
+
+    # File dialogs. These wrap the *native* OS file dialogs
+    # (`tkinter.filedialog`) — the one standard dialog ttkbootstrap does not
+    # restyle, because the OS draws it. They live here so a file path is fetched
+    # through the same `Querybox.get_*` facade as every other value, and they
+    # normalize the stdlib "" -on-cancel to `None` to match that contract.
+
+    @staticmethod
+    def get_open_filename(parent: Optional[tkinter.Misc] = None, **kwargs: Any) -> Optional[str]:
+        """Show an *open file* dialog. Returns the chosen path, or ``None`` if
+        cancelled.
+
+        Wraps ``tkinter.filedialog.askopenfilename``; forward its options
+        (``title``, ``filetypes``, ``initialdir``, ``initialfile``, ...) as
+        keyword arguments.
+        """
+        if parent is not None:
+            kwargs["parent"] = parent
+        return filedialog.askopenfilename(**kwargs) or None
+
+    @staticmethod
+    def get_open_filenames(parent: Optional[tkinter.Misc] = None, **kwargs: Any) -> Optional[Tuple[str, ...]]:
+        """Show an *open multiple files* dialog. Returns a tuple of paths, or
+        ``None`` if cancelled.
+
+        Wraps ``tkinter.filedialog.askopenfilenames``.
+        """
+        if parent is not None:
+            kwargs["parent"] = parent
+        paths = filedialog.askopenfilenames(**kwargs)
+        return tuple(paths) if paths else None
+
+    @staticmethod
+    def get_save_filename(parent: Optional[tkinter.Misc] = None, **kwargs: Any) -> Optional[str]:
+        """Show a *save as* dialog. Returns the chosen path, or ``None`` if
+        cancelled.
+
+        Wraps ``tkinter.filedialog.asksaveasfilename``; forward its options
+        (``title``, ``filetypes``, ``defaultextension``, ``initialfile``, ...)
+        as keyword arguments.
+        """
+        if parent is not None:
+            kwargs["parent"] = parent
+        return filedialog.asksaveasfilename(**kwargs) or None
+
+    @staticmethod
+    def get_directory(parent: Optional[tkinter.Misc] = None, **kwargs: Any) -> Optional[str]:
+        """Show a *choose directory* dialog. Returns the chosen path, or ``None``
+        if cancelled.
+
+        Wraps ``tkinter.filedialog.askdirectory``.
+        """
+        if parent is not None:
+            kwargs["parent"] = parent
+        return filedialog.askdirectory(**kwargs) or None

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -263,3 +263,42 @@ def test_colorchooserdialog_build_without_global_api(root):
     dlg.build()   # full body + buttonbox (regressed on the ToolTip call)
     assert dlg._toplevel is not None
     dlg._toplevel.destroy()
+
+
+# --- Querybox file dialogs (native, surfaced through the facade) -----------
+
+_FILE_METHODS = ["get_open_filename", "get_open_filenames", "get_save_filename", "get_directory"]
+
+
+def test_filedialog_reexported_at_top_level():
+    import tkinter
+    assert ttk.filedialog is tkinter.filedialog
+    assert "filedialog" in ttk.__all__
+
+
+@pytest.mark.parametrize("method", _FILE_METHODS)
+def test_querybox_file_methods_are_static_with_parent(method):
+    assert isinstance(inspect.getattr_static(Querybox, method), staticmethod)
+    assert "parent" in inspect.signature(getattr(Querybox, method)).parameters
+
+
+def test_querybox_file_dialogs_normalize_cancel_to_none(monkeypatch):
+    # The stdlib file dialogs return "" / () on cancel; the wrappers normalize
+    # that to None to match the rest of the get_* facade. Monkeypatch the native
+    # calls so no OS dialog opens.
+    from ttkbootstrap.dialogs import query
+
+    monkeypatch.setattr(query.filedialog, "askopenfilename", lambda **kw: "")
+    assert Querybox.get_open_filename() is None
+    monkeypatch.setattr(query.filedialog, "askopenfilename", lambda **kw: "C:/a/b.txt")
+    assert Querybox.get_open_filename(title="Open") == "C:/a/b.txt"
+
+    monkeypatch.setattr(query.filedialog, "askopenfilenames", lambda **kw: ())
+    assert Querybox.get_open_filenames() is None
+    monkeypatch.setattr(query.filedialog, "askopenfilenames", lambda **kw: ("a", "b"))
+    assert Querybox.get_open_filenames() == ("a", "b")
+
+    monkeypatch.setattr(query.filedialog, "asksaveasfilename", lambda **kw: "")
+    assert Querybox.get_save_filename() is None
+    monkeypatch.setattr(query.filedialog, "askdirectory", lambda **kw: "")
+    assert Querybox.get_directory() is None


### PR DESCRIPTION
## Summary

Authors the **Dialogs** feature guide (the ★ "homeless" subsystem), surfaces the native file dialog through the library, and does a teach-by-building robustness pass over the feature guides authored this cycle. Docs + a small additive API change.

### 1. Dialogs feature guide + essentials How-Tos *(docs)*

New `feature-guides/dialogs.rst` teaching the shipped dialog subsystem via the *show → read → act* shape:
- **Messagebox** — taught through a real quit-with-unsaved-changes flow; the button families; keyword-only `parent=`; custom `"label:bootstyle"` buttons; the localization-of-returned-labels gotcha.
- **Querybox** — *get → check `None` → use*, with results applied live (color/font/date dropped into widgets); the full method set; the empty-vs-cancel distinction.
- **Pickers** — `get_date`/`get_font`/`get_color` (`ColorChoice` rgb/hsl/hex).
- **File dialogs** — see §2.
- **Driving the dialog classes** — `MessageDialog`/`QueryDialog`, `default=`, `.show(position=)`, non-blocking `command=`, and the custom-`Toplevel` pattern (cross-linked to the multiple-windows how-to).

Plus two essentials-strand How-Tos: **Clipboard & selection** and **Handle callback errors** (`report_callback_exception` + `TclError`). Wired into the feature-guides + How-To bands.

### 2. File dialogs surfaced through `Querybox` + `ttk.filedialog` *(new, additive)*

filedialog was the one standard dialog with no ttkbootstrap entry point — callers dropped to `from tkinter import filedialog` while every other dialog was `ttk.`. Closed that inconsistency:
- **`Querybox.get_open_filename` / `get_open_filenames` / `get_save_filename` / `get_directory`** — static-method wrappers over `tkinter.filedialog`, so a path is fetched through the same `get_*` facade as every other value; the stdlib `""`/`()`-on-cancel is normalized to `None` to match the facade contract.
- **`ttk.filedialog`** — the stdlib module re-exported at top level for the variants the four don't cover (e.g. `askopenfile`).

Additive — `tkinter.filedialog` still works unchanged. filedialog is *not superseded* (native OS chrome; ttkbootstrap can't restyle it), but "not restyled" is no reason to make it the one dialog you can't reach through the library.

### 3. Feature-guide robustness pass *(docs)*

Reworked the guides authored this cycle so they teach by building, not tour options:
- **Typography** — method-by-method `Fonts` walkthrough → a task-driven "build a type system."
- **Localization** — added a "putting it together" bilingual-app build; fixed a stale xref (Windows → Dialogs).
- **Validation** — added "validating a form" (validate-all-then-submit; flag every bad field, not just the first).
- **Dialogs** — the rewrite above.

Screenshot placeholders added at the visual moments (custom buttons, pickers, type scale, custom dialog).

## Verification

- `test_dialogs_api.py`: **34 passed** (+3 new — file-method surface, static-method shape, cancel→`None` normalization via monkeypatched filedialog, so no OS dialog opens).
- Full suite: **641 passed**, only the known `nl.msg` localization env flake (confirmed transient, unrelated).
- Every guide example's API verified headlessly, including the live locale-switch and the form validation flagging behavior.
- Full-site `sphinx -b html -W --keep-going` clean, exit 0.
- Logged in `development/2_0_breaking_changes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)