### PR TITLE
docs+fix: Widgets catalog Inputs family + input focus-color fix

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -1218,6 +1218,19 @@ signal *where keyboard input goes*, not where the pointer happens to be. Reservi
 it for the real `focus` state matches conventional input behavior and removes a
 distracting hover flicker when the pointer sweeps across a form.
 
+**Follow-up (2026-07-11): `Combobox`/`Spinbox` base border was still tinted.** The
+above dropped the *hover* map, but colored `Combobox`/`Spinbox` styles still forced
+their **base** `bordercolor` to the accent (a leftover `border = focus_ring`
+override in `builders/combobox.py` and `builders/spinbox.py`), so a
+`bootstyle`-colored combobox/spinbox drew a **persistent colored border** at rest —
+unlike `Entry`, whose base border is the neutral `colors.border` and which shows
+the accent only on `focus`. That override is now removed, so **all three inputs
+match: a neutral hairline at rest, the accent on `focus` (and `danger` on
+`invalid`)**. This is a **1.x → 2.0 visual change** — in 1.x a colored input carried
+a persistent colored border; in 2.0 the `bootstyle` color on an input is the
+**focus color**, not a resting fill. (Widgets-catalog Inputs pages document the
+focus-color model.)
+
 ## `card` / `highlight` frames: single hairline border (`RAISED`, bevel suppressed)  *(Visual)*
 
 **What.** The `card` and `highlight` frame variants now draw their border with

--- a/docs/widgets/combobox.rst
+++ b/docs/widgets/combobox.rst
@@ -1,0 +1,106 @@
+Combobox
+========
+
+A **combobox** is a text entry with a dropdown list of choices. ``Combobox`` is
+the native ``ttk.Combobox``, styled with ``bootstyle=``. This page covers offering
+choices, reacting to a selection, the pick-only vs. editable modes, then the
+``bootstyle`` color and states.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A combobox in light and dark themes, closed and with its dropdown list open.
+
+Usage
+-----
+
+Pass the choices as ``values=`` and bind the selection to a ``StringVar`` with
+``textvariable=``. Read it with ``.get()``:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   color = ttk.StringVar()
+   ttk.Combobox(app, textvariable=color, values=["Red", "Green", "Blue"]).pack(padx=10, pady=10)
+
+   ttk.Button(app, text="Use", command=lambda: print(color.get()), bootstyle="primary").pack()
+
+   app.mainloop()
+
+Give the variable an initial ``value`` to preselect an item, or call ``.set()`` /
+``.current(index)`` to select one programmatically:
+
+.. code-block:: python
+
+   color.set("Green")                  # by value
+   combo.current(0)                    # by index -> "Red"
+
+Reacting to a selection
+-----------------------
+
+To run code the moment the user picks an item, bind the ``<<ComboboxSelected>>``
+virtual event:
+
+.. code-block:: python
+
+   def on_pick(event):
+       print("picked", color.get())
+
+   combo.bind("<<ComboboxSelected>>", on_pick)
+
+Pick-only vs. editable
+----------------------
+
+By default the user can also *type* into a combobox. Set ``state="readonly"`` to
+make it **pick-only** — the value is always one of your ``values``, which is what
+you usually want for a fixed set of choices:
+
+.. code-block:: python
+
+   ttk.Combobox(app, values=["Small", "Medium", "Large"], state="readonly")
+
+Leave the state default to let the user type a value that isn't in the list — an
+editable combobox, useful for a "recent / or type your own" field.
+
+Color
+-----
+
+``bootstyle`` sets the combobox's **accent** — the border, the focus ring, and the
+dropdown arrow — from the semantic colors:
+
+.. code-block:: python
+
+   ttk.Combobox(app, values=["Red", "Green", "Blue"], bootstyle="success")
+
+States
+------
+
+**Disabled** greys the whole widget out; **readonly** (above) keeps it usable as a
+pick-only control:
+
+.. code-block:: python
+
+   combo.state(["disabled"])           # greyed out, no interaction
+   combo.state(["readonly"])           # pick-only, not typeable
+   combo.state(["!disabled"])          # re-enable
+
+API & reference
+---------------
+
+``Combobox`` is the native ``ttk.Combobox`` — ttkbootstrap adds ``bootstyle=`` but
+no other Python API. For its constructor and options (``values``,
+``textvariable``, ``state``, ``height``, ``postcommand``, …) and the ``get`` /
+``set`` / ``current`` methods, see the
+`tkinter.ttk.Combobox <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Combobox>`__
+reference.
+
+.. seealso::
+
+   :doc:`Entry <entry>` for a plain text field and :doc:`Spinbox <spinbox>` for a
+   stepper over an ordered range. Want to restyle the combobox yourself? The
+   :doc:`Style Reference › Combobox </reference/style-reference/combobox>` and its
+   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/docs/widgets/combobox.rst
+++ b/docs/widgets/combobox.rst
@@ -68,8 +68,10 @@ editable combobox, useful for a "recent / or type your own" field.
 Color
 -----
 
