### PR TITLE
docs: Widgets catalog — Shipped indicators (Meter rewrite + Floodgauge + LabeledScale)

### DIFF
--- a/docs/reference/api/widgets.rst
+++ b/docs/reference/api/widgets.rst
@@ -8,15 +8,10 @@ directly as ``ttkbootstrap.<Name>``. For usage, screenshots, and worked
 examples, see the :doc:`Widgets catalog </widgets/index>`; this page is the
 complete lookup reference.
 
-.. note::
-
-   Spike scope: ``Meter`` proves the autodoc pattern (napoleon Google
-   docstrings, ``__init__`` parameter tables via ``autoclass_content = "both"``,
-   inherited tkinter members excluded). The remaining shipped widgets are added
-   in a later slice.
-
 .. autosummary::
    :toctree: generated
    :nosignatures:
 
    Meter
+   Floodgauge
+   LabeledScale

--- a/docs/widgets/floodgauge.rst
+++ b/docs/widgets/floodgauge.rst
@@ -1,0 +1,87 @@
+Floodgauge
+==========
+
+A **floodgauge** is a progress bar that shows its value *as text across the bar* —
+a percentage, a count, a status word. ``Floodgauge`` is a ttkbootstrap widget (a
+real class with its own API, imported as ``ttk.Floodgauge``). This page covers
+driving the value and its label, the indeterminate mode, the orientation, then the
+``bootstyle`` color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A floodgauge filled to 75% with "75% complete" shown across it, in light and
+   dark themes.
+
+Usage
+-----
+
+``value`` and ``maximum`` set the fill, and ``mask`` formats the value into the
+label — a ``str.format`` template where ``{}`` is the current value. Bind a
+variable to drive it as work advances:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.widgets import Floodgauge
+
+   app = ttk.App()
+
+   progress = ttk.IntVar(value=0)
+   gauge = Floodgauge(app, variable=progress, maximum=100, mask="{}% complete",
+                      bootstyle="info")
+   gauge.pack(fill="x", padx=10, pady=10)
+
+   progress.set(75)                     # the bar fills and the label updates
+
+   app.mainloop()
+
+For a fixed caption instead of the value, pass ``text`` instead of ``mask``.
+
+Indeterminate mode
+------------------
+
+When you can't measure progress, set ``mode="indeterminate"`` and animate it with
+``start()`` / ``stop()`` (``step`` advances it manually):
+
+.. code-block:: python
+
+   gauge = Floodgauge(app, mode="indeterminate", text="Working…", bootstyle="info")
+   gauge.pack(fill="x")
+
+   gauge.start()                        # animate while a task runs…
+   gauge.stop()                         # …then stop
+
+Orientation
+-----------
+
+``orient="vertical"`` stands the gauge up (the default is ``"horizontal"``):
+
+.. code-block:: python
+
+   Floodgauge(app, value=60, maximum=100, orient="vertical", mask="{}%")
+
+Color
+-----
+
+``bootstyle`` colors the bar and its text from the semantic palette:
+
+.. code-block:: python
+
+   Floodgauge(app, value=50, maximum=100, mask="{}%", bootstyle="success")
+
+API & reference
+---------------
+
+For the complete option list and methods, see :class:`~ttkbootstrap.Floodgauge` on
+the :doc:`Widgets API page </reference/api/widgets>`:
+
+.. autosummary::
+   :nosignatures:
+
+   ~ttkbootstrap.Floodgauge
+
+.. seealso::
+
+   :doc:`Progressbar <progressbar>` for a plain bar without the value label, and
+   :doc:`Meter <meter>` for a radial indicator.

--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -127,6 +127,18 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
 
       A radial progress meter and dial.
 
+   .. grid-item-card:: Floodgauge
+      :link: floodgauge
+      :link-type: doc
+
+      A progress bar that shows its value as text across the bar.
+
+   .. grid-item-card:: LabeledScale
+      :link: labeledscale
+      :link-type: doc
+
+      A scale with a value label that tracks the handle.
+
 .. toctree::
    :hidden:
 
@@ -149,3 +161,5 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
    separator
    sizegrip
    meter
+   floodgauge
+   labeledscale

--- a/docs/widgets/labeledscale.rst
+++ b/docs/widgets/labeledscale.rst
@@ -40,7 +40,7 @@ Where the label sits
 --------------------
 
 ``compound`` places the value label above (``"top"``, the default) or below
-(``"bottom"``) the scale:
+(``"bottom"``) the scale — those are the only two positions:
 
 .. code-block:: python
 

