### PR TITLE
docs: Widgets catalog — Shipped interactive (DateEntry/Tableview/Toast/Tooltip)

### DIFF
--- a/docs/reference/api/widgets.rst
+++ b/docs/reference/api/widgets.rst
@@ -16,11 +16,6 @@ complete lookup reference.
    Floodgauge
    LabeledScale
    DateEntry
+   Tableview
    ToastNotification
    ToolTip
-
-.. note::
-
-   ``Tableview``'s API reference is pending a docstring cleanup (its source
-   docstrings use Markdown examples that need porting to reStructuredText). Until
-   then, see the :doc:`Tableview widget page </widgets/tableview>` for usage.

--- a/docs/reference/api/widgets.rst
+++ b/docs/reference/api/widgets.rst
@@ -15,3 +15,12 @@ complete lookup reference.
    Meter
    Floodgauge
    LabeledScale
+   DateEntry
+   ToastNotification
+   ToolTip
+
+.. note::
+
+   ``Tableview``'s API reference is pending a docstring cleanup (its source
+   docstrings use Markdown examples that need porting to reStructuredText). Until
+   then, see the :doc:`Tableview widget page </widgets/tableview>` for usage.

--- a/docs/widgets/dateentry.rst
+++ b/docs/widgets/dateentry.rst
@@ -1,0 +1,82 @@
+DateEntry
+=========
+
+A **date entry** is a text field with a calendar button — the user types a date or
+picks one from a pop-up calendar. ``DateEntry`` is a ttkbootstrap widget (a real
+class with its own API, imported as ``ttk.DateEntry``). This page covers reading
+and setting the date, the format and calendar options, then the ``bootstyle``
+color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A date entry closed, and with its pop-up calendar open, in light and dark
+   themes.
+
+Usage
+-----
+
+Create a ``DateEntry`` and read the chosen date with ``get_date()`` — it returns a
+:class:`~datetime.datetime`. ``set_date()`` puts one in:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.widgets import DateEntry
+   from datetime import datetime
+
+   app = ttk.App()
+
+   picker = DateEntry(app)
+   picker.pack(padx=10, pady=10)
+
+   def use_date():
+       print(picker.get_date())          # -> a datetime
+
+   ttk.Button(app, text="Use date", command=use_date, bootstyle="primary").pack()
+
+   picker.set_date(datetime(2025, 6, 1)) # preselect
+
+   app.mainloop()
+
+The widget exposes its parts as ``picker.entry`` (the text field) and
+``picker.button`` (the calendar button), and ``enable()`` / ``disable()`` toggle
+interaction.
+
+Format and calendar
+-------------------
+
+``date_format`` is a ``strftime`` pattern for how the date reads in the field;
+``start_date`` sets which date (and month) the calendar opens on; ``first_weekday``
+sets the leftmost column (``0`` = Monday … ``6`` = Sunday):
+
+.. code-block:: python
+
+   DateEntry(app, date_format="%Y-%m-%d", start_date=datetime(2025, 1, 1), first_weekday=6)
+
+Color
+-----
+
+``bootstyle`` colors the entry border and the calendar accents from the semantic
+palette:
+
+.. code-block:: python
+
+   DateEntry(app, bootstyle="success")
+
+API & reference
+---------------
+
+For the complete option list and methods, see :class:`~ttkbootstrap.DateEntry` on
+the :doc:`Widgets API page </reference/api/widgets>`:
+
+.. autosummary::
+   :nosignatures:
+
+   ~ttkbootstrap.DateEntry
+
+.. seealso::
+
+   The date **picker dialog** (``Querybox.get_date``) in the
+   :doc:`Dialogs guide </user-guide/feature-guides/dialogs>` for asking a date
+   without a permanent field, and :doc:`Entry <entry>` for a plain text field.

--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -139,6 +139,30 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
 
       A scale with a value label that tracks the handle.
 
