### PR TITLE
docs: Widgets catalog — the Command family (Menubutton/OptionMenu)

### DIFF
--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -49,6 +49,18 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
 
       One option in a mutually exclusive group; segmented look too.
 
+   .. grid-item-card:: Menubutton
+      :link: menubutton
+      :link-type: doc
+
+      A button that opens a dropdown menu.
+
+   .. grid-item-card:: OptionMenu
+      :link: optionmenu
+      :link-type: doc
+
+      A dropdown that picks one value from a fixed list.
+
    .. grid-item-card:: Meter
       :link: meter
       :link-type: doc
@@ -64,4 +76,6 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
    spinbox
    checkbutton
    radiobutton
+   menubutton
+   optionmenu
    meter

--- a/docs/widgets/menubutton.rst
+++ b/docs/widgets/menubutton.rst
@@ -1,0 +1,104 @@
+Menubutton
+==========
+
+A **menubutton** is a button that opens a dropdown menu when clicked.
+``Menubutton`` is the native ``ttk.Menubutton``, styled with ``bootstyle=``. This
+page covers attaching its menu, choosing where the menu opens, then the
+``bootstyle`` colors, variants, and states.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A primary menubutton in light and dark themes, closed and with its dropdown
+   menu open.
+
+Usage
+-----
+
+A menubutton owns a :doc:`Menu </user-guide/feature-guides/menus>`. Build the menu
+with the menubutton as its parent, add items, then attach it — either with
+``menu=`` at construction or by assigning ``menubutton["menu"]``:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   menubutton = ttk.Menubutton(app, text="Actions", bootstyle="primary")
+   menubutton.pack(padx=10, pady=10)
+
+   menu = ttk.Menu(menubutton)
+   menu.add_command(label="New", command=lambda: print("new"))
+   menu.add_command(label="Open", command=lambda: print("open"))
+   menu.add_separator()
+   menu.add_command(label="Quit", command=app.destroy)
+
+   menubutton["menu"] = menu
+
+   app.mainloop()
+
+The menu is a full ``Menu`` — it takes commands, separators, checkbuttons, and
+radiobuttons. Building menus (including stateful items and submenus) is covered in
+the :doc:`Menus guide </user-guide/feature-guides/menus>`.
+
+Where the menu opens
+--------------------
+
+``direction=`` sets which way the menu drops relative to the button — ``below``
+(the default), ``above``, ``left``, ``right``, or ``flush`` (over the button):
+
+.. code-block:: python
+
+   ttk.Menubutton(app, text="More", menu=menu, direction="right")
+
+.. admonition:: Across platforms
+   :class: note
+
+   The button itself is themed consistently on every platform. Its dropdown,
+   though, is a native :doc:`Menu </user-guide/feature-guides/menus>`, and menus
+   are where the platform shows through. On **macOS** the menu opens as a native
+   pop-up anchored over the button, so ``direction`` has little effect there; on
+   **Windows and Linux** it drops in the requested direction. The
+   :doc:`Menus guide </user-guide/feature-guides/menus>` covers the cross-platform
+   menu behavior in full.
+
+Colors and variants
+-------------------
+
+``bootstyle`` sets the button's color from the semantic palette, and a
+``outline`` variant gives a bordered button instead of a filled one:
+
+.. code-block:: python
+
+   ttk.Menubutton(app, text="Solid",   bootstyle="primary")
+   ttk.Menubutton(app, text="Outline", bootstyle="primary-outline")
+
+States
+------
+
+Toggle the ``disabled`` state to grey the button out and block it from opening its
+menu:
+
+.. code-block:: python
+
+   menubutton.state(["disabled"])      # greyed out, won't open
+   menubutton.state(["!disabled"])     # re-enable
+
+API & reference
+---------------
+
+``Menubutton`` is the native ``ttk.Menubutton`` — ttkbootstrap adds ``bootstyle=``
+but no other Python API. For its constructor and options (``text``, ``menu``,
+``direction``, ``state``, ``image``, ``compound``, …) see the
+`tkinter.ttk.Menubutton <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Menubutton>`__
+reference.
+
+.. seealso::
+
+   :doc:`OptionMenu <optionmenu>` when the menu is just a list of values to pick
+   one from, and the :doc:`Menus guide </user-guide/feature-guides/menus>` for
+   building the menu itself. Want to restyle the menubutton yourself? The
+   :doc:`Style Reference › Menubutton </reference/style-reference/menubutton>` and
+   its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/docs/widgets/optionmenu.rst
+++ b/docs/widgets/optionmenu.rst
@@ -1,0 +1,104 @@
+OptionMenu
+==========
+
+An **option menu** is a dropdown that picks one value from a fixed list, bound to
+a variable — a compact alternative to a group of :doc:`radiobuttons
+<radiobutton>`. ``OptionMenu`` is the native ``ttk.OptionMenu``, styled with
+``bootstyle=``. This page covers building one, reacting to a choice, then the
+``bootstyle`` color and states.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   An option menu in light and dark themes, closed and with its list open.
+
+Usage
+-----
+
+Unlike a menubutton, an option menu **builds its own menu** from the values you
+pass. The constructor takes the parent, the bound variable, a **default** value,
+then the list of choices:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   size = ttk.StringVar()
+   ttk.OptionMenu(app, size, "Medium", "Small", "Medium", "Large").pack(padx=10, pady=10)
+
+   ttk.Button(app, text="Order", command=lambda: print(size.get()), bootstyle="primary").pack()
+
+   app.mainloop()
+
+The second argument is the variable the selection is stored in; the third is the
+value shown initially; the rest are the choices. Read the selection with the
+variable's ``.get()``, and set it with ``.set()``.
+
+.. note::
+
+   Include the default among the choices if you want it selectable again after the
+   user picks something else — the default value is *shown* first but is not added
+   to the list automatically.
+
+Reacting to a choice
+--------------------
+
+Pass ``command=`` to run code when the user picks an item; it receives the chosen
+value as its argument:
+
+.. code-block:: python
+
+   def on_choice(value):
+       print("chose", value)
+
+   ttk.OptionMenu(app, size, "Medium", "Small", "Medium", "Large", command=on_choice)
+
+Color
+-----
+
+``bootstyle`` sets the button's color from the semantic palette, with an
+``outline`` variant for a bordered button:
+
+.. code-block:: python
+
+   ttk.OptionMenu(app, size, "Medium", "Small", "Medium", "Large", bootstyle="success")
+   ttk.OptionMenu(app, size, "Medium", "Small", "Medium", "Large", bootstyle="info-outline")
+
+.. admonition:: Across platforms
+   :class: note
+
+   An option menu opens a native menu, so — like a :doc:`menubutton <menubutton>`
+   — its dropdown follows the platform: on **macOS** a native pop-up anchored over
+   the button, on **Windows and Linux** a themed drop-down list. The button itself
+   is themed consistently everywhere.
+
+States
+------
+
+Toggle the ``disabled`` state to grey the control out and block it from opening:
+
+.. code-block:: python
+
+   option.state(["disabled"])          # greyed out, won't open
+   option.state(["!disabled"])         # re-enable
+
+API & reference
+---------------
+
+``OptionMenu`` is the native ``ttk.OptionMenu`` — ttkbootstrap adds ``bootstyle=``
+but no other Python API. Its constructor is
+``OptionMenu(master, variable, default, *values, command=None, direction="below")``;
+see the
+`tkinter.ttk.OptionMenu <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.OptionMenu>`__
+reference.
+
+.. seealso::
+
+   :doc:`Menubutton <menubutton>` when you need a full menu (commands,
+   separators, submenus) rather than a list of values, :doc:`Combobox <combobox>`
+   for a version the user can also type into, and :doc:`Radiobutton <radiobutton>`
+   for a visible group. An option menu renders as a menubutton, so its
+   customization surface is
+   :doc:`Style Reference › Menubutton </reference/style-reference/menubutton>`.