--- a/docs/widgets/labeledscale.rst
+++ b/docs/widgets/labeledscale.rst
@@ -1,0 +1,71 @@
+LabeledScale
+============
+
+A **labeled scale** is a :doc:`Scale <scale>` with a value label that rides along
+the handle, so the user sees the exact number they are setting. ``LabeledScale``
+is a ttkbootstrap widget (a real class with its own API, imported as
+``ttk.LabeledScale``). This page covers building one, where the label sits, then
+the ``bootstyle`` color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A labeled scale partway along its track with the value label above the handle,
+   in light and dark themes.
+
+Usage
+-----
+
+Set the range with ``from_`` and ``to`` and bind a variable — the label shows the
+variable's value and follows the handle as it moves:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.widgets import LabeledScale
+
+   app = ttk.App()
+
+   level = ttk.IntVar(value=40)
+   LabeledScale(app, variable=level, from_=0, to=100, bootstyle="info").pack(fill="x", padx=20, pady=20)
+
+   ttk.Button(app, text="Apply", command=lambda: print(level.get()), bootstyle="primary").pack()
+
+   app.mainloop()
+
+Read the chosen value from the bound variable's ``.get()``. The label shows whole
+numbers, so bind an ``IntVar`` for a clean readout.
+
+Where the label sits
+--------------------
+
+``compound`` places the value label above (``"top"``, the default) or below
+(``"bottom"``) the scale:
+
+.. code-block:: python
+
+   LabeledScale(app, variable=level, from_=0, to=100, compound="bottom")
+
+Color
+-----
+
+``bootstyle`` colors the handle and the filled track from the semantic palette:
+
+.. code-block:: python
+
+   LabeledScale(app, variable=level, from_=0, to=100, bootstyle="success")
+
+API & reference
+---------------
+
+For the complete option list, see :class:`~ttkbootstrap.LabeledScale` on the
+:doc:`Widgets API page </reference/api/widgets>`:
+
+.. autosummary::
+   :nosignatures:
+
+   ~ttkbootstrap.LabeledScale
+
+.. seealso::
+
+   :doc:`Scale <scale>` for the plain slider it builds on.

--- a/docs/widgets/meter.rst
+++ b/docs/widgets/meter.rst
@@ -1,49 +1,100 @@
 Meter
 =====
 
-A radial meter for showing the progress of a long-running operation or an amount
-completed. It can also act as an interactive dial. ``Meter`` is a ttkbootstrap
-widget — a real class with its own API.
+A **meter** shows an amount as a radial dial — a percentage used, a score, a
+live reading. ``Meter`` is a ttkbootstrap widget (a real class with its own API,
+imported as ``ttk.Meter``). This page covers showing and updating a value, the
+full/semicircle shapes, the interactive dial, the striped look, then the
+``bootstyle`` color.
 
-.. Screenshots (light/dark pairs) are added in a later documentation slice.
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
 
-Semantic styling
-----------------
+   A semicircle meter reading 65% and a full-circle meter, in light and dark
+   themes.
 
-Set the indicator color with ``bootstyle=``:
+Usage
+-----
+
+``amount_used`` is the current value and ``amount_total`` the maximum (default
+100); ``subtext`` labels it:
 
 .. code-block:: python
 
    import ttkbootstrap as ttk
+   from ttkbootstrap.widgets import Meter
 
    app = ttk.App()
 
-   meter = ttk.Meter(
-       app,
-       bootstyle="success",
-       subtext="progress",
-       amountused=65,
-   )
+   meter = Meter(app, amount_used=65, amount_total=100, subtext="storage used",
+                 bootstyle="success")
    meter.pack(padx=16, pady=16)
 
    app.mainloop()
 
-Common tasks
-------------
+Read and change the value through ``amount_used_var`` (a variable that tracks the
+dial), or with ``configure``; ``step`` nudges it by an amount:
 
-- **Read or set the value** — the ``amountused`` option holds the current value;
-  bind ``amountusedvar`` to drive it reactively.
-- **Full or semicircle** — set ``metertype`` to ``"full"`` or ``"semi"``.
-- **Striped indicator** — set ``stripethickness`` for a segmented arc.
-- **Interactive dial** — pass ``interactive=True`` to let the user drag the arc.
+.. code-block:: python
 
-API reference
--------------
+   meter.amount_used_var.get()          # -> the current value
+   meter.configure(amount_used=80)      # set it
+   meter.step(5)                        # advance by 5
 