+   .. grid-item-card:: DateEntry
+      :link: dateentry
+      :link-type: doc
+
+      A text field with a pop-up calendar for choosing a date.
+
+   .. grid-item-card:: Tableview
+      :link: tableview
+      :link-type: doc
+
+      A data table with sorting, search, and pagination.
+
+   .. grid-item-card:: Toast
+      :link: toast
+      :link-type: doc
+
+      A temporary notification that pops up and fades.
+
+   .. grid-item-card:: Tooltip
+      :link: tooltip
+      :link-type: doc
+
+      A help popup that appears on hover.
+
 .. toctree::
    :hidden:
 
@@ -163,3 +187,7 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
    meter
    floodgauge
    labeledscale
+   dateentry
+   tableview
+   toast
+   tooltip

--- a/docs/widgets/tableview.rst
+++ b/docs/widgets/tableview.rst
@@ -1,0 +1,116 @@
+Tableview
+=========
+
+A **tableview** is a data table — rows and columns with built-in sorting, an
+optional search bar, and pagination. ``Tableview`` is a ttkbootstrap widget (a
+real class with its own API, imported as ``ttk.Tableview``). This page covers
+building one from data, the search and pagination options, adding and reading
+rows, reacting to a selection, then the ``bootstyle`` color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A tableview with column headers, several rows, a search bar, and pagination
+   controls, in light and dark themes.
+
+Usage
+-----
+
+Give it ``coldata`` (the column headings) and ``rowdata`` (a list of rows, each a
+list of cell values). Click a header to sort by that column:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.widgets import Tableview
+
+   app = ttk.App()
+
+   table = Tableview(
+       app,
+       coldata=["Name", "Role", "Age"],
+       rowdata=[
+           ["Ada Lovelace", "Engineer", 36],
+           ["Grace Hopper", "Admiral", 85],
+           ["Alan Turing", "Cryptographer", 41],
+       ],
+       bootstyle="primary",
+   )
+   table.pack(fill="both", expand=True, padx=10, pady=10)
+
+   app.mainloop()
+
+``coldata`` entries can also be dictionaries (``{"text": "Age", "width": 60,
+"anchor": "e"}``) for per-column width, alignment, and more.
+
+Search and pagination
+---------------------
+
+For a large table, turn on the search bar and page the rows:
+
+.. code-block:: python
+
+   Tableview(
+       app,
+       coldata=["Name", "Role", "Age"],
+       rowdata=rows,
+       searchable=True,          # a search bar above the table (Enter to filter)
+       paginated=True,           # page controls below it
+       pagesize=10,              # rows per page
+   )
+
+Adding and reading rows
+-----------------------
+
+``insert_row`` adds a row (it refreshes the view for you); ``get_rows`` returns the
+rows, and ``get_rows(selected=True)`` just the selected ones:
+
+.. code-block:: python
+
+   table.insert_row("end", ["Katherine Johnson", "Mathematician", 101])
+
+   for row in table.get_rows():
+       print(row.values)                 # each row's cell values
+
+   selected = table.get_rows(selected=True)
+
+``delete_row`` removes one, and ``build_table_data(coldata, rowdata)`` replaces the
+whole dataset.
+
+Reacting to a selection
+-----------------------
+
+Pass ``on_select=`` a callback to run when the selection changes — it receives the
+list of selected rows:
+
+.. code-block:: python
+
+   def on_select(rows):
+       print("selected", [r.values for r in rows])
+
+   Tableview(app, coldata=cols, rowdata=rows, on_select=on_select)
+
+Color
+-----
+
+``bootstyle`` colors the header, selection, and accents from the semantic palette;
+``stripecolor`` sets an alternating row tint:
+
+.. code-block:: python
+
+   Tableview(app, coldata=cols, rowdata=rows, bootstyle="info")
+
+API & reference
+---------------
+
+``Tableview`` ships a large API — ``TableColumn`` / ``TableRow`` objects, sorting,
+filtering, CSV export, and programmatic selection — beyond what this page covers.
+The full class reference on the :doc:`Widgets API page </reference/api/widgets>`
+is pending a docstring cleanup; until then, read the methods in the source
+(``ttkbootstrap.widgets.tableview``).
+
+.. seealso::
+
+   :doc:`Build your first app </user-guide/getting-started/build-your-first-app>`
+   builds a form that feeds a ``Tableview``, and the ``Treeview`` widget for the
+   native tree/table it is built on.

