### PR TITLE
docs: Widgets Containers family + bootstyle spaces convention sweep

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,7 @@ Why ttkbootstrap
 
    .. grid-item-card:: :octicon:`paintbrush;1.5em;sd-mr-1` Semantic styling
 
-      One keyword does it: ``bootstyle="primary"``, ``bootstyle="success-outline"``.
+      One keyword does it: ``bootstyle="primary"``, ``bootstyle="success outline"``.
       Describe intent, not hex codes — the same code looks right across 30 light
       and dark themes and re-themes at runtime.
 
@@ -77,7 +77,7 @@ A themed window is a handful of lines — every widget takes ``bootstyle``:
    ttk.Label(app, text="Hello from ttkbootstrap!").pack(padx=16, pady=(16, 8))
    ttk.Button(app, text="Primary", bootstyle="primary").pack(padx=16, pady=4)
    ttk.Button(app, text="Success", bootstyle="success").pack(padx=16, pady=4)
-   ttk.Button(app, text="Danger Outline", bootstyle="danger-outline").pack(padx=16, pady=(4, 16))
+   ttk.Button(app, text="Danger Outline", bootstyle="danger outline").pack(padx=16, pady=(4, 16))
 
    app.mainloop()
 

--- a/docs/user-guide/foundations/state-and-variables.rst
+++ b/docs/user-guide/foundations/state-and-variables.rst
@@ -75,7 +75,7 @@ the box is checked:
    agree.trace_add("write", refresh)
 
    ttk.Checkbutton(app, text="I accept the terms", variable=agree,
-                   bootstyle="round-toggle").pack(padx=20, pady=(20, 10))
+                   bootstyle="round toggle").pack(padx=20, pady=(20, 10))
    submit.pack(padx=20, pady=(0, 20))
 
    app.mainloop()

--- a/docs/user-guide/getting-started/quickstart.rst
+++ b/docs/user-guide/getting-started/quickstart.rst
@@ -15,7 +15,7 @@ Hello ttkbootstrap
    ttk.Label(app, text="Hello from ttkbootstrap!").pack(padx=16, pady=(16, 8))
    ttk.Button(app, text="Primary", bootstyle="primary").pack(padx=16, pady=4)
    ttk.Button(app, text="Success", bootstyle="success").pack(padx=16, pady=4)
-   ttk.Button(app, text="Danger Outline", bootstyle="danger-outline").pack(padx=16, pady=(4, 16))
+   ttk.Button(app, text="Danger Outline", bootstyle="danger outline").pack(padx=16, pady=(4, 16))
 
    app.mainloop()
 
@@ -25,7 +25,7 @@ A few things to notice:
   ``theme=`` to choose one; it defaults to ``bootstrap-light``.
 - Every ttkbootstrap widget accepts ``bootstyle=``. The value describes intent
   — a color (``"primary"``), a variant (``"outline"``), or both
-  (``"danger-outline"``) — not a literal color.
+  (``"danger outline"``) — not a literal color.
 - ``pack`` (and ``grid``/``place``) **return the widget**, so you can construct
   and place in one expression — no separate variable needed unless you keep a
   reference.

--- a/docs/user-guide/how-to/scrollable.rst
+++ b/docs/user-guide/how-to/scrollable.rst
@@ -25,7 +25,7 @@ they overflow:
    scroller.pack(fill="both", expand=True, padx=10, pady=10)
 
    for i in range(40):
-       option = ttk.Checkbutton(scroller, text=f"Option {i + 1}", bootstyle="round-toggle")
+       option = ttk.Checkbutton(scroller, text=f"Option {i + 1}", bootstyle="round toggle")
        option.pack(anchor="w", pady=2)
 
    app.mainloop()

--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -98,7 +98,7 @@ For a **toolbar**, pack icon-only buttons side by side in a frame:
    toolbar.pack(fill=X)
 
    for name, action in [("save", save), ("printer", print_doc), ("trash", delete)]:
-       button = ttk.Button(toolbar, icon=name, icon_only=True, command=action, bootstyle="secondary-link")
+       button = ttk.Button(toolbar, icon=name, icon_only=True, command=action, bootstyle="secondary link")
        button.pack(side=LEFT)
 
 The default button
@@ -173,9 +173,9 @@ Combine a color with a variant to change visual weight — ``outline``, ``link``
 .. code-block:: python
 
    ttk.Button(app, text="Solid",   bootstyle="primary")
-   ttk.Button(app, text="Outline", bootstyle="primary-outline")
-   ttk.Button(app, text="Link",    bootstyle="primary-link")
-   ttk.Button(app, text="Ghost",   bootstyle="primary-ghost")
+   ttk.Button(app, text="Outline", bootstyle="primary outline")
+   ttk.Button(app, text="Link",    bootstyle="primary link")
+   ttk.Button(app, text="Ghost",   bootstyle="primary ghost")
 
 - **solid** (the default) — a filled button for the primary action.
 - **outline** — a bordered button for a secondary action next to a solid one.

--- a/docs/widgets/checkbutton.rst
+++ b/docs/widgets/checkbutton.rst
@@ -45,13 +45,13 @@ Switch and toolbutton looks
 ---------------------------
 
 The same control renders three ways — combine the look with a color. A
-``round-toggle`` or ``square-toggle`` draws it as a **switch**, which reads better
+``round toggle`` or ``square toggle`` draws it as a **switch**, which reads better
 than a checkbox for a settings on/off:
 
 .. code-block:: python
 
-   ttk.Checkbutton(app, text="Wi-Fi", variable=agree, bootstyle="round-toggle")
-   ttk.Checkbutton(app, text="Wi-Fi", variable=agree, bootstyle="square-toggle")
+   ttk.Checkbutton(app, text="Wi-Fi", variable=agree, bootstyle="round toggle")
+   ttk.Checkbutton(app, text="Wi-Fi", variable=agree, bootstyle="square toggle")
 
 ``toolbutton`` draws it as a button that stays pressed while checked — for a
 toolbar or a filter chip:
@@ -85,7 +85,7 @@ Color
 .. code-block:: python
 
    ttk.Checkbutton(app, text="Success", variable=agree, bootstyle="success")
-   ttk.Checkbutton(app, text="Danger",  variable=agree, bootstyle="danger-round-toggle")
+   ttk.Checkbutton(app, text="Danger",  variable=agree, bootstyle="danger round toggle")
 
 States
 ------

--- a/docs/widgets/frame.rst
+++ b/docs/widgets/frame.rst
@@ -3,8 +3,8 @@ Frame
 
 A **frame** is a rectangular container that groups and lays out other widgets.
 ``Frame`` is the native ``ttk.Frame``, styled with ``bootstyle=``. This page covers
-using it to structure a layout, padding its contents, then the ``bootstyle`` color
-and the bordered card variants.
+using it to structure a layout, padding its contents, then adding a border and a
+colored background.
 
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder

--- a/docs/widgets/frame.rst
+++ b/docs/widgets/frame.rst
@@ -41,31 +41,42 @@ layouts — a header, a sidebar, a form — each managed independently:
 manager you use *inside* a frame is independent of the one used to place the frame
 itself — see :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>`.
 
-Color
------
+Adding a border
+---------------
 
-By default a frame is invisible — it takes the window background. Give it a
-``bootstyle`` color to make it a visible band (a header, a footer, a colored
-section):
-
-.. code-block:: python
-
-   ttk.Frame(app, padding=10, bootstyle="secondary")
-
-Put ``inverse-<color>`` labels inside a colored frame so their text reads against
-the fill (as the header above does).
-
-Card and highlight variants
----------------------------
-
-Two variants give a frame a **hairline border** to set a region off from the
-background — a ``card`` for grouped content, and ``highlight`` which turns its
-border to the accent color when something inside has focus:
+By default a frame is invisible — it takes the window background. The most common
+reason to style one is to **set a region off with a border**. The ``card`` variant
+draws a hairline border around the frame's contents:
 
 .. code-block:: python
 
    ttk.Frame(app, padding=16, bootstyle="card")
-   ttk.Frame(app, padding=16, bootstyle="highlight")
+
+The ``highlight`` variant is the same hairline, but drawn in the **accent color
+while the frame is in the** ``focus`` **state**. A frame does not track its
+children's focus on its own, so you set that state yourself — for example, to make
+a card glow while an entry inside it is focused:
+
+.. code-block:: python
+
+   card = ttk.Frame(app, padding=16, bootstyle="highlight")
+   card.pack()
+   entry = ttk.Entry(card)
+   entry.pack()
+
+   entry.bind("<FocusIn>",  lambda event: card.state(["focus"]))
+   entry.bind("<FocusOut>", lambda event: card.state(["!focus"]))
+
+Colored background
+------------------
+
+Less often, give a frame a ``bootstyle`` color to make it a filled band — a
+colored header or footer. Put ``inverse-<color>`` labels inside so their text
+reads against the fill (as the header in `Usage`_ does):
+
+.. code-block:: python
+
+   ttk.Frame(app, padding=10, bootstyle="secondary")
 
 API & reference
 ---------------

--- a/docs/widgets/frame.rst
+++ b/docs/widgets/frame.rst
@@ -1,0 +1,88 @@
+Frame
+=====
+
+A **frame** is a rectangular container that groups and lays out other widgets.
+``Frame`` is the native ``ttk.Frame``, styled with ``bootstyle=``. This page covers
+using it to structure a layout, padding its contents, then the ``bootstyle`` color
+and the bordered card variants.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A window split into frames — a colored header frame above a plain content
+   frame — in light and dark themes.
+
+Usage
+-----
+
+A frame holds other widgets: pass the frame as their ``master``, then place the
+frame in its own parent. Frames are how you break a window into regions and nest
+layouts — a header, a sidebar, a form — each managed independently:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.constants import *
+
+   app = ttk.App()
+
+   header = ttk.Frame(app, padding=10, bootstyle="primary")
+   header.pack(fill=X)
+   ttk.Label(header, text="Dashboard", bootstyle="inverse-primary").pack()
+
+   content = ttk.Frame(app, padding=20)
+   content.pack(fill=BOTH, expand=YES)
+   ttk.Label(content, text="Body goes here").pack()
+
+   app.mainloop()
+
+``padding=`` insets the frame's contents so its children don't hug the edges
+(one value for all sides, or ``(left, top, right, bottom)``). Which geometry
+manager you use *inside* a frame is independent of the one used to place the frame
+itself — see :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>`.
+
+Color
+-----
+
+By default a frame is invisible — it takes the window background. Give it a
+``bootstyle`` color to make it a visible band (a header, a footer, a colored
+section):
+
+.. code-block:: python
+
+   ttk.Frame(app, padding=10, bootstyle="secondary")
+
+Put ``inverse-<color>`` labels inside a colored frame so their text reads against
+the fill (as the header above does).
+
+Card and highlight variants
+---------------------------
+
+Two variants give a frame a **hairline border** to set a region off from the
+background — a ``card`` for grouped content, and ``highlight`` which turns its
+border to the accent color when something inside has focus:
+
+.. code-block:: python
+
+   ttk.Frame(app, padding=16, bootstyle="card")
+   ttk.Frame(app, padding=16, bootstyle="highlight")
+
+API & reference
+---------------
+
+``Frame`` is the native ``ttk.Frame`` — ttkbootstrap adds ``bootstyle=`` but no
+other Python API. For its constructor and options (``padding``, ``width``,
+``height``, ``borderwidth``, ``relief``, …) see the
+`tkinter.ttk.Frame <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Frame>`__
+reference.
+
+.. seealso::
+
+   :doc:`Labelframe <labelframe>` for a frame with a titled border, and
+   :doc:`Notebook <notebook>` / :doc:`Panedwindow <panedwindow>` for tabbed and
+   split containers. For laying widgets out inside a frame, see
+   :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>`. Want to
+   restyle the frame yourself? The
+   :doc:`Style Reference › Frame </reference/style-reference/frame>` and its
+   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
+   document the hand-styling surface.

--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -61,6 +61,30 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
 
       A dropdown that picks one value from a fixed list.
 
+   .. grid-item-card:: Frame
+      :link: frame
+      :link-type: doc
+
+      A container that groups and lays out widgets; card variants.
+
+   .. grid-item-card:: Labelframe
+      :link: labelframe
+      :link-type: doc
+
+      A frame with a titled border for a section of a form.
+
+   .. grid-item-card:: Notebook
+      :link: notebook
+      :link-type: doc
+
+      A tabbed container — one page per tab.
+
+   .. grid-item-card:: Panedwindow
+      :link: panedwindow
+      :link-type: doc
+
+      Resizable panes split by a draggable sash.
+
    .. grid-item-card:: Meter
       :link: meter
       :link-type: doc
@@ -78,4 +102,8 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
    radiobutton
    menubutton
    optionmenu
+   frame
+   labelframe
+   notebook
+   panedwindow
    meter

--- a/docs/widgets/labelframe.rst
+++ b/docs/widgets/labelframe.rst
@@ -1,0 +1,66 @@
+Labelframe
+==========
+
+A **labelframe** is a frame with a titled border — it groups related widgets under
+a caption. ``Labelframe`` is the native ``ttk.Labelframe``, styled with
+``bootstyle=``. This page covers grouping widgets under a label, then the
+``bootstyle`` color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A "Contact" labelframe grouping a couple of fields, in light and dark themes.
+
+Usage
+-----
+
+Set the caption with ``text=`` and place the grouped widgets inside the labelframe
+as their ``master``. It is the natural container for a **section of a form**:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.constants import *
+
+   app = ttk.App()
+
+   contact = ttk.Labelframe(app, text="Contact", padding=12)
+   contact.pack(fill=X, padx=10, pady=10)
+
+   ttk.Label(contact, text="Name").pack(anchor=W)
+   ttk.Entry(contact).pack(fill=X)
+   ttk.Label(contact, text="Email").pack(anchor=W)
+   ttk.Entry(contact).pack(fill=X)
+
+   app.mainloop()
+
+Like a plain :doc:`Frame <frame>`, use ``padding=`` to inset the contents; arrange
+the children with any geometry manager.
+
+Color
+-----
+
+``bootstyle`` colors the border and the caption text from the semantic palette —
+use it to tie a section to a color, or to signal an important or dangerous group:
+
+.. code-block:: python
+
+   ttk.Labelframe(app, text="Danger zone", padding=12, bootstyle="danger")
+
+API & reference
+---------------
+
+``Labelframe`` is the native ``ttk.Labelframe`` — ttkbootstrap adds ``bootstyle=``
+but no other Python API. For its constructor and options (``text``, ``padding``,
+``labelanchor``, ``labelwidget``, ``width``, ``height``, …) see the
+`tkinter.ttk.Labelframe <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Labelframe>`__
+reference.
+
+.. seealso::
+
+   :doc:`Frame <frame>` for a plain container, and
+   :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>` for laying
+   out the widgets inside. Want to restyle the labelframe yourself? The
+   :doc:`Style Reference › Labelframe </reference/style-reference/labelframe>` and
+   its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/docs/widgets/menubutton.rst
+++ b/docs/widgets/menubutton.rst
@@ -72,7 +72,7 @@ Colors and variants
 .. code-block:: python
 
    ttk.Menubutton(app, text="Solid",   bootstyle="primary")