-``bootstyle`` sets the combobox's **accent** — the border, the focus ring, and the
-dropdown arrow — from the semantic colors:
+Like the other inputs, ``bootstyle`` sets the combobox's **focus color**: the
+border is a neutral hairline at rest and shows the accent color when the field has
+focus (and ``danger`` when a validation rule fails). The dropdown arrow keeps a
+constant color across styles.
 
 .. code-block:: python
 

--- a/docs/widgets/entry.rst
+++ b/docs/widgets/entry.rst
@@ -34,13 +34,16 @@ change the field:
 
    app.mainloop()
 
-You can also work with the text directly — ``insert`` adds at an index, ``delete``
-removes a range, and ``"end"`` marks the far end:
+You can also work with the text directly, by **character position**. An entry
+numbers positions from ``0`` — before the first character — and the string
+``"end"`` is the position past the last. ``insert(index, text)`` adds text at a
+position; ``delete(first, last)`` removes the characters between two:
 
 .. code-block:: python
 
-   entry.insert(0, "default")          # insert at the start
-   entry.delete(0, "end")              # clear the whole field
+   entry.insert(0, "default")          # insert before the first character
+   entry.insert("end", "!")            # append after the last
+   entry.delete(0, "end")              # remove everything from 0 to the end
 
 A password field
 ----------------

