### PR TITLE
docs: Widgets catalog — the Range & misc family (Label/Progressbar/Scale/Scrollbar/Separator/Sizegrip)

### DIFF
--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -85,6 +85,42 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
 
       Resizable panes split by a draggable sash.
 
+   .. grid-item-card:: Label
+      :link: label
+      :link-type: doc
+
+      Read-only text or an image — captions, headings, status lines.
+
+   .. grid-item-card:: Progressbar
+      :link: progressbar
+      :link-type: doc
+
+      Determinate or indeterminate progress; striped and vertical.
+
+   .. grid-item-card:: Scale
+      :link: scale
+      :link-type: doc
+
+      A slider for choosing a number from a range.
+
+   .. grid-item-card:: Scrollbar
+      :link: scrollbar
+      :link-type: doc
+
+      Scrolls a Text, Listbox, Treeview, or Canvas.
+
+   .. grid-item-card:: Separator
+      :link: separator
+      :link-type: doc
+
+      A thin line that divides content into groups.
+
+   .. grid-item-card:: Sizegrip
+      :link: sizegrip
+      :link-type: doc
+
+      The corner handle for resizing a window.
+
    .. grid-item-card:: Meter
       :link: meter
       :link-type: doc
@@ -106,4 +142,10 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
    labelframe
    notebook
    panedwindow
+   label
+   progressbar
+   scale
+   scrollbar
+   separator
+   sizegrip
    meter

--- a/docs/widgets/label.rst
+++ b/docs/widgets/label.rst
@@ -53,6 +53,20 @@ against it:
 
    ttk.Label(app, text="Header", bootstyle="inverse-primary")
 
+.. note::
+
+   ``Label`` is one of the few ttk widgets that also accepts ``foreground``,
+   ``background``, and ``font`` **directly** as options — most ttk widgets take
+   their colors only from a style. A value set this way overrides the
+   ``bootstyle`` color, which is handy for a one-off:
+
+   .. code-block:: python
+
+      ttk.Label(app, text="Note", foreground="#b02a37", background="#fff3cd")
+
+   Prefer ``bootstyle`` for anything themed, though — a hard-coded color here does
+   not follow a theme switch.
+
 Wrapping long text
 ------------------
 

--- a/docs/widgets/label.rst
+++ b/docs/widgets/label.rst
@@ -1,0 +1,99 @@
+Label
+=====
+
+A **label** displays a line of read-only text (or an image) — a caption, a field
+name, a status line. ``Label`` is the native ``ttk.Label``, styled with
+``bootstyle=``. This page covers showing static and dynamic text, coloring it,
+wrapping long text, then fonts and images.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A heading label and a colored status label in light and dark themes.
+
+Usage
+-----
+
+Pass ``text=`` for a fixed string. For text that changes at runtime, bind a
+``StringVar`` with ``textvariable=`` and ``set`` it — the label updates itself:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   ttk.Label(app, text="Welcome").pack(padx=10, pady=10)
+
+   status = ttk.StringVar(value="Ready")
+   ttk.Label(app, textvariable=status).pack()
+
+   status.set("Loading…")            # the label follows
+
+   app.mainloop()
+
+You can also change a fixed label later with ``label.configure(text="…")``.
+
+Color
+-----
+
+``bootstyle`` colors the **text** from the semantic palette — use it to signal
+status (``success``, ``danger``, ``secondary`` for muted):
+
+.. code-block:: python
+
+   ttk.Label(app, text="Saved", bootstyle="success")
+   ttk.Label(app, text="Failed", bootstyle="danger")
+
+To put a label on a **colored fill** (inside a colored :doc:`Frame <frame>`, say),
+use ``inverse-<color>`` — it paints the background the color and the text to read
+against it:
+
+.. code-block:: python
+
+   ttk.Label(app, text="Header", bootstyle="inverse-primary")
+
+Wrapping long text
+------------------
+
+A label is a single line by default and will run off the edge. Set ``wraplength=``
+(in pixels) to wrap it into a block, and ``justify=`` for the alignment of the
+wrapped lines:
+
+.. code-block:: python
+
+   ttk.Label(app, text="A long paragraph that should wrap…", wraplength=200, justify="left")
+
+Fonts and images
+----------------
+
+Set ``font=`` to change the type — a Tk font spec, a named font, or a
+:class:`~ttkbootstrap.Font`:
+
+.. code-block:: python
+
+   ttk.Label(app, text="Heading", font="-size 18 -weight bold")
+
+A label can also show an image (with or without text) via ``image=`` and
+``compound=``. Building and keeping a reference to images is covered in
+:doc:`Show images and icons </user-guide/how-to/working-with-images>`; type styling
+in the :doc:`Typography guide </user-guide/feature-guides/typography>`.
+
+API & reference
+---------------
+
+``Label`` is the native ``ttk.Label`` — ttkbootstrap adds ``bootstyle=`` but no
+other Python API. For its constructor and options (``text``, ``textvariable``,
+``font``, ``image``, ``compound``, ``wraplength``, ``justify``, ``anchor``,
+``width``, …) see the
+`tkinter.ttk.Label <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Label>`__
+reference.
+
+.. seealso::
+
+   The :doc:`Typography guide </user-guide/feature-guides/typography>` for fonts,
+   and :doc:`Show images and icons </user-guide/how-to/working-with-images>` for
+   the image side. Want to restyle the label yourself? The
+   :doc:`Style Reference › Label </reference/style-reference/label>` and its
+   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
+   document the hand-styling surface.