--- a/docs/widgets/tableview.rst
+++ b/docs/widgets/tableview.rst
@@ -105,9 +105,13 @@ API & reference
 
 ``Tableview`` ships a large API — ``TableColumn`` / ``TableRow`` objects, sorting,
 filtering, CSV export, and programmatic selection — beyond what this page covers.
-The full class reference on the :doc:`Widgets API page </reference/api/widgets>`
-is pending a docstring cleanup; until then, read the methods in the source
-(``ttkbootstrap.widgets.tableview``).
+For the complete list, see :class:`~ttkbootstrap.Tableview` on the
+:doc:`Widgets API page </reference/api/widgets>`:
+
+.. autosummary::
+   :nosignatures:
+
+   ~ttkbootstrap.Tableview
 
 .. seealso::
 

--- a/docs/widgets/toast.rst
+++ b/docs/widgets/toast.rst
@@ -1,0 +1,84 @@
+Toast
+=====
+
+A **toast** is a small notification that pops up, lingers, and fades on its own —
+non-blocking feedback like "Saved" or "Copied". ``ToastNotification`` is a
+ttkbootstrap widget (a real class with its own API, imported as
+``ttk.ToastNotification``). This page covers showing one, how long it stays, where
+it appears, then the ``bootstyle`` color and icon.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A success toast in the bottom-right corner reading "Saved — your file was
+   saved", in light and dark themes.
+
+Usage
+-----
+
+Unlike most widgets you don't ``pack`` a toast — you build it with a ``title`` and
+``message`` and call ``show_toast()`` to display it:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.widgets import ToastNotification
+
+   app = ttk.App()
+
+   def save():
+       toast = ToastNotification(
+           title="Saved",
+           message="Your file was saved.",
+           duration=3000,               # visible for 3 seconds
+           bootstyle="success",
+       )
+       toast.show_toast()
+
+   ttk.Button(app, text="Save", command=save, bootstyle="primary").pack(padx=20, pady=20)
+
+   app.mainloop()
+
+``duration`` is in milliseconds; **omit it** and the toast stays until it is
+clicked. ``hide_toast()`` dismisses one early.
+
+Where it appears
+----------------
+
+``position`` is an ``(x, y, anchor)`` tuple — the ``x``/``y`` offset from the
+corner named by ``anchor`` (``"ne"``, ``"se"``, ``"sw"``, ``"nw"``). The default is
+the bottom-right:
+
+.. code-block:: python
+
+   ToastNotification(title="Done", message="Export finished.", position=(10, 60, "ne"))
+
+Color and icon
+--------------
+
+``bootstyle`` colors the toast from the semantic palette, and ``icon`` sets the
+glyph shown beside the text (a Bootstrap Icons name):
+
+.. code-block:: python
+
+   ToastNotification(title="Heads up", message="Low disk space.",
+                     bootstyle="warning", icon="exclamation-triangle")
+
+Set ``alert=True`` to also ring the system bell when the toast appears.
+
+API & reference
+---------------
+
+For the complete option list, see :class:`~ttkbootstrap.ToastNotification` on the
+:doc:`Widgets API page </reference/api/widgets>`:
+
+.. autosummary::
+   :nosignatures:
+
+   ~ttkbootstrap.ToastNotification
+
+.. seealso::
+
+   The :doc:`Dialogs guide </user-guide/feature-guides/dialogs>` for a
+   ``Messagebox`` when you need the user to acknowledge or answer, rather than a
+   toast that fades on its own.

