### PR TITLE
docs: Widgets catalog — the Choice family (Checkbutton/Radiobutton)

### DIFF
--- a/docs/widgets/checkbutton.rst
+++ b/docs/widgets/checkbutton.rst
@@ -90,16 +90,37 @@ Color
 States
 ------
 
-Toggle the ``disabled`` state to grey the control out and block interaction; the
-selected/unselected visual follows the bound variable, so you set it by changing
-the variable, not a state:
+Toggle ``disabled`` to grey the control out and block clicks:
 
 .. code-block:: python
 
-   check.state(["disabled"])           # greyed out, not clickable
-   check.state(["!disabled"])          # re-enable
+   check.state(["disabled"])
+   check.state(["!disabled"])
 
-   agree.set(True)                     # check it programmatically
+Read or change the value through the bound variable, or drive the widget directly
+with ``invoke`` (toggle) and ``instate`` (read):
+
+.. code-block:: python
+
+   agree.get()                     # -> True / False
+   agree.set(True)                 # check it
+
+   check.invoke()                  # toggle it programmatically
+   check.instate(["selected"])     # read the checked state directly
+
+The ``alternate`` state shows an indeterminate "mixed" mark — for a "select all"
+that is only partly on:
+
+.. code-block:: python
+
+   check.state(["alternate"])
+   check.state(["!alternate"])
+
+.. note::
+
+   A checkbutton created without ``variable=`` starts in the ``alternate`` state.
+   Bind a ``variable=``, or clear it with ``check.state(["!alternate"])``, to start
+   it unchecked.
 
 API & reference
 ---------------

--- a/docs/widgets/checkbutton.rst
+++ b/docs/widgets/checkbutton.rst
@@ -1,0 +1,120 @@
+Checkbutton
+===========
+
+A **checkbutton** is an on/off control bound to a variable. ``Checkbutton`` is the
+native ``ttk.Checkbutton``, styled with ``bootstyle=``. This page covers binding
+it, reacting to a toggle, the switch and toolbutton looks, non-boolean values,
+then the ``bootstyle`` color and states.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A checkbox, a round toggle switch, and a toolbutton checkbutton — each shown
+   on and off, in light and dark themes.
+
+Usage
+-----
+
+Bind the checkbutton to a ``BooleanVar`` with ``variable=``. The variable is
+``True`` when checked and ``False`` when not; read it with ``.get()``:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   agree = ttk.BooleanVar()
+   ttk.Checkbutton(app, text="I agree", variable=agree).pack(padx=10, pady=10)
+
+   ttk.Button(app, text="Continue", command=lambda: print(agree.get()), bootstyle="primary").pack()
+
+   app.mainloop()
+
+To run code the moment it is toggled, pass ``command=`` — it fires on each change,
+after the variable has updated:
+
+.. code-block:: python
+
+   def on_toggle():
+       print("now", agree.get())
+
+   ttk.Checkbutton(app, text="Notifications", variable=agree, command=on_toggle)
+
+Switch and toolbutton looks
+---------------------------
+
+The same control renders three ways — combine the look with a color. A
+``round-toggle`` or ``square-toggle`` draws it as a **switch**, which reads better
+than a checkbox for a settings on/off:
+
+.. code-block:: python
+
+   ttk.Checkbutton(app, text="Wi-Fi", variable=agree, bootstyle="round-toggle")
+   ttk.Checkbutton(app, text="Wi-Fi", variable=agree, bootstyle="square-toggle")
+
+``toolbutton`` draws it as a button that stays pressed while checked — for a
+toolbar or a filter chip:
+
+.. code-block:: python
+
+   ttk.Checkbutton(app, text="Bold", variable=agree, bootstyle="toolbutton")
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A round toggle, a square toggle, and a toolbutton checkbutton, each in its on
+   and off state.
+
+Non-boolean values
+------------------
+
+The value need not be a boolean. Bind a ``StringVar`` (or ``IntVar``) and set
+``onvalue=`` / ``offvalue=`` to store your own values for the two states:
+
+.. code-block:: python
+
+   status = ttk.StringVar(value="off")
+   ttk.Checkbutton(app, text="Active", variable=status, onvalue="on", offvalue="off")
+
+Color
+-----
+
+``bootstyle`` sets the color of the check mark or toggle when it is **on**:
+
+.. code-block:: python
+
+   ttk.Checkbutton(app, text="Success", variable=agree, bootstyle="success")
+   ttk.Checkbutton(app, text="Danger",  variable=agree, bootstyle="danger-round-toggle")
+
+States
+------
+
+Toggle the ``disabled`` state to grey the control out and block interaction; the
+selected/unselected visual follows the bound variable, so you set it by changing
+the variable, not a state:
+
+.. code-block:: python
+
+   check.state(["disabled"])           # greyed out, not clickable
+   check.state(["!disabled"])          # re-enable
+
+   agree.set(True)                     # check it programmatically
+
+API & reference
+---------------
+
+``Checkbutton`` is the native ``ttk.Checkbutton`` — ttkbootstrap adds ``bootstyle=``
+but no other Python API. For its constructor and options (``variable``, ``text``,
+``command``, ``onvalue``, ``offvalue``, ``state``, …) see the
+`tkinter.ttk.Checkbutton <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Checkbutton>`__
+reference.
+
+.. seealso::
+
+   :doc:`Radiobutton <radiobutton>` for a mutually exclusive group of choices.
+   Want to restyle the checkbutton yourself? The
+   :doc:`Style Reference › Checkbutton </reference/style-reference/checkbutton>`
+   (and :doc:`Toggle </reference/style-reference/toggle>` for the switch look) and
+   its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -37,6 +37,18 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
 
       An entry with up/down arrows for stepping a range or list.
 
