### PR TITLE
docs: Widgets catalog — authoring plan + Button gold-standard template (Phase 0)

### DIFF
--- a/development/2_0_docs_design.md
+++ b/development/2_0_docs_design.md
@@ -393,6 +393,50 @@ tasks* (determinate/indeterminate `mode`, `mask`/`text`, `.start()/.stop()/
 .step()`, bind `variable`), cross-links to **API Reference › Floodgauge**. Style
 Reference is N/A (Canvas).
 
+### 5a-plan. Widgets-catalog authoring plan (LOCKED 2026-07-11)
+
+Coverage decided from a full inventory (19 native `BootMixin` + 8 shipped
+widgets). **~27 pages; 2 done (Button — to rewrite, Meter), ~25 to author.**
+
+- **Native (19):** Button, Checkbutton (folds in `toggle`), Radiobutton, Entry,
+  Combobox, Spinbox, Menubutton (folds in `toolbutton`), OptionMenu, Label,
+  Frame, Labelframe, Notebook, Panedwindow, Progressbar, Scale, Scrollbar,
+  Separator, Sizegrip, Treeview. Depth → **Style Reference**; API → `tkinter.ttk`.
+- **Shipped (8):** Meter, Floodgauge, DateEntry, Tableview, Scrolled, Toast,
+  Tooltip, LabeledScale. Depth → **API Reference**.
+- **Text & Canvas — IN, and robust (author call 2026-07-11):** these are the most
+  *expansive* widgets and get very robust, example-heavy pages (Text: indices/
+  tags/marks/search/undo/editing; Canvas: items/coords/tags/scrolling/events).
+  They are `AutoStyleMixin` (no `bootstyle`), so the skeleton **flexes** —
+  usage dominates, the Variants/Colors sections shrink to "themed automatically."
+- **Scrolled** — thin catalog stub that cross-links the *Scroll long content*
+  How-To (which owns the usage), to avoid duplication.
+- **Covered elsewhere, NOT in the catalog:** `Menu` (Menus feature guide);
+  `Tk`/`TkFrame`/`TkLabel`/`LabelFrame` (infra).
+
+**Depth is calibrated, not padded:** Treeview/Notebook/Tableview/Combobox/Text/
+Canvas are rich; Separator/Sizegrip/Frame/Panedwindow are short honest pages.
+Uniform *shape* (the §5a skeleton), not uniform *length*.
+
+**Usage-first (author bar):** every page leads with *using* the widget (real
+patterns driven by its actual API — `command=`, `textvariable=`, `icon=`/
+`icon_only=`, selection, …), each snippet **verified headlessly**, *then* the
+bootstyle/variants/colors/states surface. Screenshots are placeholders (later
+slice).
+
+**No-gaps mechanism:** a coverage **sync test** — assert every widget in
+`ttk.__all__` (BootMixin + shipped) has a `docs/widgets/<name>.rst` page **or** an
+explicit `COVERED_ELSEWHERE` allowlist entry (e.g. `Menu → Menus guide`). Adding a
+widget later without a page fails CI.
+
+**Sequence:** Phase 0 = rewrite `button.rst` as the gold-standard template (sign
+-off gate). Phase 1 = **one PR per family**: Inputs (Entry/Combobox/Spinbox) ·
+Choice (Checkbutton/Radiobutton) · Command (Menubutton/OptionMenu) · Containers
+(Frame/Labelframe/Notebook/Panedwindow) · Range & misc (Progressbar/Scale/
+Scrollbar/Separator/Sizegrip/Label) · Shipped (Floodgauge/DateEntry/Tableview/
+LabeledScale/Toast/Tooltip/Scrolled) · **Text** · **Canvas** (each its own PR,
+given their size).
+
 ### 5b. Style Reference (generated) — for native widgets & any widget with a ttk style surface
 
 Reimagines today's thin "Style guide" into an *exhaustive, generated* reference

--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -1,25 +1,22 @@
 Button
 ======
 