-   ttk.Menubutton(app, text="Outline", bootstyle="primary-outline")
+   ttk.Menubutton(app, text="Outline", bootstyle="primary outline")
 
 States
 ------

--- a/docs/widgets/notebook.rst
+++ b/docs/widgets/notebook.rst
@@ -49,6 +49,9 @@ The user clicks a tab to switch; ``select`` switches programmatically, and
    notebook.select(0)                       # or by index
    current = notebook.index(notebook.select())   # -> the selected tab's index
 
+Reacting to a tab change
+------------------------
+
 To run code when the page changes — lazy-load its contents, say — bind the
 ``<<NotebookTabChanged>>`` virtual event:
 
@@ -56,18 +59,24 @@ To run code when the page changes — lazy-load its contents, say — bind the
 
    notebook.bind("<<NotebookTabChanged>>", lambda event: print("now on", notebook.index("current")))
 
-Disabling and hiding tabs
--------------------------
+Disabling and removing tabs
+---------------------------
 
-``tab(page, state=...)`` sets a tab's state — ``"disabled"`` greys it out and
-blocks selection, ``"hidden"`` removes it from the bar (``add`` it again to
-restore). ``hide`` / ``forget`` also remove a page (``forget`` permanently):
+Disable a tab to grey it out and block selection while leaving it in place; set it
+back to ``"normal"`` to re-enable:
 
 .. code-block:: python
 
    notebook.tab(advanced, state="disabled")   # visible but not selectable
    notebook.tab(advanced, state="normal")     # re-enable
