### PR TITLE
docs: add Text catalog page

### DIFF
--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -91,6 +91,12 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
 
       Read-only text or an image — captions, headings, status lines.
 
+   .. grid-item-card:: Text
+      :link: text
+      :link-type: doc
+
+      A multi-line editor — tags, marks, search, and undo.
+
    .. grid-item-card:: Progressbar
       :link: progressbar
       :link-type: doc
@@ -179,6 +185,7 @@ and to the deep :doc:`Style Reference </reference/style-reference/index>`.
    notebook
    panedwindow
    label
+   text
    progressbar
    scale
    scrollbar

--- a/docs/widgets/text.rst
+++ b/docs/widgets/text.rst
@@ -209,11 +209,26 @@ API & reference
 ---------------
 
 ``Text`` is tkinter's ``tk.Text`` — ttkbootstrap themes it but adds no Python
-API. For the full set of methods (``insert``, ``delete``, ``get``, ``index``,
-``search``, ``tag_*``, ``mark_*``, ``edit_*``, ``see``, ``bbox``, …) and options,
-see the
-`tkinter.Text <https://docs.python.org/3/library/tkinter.html>`__ documentation
-and the Tk ``text`` manual page.
+API. Its methods cover editing (``insert``, ``delete``, ``replace``, ``get``),
+positions (``index``, ``see``, ``bbox``), tags (``tag_add``, ``tag_configure``,
+``tag_bind``, ``tag_remove``, ``tag_names``), marks (``mark_set``, ``mark_gravity``,
+``mark_unset``), search (``search``), and the undo stack (``edit_undo``,
+``edit_redo``, ``edit_separator``, ``edit_modified``).
+
+The standard library reference doesn't document the text widget in full, so the
+authoritative sources are the Tk manuals:
+
+- `Tk text manual page <https://www.tcl-lang.org/man/tcl8.6/TkCmd/text.htm>`__ —
+  the canonical, complete reference. It's written in Tcl, so a subcommand like
+  ``tag configure`` is the Python method ``tag_configure`` (spaces become
+  underscores).
+- The tkinter-oriented walkthroughs by John Shipman are easier to read from
+  Python: `the text widget <https://tkdocs.com/shipman/text.html>`__,
+  `indices <https://tkdocs.com/shipman/text-index.html>`__,
+  `marks <https://tkdocs.com/shipman/text-mark.html>`__,
+  `tags <https://tkdocs.com/shipman/text-tag.html>`__,
+  `the undo stack <https://tkdocs.com/shipman/text-undo-stack.html>`__, and
+  `methods <https://tkdocs.com/shipman/text-methods.html>`__.
 
 .. seealso::
 

--- a/docs/widgets/text.rst
+++ b/docs/widgets/text.rst
@@ -187,7 +187,9 @@ To keep tkinter's default look and style the widget entirely yourself, pass
 Scrolling
 ---------
 
-A text widget doesn't scroll on its own. The quickest option is the ready-made
+A text widget already scrolls on its own — the mouse wheel, Page Up/Down, and
+the arrow keys move the view, and it follows the cursor as you type. What it
+doesn't show is a **scrollbar**. The quickest way to add one is the ready-made
 ``ScrolledText`` — a text widget with a scrollbar already wired in. It forwards
 the text methods (``insert``, ``get``, ``tag_*``, …) to the inner widget, so you
 use it just like a ``Text``:

--- a/docs/widgets/text.rst
+++ b/docs/widgets/text.rst
@@ -1,0 +1,220 @@
+Text
+====
+
+A **text** widget is a multi-line editor — anything from a comments box to a
+code pane. ``Text`` is tkinter's ``tk.Text``; ttkbootstrap themes it to match the
+active theme automatically (there is no ``bootstyle`` — it follows the theme, and
+you fine-tune with fonts, colors, and tags). This page covers inserting and
+reading text, indices, editing, tags for styled spans, marks, searching, undo,
+and appearance.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A text widget with several lines, one span highlighted by a tag, in light and
+   dark themes.
+
+Usage
+-----
+
+Create it with a size in ``width`` (characters) and ``height`` (lines), then
+``insert`` text at an index and ``get`` it back:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   text = ttk.Text(app, width=40, height=8)
+   text.pack(fill="both", expand=True, padx=10, pady=10)
+
+   text.insert("end", "Hello world\n")
+   text.insert("end", "A second line.\n")
+
+   print(text.get("1.0", "end-1c"))     # all the text, without the trailing newline
+
+   app.mainloop()
+
+Indices — pointing at a position
+--------------------------------
+
+Every position in a text widget is an **index**, written ``"line.column"`` —
+lines count from **1**, columns from **0**. So ``"1.0"`` is the very start and
+``"2.5"`` is line 2, column 5. Several names and modifiers make indices easy to
+express:
+
+- ``"end"`` — just past the last character (``"end-1c"`` is the last character
+  itself, since Text always keeps a trailing newline).
+- ``"insert"`` — where the blinking cursor is.
+- ``"1.0 lineend"`` / ``"insert linestart"`` — the end or start of a line.
+- ``"insert wordstart"`` / ``"insert +5c"`` — word boundaries and character
+  offsets.
+
+.. code-block:: python
+
+   text.get("insert linestart", "insert lineend")   # the current line's text
+   line_count = int(text.index("end-1c").split(".")[0])
+
+``index(expr)`` resolves any of these to a concrete ``"line.column"`` string.
+
+Editing
+-------
+
+``insert(index, text)`` adds text, ``delete(start, end)`` removes a range, and
+``replace(start, end, text)`` does both. Insert at ``"insert"`` to type where the
+cursor is, or at ``"end"`` to append:
+
+.. code-block:: python
+
+   text.insert("end", "appended\n")
+   text.delete("1.0", "2.0")                 # remove the first line
+   text.replace("1.0", "1.5", "Howdy")       # swap the first five characters
+
+To make the widget read-only, set its ``state`` to ``"disabled"`` — and back to
+``"normal"`` before editing from code, since a disabled widget **silently
+ignores** ``insert`` and ``delete`` too (no error, no change):
+
+.. code-block:: python
+
+   text.configure(state="disabled")          # read-only to the user
+   text.configure(state="normal")            # editable again
+
+Tags — styling spans
+--------------------
+
+A **tag** names a set of character ranges you can style and bind as a group.
+Configure the tag once, then apply it to any span with ``tag_add``:
+
+.. code-block:: python
+
+   text.tag_configure("warn", foreground="#d9534f", font=("TkDefaultFont", 10, "bold"))
+   text.tag_add("warn", "2.0", "2.7")        # style line 2, columns 0–7
+
+``tag_configure`` takes the same appearance options as the widget —
+``foreground``, ``background``, ``font``, ``underline``, ``justify``, spacing, and
+more. ``tag_remove`` strips a tag from a range; ``tag_names(index)`` lists the
+tags covering a position.
+
+Tags also carry **events**, which is how you make text clickable — bind an event
+to the tag and it fires for every span wearing it:
+
+.. code-block:: python
+
+   text.tag_configure("link", foreground="#0d6efd", underline=True)
+   text.tag_add("link", "1.0", "1.11")
+   text.tag_bind("link", "<Button-1>", lambda e: print("clicked the link"))
+
+Marks — floating positions
+--------------------------
+
+A **mark** is a named position that floats with the text as it changes — unlike a
+plain index, which is just a snapshot. ``"insert"`` (the cursor) and ``"end"`` are
+built-in marks; set your own with ``mark_set``:
+
+.. code-block:: python
+
+   text.mark_set("anchor", "insert")         # remember where the cursor is
+   text.insert("1.0", "prefix ")             # text shifts...
+   text.index("anchor")                      # ...and the mark moved with it
+
+Searching
+---------
+
+``search(pattern, start, stop)`` returns the index of the next match, or ``""`` if
+none. Pass a ``count`` variable to learn the match length, and ``nocase=True`` or
+``regexp=True`` to widen the match. To highlight **every** match, loop from each
+hit's end:
+
+.. code-block:: python
+
+   import tkinter as tk
+
+   def highlight_all(text, pattern):
+       text.tag_configure("hit", background="#fff3cd")
+       count = tk.IntVar()
+       start = "1.0"
+       while True:
+           pos = text.search(pattern, start, "end", count=count, nocase=True)
+           if not pos:
+               break
+           end = f"{pos}+{count.get()}c"
+           text.tag_add("hit", pos, end)
+           start = end
+
+Undo and redo
+-------------
+
+Create the widget with ``undo=True`` and Tk maintains an undo stack for you —
+``Ctrl+Z`` / ``Ctrl+Y`` work out of the box, and you can drive it from code with
+``edit_undo()`` / ``edit_redo()``. ``edit_separator()`` marks a boundary between
+undo steps, and ``edit_reset()`` clears the history:
+
+.. code-block:: python
+
+   text = ttk.Text(app, undo=True, autoseparators=True)
+
+   text.insert("end", "typed something")
+   text.edit_undo()                          # take it back
+
+``edit_modified()`` reports (or clears) whether the content has changed since it
+was last saved — handy for a "you have unsaved changes" prompt.
+
+Appearance
+----------
+
+The text widget picks up the theme's colors automatically and re-themes when you
+switch themes — you don't style it with ``bootstyle``. To customize, pass the
+usual tk options directly: ``font`` for the editor font, ``foreground`` /
+``background`` for the text and page colors, ``insertbackground`` for the cursor,
+``padx`` / ``pady`` for an inner margin, and ``wrap`` (``"word"``, ``"char"``, or
+``"none"``) for line wrapping:
+
+.. code-block:: python
+
+   ttk.Text(app, font=("Consolas", 11), wrap="word", padx=8, pady=8)
+
+For color that varies *within* the text — a highlighted span, a colored keyword —
+use tags, as above.
+
+To keep tkinter's default look and style the widget entirely yourself, pass
+``autostyle=False`` — it opts out of the automatic theming:
+
+.. code-block:: python
+
+   ttk.Text(app, autostyle=False, background="white", foreground="black")
+
+Scrolling
+---------
+
+A text widget doesn't scroll on its own. The quickest option is the ready-made
+``ScrolledText`` — a text widget with a scrollbar already wired in. It forwards
+the text methods (``insert``, ``get``, ``tag_*``, …) to the inner widget, so you
+use it just like a ``Text``:
+
+.. code-block:: python
+
+   text = ttk.ScrolledText(app, width=40, height=10, wrap="word", auto_hide=True)
+   text.pack(fill="both", expand=True, padx=10, pady=10)
+
+   text.insert("end", "a lot of text...\n")
+
+``auto_hide=True`` hides the scrollbar until the pointer is over the widget. To
+wire a plain :doc:`Scrollbar <scrollbar>` to a bare ``Text`` yourself, see
+:doc:`Scroll long content </user-guide/how-to/scrollable>`.
+
+API & reference
+---------------
+
+``Text`` is tkinter's ``tk.Text`` — ttkbootstrap themes it but adds no Python
+API. For the full set of methods (``insert``, ``delete``, ``get``, ``index``,
+``search``, ``tag_*``, ``mark_*``, ``edit_*``, ``see``, ``bbox``, …) and options,
+see the
+`tkinter.Text <https://docs.python.org/3/library/tkinter.html>`__ documentation
+and the Tk ``text`` manual page.
+
+.. seealso::
+
+   :doc:`Entry <entry>` for a single-line field, and
+   :doc:`Scroll long content </user-guide/how-to/scrollable>` for adding a
+   scrollbar.