--- a/docs/widgets/tooltip.rst
+++ b/docs/widgets/tooltip.rst
@@ -1,0 +1,73 @@
+Tooltip
+=======
+
+A **tooltip** is a small help popup that appears when the pointer hovers over a
+widget. ``ToolTip`` is a ttkbootstrap widget (a real class with its own API,
+imported as ``ttk.ToolTip``). This page covers attaching one, the hover delay and
+wrapping, then the ``bootstyle`` color.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A button with a tooltip popup showing beneath the pointer, in light and dark
+   themes.
+
+Usage
+-----
+
+You don't ``pack`` a tooltip — you **attach** it to an existing widget by passing
+that widget and the ``text`` to show. It manages the hover itself:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.widgets import ToolTip
+
+   app = ttk.App()
+
+   save = ttk.Button(app, text="Save", bootstyle="primary")
+   save.pack(padx=20, pady=20)
+
+   ToolTip(save, text="Save the current file (Ctrl+S)")
+
+   app.mainloop()
+
+There is nothing to keep a reference to — the ``ToolTip`` wires itself to the
+widget's enter/leave events.
+
+Delay and wrapping
+------------------
+
+``delay`` is how long (in milliseconds) the pointer must rest before the tip shows
+(default 500); ``wraplength`` (in pixels) wraps a long tip onto multiple lines:
+
+.. code-block:: python
+
+   ToolTip(save, text="A longer explanation that should wrap onto a few lines.",
+           delay=250, wraplength=200)
+
+Color
+-----
+
+``bootstyle`` colors the tooltip from the semantic palette — use it to match the
+tip to the kind of control (``danger`` for a destructive action, say):
+
+.. code-block:: python
+
+   ToolTip(delete_button, text="This cannot be undone", bootstyle="danger")
+
+API & reference
+---------------
+
+For the complete option list, see :class:`~ttkbootstrap.ToolTip` on the
+:doc:`Widgets API page </reference/api/widgets>`:
+
+.. autosummary::
+   :nosignatures:
+
+   ~ttkbootstrap.ToolTip
+
+.. seealso::
+
+   :doc:`Toast <toast>` for a temporary notification that appears on its own
+   rather than on hover.

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -422,46 +422,7 @@ class Tableview(ttk.Frame):
     The object has a right-click menu on the header and the cells that
     allow you to configure various settings.
 
-    Examples:
-
-        Adding data with the constructor
-        ```python
-        import ttkbootstrap as ttk
-        from ttkbootstrap.constants import *
-
-        app = ttk.App()
-        colors = app.style.colors
-
-        coldata = [
-            {"text": "LicenseNumber", "stretch": False},
-            "CompanyName",
-            {"text": "UserCount", "stretch": False},
-        ]
-
-        rowdata = [
-            ('A123', 'IzzyCo', 12),
-            ('A136', 'Kimdee Inc.', 45),
-            ('A158', 'Farmadding Co.', 36)
-        ]
-
-        dt = ttk.Tableview(
-            master=app,
-            coldata=coldata,
-            rowdata=rowdata,
-            paginated=True,
-            searchable=True,
-            bootstyle=PRIMARY,
-            stripecolor=(colors.light, None),
-        )
-        dt.pack(fill=BOTH, expand=YES, padx=10, pady=10)
-
-        app.mainloop()
-        ```
-
-        Add data with methods
-        ```python
-        dt.insert_row('end', ['Marzale LLC', 26])
-        ```
+    See the :doc:`Tableview widget page </widgets/tableview>` for usage examples.
     """
 
     def __init__(
@@ -576,16 +537,6 @@ class Tableview(ttk.Frame):
                 The callback receives a list of selected TableRow objects as its argument.
                 When no rows are selected, the callback receives an empty list.
 
-                Example:
-                ```python
-                def handle_selection(selected_rows):
-                    print(f"Selected {len(selected_rows)} rows")
-                    for row in selected_rows:
-                        print(row.values)
-
-                tableview = Tableview(master, on_select=handle_selection, ...)
-                ```
-
             iid_field (Union[int, str, None]):
                 Optional column index or header name to use as the unique identifier (iid)
                 for each row. If specified as an integer, it represents the column index.
@@ -593,23 +544,6 @@ class Tableview(ttk.Frame):
                 the value from this field will be used as the row's iid instead of the
                 auto-generated iid. This is useful when you have a natural key field like
                 an ID or unique code that you want to use for row identification.
-
-                Example:
-                ```python
-                # Using column index
-                tableview = Tableview(
-                    coldata=["ID", "Name", "Age"],
-                    rowdata=[[1, "Alice", 25], [2, "Bob", 30]],
-                    iid_field=0  # Use first column (ID) as iid
-                )
-
-                # Using column name
-                tableview = Tableview(
-                    coldata=["ID", "Name", "Age"],
-                    rowdata=[[1, "Alice", 25], [2, "Bob", 30]],
-                    iid_field="ID"  # Use ID column as iid
-                )
-                ```
         """
         super().__init__(master)
         self._tablecols = []