-   notebook.hide(advanced)                     # remove from the bar (add() to restore)
+
+To take a tab off the bar, ``hide`` it — the page is kept, and ``add``-ing it again
+restores it — or ``forget`` it to remove it for good:
+
+.. code-block:: python
+
+   notebook.hide(advanced)                     # remove from the bar; add() restores it
+   notebook.forget(advanced)                   # remove permanently
 
 Color
 -----

--- a/docs/widgets/notebook.rst
+++ b/docs/widgets/notebook.rst
@@ -1,0 +1,99 @@
+Notebook
+========
+
+A **notebook** is a tabbed container — one page per tab, with only the selected
+page visible. ``Notebook`` is the native ``ttk.Notebook``, styled with
+``bootstyle=``. This page covers adding tabs, switching between them, reacting to a
+tab change, disabling or hiding a tab, then the ``bootstyle`` color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A three-tab notebook with the middle tab selected, in light and dark themes.
+
+Usage
+-----
+
+Each page is a widget — usually a :doc:`Frame <frame>` — added with ``add`` and a
+tab ``text``. Build a frame per page, fill it, and add it:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.constants import *
+
+   app = ttk.App()
+
+   notebook = ttk.Notebook(app)
+   notebook.pack(fill=BOTH, expand=YES, padx=10, pady=10)
+
+   general = ttk.Frame(notebook, padding=16)
+   ttk.Label(general, text="General settings").pack()
+   notebook.add(general, text="General")
+
+   advanced = ttk.Frame(notebook, padding=16)
+   ttk.Label(advanced, text="Advanced settings").pack()
+   notebook.add(advanced, text="Advanced")
+
+   app.mainloop()
+
+Switching tabs
+--------------
+
+The user clicks a tab to switch; ``select`` switches programmatically, and
+``index("current")`` (or ``select()`` with no argument) reports the current tab:
+
+.. code-block:: python
+
+   notebook.select(advanced)               # show a page by its widget
+   notebook.select(0)                       # or by index
+   current = notebook.index(notebook.select())   # -> the selected tab's index
+
+To run code when the page changes — lazy-load its contents, say — bind the
+``<<NotebookTabChanged>>`` virtual event:
+
+.. code-block:: python
+
+   notebook.bind("<<NotebookTabChanged>>", lambda event: print("now on", notebook.index("current")))
+
+Disabling and hiding tabs
+-------------------------
+
+``tab(page, state=...)`` sets a tab's state — ``"disabled"`` greys it out and
+blocks selection, ``"hidden"`` removes it from the bar (``add`` it again to
+restore). ``hide`` / ``forget`` also remove a page (``forget`` permanently):
+
+.. code-block:: python
+
+   notebook.tab(advanced, state="disabled")   # visible but not selectable
+   notebook.tab(advanced, state="normal")     # re-enable
+   notebook.hide(advanced)                     # remove from the bar (add() to restore)
+
+Color
+-----
+
+``bootstyle`` colors the selected tab and the notebook's accents from the semantic
+palette:
+
+.. code-block:: python
+
+   ttk.Notebook(app, bootstyle="primary")
+
+API & reference
+---------------
+
+``Notebook`` is the native ``ttk.Notebook`` — ttkbootstrap adds ``bootstyle=`` but
+no other Python API. For its constructor and the tab-management methods
+(``add``, ``insert``, ``select``, ``tab``, ``hide``, ``forget``, ``index``,
+``tabs``) see the
+`tkinter.ttk.Notebook <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Notebook>`__
+reference.
+
+.. seealso::
+
+   :doc:`Frame <frame>` for the page containers, and
+   :doc:`Panedwindow <panedwindow>` for a split rather than tabbed layout. Want to
+   restyle the notebook yourself? The
+   :doc:`Style Reference › Notebook </reference/style-reference/notebook>` and its
+   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
+   document the hand-styling surface.