-A clickable action trigger. ``Button`` is the native ``ttk.Button``, styled with
-``bootstyle=``.
+A **button** runs an action when clicked. ``Button`` is the native
+``ttk.Button``, styled with ``bootstyle=``. This page covers using one — wiring
+the action, adding an icon, laying out a row, the default button, and disabling —
+then the ``bootstyle`` colors, variants, and states.
 
-.. Screenshots (light/dark pairs) are added in a later documentation slice. The
-   directives below are the intended pattern:
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
 
-   .. image:: /_static/examples/button-hero-light.png
-      :class: tb-screenshot-light
-      :alt: Button — light theme
+   A row of buttons in light and dark themes: a solid primary, an outline, a
+   link, and an icon button.
 
-   .. image:: /_static/examples/button-hero-dark.png
-      :class: tb-screenshot-dark
-      :alt: Button — dark theme
+Usage
+-----
 
-Semantic styling
-----------------
-
-Set intent with ``bootstyle=``. The button renders correctly across every theme
-without hard-coding a color.
+Wire the action with ``command=`` — the function to call on each click. Pass the
+function itself, without parentheses; tkinter calls it for you:
 
 .. code-block:: python
 
@@ -27,20 +24,148 @@ without hard-coding a color.
 
    app = ttk.App()
 
-   ttk.Button(app, text="Primary",   bootstyle="primary").pack(padx=8, pady=4)
-   ttk.Button(app, text="Secondary", bootstyle="secondary").pack(padx=8, pady=4)
-   ttk.Button(app, text="Success",   bootstyle="success").pack(padx=8, pady=4)
-   ttk.Button(app, text="Info",      bootstyle="info").pack(padx=8, pady=4)
-   ttk.Button(app, text="Warning",   bootstyle="warning").pack(padx=8, pady=4)
-   ttk.Button(app, text="Danger",    bootstyle="danger").pack(padx=8, pady=4)
+   def greet():
+       print("clicked")
+
+   ttk.Button(app, text="Greet", command=greet, bootstyle="primary").pack(padx=10, pady=10)
 
    app.mainloop()