--- a/docs/widgets/text.rst
+++ b/docs/widgets/text.rst
@@ -215,20 +215,11 @@ positions (``index``, ``see``, ``bbox``), tags (``tag_add``, ``tag_configure``,
 ``mark_unset``), search (``search``), and the undo stack (``edit_undo``,
 ``edit_redo``, ``edit_separator``, ``edit_modified``).
 
-The standard library reference doesn't document the text widget in full, so the
-authoritative sources are the Tk manuals:
-
-- `Tk text manual page <https://www.tcl-lang.org/man/tcl8.6/TkCmd/text.htm>`__ —
-  the canonical, complete reference. It's written in Tcl, so a subcommand like
-  ``tag configure`` is the Python method ``tag_configure`` (spaces become
-  underscores).
-- The tkinter-oriented walkthroughs by John Shipman are easier to read from
-  Python: `the text widget <https://tkdocs.com/shipman/text.html>`__,
-  `indices <https://tkdocs.com/shipman/text-index.html>`__,
-  `marks <https://tkdocs.com/shipman/text-mark.html>`__,
-  `tags <https://tkdocs.com/shipman/text-tag.html>`__,
-  `the undo stack <https://tkdocs.com/shipman/text-undo-stack.html>`__, and
-  `methods <https://tkdocs.com/shipman/text-methods.html>`__.
+The standard library reference doesn't document the text widget in full. The
+canonical, complete reference is the
+`Tk text manual page <https://www.tcl-lang.org/man/tcl8.6/TkCmd/text.htm>`__ —
+it's written in Tcl, so a subcommand like ``tag configure`` is the Python method
+``tag_configure`` (spaces become underscores).
 
 .. seealso::
 


### PR DESCRIPTION
Adds the **Text** catalog page — tkinter's `tk.Text`, one of the big tk-only topics. Robust and example-heavy per the authoring plan.

## Sections (usage-first)
- **Usage** — `insert` / `get`
- **Indices** — `"line.column"` (1-based line, 0-based column) + `end` / `insert` / `linestart` / `wordstart` / `+Nc` modifiers
- **Editing** — `insert` / `delete` / `replace`; read-only via `state="disabled"` (a disabled widget **silently ignores** edits — verified, no error/no change)
- **Tags** — styled spans (`tag_configure` / `tag_add`) and **clickable** text (`tag_bind`)
- **Marks** — floating positions vs. snapshot indices
- **Searching** — `search` with a `count` var, `nocase`, `regexp`, and a highlight-all loop
- **Undo/redo** — `undo=True`, `edit_undo`/`edit_redo`/`edit_separator`/`edit_modified`
- **Appearance** — auto theme colors (no `bootstyle`); `font`/`foreground`/`background`/`insertbackground`/`wrap`; `autostyle=False` to opt out of theming entirely
- **Scrolling** — the ready-made `ttk.ScrolledText` (`auto_hide`, forwards text methods to the inner widget) + link to the scroll how-to

## Grounding notes
Confirmed against the real API: `ttk.Text` **rejects** `bootstyle` but **accepts** `autostyle=` (auto-styled tk widget); `get("1.0", "end-1c")` strips the widget's mandatory trailing newline; a disabled Text ignores rather than errors on `insert`/`delete`; `ScrolledText` is re-exported as `ttk.ScrolledText`, uses `auto_hide` (snake_case), and delegates `insert`/`get`/`tag_*` to its inner Text.

Every snippet executed headlessly; fresh `sphinx -b html -W` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)