--- a/docs/widgets/optionmenu.rst
+++ b/docs/widgets/optionmenu.rst
@@ -64,7 +64,7 @@ Color
 .. code-block:: python
 
    ttk.OptionMenu(app, size, "Medium", "Small", "Medium", "Large", bootstyle="success")
-   ttk.OptionMenu(app, size, "Medium", "Small", "Medium", "Large", bootstyle="info-outline")
+   ttk.OptionMenu(app, size, "Medium", "Small", "Medium", "Large", bootstyle="info outline")
 
 .. admonition:: Across platforms
    :class: note

--- a/docs/widgets/panedwindow.rst
+++ b/docs/widgets/panedwindow.rst
@@ -1,0 +1,82 @@
+Panedwindow
+===========
+
+A **panedwindow** holds two or more panes separated by a draggable **sash**, so
+the user can resize them against each other — a sidebar next to content, an editor
+above a console. ``Panedwindow`` is the native ``ttk.Panedwindow``, styled with
+``bootstyle=``. This page covers adding panes, controlling how they share space,
+then the ``bootstyle`` color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A horizontal panedwindow — a narrow sidebar and a wide content pane with the
+   sash between them — in light and dark themes.
+
+Usage
+-----
+
+Set ``orient=`` to ``HORIZONTAL`` (panes side by side, a vertical sash) or
+``VERTICAL`` (panes stacked, a horizontal sash), then ``add`` each pane — usually
+a :doc:`Frame <frame>`:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.constants import *
+
+   app = ttk.App()
+
+   paned = ttk.Panedwindow(app, orient=HORIZONTAL)
+   paned.pack(fill=BOTH, expand=YES)
+
+   sidebar = ttk.Frame(paned, padding=10)
+   ttk.Label(sidebar, text="Sidebar").pack()
+   paned.add(sidebar, weight=1)
+
+   content = ttk.Frame(paned, padding=10)
+   ttk.Label(content, text="Content").pack()
+   paned.add(content, weight=4)
+
+   app.mainloop()
+
+Sharing space
+-------------
+
+``weight`` sets how the panes divide **extra** space when the window resizes — a
+pane with ``weight=4`` grows four times as fast as one with ``weight=1``, so the
+content pane above stays dominant while the sidebar stays slim. Set the sash
+position explicitly with ``sashpos`` (after the window is laid out):
+
+.. code-block:: python
+
+   paned.sashpos(0, 200)                    # put the first sash 200px from the start
+
+The user can always drag the sash to override these.
+
+Color
+-----
+
+``bootstyle`` colors the sash from the semantic palette:
+
+.. code-block:: python
+
+   ttk.Panedwindow(app, orient=VERTICAL, bootstyle="secondary")
+
+API & reference
+---------------
+
+``Panedwindow`` is the native ``ttk.Panedwindow`` — ttkbootstrap adds ``bootstyle=``
+but no other Python API. For its constructor and pane methods (``add``,
+``insert``, ``forget``, ``sashpos``, ``pane``) see the
+`tkinter.ttk.Panedwindow <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Panedwindow>`__
+reference.
+
+.. seealso::
+
+   :doc:`Notebook <notebook>` for a tabbed rather than split layout, and
+   :doc:`Frame <frame>` for the pane containers. Want to restyle the panedwindow
+   yourself? The
+   :doc:`Style Reference › Panedwindow </reference/style-reference/panedwindow>`
+   and its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/docs/widgets/panedwindow.rst
+++ b/docs/widgets/panedwindow.rst
@@ -45,14 +45,14 @@ Sharing space
 
 ``weight`` sets how the panes divide **extra** space when the window resizes — a
 pane with ``weight=4`` grows four times as fast as one with ``weight=1``, so the