--- a/docs/widgets/progressbar.rst
+++ b/docs/widgets/progressbar.rst
@@ -1,0 +1,91 @@
+Progressbar
+===========
+
+A **progressbar** shows how far along a task is — either a known fraction
+(*determinate*) or just that work is happening (*indeterminate*). ``Progressbar``
+is the native ``ttk.Progressbar``, styled with ``bootstyle=``. This page covers
+both modes, driving the value, the striped and vertical looks, then the
+``bootstyle`` color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A determinate bar partway across and an indeterminate bar, in light and dark
+   themes.
+
+Determinate: a known amount
+---------------------------
+
+The default mode. ``maximum`` is the full value and ``value`` is the current
+progress; bind ``variable=`` to drive it from your code as the work advances:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   progress = ttk.IntVar(value=0)
+   ttk.Progressbar(app, variable=progress, maximum=100, bootstyle="success").pack(fill="x", padx=10, pady=10)
+
+   progress.set(65)                  # jump to 65%
+
+   app.mainloop()
+
+``bar.step(amount)`` advances the value by ``amount`` (default 1) without a
+variable — handy in a loop that processes items.
+
+Indeterminate: work is happening
+--------------------------------
+
+When you can't measure progress, use ``mode="indeterminate"`` — a block bounces
+back and forth. ``start()`` begins the animation and ``stop()`` ends it:
+
+.. code-block:: python
+
+   spinner = ttk.Progressbar(app, mode="indeterminate", bootstyle="info")
+   spinner.pack(fill="x", padx=10)
+
+   spinner.start()                   # animate while a task runs…
+   spinner.stop()                    # …then stop
+
+``start()`` takes an optional interval in milliseconds between steps.
+
+Striped and vertical
+--------------------
+
+A ``striped`` variant gives the bar a segmented arc; ``orient="vertical"`` stands
+it up (drive its height with the same ``value``):
+
+.. code-block:: python
+
+   ttk.Progressbar(app, value=60, maximum=100, bootstyle="success striped")
+   ttk.Progressbar(app, value=60, maximum=100, orient="vertical")
+
+Color
+-----
+
+``bootstyle`` colors the bar from the semantic palette:
+
+.. code-block:: python
+
+   ttk.Progressbar(app, value=50, bootstyle="warning")
+
+API & reference
+---------------
+
+``Progressbar`` is the native ``ttk.Progressbar`` — ttkbootstrap adds ``bootstyle=``
+but no other Python API. For its constructor and options (``mode``, ``maximum``,
+``value``, ``variable``, ``orient``, ``length``) and the ``start`` / ``stop`` /
+``step`` methods, see the
+`tkinter.ttk.Progressbar <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Progressbar>`__
+reference.
+
+.. seealso::
+
+   the ``Floodgauge`` widget for a progress indicator that also shows a
+   value/label, and :doc:`Meter <meter>` for a radial one. Want to restyle the
+   progressbar yourself? The
+   :doc:`Style Reference › Progressbar </reference/style-reference/progressbar>`
+   and its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/docs/widgets/scale.rst
+++ b/docs/widgets/scale.rst
@@ -1,0 +1,90 @@
+Scale
+=====
+
+A **scale** is a slider for choosing a number from a continuous range by dragging
+a handle. ``Scale`` is the native ``ttk.Scale``, styled with ``bootstyle=``. This
+page covers binding its value, reacting as it moves, the orientation, then the
+``bootstyle`` color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A horizontal scale partway along its track in light and dark themes.
+
+Usage
+-----
+
+Set the range with ``from_`` and ``to``, and bind the value to a variable — a
+``DoubleVar`` (the scale's value is a float) or an ``IntVar``:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   volume = ttk.DoubleVar(value=30)
+   ttk.Scale(app, from_=0, to=100, variable=volume).pack(fill="x", padx=10, pady=10)
+
+   ttk.Button(app, text="Apply", command=lambda: print(volume.get()), bootstyle="primary").pack()
+
+   app.mainloop()
+
+Read the value with the variable's ``.get()`` (or the scale's own ``.get()``).
+Like a :doc:`Spinbox <spinbox>`, ``from_`` has a trailing underscore because
+``from`` is a Python keyword.
+
+.. note::
+
+   A scale's value is a **float**, even over an integer-looking range. Round it
+   (``round(volume.get())``) or bind an ``IntVar`` if you need a whole number.
+
+Reacting as it moves
+--------------------
+
+``command=`` runs continuously while the user drags — for a live preview. It
+receives the new value (a string) as its argument:
+
+.. code-block:: python
+
+   def on_slide(value):
+       print("volume", round(float(value)))
+
+   ttk.Scale(app, from_=0, to=100, variable=volume, command=on_slide)
+
+Orientation
+-----------
+
+``orient="vertical"`` stands the scale up (the default is ``"horizontal"``):
+
+.. code-block:: python
+
+   ttk.Scale(app, from_=100, to=0, orient="vertical", variable=volume)
+
+Color
+-----
+
+``bootstyle`` colors the handle and the filled part of the track from the semantic
+palette:
+
+.. code-block:: python
+
+   ttk.Scale(app, from_=0, to=100, variable=volume, bootstyle="info")
+
+API & reference
+---------------
+
+``Scale`` is the native ``ttk.Scale`` — ttkbootstrap adds ``bootstyle=`` but no
+other Python API. For its constructor and options (``from_``, ``to``,
+``variable``, ``command``, ``orient``, ``length``, ``value``) see the
+`tkinter.ttk.Scale <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Scale>`__
+reference.
+
+.. seealso::
+
+   the ``LabeledScale`` widget for a scale with a value label that tracks the
+   handle, and :doc:`Spinbox <spinbox>` for a stepped numeric entry. Want to
+   restyle the scale yourself? The
+   :doc:`Style Reference › Scale </reference/style-reference/scale>` and its
+   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
+   document the hand-styling surface.