--- a/docs/widgets/entry.rst
+++ b/docs/widgets/entry.rst
@@ -1,0 +1,116 @@
+Entry
+=====
+
+An **entry** is a single-line text field. ``Entry`` is the native ``ttk.Entry``,
+styled with ``bootstyle=``. This page covers reading and writing its value,
+masking a password, validating input, then the ``bootstyle`` color and states.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A labeled entry in light and dark themes, and the same entry with a
+   ``danger``-red focus border when its value is invalid.
+
+Usage
+-----
+
+Bind the entry to a **variable** with ``textvariable=`` — a ``StringVar`` that
+stays in sync with what the user types. Read it with ``.get()``; ``.set()`` it to
+change the field:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   name = ttk.StringVar()
+   ttk.Entry(app, textvariable=name).pack(padx=10, pady=10)
+
+   def greet():
+       print("Hello,", name.get())
+
+   ttk.Button(app, text="Greet", command=greet, bootstyle="primary").pack()
+
+   app.mainloop()
+
+You can also work with the text directly — ``insert`` adds at an index, ``delete``
+removes a range, and ``"end"`` marks the far end:
+
+.. code-block:: python
+
+   entry.insert(0, "default")          # insert at the start
+   entry.delete(0, "end")              # clear the whole field
+
+A password field
+----------------
+
+``show=`` replaces every typed character with a mask, for passwords and secrets:
+
+.. code-block:: python
+
+   ttk.Entry(app, show="•", bootstyle="primary")
+
+The variable still holds the real text — only the display is masked.
+
+Validating input
+----------------
+
+Attach a validation rule and a value that fails it flags the entry with a
+``danger`` border until it becomes valid again:
+
+.. code-block:: python
+
+   from ttkbootstrap import Validation
+
+   email = ttk.Entry(app)
+   email.pack(padx=10, pady=10)
+   Validation.regex(email, r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+The rule set, custom rules, and when they fire are covered in the
+:doc:`Input validation guide </user-guide/feature-guides/validation>`.
+
+Color
+-----
+
+``bootstyle`` sets the entry's **accent** — the border and the focus ring — from
+the semantic colors. Use it to tie an entry to a section's color, or to signal
+state (``success``/``danger``) yourself:
+
+.. code-block:: python
+
+   ttk.Entry(app, bootstyle="success")
+   ttk.Entry(app, bootstyle="danger")
+
+An entry has no solid/outline variants — it is always a bordered field; the color
+is the accent, shown most visibly when the field has focus.
+
+States
+------
+
+Two states matter for an entry. **Disabled** greys it out and blocks all
+interaction; **readonly** lets the user select and copy the text but not change
+it:
+
+.. code-block:: python
+
+   entry.state(["disabled"])           # greyed out, no interaction
+   entry.state(["readonly"])           # selectable, not editable
+   entry.state(["!disabled", "!readonly"])   # back to normal
+
+API & reference
+---------------
+
+``Entry`` is the native ``ttk.Entry`` — ttkbootstrap adds ``bootstyle=`` but no
+other Python API. For its constructor and options (``textvariable``, ``show``,
+``width``, ``justify``, ``state``, …) see the
+`tkinter.ttk.Entry <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Entry>`__
+reference.
+
+.. seealso::
+
+   :doc:`Combobox <combobox>` and :doc:`Spinbox <spinbox>` for entries with a
+   dropdown or numeric stepper. Want to restyle the entry yourself? The
+   :doc:`Style Reference › Entry </reference/style-reference/entry>` and its
+   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/docs/widgets/entry.rst
+++ b/docs/widgets/entry.rst
@@ -59,8 +59,7 @@ The variable still holds the real text — only the display is masked.
 Validating input
 ----------------
 
-Attach a validation rule and a value that fails it flags the entry with a
-``danger`` border until it becomes valid again:
+Attach a validation rule with the :class:`~ttkbootstrap.Validation` helpers:
 
 .. code-block:: python
 
@@ -70,7 +69,13 @@ Attach a validation rule and a value that fails it flags the entry with a
    email.pack(padx=10, pady=10)
    Validation.regex(email, r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
-The rule set, custom rules, and when they fire are covered in the
+By default the rule runs when the entry **loses focus**. If the value passes,
+nothing changes; if it fails, the entry takes on a ``danger``-colored border that
+stays until the value becomes valid again — so the field flags itself only after
+the user leaves it, not on every keystroke. Pass ``when=`` to validate at a
+different time (for example ``when="key"`` to check as they type).
+
+The full rule set, custom rules, and the ``when=`` options are covered in the
 :doc:`Input validation guide </user-guide/feature-guides/validation>`.
 
 Color

--- a/docs/widgets/entry.rst
+++ b/docs/widgets/entry.rst
@@ -81,17 +81,17 @@ The full rule set, custom rules, and the ``when=`` options are covered in the
 Color
 -----
 
-``bootstyle`` sets the entry's **accent** — the border and the focus ring — from
-the semantic colors. Use it to tie an entry to a section's color, or to signal
-state (``success``/``danger``) yourself:
+On an entry, ``bootstyle`` sets the **focus color**. At rest the border is a
+neutral hairline; when the field takes focus, the border shows the accent color
+you chose. (A failed validation rule overrides it with a ``danger`` border — see
+`Validating input`_.)
 
 .. code-block:: python
 
-   ttk.Entry(app, bootstyle="success")
-   ttk.Entry(app, bootstyle="danger")
+   ttk.Entry(app, bootstyle="primary")     # border turns primary on focus
 
-An entry has no solid/outline variants — it is always a bordered field; the color
-is the accent, shown most visibly when the field has focus.
+An entry has no solid/outline variants — it is always a bordered field, and the
+color is the focus accent, not a persistent fill.
 
 States
 ------

--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -19,6 +19,24 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
 
       A clickable action trigger — solid, outline, link, and ghost variants.
 
+   .. grid-item-card:: Entry
+      :link: entry
+      :link-type: doc
+
+      A single-line text field — binding, masking, and validation.
+
+   .. grid-item-card:: Combobox
+      :link: combobox
+      :link-type: doc
+
+      A text field with a dropdown of choices — pick-only or editable.
+
+   .. grid-item-card:: Spinbox
+      :link: spinbox
+      :link-type: doc
+
+      An entry with up/down arrows for stepping a range or list.
+
    .. grid-item-card:: Meter
       :link: meter
       :link-type: doc
@@ -29,4 +47,7 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
    :hidden:
 
    button
+   entry
+   combobox
+   spinbox
    meter

--- a/docs/widgets/spinbox.rst
+++ b/docs/widgets/spinbox.rst
@@ -65,8 +65,10 @@ trace the variable (see :doc:`State & variables
 Color
 -----
 
-``bootstyle`` sets the spinbox's **accent** — the border, the focus ring, and the
-arrows — from the semantic colors:
+Like the other inputs, ``bootstyle`` sets the spinbox's **focus color**: the
+border is a neutral hairline at rest and shows the accent color when the field has
+focus (and ``danger`` when a validation rule fails). The stepper arrows keep a
+constant color across styles.
 
 .. code-block:: python
 

--- a/docs/widgets/spinbox.rst
+++ b/docs/widgets/spinbox.rst
@@ -1,0 +1,103 @@
+Spinbox
+=======
+
+A **spinbox** is an entry with up/down arrows for stepping through a range of
+values. ``Spinbox`` is the native ``ttk.Spinbox``, styled with ``bootstyle=``.
+This page covers stepping over a numeric range, stepping through a list, reacting
+to the arrows, then the ``bootstyle`` color and states.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A numeric spinbox and a list spinbox in light and dark themes, showing the
+   up/down arrows.
+
+Usage
+-----
+
+Give a numeric range with ``from_``, ``to``, and ``increment`` (the step per
+arrow click), and bind the value to a variable:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   quantity = ttk.IntVar(value=1)
+   ttk.Spinbox(app, from_=1, to=10, increment=1, textvariable=quantity).pack(padx=10, pady=10)
+
+   ttk.Button(app, text="Order", command=lambda: print(quantity.get()), bootstyle="primary").pack()
+
+   app.mainloop()
+
+``from_`` has a trailing underscore because ``from`` is a Python keyword; ``to``
+and ``increment`` do not. Read the value with the bound variable's ``.get()`` or
+the spinbox's own ``.get()`` (which returns a string).
+
+Stepping through a list
+-----------------------
+
+Pass ``values=`` instead of a range to step through a fixed list. Add
+``wrap=True`` so it cycles from the last item back to the first:
+
+.. code-block:: python
+
+   ttk.Spinbox(app, values=["Small", "Medium", "Large"], wrap=True)
+
+Reacting to the arrows
+----------------------
+
+``command=`` runs each time the user clicks an arrow — handy to recompute
+something as the value steps:
+
+.. code-block:: python
+
+   def on_step():
+       print("now", quantity.get())
+
+   ttk.Spinbox(app, from_=0, to=100, increment=5, textvariable=quantity, command=on_step)
+
+``command`` fires only for the arrows, not for typing; to react to typed edits too,
+trace the variable (see :doc:`State & variables
+</user-guide/foundations/state-and-variables>`).
+
+Color
+-----
+
+``bootstyle`` sets the spinbox's **accent** — the border, the focus ring, and the
+arrows — from the semantic colors:
+
+.. code-block:: python
+
+   ttk.Spinbox(app, from_=0, to=10, bootstyle="info")
+
+States
+------
+
+**Disabled** greys the whole widget out; **readonly** lets the arrows still step
+the value but blocks typing:
+
+.. code-block:: python
+
+   spin.state(["disabled"])            # greyed out, no interaction
+   spin.state(["readonly"])            # arrows work, not typeable
+   spin.state(["!disabled", "!readonly"])   # back to normal
+
+API & reference
+---------------
+
+``Spinbox`` is the native ``ttk.Spinbox`` — ttkbootstrap adds ``bootstyle=`` but
+no other Python API. For its constructor and options (``from_``, ``to``,
+``increment``, ``values``, ``wrap``, ``textvariable``, ``command``, ``format``,
+…) see the
+`tkinter.ttk.Spinbox <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Spinbox>`__
+reference.
+
+.. seealso::
+
+   :doc:`Entry <entry>` for a plain text field and :doc:`Combobox <combobox>` for
+   a dropdown of choices. Want to restyle the spinbox yourself? The
+   :doc:`Style Reference › Spinbox </reference/style-reference/spinbox>` and its
+   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/src/ttkbootstrap/style/builders/combobox.py
+++ b/src/ttkbootstrap/style/builders/combobox.py
@@ -49,9 +49,6 @@ def build_combobox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     builder.style.element_create(f"{element}.padding", "from", TTK_CLAM)
     builder.style.element_create(f"{element}.textarea", "from", TTK_CLAM)
 
-    if all([colorname, colorname != DEFAULT]):
-        border = focus_ring
-
     builder.configure(
         ttk_style,
         bordercolor=border,

--- a/src/ttkbootstrap/style/builders/spinbox.py
+++ b/src/ttkbootstrap/style/builders/spinbox.py
@@ -33,9 +33,6 @@ def build_spinbox_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         ttk_style = f"{colorname}.{ttk_class}"
         focus_color = builder.colors.get(colorname)
 
-    if all([colorname, colorname != DEFAULT]):
-        border_color = focus_color
-
     element = ttk_style.replace(".TS", ".S")
     # The carets keep one fixed color in every state (no focus/hover/pressed/
     # disabled recolor) so they read as steady glyphs rather than reacting to


### PR DESCRIPTION
## Summary

**Phase 1, Inputs family** — usage-first catalog pages for **Entry**, **Combobox**, **Spinbox** (cloned from the Button template; one concept per digestible section), **plus a style-engine fix** surfaced while documenting them.

### Catalog pages
- **Entry** — `textvariable` binding + the character-position index model (`insert`/`delete`, `0`/`"end"`), password `show=`, validation (what fires, when, pass/fail behavior; `when=`), focus color, disabled/readonly.
- **Combobox** — `values`+binding, `<<ComboboxSelected>>`, pick-only vs. editable, focus color, states.
- **Spinbox** — `from_`/`to`/`increment` range, `values`+`wrap` list, `command=` on the arrows (+ trace note), focus color, states.

Each cross-links the others and its Style Reference; wired into the catalog index.

### Style fix — input accent border on focus only
Documenting the color behavior surfaced an inconsistency: colored **Combobox/Spinbox** styles forced their *base* border to the accent (a leftover `border = focus_ring` override), drawing a **persistent colored border** at rest — unlike **Entry** (neutral border, accent on focus). Removed the override in `builders/combobox.py` + `builders/spinbox.py`; the existing `focus !disabled`/`invalid` maps now give all three inputs the same behavior. This completes the 2.0 focus-only-accent intent and is a **1.x → 2.0 visual change** (1.x colored inputs had a persistent border) — logged in `2_0_breaking_changes.md`.

## Verification
- Every snippet exercised headlessly; ground-truthed the border behavior via `ttk::style lookup`/`map` (all three inputs now `#d6d6d6` base, accent on `focus`).
- Full suite **648 passed**; `sphinx -b html -W` clean.

Docs + a small style fix; targets `2.0`. Next family: **Choice** (Checkbutton/Radiobutton).

🤖 Generated with [Claude Code](https://claude.com/claude-code)