-content pane above stays dominant while the sidebar stays slim. Set the sash
-position explicitly with ``sashpos`` (after the window is laid out):
+content pane above stays dominant while the sidebar stays slim.
+
+For the starting split, set a sash position explicitly with ``sashpos`` (after the
+window is laid out). The user can always drag the sash to override it:
 
 .. code-block:: python
 
    paned.sashpos(0, 200)                    # put the first sash 200px from the start
-
-The user can always drag the sash to override these.
 
 Color
 -----

--- a/docs/widgets/radiobutton.rst
+++ b/docs/widgets/radiobutton.rst
@@ -35,8 +35,13 @@ matching button and clears the rest:
    app.mainloop()
 
 Giving the variable an initial ``value`` (``"medium"`` above) preselects that
-button. To react the moment the selection changes, pass ``command=`` — it fires on
-the button that becomes selected:
+button.
+
+Reacting to a choice
+--------------------
+
+To run code the moment the selection changes, pass ``command=`` — it fires on the
+button that becomes selected:
 
 .. code-block:: python
 

--- a/docs/widgets/radiobutton.rst
+++ b/docs/widgets/radiobutton.rst
@@ -78,7 +78,7 @@ Color
 .. code-block:: python
 
    ttk.Radiobutton(app, text="Info", variable=size, value="s", bootstyle="info")
-   ttk.Radiobutton(app, text="On", variable=view, value="x", bootstyle="success-toolbutton")
+   ttk.Radiobutton(app, text="On", variable=view, value="x", bootstyle="success toolbutton")
 
 States
 ------


### PR DESCRIPTION
## Summary

**Phase 1, Containers family** (Frame/Labelframe/Notebook/Panedwindow) **plus a docs-wide bootstyle convention fix** flagged during review.

### Containers pages (usage-first, depth-calibrated)
- **Frame** — nesting frames for layout, padding; **styling leads with adding a border** (the `card` variant — the likely need) over a colored background. **`highlight` corrected**: it shows the accent border in the `focus` state, which a frame does *not* track from its children automatically — you set it yourself (shown by binding a child's `<FocusIn>`/`<FocusOut>` to the frame's state).
- **Labelframe** — a titled form section, padding, color.
- **Notebook** — tabs, `select`/`index`, `<<NotebookTabChanged>>`, disable/hide, color.
- **Panedwindow** — `orient` + `add(pane, weight=)`, weight-based sharing, `sashpos`, color.

### bootstyle spaces convention sweep
The 2.0 convention is **spaces** between bootstyle tokens, not dashes (`"primary outline"`, `"round toggle"`, `"success toolbutton"`). The #1159 grammar sweep converted the guides; pages authored afterward had drifted back to dashes. Converted across the widget catalog + Quickstart + the landing hero + a couple how-to/foundations pages. **Kept dashed**: `inverse-<color>` (the space form is rejected) and the deliberate `not-a-real-style` example; **restored** the grammar guide's intentional `"primary-outline"` separator-flexible example the sweep had clobbered.

## Verification
- Every snippet exercised headlessly (containers incl. the `highlight` focus-binding pattern; all converted space forms render on their widgets).
- Only `not-a-real-style` remains dashed; `inverse-` preserved; grammar equivalence sentence intact.
- `sphinx -b html -W` clean.

Docs-only; targets `2.0`. Next: **Range & misc** (Progressbar/Scale/Scrollbar/Separator/Sizegrip/Label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)