--- a/docs/widgets/scrollbar.rst
+++ b/docs/widgets/scrollbar.rst
@@ -1,0 +1,75 @@
+Scrollbar
+=========
+
+A **scrollbar** scrolls a widget whose contents are larger than its view — a
+``Text``, a ``Listbox``, a ``Treeview``, or a ``Canvas``. ``Scrollbar`` is the
+native ``ttk.Scrollbar``, styled with
+``bootstyle=``. This page covers wiring it to a widget, the orientation, then the
+``bootstyle`` color and variants.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A scrolled text box with a vertical scrollbar in light and dark themes.
+
+Wiring it up
+------------
+
+A scrollbar and its widget are connected **both ways**: the scrollbar tells the
+widget where to scroll (``command``), and the widget tells the scrollbar where it
+is so the thumb tracks (``set``). Wire both:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.constants import *
+
+   app = ttk.App()
+
+   text = ttk.Text(app, height=8, width=40)
+   scroll = ttk.Scrollbar(app, orient=VERTICAL, command=text.yview)
+   text.configure(yscrollcommand=scroll.set)
+
+   text.pack(side=LEFT, fill=BOTH, expand=YES)
+   scroll.pack(side=RIGHT, fill=Y)
+
+   app.mainloop()
+
+- ``command=text.yview`` — the scrollbar drives the text's vertical view.
+- ``yscrollcommand=scroll.set`` — the text reports its position back so the thumb
+  follows. (Use ``xview`` / ``xscrollcommand`` with a ``HORIZONTAL`` scrollbar.)
+
+.. tip::
+
+   For a text area or a frame of widgets, ttkbootstrap's
+   :doc:`ScrolledText / ScrolledFrame </user-guide/how-to/scrollable>` do this
+   wiring for you — reach for a bare ``Scrollbar`` when you attach one to a
+   ``Listbox``, ``Canvas``, or ``Treeview`` yourself.
+
+Color and variants
+------------------
+
+``bootstyle`` colors the thumb from the semantic palette. A ``round`` variant
+gives it rounded ends, and ``thin`` makes it a slim track for dense UIs:
+
+.. code-block:: python
+
+   ttk.Scrollbar(app, orient=VERTICAL, command=text.yview, bootstyle="primary round")
+   ttk.Scrollbar(app, orient=VERTICAL, command=text.yview, bootstyle="secondary thin")
+
+API & reference
+---------------
+
+``Scrollbar`` is the native ``ttk.Scrollbar`` — ttkbootstrap adds ``bootstyle=``
+but no other Python API. For its constructor and options (``orient``, ``command``)
+and the ``set`` method, see the
+`tkinter.ttk.Scrollbar <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Scrollbar>`__
+reference.
+
+.. seealso::
+
+   :doc:`Scroll long content </user-guide/how-to/scrollable>` for the ready-made
+   ``ScrolledText`` / ``ScrolledFrame``. Want to restyle the scrollbar yourself?
+   The :doc:`Style Reference › Scrollbar </reference/style-reference/scrollbar>`
+   and its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/docs/widgets/separator.rst
+++ b/docs/widgets/separator.rst
@@ -1,0 +1,60 @@
+Separator
+=========
+
+A **separator** is a thin line that divides content into groups — between sections
+of a form or items in a menu-like list. ``Separator`` is the native
+``ttk.Separator``, styled with ``bootstyle=``.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   Two stacked sections divided by a horizontal separator, in light and dark
+   themes.
+
+Usage
+-----
+
+Set ``orient=`` to ``HORIZONTAL`` (a line across, to divide stacked content) or
+``VERTICAL`` (a line down, to divide side-by-side content), and let it fill across
+its space:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.constants import *
+
+   app = ttk.App()
+
+   ttk.Label(app, text="Section one").pack()
+   ttk.Separator(app, orient=HORIZONTAL).pack(fill=X, pady=8)
+   ttk.Label(app, text="Section two").pack()
+
+   app.mainloop()
+
+A horizontal separator needs ``fill=X`` (a vertical one ``fill=Y``) to stretch —
+otherwise it collapses to nothing.
+
+Color
+-----
+
+``bootstyle`` colors the line from the semantic palette; the default is a subtle
+border tone that suits most dividers:
+
+.. code-block:: python
+
+   ttk.Separator(app, orient=HORIZONTAL, bootstyle="primary")
+
+API & reference
+---------------
+
+``Separator`` is the native ``ttk.Separator`` — ttkbootstrap adds ``bootstyle=``
+but no other Python API. For its constructor see the
+`tkinter.ttk.Separator <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Separator>`__
+reference.
+
+.. seealso::
+
+   Want to restyle the separator yourself? The
+   :doc:`Style Reference › Separator </reference/style-reference/separator>` and
+   its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+   guide document the hand-styling surface.