### PR DESCRIPTION
## Summary

**Phase 1, third family.** Two usage-first catalog pages on the template shape:

- **Menubutton** — attach a `Menu` (`menu=` / `["menu"]`), `direction=` (incl. `flush`), colors + `outline` variant, `disabled`; cross-links the **Menus guide** for building the menu itself.
- **OptionMenu** — builds its own menu from `(variable, default, *values)`; `command=` receives the chosen value; a note that the default isn't auto-added to the list; color + `outline`; `disabled`.

**Cross-platform** (per your steer, especially on menubutton): both carry an *"Across platforms"* note — the button is themed consistently everywhere, but the dropdown is a **native menu**, which is where the platform shows through: a macOS pop-up anchored over the button (so `direction` has little effect) vs. a themed drop-down on Windows/Linux — deferring to the Menus guide for the full picture.

## Verification
- Every snippet exercised headlessly, including the ground-truthed *default-not-added-to-list* behavior and all color/outline/direction/state forms.
- No platform conditionals in the menubutton builder (button themed uniformly); `direction` accepts `above`/`below`/`left`/`right`/`flush`.
- Rule-scan clean; `sphinx -b html -W` clean.

Docs-only; targets `2.0`. Next family: **Containers** (Frame/Labelframe/Notebook/Panedwindow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)