### PR TITLE
docs: expand Tableview catalog page

### DIFF
--- a/docs/widgets/tableview.rst
+++ b/docs/widgets/tableview.rst
@@ -1,11 +1,13 @@
 Tableview
 =========
 
-A **tableview** is a data table — rows and columns with built-in sorting, an
-optional search bar, and pagination. ``Tableview`` is a ttkbootstrap widget (a
-real class with its own API, imported as ``ttk.Tableview``). This page covers
-building one from data, the search and pagination options, adding and reading
-rows, reacting to a selection, then the ``bootstyle`` color.
+A **tableview** is a data table — rows and columns with click-to-sort headers,
+an optional search bar, pagination, CSV export, and a built-in right-click menu.
+``Tableview`` is a ttkbootstrap widget (a real class with its own API, imported
+as ``ttk.Tableview``). This page builds one from data, then works through
+configuring columns, sorting, filtering, reading and changing rows, the
+right-click menu, reacting to a selection, exporting, and the ``bootstyle``
+color.
 
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder
@@ -16,8 +18,8 @@ rows, reacting to a selection, then the ``bootstyle`` color.
 Usage
 -----
 
-Give it ``coldata`` (the column headings) and ``rowdata`` (a list of rows, each a
-list of cell values). Click a header to sort by that column:
+Give it ``coldata`` (the column headings) and ``rowdata`` (a list of rows, each
+a list of cell values). Click a header to sort by that column:
 
 .. code-block:: python
 
@@ -40,13 +42,32 @@ list of cell values). Click a header to sort by that column:
 
    app.mainloop()
 
-``coldata`` entries can also be dictionaries (``{"text": "Age", "width": 60,
-"anchor": "e"}``) for per-column width, alignment, and more.
+Configuring columns
+-------------------
+
+Each entry in ``coldata`` can be a plain string (just the heading) or a
+dictionary of column settings. Mix the two freely — use a dictionary only for
+the columns that need one. The common keys are ``text`` (the heading),
+``width`` (pixels), ``anchor`` (cell alignment — ``"w"``, ``"center"``,
+``"e"``), and ``stretch`` (whether the column grows with the table):
+
+.. code-block:: python
+
+   coldata = [
+       "Name",                                       # a plain heading
+       {"text": "Role", "stretch": True},            # takes up the slack
+       {"text": "Age", "width": 60, "anchor": "e"},  # narrow, right-aligned
+   ]
+
+   Tableview(app, coldata=coldata, rowdata=rows)
 
 Search and pagination
 ---------------------
 
-For a large table, turn on the search bar and page the rows:
+For a large table, turn on the search bar and page the rows. ``searchable``
+adds a search field above the table (type and press Enter to filter across all
+columns); ``paginated`` adds page controls below it, ``pagesize`` rows at a
+time:
 
 .. code-block:: python
 
@@ -54,34 +75,94 @@ For a large table, turn on the search bar and page the rows:
        app,
        coldata=["Name", "Role", "Age"],
        rowdata=rows,
-       searchable=True,          # a search bar above the table (Enter to filter)
-       paginated=True,           # page controls below it
-       pagesize=10,              # rows per page
+       searchable=True,
+       paginated=True,
+       pagesize=10,
    )
 
-Adding and reading rows
------------------------
+The page controls are wired for you. To move between pages in code, call
+``goto_first_page()``, ``goto_last_page()``, ``goto_next_page()``,
+``goto_prev_page()``.
 
-``insert_row`` adds a row (it refreshes the view for you); ``get_rows`` returns the
-rows, and ``get_rows(selected=True)`` just the selected ones:
+Sorting
+-------
+
+Clicking a header sorts by that column and toggles direction on the next click —
+no code needed. To sort from code, call ``sort_column_data`` with the column id
+(``cid``, the zero-based column position) and a direction (``sort=0`` ascending,
+``sort=1`` descending):
+
+.. code-block:: python
+
+   table.sort_column_data(cid=2, sort=0)   # sort by the Age column, ascending
+
+``reset_column_sort()`` restores the original row order.
+
+Filtering
+---------
+
+Filtering hides the rows that don't match, leaving the rest in place.
+``search_table_data(criteria)`` keeps rows matching a substring across every
+column; ``filter_column_to_value(cid=, value=)`` keeps rows whose cell in one
+column equals a value:
+
+.. code-block:: python
+
+   table.search_table_data("Engineer")               # match anywhere
+   table.filter_column_to_value(cid=1, value="Admiral")   # match one column
+
+   filtered = table.get_rows(filtered=True)          # the rows now showing
+   print(table.is_filtered)                          # True while a filter is on
+
+``reset_row_filters()`` clears the filter and shows every row again.
+
+Reading and changing rows
+-------------------------
+
+``get_rows()`` returns the table's rows as objects — each has a ``.values`` list
+(its cells) and an ``.iid`` (its row id). ``get_rows(selected=True)`` returns
+just the selected rows:
+
+.. code-block:: python
+
+   for row in table.get_rows():
+       print(row.values)                 # ["Ada Lovelace", "Engineer", 36]
+
+   selected = table.get_rows(selected=True)
+
+``insert_row`` adds a row and ``delete_row`` removes one by ``iid``. Both change
+the underlying data; call ``load_table_data()`` afterward to redraw:
 
 .. code-block:: python
 
    table.insert_row("end", ["Katherine Johnson", "Mathematician", 101])
