### PR TITLE
docs: finish + deepen the Windows guide (retitle, cross-platform)

### DIFF
--- a/docs/reference/events/event-object.rst
+++ b/docs/reference/events/event-object.rst
@@ -3,8 +3,8 @@ The event object
 
 A callback bound with ``bind`` receives one argument: an ``event`` object whose
 attributes describe what happened. tkinter fills these from the underlying Tk
-event; **an attribute that does not apply to the event type holds the string
-``"??"``** (or a meaningless value), so read only the ones relevant to the event
+event; **an attribute that does not apply to the event type holds the string**
+``"??"`` (or a meaningless value), so read only the ones relevant to the event
 you bound.
 
 .. list-table::

--- a/docs/user-guide/feature-guides/dialogs.rst
+++ b/docs/user-guide/feature-guides/dialogs.rst
@@ -311,7 +311,7 @@ accept them.
 
 .. seealso::
 
-   :doc:`Windows & high-DPI </user-guide/feature-guides/windows>` for the focus,
+   :doc:`Windows </user-guide/feature-guides/windows>` for the focus,
    modality, and lifecycle mechanics the dialogs are built on;
    :doc:`Input validation </user-guide/feature-guides/validation>` for validating
    fields in a form dialog; and the :doc:`Multiple windows how-to

--- a/docs/user-guide/feature-guides/icons.rst
+++ b/docs/user-guide/feature-guides/icons.rst
@@ -176,6 +176,6 @@ A small toolbar of icon-only buttons beside a labeled action:
 .. seealso::
 
    For the *application* (window/taskbar) icon, see
-   :doc:`Windows & high-DPI </user-guide/feature-guides/windows>`. For
+   :doc:`Windows </user-guide/feature-guides/windows>`. For
    raster images and Pillow, see
    :doc:`Working with images </user-guide/how-to/working-with-images>`.

--- a/docs/user-guide/feature-guides/windows.rst
+++ b/docs/user-guide/feature-guides/windows.rst
@@ -1,9 +1,79 @@
-Windows & high-DPI
-==================
+Windows
+=======
 
 ``App`` (also exported as ``ttk.Window``) and ``ttk.Toplevel`` are enhanced
-replacements for ``tk.Tk``/``tk.Toplevel`` that fold window setup into the
-constructor and add ttkbootstrap-specific conveniences.
+replacements for ``tk.Tk`` / ``tk.Toplevel`` that fold window setup — size,
+position, icon, constraints — into the constructor, so a window is configured in
+one call instead of a scatter of ``geometry`` / ``minsize`` / ``wm_*`` calls
+afterward. Keep **one** ``App`` per program (the single-root rule — see
+:doc:`Structuring an app </user-guide/getting-started/app-structures>`); every
+other window is a ``Toplevel``.
+
+Creating the main window
+------------------------
+
+The one thing ``App`` needs is nothing — ``ttk.App()`` gives you a themed window.
+Everything else is a keyword you set once, up front:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(
+       title="Invoices",
+       theme="nord-light",
+       size=(800, 600),
+       position=(200, 120),
+       minsize=(480, 360),
+   )
+
+   app.mainloop()
+
+- **``size=(width, height)``** and **``position=(x, y)``** are pixel tuples; set
+  either or both. ``position`` is signed and **edge-relative** — a negative
+  coordinate measures from the opposite screen edge, so ``position=(-20, -20)``
+  pins the window near the bottom-right corner.
+- **``minsize`` / ``maxsize=(width, height)``** clamp how far the user can resize;
+  **``resizable=(horizontal, vertical)``** takes two booleans to lock an axis
+  entirely (``resizable=(True, False)`` allows width but fixes height).
+- **``alpha``** sets window transparency from ``0.0`` to ``1.0`` (opaque).
+- **``iconphoto``** sets the titlebar icon from an image path; the default is
+  ttkbootstrap's brand icon, and ``iconphoto=None`` leaves the platform default.
+
+.. note::
+
+   ``theme=`` is the canonical name; ``themename=`` is a permanent alias (the
+   pre-2.0 spelling). ``Window`` is likewise a permanent alias for ``App`` — use
+   whichever reads better. For choosing and switching themes, see
+   :doc:`Theming & Colors </user-guide/feature-guides/theming>`.
+
+Second windows — ``Toplevel``
+-----------------------------
+
+Every window after the first is a ``ttk.Toplevel``. It shares ``App``'s
+constructor conveniences (``size``, ``position``, ``iconphoto``, …) and inherits
+the app's theme and icon automatically.
+
+.. warning::
+
+   ``Toplevel``'s **first positional argument is the title**, not the parent —
+   ``ttk.Toplevel(app)`` sets the *title* to the app object. Pass the parent as
+   ``master=``:
+
+   .. code-block:: python
+
+      win = ttk.Toplevel(master=app, title="Details", size=(400, 300))
+
+``Toplevel`` adds a few window-manager options ``App`` doesn't need:
+
+- **``topmost=True``** keeps the window above all others.
+- **``tool_window=True``** gives it a thin tool-window frame and keeps it off the
+  taskbar (Windows).
+- **``window_type=...``** requests a window kind from the OS — ``"splash"``,
+  ``"utility"``, ``"tooltip"`` — used for borderless/auxiliary windows (mapped to
+  native styles on macOS, an X11 hint on Linux).
+- **``iconify=True``** starts the window minimized.
+- **``transient=parent``** marks it a satellite of ``parent`` (next section).
 
 Focus, modality & lifecycle
 ---------------------------
@@ -11,17 +81,7 @@ Focus, modality & lifecycle
 Beyond its size and position, a window has three behaviors you control in code:
 which window has the **keyboard focus**, whether it is **modal** (blocks the rest
 of the app), and its **lifecycle** — mapping, closing, and cleanup. These apply
-to any window; a second window is always a ``Toplevel``.
-
-.. note::
-
-   ``ttk.Toplevel``'s first positional argument is the **title**, not the parent
-   — ``ttk.Toplevel(app)`` would set the title to the app object. Pass the parent
-   as ``master=``:
-
-   .. code-block:: python
-
-      win = ttk.Toplevel(master=app, title="Details")
+to any window.
 
 Focus
 ~~~~~
@@ -66,7 +126,9 @@ Two calls make it so:
 Because ``wait_window`` returns only *after* the window closes, the window can
 leave a result behind for the caller to read — that is how a dialog "returns a
 value." The :doc:`Multiple windows how-to </user-guide/how-to/multiple-windows>`
-puts these together into a reusable modal dialog.
+puts these together into a reusable modal dialog, and the
+:doc:`Dialogs guide </user-guide/feature-guides/dialogs>` covers the shipped
+modal dialogs built on the same mechanism.
 
 Lifecycle
 ~~~~~~~~~
@@ -91,23 +153,74 @@ window. Register a handler to confirm or veto the close instead:
 
    win.protocol("WM_DELETE_WINDOW", on_close)
 
-Still to come in this guide
----------------------------
+Positioning
+-----------
 
-.. note::
+``place_window_center()`` centers a window on screen — on the monitor under the
+mouse cursor when the optional ``screeninfo`` package is installed, and clamped so
+the window stays fully visible either way. Call it *after* the window's size is
+known (the constructor ``size`` counts):
 
-   The rest of this guide is being written for 2.0. It will also cover:
+.. code-block:: python
 
-- **The constructor surface** — ``title``, ``size``, ``position`` (signed and
-  edge-relative), ``minsize``/``maxsize``, ``resizable``, ``alpha``,
-  ``iconphoto``, plus the renamed ``high_dpi``/``override_redirect``.
-- **Positioning** — ``place_window_center()`` (monitor-aware when ``screeninfo``
-  is installed, clamped on-screen).
-- **Light/dark mode** — the settable ``theme_mode`` property, ``toggle_theme()``,
-  and ``set_theme_modes(light=, dark=)``.
-- **Toplevels** — ``window_type``, ``topmost``, ``tool_window``, and inherited
-  app icons.
-- **High-DPI** — ``enable_high_dpi_awareness()`` and ``scale_size()``.
-- **Sidebar: the deferred-config seam** — how ``set_locale``,
-  ``set_global_family``, and ``set_default_button`` can be called before the root
-  exists and flush when it comes up.
+   win = ttk.Toplevel(master=app, title="About", size=(360, 200))
+   win.place_window_center()
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A small Toplevel centered over its parent window with ``place_window_center``.
+
+Light & dark
+------------
+
+A window follows the active theme, and its light/dark mode is switched through the
+same ``App``: ``app.theme_mode`` reads ``"light"`` / ``"dark"``,
+``app.toggle_theme()`` flips between the family's pair, and
+``App(light_theme=..., dark_theme=...)`` designates which two to toggle. The
+:doc:`Theming & Colors </user-guide/feature-guides/theming>` guide covers this in
+full.
+
+High-DPI displays
+-----------------
+
+On a high-resolution display, an unaware app renders tiny and blurry. ``App``
+turns on high-DPI awareness by **default** (``high_dpi=True``) on Windows, so most
+apps need nothing. Two utilities cover the rest:
+
+- **``enable_high_dpi_awareness(root=None, scaling=None)``** — the manual control.
+  On Windows it must run *before* the root exists (``App`` already does this); on
+  Linux, pass the root and a ``scaling`` factor (``1.6``–``2.0`` is typical) after
+  creating it to scale the whole UI.
+- **``scale_size(widget, size)``** — convert a logical size to physical pixels for
+  the current display, for code that sets pixel geometry or builds image assets:
+
+  .. code-block:: python
+
+     ttk.scale_size(app, 24)          # 24 logical px -> physical px for this display
+     ttk.scale_size(app, [24, 24])    # a (width, height) pair -> scaled ints
+
+.. admonition:: Sidebar — the deferred-config seam
+   :class: note
+
+   A few settings need to apply before any widget is built but read most naturally
+   at the top of the file, before ``App()`` exists. ``set_locale``,
+   ``set_global_family``, and ``set_default_button`` **queue** when called
+   pre-root and flush the moment the root comes up (they apply live if a root
+   already exists), so this works as written:
+
+   .. code-block:: python
+
+      import ttkbootstrap as ttk
+
+      ttk.set_global_family("Segoe UI")     # queued...
+      ttk.set_default_button("primary")
+
+      app = ttk.App()                        # ...applied here
+
+.. seealso::
+
+   :doc:`Structuring an app </user-guide/getting-started/app-structures>` for the
+   single-root rule, :doc:`Theming & Colors </user-guide/feature-guides/theming>`
+   for themes and light/dark, and the :doc:`Multiple windows how-to
+   </user-guide/how-to/multiple-windows>` for second-window recipes.

--- a/docs/user-guide/feature-guides/windows.rst
+++ b/docs/user-guide/feature-guides/windows.rst
@@ -29,15 +29,15 @@ Everything else is a keyword you set once, up front:
 
    app.mainloop()
 
-- **``size=(width, height)``** and **``position=(x, y)``** are pixel tuples; set
+- ``size=(width, height)`` and ``position=(x, y)`` are pixel tuples; set
   either or both. ``position`` is signed and **edge-relative** — a negative
   coordinate measures from the opposite screen edge, so ``position=(-20, -20)``
   pins the window near the bottom-right corner.
-- **``minsize`` / ``maxsize=(width, height)``** clamp how far the user can resize;
-  **``resizable=(horizontal, vertical)``** takes two booleans to lock an axis
+- ``minsize`` / ``maxsize=(width, height)`` clamp how far the user can resize;
+  ``resizable=(horizontal, vertical)`` takes two booleans to lock an axis
   entirely (``resizable=(True, False)`` allows width but fixes height).
-- **``alpha``** sets window transparency from ``0.0`` to ``1.0`` (opaque).
-- **``iconphoto``** sets the titlebar icon from an image path; the default is
+- ``alpha`` sets window transparency from ``0.0`` to ``1.0`` (opaque).
+- ``iconphoto`` sets the titlebar icon from an image path; the default is
   ttkbootstrap's brand icon, and ``iconphoto=None`` leaves the platform default.
 
 .. note::
@@ -66,14 +66,14 @@ the app's theme and icon automatically.
 
 ``Toplevel`` adds a few window-manager options ``App`` doesn't need:
 
-- **``topmost=True``** keeps the window above all others.
-- **``tool_window=True``** gives it a thin tool-window frame and keeps it off the
+- ``topmost=True`` keeps the window above all others.
+- ``tool_window=True`` gives it a thin tool-window frame and keeps it off the
   taskbar (Windows).
-- **``window_type=...``** requests a window kind from the OS — ``"splash"``,
+- ``window_type=...`` requests a window kind from the OS — ``"splash"``,
   ``"utility"``, ``"tooltip"`` — used for borderless/auxiliary windows (mapped to
   native styles on macOS, an X11 hint on Linux).
-- **``iconify=True``** starts the window minimized.
-- **``transient=parent``** marks it a satellite of ``parent`` (next section).
+- ``iconify=True`` starts the window minimized.
+- ``transient=parent`` marks it a satellite of ``parent`` (next section).
 
 Focus, modality & lifecycle
 ---------------------------
@@ -188,11 +188,11 @@ On a high-resolution display, an unaware app renders tiny and blurry. ``App``
 turns on high-DPI awareness by **default** (``high_dpi=True``) on Windows, so most
 apps need nothing. Two utilities cover the rest:
 
-- **``enable_high_dpi_awareness(root=None, scaling=None)``** — the manual control.
+- ``enable_high_dpi_awareness(root=None, scaling=None)`` — the manual control.
   On Windows it must run *before* the root exists (``App`` already does this); on
   Linux, pass the root and a ``scaling`` factor (``1.6``–``2.0`` is typical) after
   creating it to scale the whole UI.
-- **``scale_size(widget, size)``** — convert a logical size to physical pixels for
+- ``scale_size(widget, size)`` — convert a logical size to physical pixels for
   the current display, for code that sets pixel geometry or builds image assets:
 
   .. code-block:: python

--- a/docs/user-guide/feature-guides/windows.rst
+++ b/docs/user-guide/feature-guides/windows.rst
@@ -9,6 +9,11 @@ afterward. Keep **one** ``App`` per program (the single-root rule — see
 :doc:`Structuring an app </user-guide/getting-started/app-structures>`); every
 other window is a ``Toplevel``.
 
+Windowing is also where the three platforms diverge most — DPI, transparency,
+maximize, and borderless windows all behave differently on Windows, macOS, and
+Linux. This guide flags those differences as it goes, and collects them in
+`Cross-platform behavior`_ at the end.
+
 Creating the main window
 ------------------------
 
@@ -29,23 +34,90 @@ Everything else is a keyword you set once, up front:
 
    app.mainloop()
 
-- ``size=(width, height)`` and ``position=(x, y)`` are pixel tuples; set
-  either or both. ``position`` is signed and **edge-relative** — a negative
-  coordinate measures from the opposite screen edge, so ``position=(-20, -20)``
-  pins the window near the bottom-right corner.
-- ``minsize`` / ``maxsize=(width, height)`` clamp how far the user can resize;
-  ``resizable=(horizontal, vertical)`` takes two booleans to lock an axis
-  entirely (``resizable=(True, False)`` allows width but fixes height).
-- ``alpha`` sets window transparency from ``0.0`` to ``1.0`` (opaque).
-- ``iconphoto`` sets the titlebar icon from an image path; the default is
-  ttkbootstrap's brand icon, and ``iconphoto=None`` leaves the platform default.
-
 .. note::
 
    ``theme=`` is the canonical name; ``themename=`` is a permanent alias (the
    pre-2.0 spelling). ``Window`` is likewise a permanent alias for ``App`` — use
    whichever reads better. For choosing and switching themes, see
    :doc:`Theming & Colors </user-guide/feature-guides/theming>`.
+
+Window geometry
+~~~~~~~~~~~~~~~
+
+A window's size and location are one value in tkinter — the **geometry string**,
+``"WIDTHxHEIGHT+X+Y"`` (e.g. ``"800x600+200+120"``). The ``size`` and ``position``
+constructor keywords build it for you from ``(width, height)`` and ``(x, y)``
+pixel tuples; you can also read or set it directly with ``geometry()``:
+
+.. code-block:: python
+
+   app.geometry()                 # -> "800x600+200+120"
+   app.geometry("640x480")        # resize, leave position alone
+   app.geometry("+100+100")       # move, leave size alone
+
+``x`` and ``y`` are screen pixels from the top-left, and they are **signed and
+edge-relative**: a negative value measures from the opposite edge, so
+``position=(-20, -20)`` pins the window near the bottom-right corner regardless of
+screen size.
+
+Read the current size and location back with the ``winfo_*`` accessors —
+``winfo_width()`` / ``winfo_height()`` / ``winfo_x()`` / ``winfo_y()``:
+
+.. warning::
+
+   ``winfo_width()`` / ``winfo_height()`` report ``1`` until the window has been
+   drawn. Call ``update_idletasks()`` first, or read ``winfo_reqwidth()`` /
+   ``winfo_reqheight()`` (the requested size, valid immediately). See
+   :doc:`Widget & screen info </reference/winfo>`.
+
+Size constraints
+~~~~~~~~~~~~~~~~
+
+``minsize`` and ``maxsize`` are ``(width, height)`` tuples that clamp how far the
+user can resize the window; ``resizable`` takes two booleans, one per axis, to
+lock resizing entirely:
+
+.. code-block:: python
+
+   app = ttk.App(minsize=(480, 360), resizable=(True, False))   # width flexes, height fixed
+
+``alpha`` sets whole-window transparency from ``0.0`` to ``1.0`` (opaque).
+
+.. note::
+
+   Window transparency is immediate on Windows and macOS. On Linux it needs a
+   **compositing** window manager to take effect, and ttkbootstrap applies it only
+   once the window is first shown.
+
+Window state
+------------
+
+A window is in one of a few states, read and set through ``state()``:
+``"normal"``, ``"iconic"`` (minimized), or ``"withdrawn"`` (hidden). The
+convenience methods are usually clearer — ``iconify()`` minimizes, ``deiconify()``
+restores, ``withdraw()`` hides without a taskbar entry:
+
+.. code-block:: python
+
+   app.iconify()          # minimize
+   app.deiconify()        # restore
+   app.state()            # -> "normal" / "iconic" / "withdrawn"
+
+**Maximize** and **fullscreen** are where platforms split:
+
+.. code-block:: python
+
+   app.state("zoomed")                     # maximize — Windows
+   app.attributes("-fullscreen", True)     # true fullscreen — Windows & Linux
+
+.. note::
+
+   ``state("zoomed")`` maximizes on **Windows**; on **Linux** use
+   ``attributes("-zoomed", True)`` (honored by most window managers); **macOS** has
+   no programmatic maximize — the green traffic-light button toggles native
+   fullscreen. ``attributes("-fullscreen", True)`` gives borderless fullscreen on
+   Windows and Linux, and drives native fullscreen on macOS. Provide an ``Escape``
+   binding to leave fullscreen — there is no titlebar to click.
 
 Second windows — ``Toplevel``
 -----------------------------
@@ -64,16 +136,51 @@ the app's theme and icon automatically.
 
       win = ttk.Toplevel(master=app, title="Details", size=(400, 300))
 
-``Toplevel`` adds a few window-manager options ``App`` doesn't need:
+``Toplevel`` adds a few window-manager options ``App`` doesn't need. Several are
+platform-specific — they are honored where they apply and ignored elsewhere, so
+they are safe to pass on any OS:
 
-- ``topmost=True`` keeps the window above all others.
-- ``tool_window=True`` gives it a thin tool-window frame and keeps it off the
-  taskbar (Windows).
-- ``window_type=...`` requests a window kind from the OS — ``"splash"``,
-  ``"utility"``, ``"tooltip"`` — used for borderless/auxiliary windows (mapped to
-  native styles on macOS, an X11 hint on Linux).
+- ``topmost=True`` keeps the window above all others (all platforms).
+- ``tool_window=True`` gives a thin tool-window frame and hides it from the
+  taskbar — **Windows only**.
+- ``window_type=...`` requests a window kind — ``"splash"``, ``"utility"``,
+  ``"tooltip"`` — for borderless/auxiliary windows. On **macOS** these map to
+  native window styles; on **Linux** it is a hint to the window manager; on
+  **Windows** it has no effect (use ``tool_window`` / ``override_redirect``).
 - ``iconify=True`` starts the window minimized.
-- ``transient=parent`` marks it a satellite of ``parent`` (next section).
+- ``transient=parent`` marks it a satellite of ``parent`` (see below).
+
+.. note::
+
+   ``override_redirect=True`` strips **all** window-manager decoration (no
+   titlebar, border, or controls) — the basis of a splash screen. It has **no
+   effect on macOS**, where enabling it breaks event handling, so ttkbootstrap
+   ignores it there; for borderless popups on macOS use ``window_type`` instead.
+
+Positioning
+-----------
+
+``place_window_center()`` centers a window on screen — on the monitor under the
+mouse cursor when the optional ``screeninfo`` package is installed, and clamped so
+the window stays fully visible either way. Call it *after* the window's size is
+known (the constructor ``size`` counts):
+
+.. code-block:: python
+
+   win = ttk.Toplevel(master=app, title="About", size=(360, 200))
+   win.place_window_center()
+
+.. note::
+
+   Without ``screeninfo`` installed, centering falls back to the primary screen,
+   so on a multi-monitor setup the window may land on the main display rather than
+   the active one. ``screeninfo`` is an optional dependency — ttkbootstrap's only
+   required one is Pillow.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A small Toplevel centered over its parent window with ``place_window_center``.
 
 Focus, modality & lifecycle
 ---------------------------
@@ -133,10 +240,6 @@ modal dialogs built on the same mechanism.
 Lifecycle
 ~~~~~~~~~
 
-A window can be hidden and shown without being rebuilt: ``withdraw()`` removes it
-from view, ``deiconify()`` restores it, and ``iconify()`` minimizes it. Reuse an
-expensive window this way instead of recreating it.
-
 ``destroy()`` closes a window for good and tears down its child widgets. Cancel
 any ``after`` timers or variable traces first, or they fire against dead widgets.
 
@@ -153,23 +256,16 @@ window. Register a handler to confirm or veto the close instead:
 
    win.protocol("WM_DELETE_WINDOW", on_close)
 
-Positioning
------------
+Application icon
+----------------
 
-``place_window_center()`` centers a window on screen — on the monitor under the
-mouse cursor when the optional ``screeninfo`` package is installed, and clamped so
-the window stays fully visible either way. Call it *after* the window's size is
-known (the constructor ``size`` counts):
-
-.. code-block:: python
-
-   win = ttk.Toplevel(master=app, title="About", size=(360, 200))
-   win.place_window_center()
-
-.. admonition:: 📷 Screenshot (placeholder)
-   :class: screenshot-placeholder
-
-   A small Toplevel centered over its parent window with ``place_window_center``.
+``iconphoto=`` sets the titlebar/taskbar icon from an image path; the default is
+ttkbootstrap's brand icon, and ``iconphoto=None`` leaves the platform default.
+The format that works best differs by platform — a ``.ico`` file on Windows, a
+PNG elsewhere — and ttkbootstrap picks the right mechanism for you. A ``Toplevel``
+inherits the application icon automatically. See the
+:doc:`images how-to </user-guide/how-to/working-with-images>` for building icons
+from your own art.
 
 Light & dark
 ------------
@@ -184,21 +280,70 @@ full.
 High-DPI displays
 -----------------
 
-On a high-resolution display, an unaware app renders tiny and blurry. ``App``
-turns on high-DPI awareness by **default** (``high_dpi=True``) on Windows, so most
-apps need nothing. Two utilities cover the rest:
+On a high-resolution display, a DPI-unaware app is scaled up by the OS and looks
+blurry, or renders everything tiny. Each platform handles this differently, and
+``App`` does the right thing by default:
 
-- ``enable_high_dpi_awareness(root=None, scaling=None)`` — the manual control.
-  On Windows it must run *before* the root exists (``App`` already does this); on
-  Linux, pass the root and a ``scaling`` factor (``1.6``–``2.0`` is typical) after
-  creating it to scale the whole UI.
-- ``scale_size(widget, size)`` — convert a logical size to physical pixels for
-  the current display, for code that sets pixel geometry or builds image assets:
+- **Windows** — ``App`` enables DPI awareness automatically (``high_dpi=True``),
+  so text and widgets stay crisp. It must happen before the root is created, which
+  the constructor handles; call ``enable_high_dpi_awareness()`` yourself only if
+  you are not using ``App``.
+- **macOS** — HiDPI ("Retina") is handled natively by the OS; nothing to do.
+- **Linux** — there is no automatic scaling. Pass a factor after creating the
+  root to scale the whole UI: ``enable_high_dpi_awareness(app, 1.75)`` (``1.6``–
+  ``2.0`` is typical for a 4K panel).
 
-  .. code-block:: python
+For code that sets pixel geometry or builds image assets, convert logical sizes to
+physical pixels for the current display with ``scale_size``:
 
-     ttk.scale_size(app, 24)          # 24 logical px -> physical px for this display
-     ttk.scale_size(app, [24, 24])    # a (width, height) pair -> scaled ints
+.. code-block:: python
+
+   ttk.scale_size(app, 24)          # 24 logical px -> physical px for this display
+   ttk.scale_size(app, [24, 24])    # a (width, height) pair -> scaled ints
+
+Cross-platform behavior
+-----------------------
+
+Windowing is the corner of tkinter where "write once, run anywhere" leaks the
+most. The differences below are handled or guarded by ``App``/``Toplevel`` where
+possible, but they affect what you can rely on:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 25 25 24
+
+   * - Feature
+     - Windows
+     - macOS
+     - Linux (X11)
+   * - High-DPI
+     - auto (``high_dpi=True``)
+     - native (Retina)
+     - manual ``scaling``
+   * - Transparency (``alpha``)
+     - immediate
+     - immediate
+     - needs a compositor
+   * - Maximize
+     - ``state("zoomed")``
+     - none (native fullscreen)
+     - ``attributes("-zoomed", …)``
+   * - ``tool_window``
+     - ✓
+     - —
+     - —
+   * - ``window_type`` (borderless)
+     - — (use ``override_redirect``)
+     - native styles
+     - WM hint
+   * - ``override_redirect``
+     - ✓
+     - ignored (breaks events)
+     - ✓
+   * - Taskbar grouping
+     - by app id (automatic)
+     - Dock (native)
+     - WM-dependent
 
 .. admonition:: Sidebar — the deferred-config seam
    :class: note
@@ -222,5 +367,7 @@ apps need nothing. Two utilities cover the rest:
 
    :doc:`Structuring an app </user-guide/getting-started/app-structures>` for the
    single-root rule, :doc:`Theming & Colors </user-guide/feature-guides/theming>`
-   for themes and light/dark, and the :doc:`Multiple windows how-to
-   </user-guide/how-to/multiple-windows>` for second-window recipes.
+   for themes and light/dark, :doc:`Widget & screen info </reference/winfo>` for
+   the ``winfo_*`` size/position accessors, and the
+   :doc:`Multiple windows how-to </user-guide/how-to/multiple-windows>` for
+   second-window recipes.

--- a/docs/user-guide/foundations/layout-with-grid.rst
+++ b/docs/user-guide/foundations/layout-with-grid.rst
@@ -86,8 +86,8 @@ they stretch to fill it. This pairing is the whole secret to a responsive grid:
 
 .. admonition:: The key idea
 
-   **``weight`` on the column so the cell grows; ``sticky`` on the widget so it
-   grows with the cell.** You almost always need both — one without the other
+   ``weight`` on the column so the cell grows; ``sticky`` on the widget so it
+   grows with the cell. You almost always need both — one without the other
    leaves either an empty gap or a stuck widget. A weight of ``0`` (the default)
    means "stay at content size"; larger weights split the spare space in
    proportion.

--- a/docs/user-guide/foundations/layout-with-pack.rst
+++ b/docs/user-guide/foundations/layout-with-pack.rst
@@ -74,7 +74,7 @@ That's the distinction worth remembering:
 
 .. admonition:: ``fill`` vs ``expand``
 
-   **``fill``** stretches a widget within the space it already has. **``expand``**
+   ``fill`` stretches a widget within the space it already has. ``expand``
    grows that space to swallow whatever is left over. A region that should grow
    with the window — a content area, a text box — wants **both**: ``expand=True``
    to *receive* the space and ``fill="both"`` to *stretch into* it.

--- a/docs/user-guide/getting-started/app-structures.rst
+++ b/docs/user-guide/getting-started/app-structures.rst
@@ -20,6 +20,6 @@ guide covers how to structure a real application:
 
 .. seealso::
 
-   :doc:`Windows & high-DPI </user-guide/feature-guides/windows>` for the
+   :doc:`Windows </user-guide/feature-guides/windows>` for the
    full ``App``/``Toplevel`` surface (positioning, icons, ``window_type``,
    light/dark mode).

--- a/docs/user-guide/how-to/working-with-images.rst
+++ b/docs/user-guide/how-to/working-with-images.rst
@@ -104,7 +104,7 @@ to build or keep alive, and the glyph recolors with the theme and widget state:
    ttk.Button(app, text="Settings", icon="gear-fill")
 
 See the :doc:`Icons guide </user-guide/feature-guides/icons>` for the full icon
-API, and :doc:`Windows & high-DPI </user-guide/feature-guides/windows>`
+API, and :doc:`Windows </user-guide/feature-guides/windows>`
 for setting the *application* icon.
 
 A worked example

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -142,12 +142,12 @@ Each subsystem, end to end — its concepts and its usage in one place.
       Theme-aware Bootstrap Icons glyphs — the ``icon=`` keyword, ``apply_icon``,
       and the standalone ``Icon`` image.
 
-   .. grid-item-card:: Windows & high-DPI
+   .. grid-item-card:: Windows
       :link: feature-guides/windows
       :link-type: doc
 
-      ``App``/``Toplevel``, focus & modality, positioning, application icons, and
-      DPI scaling.
+      ``App``/``Toplevel`` setup, focus & modality, positioning, high-DPI, and the
+      deferred-config seam.
 
    .. grid-item-card:: Dialogs
       :link: feature-guides/dialogs


### PR DESCRIPTION
## Summary

Finishes the Windows feature guide (it was a stub — a "Still to come" outline), reframes it out of the kitchen-sink "Windows & high-DPI" title into **"Windows"**, and gives it real windowing depth with the cross-platform behavior that windowing actually demands. Docs-only.

### Retitle + finish
"Windows & high-DPI" read as a grab-bag; high-DPI is now one section, not a co-headline. Card relabeled "Windows"; the four prose cross-refs repointed. The full previously-unwritten surface is now authored.

### Teach the models, not the options
- **Window geometry** — teaches the tkinter *geometry string* (`"WxH+X+Y"`) as the model, `geometry()` read/write, signed/edge-relative position, `winfo_*` read-back with the "returns 1 until mapped" gotcha.
- **Window state** (new) — `iconify`/`deiconify`/`withdraw`/`state`, maximize & fullscreen.
- **Second windows (Toplevel)** — the title-first `.. warning::` + the WM options.
- Kept the already-solid **Focus, modality & lifecycle** section.
- **Application icon**, **Light & dark** (brief, cross-linked to Theming & Colors), **High-DPI displays**, and the **deferred-config seam** sidebar.

### Cross-platform behavior
Woven in as ground-truthed notes *and* a consolidated table (Feature × Windows/macOS/Linux):
- `state("zoomed")` Windows vs `attributes("-zoomed")` X11 vs native fullscreen macOS.
- `tool_window` Windows-only; `window_type` macOS-native-styles / X11-hint / Windows-no-op; `override_redirect` ignored on macOS (breaks events).
- Transparency needs a compositor on X11; centering falls back to the primary screen without `screeninfo`; high-DPI Windows-auto / macOS-native / Linux-manual.

### Also fixed (bonus commit)
A separate RST rendering bug that leaked **literal double backticks**: nested inline markup (`**``code``**` — inline literal inside bold, which RST doesn't support). Found every instance with a state-machine scan over `docs/` — 19 across 4 files (the Windows guide plus three pre-existing spots: layout-with-grid, layout-with-pack, event-object) — and fixed all. Not something `-W` catches (it renders wrong silently), so the scanner is the guard.

## Verification

- All Windows-side behavior ground-truthed on a live root (geometry / `state("zoomed")` / `-fullscreen` / attributes); macOS/X11 specifics taken from the source's `winsys` branches (authoritative for ttkbootstrap's behavior). API authored against the PR B / #1103 signatures.
- Every example verified headlessly; nested-markup scanner reports 0; full-site `sphinx -b html -W --keep-going` clean, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)