-For the complete option list and methods, see :class:`~ttkbootstrap.Meter` on
-the :doc:`Widgets API page </reference/api/widgets>`. At a glance:
+Full or semicircle
+------------------
+
+``meter_type`` is ``"full"`` (the default, a complete ring) or ``"semi"`` (a
+half-circle gauge):
+
+.. code-block:: python
+
+   Meter(app, amount_used=65, meter_type="semi")
+
+An interactive dial
+-------------------
+
+Pass ``interactive=True`` to let the user **drag the arc** to set the value — the
+meter becomes an input, not just a readout:
+
+.. code-block:: python
+
+   dial = Meter(app, amount_used=30, interactive=True, subtext="volume")
+   dial.pack()
+
+   dial.amount_used_var.get()           # read what the user set
+
+Striped
+-------
+
+``stripe_thickness`` breaks the arc into segments of that width, for a chunkier
+progress look:
+
+.. code-block:: python
+
+   Meter(app, amount_used=65, stripe_thickness=10, bootstyle="info")
+
+Color
+-----
+
+``bootstyle`` colors the indicator arc from the semantic palette:
+
+.. code-block:: python
+
+   Meter(app, amount_used=50, bootstyle="warning")
+
+API & reference
+---------------
+
+For the complete option list and methods, see :class:`~ttkbootstrap.Meter` on the
+:doc:`Widgets API page </reference/api/widgets>`:
 
 .. autosummary::
    :nosignatures:
 
    ~ttkbootstrap.Meter
+
+.. seealso::
+
+   :doc:`Floodgauge <floodgauge>` for a linear progress indicator with a value,
+   and :doc:`Progressbar <progressbar>` for a plain bar.

--- a/docs/widgets/meter.rst
+++ b/docs/widgets/meter.rst
@@ -10,8 +10,7 @@ full/semicircle shapes, the interactive dial, the striped look, then the
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder
 
-   A semicircle meter reading 65% and a full-circle meter, in light and dark
-   themes.
+   A meter reading 65% with a "storage used" subtext, in light and dark themes.
 
 Usage
 -----
@@ -51,6 +50,11 @@ half-circle gauge):
 
    Meter(app, amount_used=65, meter_type="semi")
 
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   The same value as a full-circle ring and a semicircle gauge, side by side.
+
 An interactive dial
 -------------------
 
@@ -64,6 +68,11 @@ meter becomes an input, not just a readout:
 
    dial.amount_used_var.get()           # read what the user set
 
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   An interactive meter with the handle mid-arc, being dragged to a new value.
+
 Striped
 -------
 
@@ -74,6 +83,11 @@ progress look:
 
    Meter(app, amount_used=65, stripe_thickness=10, bootstyle="info")
 
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A meter whose indicator arc is broken into segments, beside a solid one.
+
 Color
 -----
 
@@ -82,6 +96,12 @@ Color
 .. code-block:: python
 
    Meter(app, amount_used=50, bootstyle="warning")
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A row of meters in primary, success, info, warning, and danger, in light and
+   dark themes.
 
 API & reference
 ---------------


### PR DESCRIPTION
## Summary

**Phase 1, Shipped family (part 1 — the value-display widgets).** These ship their own Python API, so the depth home is the **API Reference** (autodoc), not the Style Reference. Splitting the Shipped family in two keeps the PRs reviewable; the interactive ones (DateEntry/Tableview/Toast/Tooltip) follow.

- **Meter** — **rewritten** from the stale spike (option-tour bullets + *pre-2.0* option names) into a usage-first page on the 2.0 snake_case API: `amount_used`/`amount_total`/`subtext`, read via `amount_used_var`/`configure`/`step`, `meter_type` full|semi, the `interactive` dial, `stripe_thickness`, color.
- **Floodgauge** — `value`/`maximum` + `mask` label + `variable` binding, indeterminate mode (`start`/`stop`), `orient`, color.
- **LabeledScale** — `variable` + `from_`/`to`, `compound` label position, color.

Added Floodgauge/LabeledScale to the API-reference autosummary (resolves the `:class:` refs and drops the Meter-only "spike scope" note).

## Verification
- Every snippet exercised headlessly against the real APIs (incl. the corrected Meter read path `amount_used_var.get()` / `configure` / `step`).
- **autodoc** of Floodgauge/LabeledScale builds clean; `sphinx -b html -W` clean; rule-scan clean (no stale `amountused`/`metertype`).

Docs-only; targets `2.0`. Next: **Shipped part 2** (DateEntry/Tableview/Toast/Tooltip), then **Text/Canvas/Treeview**, then the coverage sync test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)