+   table.delete_row(iid="I001")
+   table.load_table_data()
 
-   for row in table.get_rows():
-       print(row.values)                 # each row's cell values
+To replace the whole dataset at once, call
+``build_table_data(coldata, rowdata)`` — it rebuilds the columns and rows from
+scratch.
 
-   selected = table.get_rows(selected=True)
+The right-click menu
+--------------------
 
-``delete_row`` removes one, and ``build_table_data(coldata, rowdata)`` replaces the
-whole dataset.
+Every table comes with a right-click menu built in. Right-clicking a **cell**
+offers sort, filter, export, move, align, and delete-row actions; right-clicking
+a **header** offers sort, hide/show columns, align, delete-column, and a
+reset-table command — the same operations described above, exposed to the user
+without any code from you.
+
+Pass ``disable_right_click=True`` to turn the menu off:
+
+.. code-block:: python
+
+   Tableview(app, coldata=cols, rowdata=rows, disable_right_click=True)
 
 Reacting to a selection
 -----------------------
 
-Pass ``on_select=`` a callback to run when the selection changes — it receives the
-list of selected rows:
+Pass ``on_select=`` a callback to run when the selection changes — it receives
+the list of selected rows:
 
 .. code-block:: python
 
@@ -90,23 +171,38 @@ list of selected rows:
 
    Tableview(app, coldata=cols, rowdata=rows, on_select=on_select)
 
-Color
------
+Exporting to CSV
+----------------
 
-``bootstyle`` colors the header, selection, and accents from the semantic palette;
-``stripecolor`` sets an alternating row tint:
+The table can write its rows to a CSV file. ``export_all_records()`` prompts for
+a filename and saves every row; ``export_current_page()`` and
+``export_current_selection()`` save just the current page or the selected rows.
+These are also on the right-click menu, so users can export without any code
+from you:
 
 .. code-block:: python
 
-   Tableview(app, coldata=cols, rowdata=rows, bootstyle="info")
+   ttk.Button(app, text="Export", command=table.export_all_records).pack()
+
+Color
+-----
+
+``bootstyle`` colors the header, selection, and accents from the semantic
+palette; ``stripecolor`` is a ``(background, foreground)`` tuple for an
+alternating row tint (pass ``None`` for a part you don't want to change):
+
+.. code-block:: python
+
+   Tableview(app, coldata=cols, rowdata=rows,
+             bootstyle="info", stripecolor=("#f2f2f2", None))
 
 API & reference
 ---------------
 
-``Tableview`` ships a large API — ``TableColumn`` / ``TableRow`` objects, sorting,
-filtering, CSV export, and programmatic selection — beyond what this page covers.
-For the complete list, see :class:`~ttkbootstrap.Tableview` on the
-:doc:`Widgets API page </reference/api/widgets>`:
+``Tableview`` has a large API beyond this page — ``TableColumn`` / ``TableRow``
+objects, per-column show/hide, row and column moves, and more filtering and
+export variants. For the complete list, see :class:`~ttkbootstrap.Tableview` on
+the :doc:`Widgets API page </reference/api/widgets>`:
 
 .. autosummary::
    :nosignatures:

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -779,7 +779,7 @@ class Tableview(ttk.Frame):
         return record
 
     def insert_rows(self, index, rowdata):
-        """Insert row after index for each row in *row. If index does
+        """Insert row after index for each row in rowdata. If index does
         not exist then the records are appended to the end of the table.
         You can also use the string 'end' to append records at the end
         of the table.


### PR DESCRIPTION
Rewrites the anemic Tableview catalog page into a full usage-first walkthrough, and fixes a latent rST warning in the source docstring that the autodoc'd page surfaces.

The Tableview expansion commit was authored during the #1182 cycle but never pushed, so it missed that merge — this brings it onto `2.0` as its own PR.

## Page now covers
- **Configuring columns** — the `coldata` string-or-dict mix (`text`/`width`/`anchor`/`stretch`)
- **Search and pagination** — plus `goto_*_page()` navigation
- **Sorting** — click-to-sort headers and `sort_column_data(cid=, sort=)`
- **Filtering** — `search_table_data` / `filter_column_to_value` / `is_filtered` / `reset_row_filters`
- **Reading and changing rows** — `get_rows()` (`.values`/`.iid`), `insert_row`/`delete_row` + `load_table_data`, `build_table_data`
- **The built-in right-click menu** — cell/header menus + `disable_right_click`
- **Reacting to a selection** — `on_select`
- **Exporting to CSV** — `export_all_records` / page / selection
- **Color** — `bootstyle` + the `(bg, fg)` `stripecolor` tuple

Every snippet was executed headlessly against the real API. Reads columns via the non-deprecated `get_rows()` / `tablecolumns` property (not the now-deprecated `get_columns()`).

## Docstring fix
`Tableview.insert_rows` opened with `*row`, which docutils reads as an unterminated inline-emphasis start-string (fresh autodoc build fails under `-W`); it was also wrong — the parameter is `rowdata`.

Sphinx `-b html -W` builds clean (fresh, non-incremental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)