+   .. grid-item-card:: Checkbutton
+      :link: checkbutton
+      :link-type: doc
+
+      An on/off control — checkbox, toggle switch, or toolbutton.
+
+   .. grid-item-card:: Radiobutton
+      :link: radiobutton
+      :link-type: doc
+
+      One option in a mutually exclusive group; segmented look too.
+
    .. grid-item-card:: Meter
       :link: meter
       :link-type: doc
@@ -50,4 +62,6 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
    entry
    combobox
    spinbox
+   checkbutton
+   radiobutton
    meter

--- a/docs/widgets/radiobutton.rst
+++ b/docs/widgets/radiobutton.rst
@@ -92,7 +92,14 @@ variable, not a state:
    radio.state(["disabled"])           # greyed out, not clickable
    radio.state(["!disabled"])          # re-enable
 
-   size.set("large")                   # select "large" programmatically
+   size.set("large")                   # select a button by its value
+   radio.invoke()                      # select this button programmatically
+
+.. note::
+
+   The shared ``variable=`` is what links a group — selecting one button clears
+   the others. Give every button in the group the same variable; without it they
+   are unrelated buttons, not a mutually exclusive set.
 
 API & reference
 ---------------

--- a/docs/widgets/radiobutton.rst
+++ b/docs/widgets/radiobutton.rst
@@ -1,0 +1,115 @@
+Radiobutton
+===========
+
+A **radiobutton** is one option in a mutually exclusive group — pick one and the
+others clear. ``Radiobutton`` is the native ``ttk.Radiobutton``, styled with
+``bootstyle=``. This page covers building a group, reacting to a choice, the
+toolbutton look, then the ``bootstyle`` color and states.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A vertical radio group and a horizontal toolbutton (segmented) group, in light
+   and dark themes.
+
+Usage
+-----
+
+A group is several radiobuttons that **share one variable**, each with a distinct
+``value=``. The shared variable holds the selected value; setting it selects the
+matching button and clears the rest:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   size = ttk.StringVar(value="medium")
+
+   for label in ["small", "medium", "large"]:
+       ttk.Radiobutton(app, text=label.title(), variable=size, value=label).pack(anchor="w", padx=10)
+
+   ttk.Button(app, text="Order", command=lambda: print(size.get()), bootstyle="primary").pack(pady=10)
+
+   app.mainloop()
+
+Giving the variable an initial ``value`` (``"medium"`` above) preselects that
+button. To react the moment the selection changes, pass ``command=`` — it fires on
+the button that becomes selected:
+
+.. code-block:: python
+
+   def on_choice():
+       print("chose", size.get())
+
+   ttk.Radiobutton(app, text="Small", variable=size, value="small", command=on_choice)
+
+The toolbutton look
+-------------------
+
+``toolbutton`` draws the group as **segmented buttons** — a connected row where the
+selected option stays pressed. Pack them side by side for a compact single-choice
+control:
+
+.. code-block:: python
+
+   from ttkbootstrap.constants import *
+
+   view = ttk.StringVar(value="list")
+   group = ttk.Frame(app)
+   group.pack()
+
+   for label in ["list", "grid", "columns"]:
+       ttk.Radiobutton(group, text=label.title(), variable=view, value=label,
+                       bootstyle="toolbutton").pack(side=LEFT)
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A three-segment toolbutton group with the middle option selected.
+
+Color
+-----
+
+``bootstyle`` sets the color of the selected indicator (or the pressed segment for
+``toolbutton``):
+
+.. code-block:: python
+
+   ttk.Radiobutton(app, text="Info", variable=size, value="s", bootstyle="info")
+   ttk.Radiobutton(app, text="On", variable=view, value="x", bootstyle="success-toolbutton")
+
+States
+------
+
+Toggle the ``disabled`` state to grey a button out and block it; which button is
+selected follows the shared variable, so you change the selection by setting the
+variable, not a state:
+
+.. code-block:: python
+
+   radio.state(["disabled"])           # greyed out, not clickable
+   radio.state(["!disabled"])          # re-enable
+
+   size.set("large")                   # select "large" programmatically
+
+API & reference
+---------------
+
+``Radiobutton`` is the native ``ttk.Radiobutton`` — ttkbootstrap adds ``bootstyle=``
+but no other Python API. For its constructor and options (``variable``, ``value``,
+``text``, ``command``, ``state``, …) see the
+`tkinter.ttk.Radiobutton <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Radiobutton>`__
+reference.
+
+.. seealso::
+
+   :doc:`Checkbutton <checkbutton>` for an independent on/off toggle, and
+   :doc:`Combobox <combobox>` when a dropdown fits better than a visible group.
+   Want to restyle the radiobutton yourself? The
+   :doc:`Style Reference › Radiobutton </reference/style-reference/radiobutton>`
+   (and :doc:`Toolbutton </reference/style-reference/toolbutton>` for the
+   segmented look) and its companion
+   :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide document
+   the hand-styling surface.


### PR DESCRIPTION
## Summary

**Phase 1, second family.** Two usage-first catalog pages on the Button template shape (one concept per digestible section):

- **Checkbutton** — `BooleanVar` binding + `command=`, the **switch looks** (`round-toggle`/`square-toggle`) and `toolbutton`, non-boolean `onvalue`/`offvalue`, indicator color, disabled state (selection follows the variable, not a state).
- **Radiobutton** — a group **sharing one variable** with distinct `value=`s, `command=` on selection, the **toolbutton (segmented)** look, indicator color, disabled state.

Each cross-links the other (and Combobox) and its Style Reference — including Toggle/Toolbutton for the variant looks. Wired into the catalog index.

## Verification
- Every snippet exercised headlessly, including combined color+variant bootstyles (`danger-round-toggle`, `success-toolbutton`).
- Rule-scan clean; `sphinx -b html -W` clean.

Docs-only; targets `2.0`. Next family: **Command** (Menubutton/OptionMenu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)