--- a/docs/widgets/sizegrip.rst
+++ b/docs/widgets/sizegrip.rst
@@ -1,0 +1,59 @@
+Sizegrip
+========
+
+A **sizegrip** is the small ribbed handle in the bottom-right corner of a window
+that the user drags to resize it. ``Sizegrip`` is the native ``ttk.Sizegrip``,
+styled with ``bootstyle=``.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A window with the ribbed sizegrip handle in its bottom-right corner, in light
+   and dark themes.
+
+Usage
+-----
+
+Place a sizegrip in the corner of a resizable window — pack it to the bottom-right.
+It wires itself to the window's resize behavior; no callback is needed:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.constants import *
+
+   app = ttk.App()
+
+   ttk.Label(app, text="Drag the corner to resize").pack(padx=20, pady=20)
+   ttk.Sizegrip(app).pack(side=BOTTOM, anchor=SE)
+
+   app.mainloop()
+
+A sizegrip is a visual affordance — the window is resizable from its edges
+regardless — so add one when a corner handle makes the resize obvious, typically
+beside a status bar.
+
+Color
+-----
+
+``bootstyle`` colors the grip dots from the semantic palette:
+
+.. code-block:: python
+
+   ttk.Sizegrip(app, bootstyle="secondary")
+
+API & reference
+---------------
+
+``Sizegrip`` is the native ``ttk.Sizegrip`` — ttkbootstrap adds ``bootstyle=`` but
+no other Python API. For its constructor see the
+`tkinter.ttk.Sizegrip <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Sizegrip>`__
+reference.
+
+.. seealso::
+
+   :doc:`Windows </user-guide/feature-guides/windows>` for window geometry and
+   resizing. Want to restyle the sizegrip yourself? The
+   :doc:`Style Reference › Sizegrip </reference/style-reference/sizegrip>` and its
+   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
+   document the hand-styling surface.