+
+To pass arguments to the callback, wrap it in a ``lambda`` — but keep real work in
+a named function:
+
+.. code-block:: python
+
+   ttk.Button(app, text="Delete", command=lambda: delete(item_id), bootstyle="danger")
+
+Icons
+-----
+
+Give a button a themed glyph with ``icon=`` — a `Bootstrap Icons
+<https://icons.getbootstrap.com/>`_ name. The glyph is rendered to match the
+button's style, so it inverts on outline buttons, mutes when disabled, and
+recolors on a theme switch:
+
+.. code-block:: python
+
+   ttk.Button(app, text="Save", icon="save", bootstyle="success")
+
+``compound=`` places the icon relative to the text (``LEFT`` — the default when
+there is text — ``RIGHT``, ``TOP``, ``BOTTOM``):
+
+.. code-block:: python
+
+   from ttkbootstrap.constants import *
+
+   ttk.Button(app, text="Next", icon="arrow-right", compound=RIGHT, bootstyle="primary")
+
+For a compact toolbar control, drop the text with ``icon_only=True`` — the button
+becomes a square sized to the glyph:
+
+.. code-block:: python
+
+   ttk.Button(app, icon="trash", icon_only=True, bootstyle="danger")
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A Save button with a leading icon, a Next button with a trailing icon, and a
+   square icon-only trash button.
+
+A row of buttons
+----------------
+
+Buttons in a row read best at a uniform width — set ``width=`` (in characters) to
+the widest label so they align. Pack them into a frame with consistent spacing:
+
+.. code-block:: python
+
+   from ttkbootstrap.constants import *
+
+   actions = ttk.Frame(app, padding=10)
+   actions.pack()
+
+   ok = ttk.Button(actions, text="OK", width=10, command=on_ok, bootstyle="success")
+   ok.pack(side=LEFT, padx=4)
+   cancel = ttk.Button(actions, text="Cancel", width=10, command=on_cancel, bootstyle="secondary")
+   cancel.pack(side=LEFT, padx=4)
+
+For a **toolbar**, pack icon-only buttons side by side in a frame:
+
+.. code-block:: python
+
+   toolbar = ttk.Frame(app, padding=4)
+   toolbar.pack(fill=X)
+
+   for name, action in [("save", save), ("printer", print_doc), ("trash", delete)]:
+       button = ttk.Button(toolbar, icon=name, icon_only=True, command=action, bootstyle="secondary-link")
+       button.pack(side=LEFT)
+
+The default button
+------------------
+
+A dialog usually has a **default** action that fires on :kbd:`Return`. There is no
+"default" flag on ``ttk.Button``; make one by giving it focus and binding the key:
+
+.. code-block:: python
+
+   submit = ttk.Button(app, text="Submit", command=on_submit, bootstyle="primary")
+   submit.pack(pady=10)
+   submit.focus_set()                         # start focused
+   app.bind("<Return>", lambda event: on_submit())
+
+Now :kbd:`Return` triggers the action from anywhere in the window, and the button
+already has the focus ring. (For the shipped dialogs, ``default=`` does this for
+you — see the :doc:`Dialogs guide </user-guide/feature-guides/dialogs>`.)
+
+Enabling and disabling
+----------------------
+
+A button you cannot use yet — until a form is valid, say — should be **disabled**.
+Toggle the standard ttk ``disabled`` state; the theme mutes it and it stops
+responding to clicks:
+
+.. code-block:: python
+
+   submit = ttk.Button(app, text="Submit", command=on_submit, bootstyle="primary")
+
+   submit.state(["disabled"])                 # greyed out, not clickable
+   submit.state(["!disabled"])                # re-enable
+
+   submit.instate(["disabled"])               # -> True/False, query the state
+
+Colors
+------
+
+``bootstyle`` sets **intent**, not a literal color, so a button renders correctly
+in every theme. The nine semantic colors:
+
+.. code-block:: python
+
+   for color in ["primary", "secondary", "success", "info", "warning",
+                 "danger", "light", "dark", "neutral"]:
+       ttk.Button(app, text=color.title(), bootstyle=color).pack(padx=8, pady=2)
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A swatch strip of the nine button colors in light and dark themes.
+
+A bare ``Button`` with no ``bootstyle`` uses the ``neutral`` default (as does
+``Menubutton``). To restore the pre-2.0 accented default, set it **before** the
+app is created — the setting is consumed when a button's style is first built:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(default_button="primary")    # or ttk.set_default_button("primary")
 
 Variants
 --------
 
-Combine a color with a variant to change visual weight — ``outline``, ``link``,
-or ``ghost``:
+Combine a color with a variant to change visual weight — ``outline``, ``link``, or
+``ghost``:
 
 .. code-block:: python
 
@@ -49,39 +174,32 @@ or ``ghost``:
    ttk.Button(app, text="Link",    bootstyle="primary-link")
    ttk.Button(app, text="Ghost",   bootstyle="primary-ghost")
 
-Colors
-------
-
-The nine semantic colors — ``primary``, ``secondary``, ``success``, ``info``,
-``warning``, ``danger``, ``light``, ``dark``, and ``neutral`` — combine with any
-variant. A bare ``Button`` with no ``bootstyle`` uses the ``neutral`` default (as
-does ``Menubutton``). To restore the pre-2.0 accented default, set it **before**
-the app is created — the setting is consumed when a button's style is first
-built:
-
-.. code-block:: python
-
-   import ttkbootstrap as ttk
-
-   app = ttk.App(default_button="primary")   # or ttk.set_default_button("primary")
+- **solid** (the default) — a filled button for the primary action.
+- **outline** — a bordered button for a secondary action next to a solid one.
+- **link** — text only, for a low-emphasis action inline with other content.
+- **ghost** — no border until hovered; for toolbars and dense UIs.
 
 States
 ------
 