@@ -864,12 +798,6 @@ class Tableview(ttk.Frame):
 
             rowdata (list[Any, list]):
                 A list of row values to be inserted into the table.
-
-        Examples:
-
-            ```python
-            Tableview.insert_rows('end', ['one', 1], ['two', 2])
-            ```
         """
         if len(rowdata) == 0:
             return
@@ -1522,20 +1450,6 @@ class Tableview(ttk.Frame):
                 the specified columns. Column names should match the headertext
                 of the desired columns. If no columns are specified, searches
                 all columns.
-
-        Examples:
-
-            Search all columns:
-            ```python
-            tableview.search_table_data("example")
-            tableview.search_table_data(12345)  # Search for numeric value
-            ```
-
-            Search specific columns:
-            ```python
-            tableview.search_table_data("example", "CompanyName")
-            tableview.search_table_data(100, "Price", "Quantity")
-            ```
         """
         if criteria is None or (isinstance(criteria, str) and not criteria):
             self.reset_row_filters()


### PR DESCRIPTION
## Summary

**Phase 1, Shipped family (part 2 — the interactive widgets).** Four usage-first pages on the template shape:

- **DateEntry** — `get_date()`/`set_date()` (returns a `datetime`), `.entry`/`.button`, `date_format`/`start_date`/`first_weekday` (blessed snake_case), color.
- **Tableview** — `coldata`/`rowdata`, `searchable`+`paginated`, `insert_row`/`get_rows`(+`selected=True`)/`on_select`, `stripecolor`; cross-links *Build your first app*.
- **Toast** — build + `show_toast()` (not `pack`), `duration`/`position`/`icon`/`alert`.
- **Tooltip** — attach to a widget by hover, `delay`/`wraplength`, color.

All four are in the API-reference autosummary and autodoc cleanly.

## Tableview docstring cleanup
Adding Tableview to autodoc surfaced broken rST in its source docstrings (Markdown ` ```python ` examples + def-list/indentation issues). Per steer, **removed the example blocks** from the Tableview docstrings — the catalog page is the home for usage examples now — rather than porting them to rST. Dropped: the class-docstring `Examples`, two param examples (`on_select`/`iid_field`), and two method examples (`insert_rows`/`search_table_data`). With the fences gone, Tableview autodocs cleanly and is fully in the API reference.

## Verification
- Every snippet exercised headlessly against real APIs.
- Suite green (647 passed; only the known `nl.msg` localization env flake fails, unrelated).
- `sphinx -b html -W` clean; rule-scan clean.

Docs (+ a Tableview docstring trim); targets `2.0`. **Remaining catalog:** Text, Canvas, Treeview, then the coverage sync test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)