### PR DESCRIPTION
## Summary

**Phase 1, fifth family.** Six usage-first pages on the template shape, depth calibrated (Label/Progressbar/Scrollbar fuller; Separator/Sizegrip short):

- **Label** — static `text` + `textvariable`, color + `inverse-` fill, `wraplength`, and fonts/images (cross-refs Typography + the images how-to).
- **Progressbar** — determinate (`value`/`variable`/`step`) vs. indeterminate (`start`/`stop`), striped + vertical, color.
- **Scale** — `from_`/`to` + `variable` (with the float-value gotcha), `command` on drag, `orient`, color.
- **Scrollbar** — the two-way `command`/`set` wiring to a Text/Listbox/Treeview/Canvas, `orient`, `round`/`thin` variants; tips that `ScrolledText`/`ScrolledFrame` do the wiring for you.
- **Separator** — `orient` + fill-to-stretch, color.
- **Sizegrip** — the corner resize handle, color.

## Notes
- Forward-references to not-yet-authored pages (Floodgauge/LabeledScale/Treeview/Text) are left as plain text to keep `-W` clean; they'll become links when those pages land.
- **Treeview** is native but wasn't in any family batch — I'll give it its own page (it's rich, like Text/Canvas).

## Verification
- Every snippet exercised headlessly (progressbar modes/step/striped/vertical, scale variable/command/orient, the scrollbar wiring, separator fill, sizegrip).
- Rule-scan clean (only the intentional `inverse-primary` dash); `sphinx -b html -W` clean.

Docs-only; targets `2.0`. Next: **Shipped** family (Floodgauge/DateEntry/Tableview/LabeledScale/Toast/Tooltip + the Meter rewrite), then **Text** / **Canvas** / **Treeview**, then the coverage sync test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)