-Disable a button through the standard ttk state; the theme mutes it
-automatically:
-
-.. code-block:: python
-
-   btn = ttk.Button(app, text="Disabled", bootstyle="primary")
-   btn.state(["disabled"])
+Buttons respond to ``hover``, ``pressed``, ``focus``, and ``disabled``
+automatically — the theme handles the visuals. You set ``disabled`` yourself (see
+`Enabling and disabling`_); the rest follow the pointer and keyboard. To style a
+state differently, see the Style Reference below.
 
 API & reference
 ---------------
 
-``Button`` is the native ``ttk.Button`` — ttkbootstrap adds no Python API of its
-own. For its constructor and options, see the
+``Button`` is the native ``ttk.Button`` — ttkbootstrap adds the ``bootstyle=`` and
+``icon=`` keywords but no other Python API. For its constructor and options
+(``text``, ``command``, ``width``, ``compound``, ``state``, …) see the
 `tkinter.ttk.Button <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Button>`__
-reference. For the full hand-styling surface (the ``bootstyle`` → ttk style-name
-mapping, element layout, configurable options, and supported states) see the
-:doc:`Style Reference </reference/style-reference/index>`.
+reference.
+
+.. seealso::
+
+   Want to restyle the button yourself? The
+   :doc:`Style Reference › Button </reference/style-reference/button>` documents
+   the hand-styling surface — the ``bootstyle`` → ttk style-name mapping, element
+   layout, configurable options, and supported states — and its companion
+   :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.

--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -151,7 +151,10 @@ in every theme. The nine semantic colors:
 
    A swatch strip of the nine button colors in light and dark themes.
 
-A bare ``Button`` with no ``bootstyle`` uses the ``neutral`` default (as does
+The default color
+-----------------
+
+A bare ``Button`` with no ``bootstyle`` uses the ``neutral`` color (as does
 ``Menubutton``). To restore the pre-2.0 accented default, set it **before** the
 app is created — the setting is consumed when a button's style is first built:
 


### PR DESCRIPTION
## Summary

**Phase 0 of the Widgets catalog** — lock the plan and rewrite **Button** as the usage-first template every other page is cloned from. This PR is the **sign-off gate**: bless the shape here and I batch the remaining ~25 pages (one PR per family).

### The plan (`development/2_0_docs_design.md §5a-plan`)
- **Coverage:** 19 native (`BootMixin`) + 8 shipped widgets; ~27 pages, 2 done (Button rewritten, Meter). **Text & Canvas are in and robust** (your call — the most expansive widgets; the skeleton flexes since they have no `bootstyle`). **Scrolled** = thin stub cross-linking the *Scroll long content* how-to. **Menu** covered by the Menus guide (not in catalog).
- **Usage-first bar:** every page leads with *using* the widget (real API-driven patterns), each snippet verified headlessly, then bootstyle/colors/variants/states.
- **No-gaps mechanism:** a coverage **sync test** (every `ttk.__all__` widget has a page or a `COVERED_ELSEWHERE` entry) — added with the batches so it enforces meaningfully.
- **Sequence:** one PR per family (Inputs · Choice · Command · Containers · Range/misc · Shipped · Text · Canvas).

### The template (`docs/widgets/button.rst`)
Rewritten from the thin bootstyle-catalog (the design flagged it "sorely lacking") into a usage-first page: **Usage** (`command=`, `lambda` args) · **Icons** (`icon=`/`compound`/`icon_only`) · **A row of buttons** (uniform `width` + a toolbar) · **The default button** (focus + `Return` bind) · **Enabling/disabling** (`state`/`instate`) · then **Colors** (9 semantic + `default_button`) · **Variants** (solid/outline/link/ghost) · **States** · **API + Style-Reference** links.

## Verification
- Every button-page snippet exercised headlessly (command, icon+compound, icon_only, width row, toolbar loop, default-button focus/bind, state/instate, colors, variants).
- `sphinx -b html -W` clean.

Docs-only; targets `2.0`. **Please review the Button page shape** — once you're happy, I'll clone it across the families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)