### PR TITLE
feat: bless tk Listbox as ttk.Listbox

### DIFF
--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -40,6 +40,7 @@ For more information, see: https://ttkbootstrap.readthedocs.io/
 from tkinter import (
     Menu as _tkMenu, Text as _tkText, Canvas as _tkCanvas, Tk as _tkTk,
     Frame as _tkFrame, LabelFrame as _tkLabelFrame, Label as _tkLabel,
+    Listbox as _tkListbox,
     Variable, StringVar, IntVar, BooleanVar, DoubleVar, PhotoImage
 )
 from tkinter.ttk import (
@@ -209,6 +210,10 @@ class Canvas(AutoStyleMixin, _tkCanvas):
     """tk Canvas with ttkbootstrap theming (accepts `autostyle=`)."""
 
 
+class Listbox(AutoStyleMixin, _tkListbox):
+    """tk Listbox with ttkbootstrap theming (accepts `autostyle=`)."""
+
+
 class TkFrame(AutoStyleMixin, _tkFrame):
     """tk Frame with ttkbootstrap theming (accepts `autostyle=`).
 
@@ -285,7 +290,7 @@ from tkinter import filedialog
 
 __all__ = [
     # Tk exports
-    "Tk", "Menu", "Text", "Canvas", "TkFrame", "TkLabel", "LabelFrame", "Variable", "StringVar", "IntVar", "BooleanVar",
+    "Tk", "Menu", "Text", "Canvas", "Listbox", "TkFrame", "TkLabel", "LabelFrame", "Variable", "StringVar", "IntVar", "BooleanVar",
     "DoubleVar", "PhotoImage",
 
     # TTk exports

--- a/tests/test_mixin_api.py
+++ b/tests/test_mixin_api.py
@@ -33,6 +33,22 @@ def test_blessed_tk_widget_is_autostylemixin_subclass():
     assert issubclass(ttk.Canvas, tkinter.Canvas)
 
 
+def test_listbox_is_blessed_autostyle_widget(root):
+    """Listbox is a blessed tk widget: AutoStyleMixin subclass, themed by
+    default, honors autostyle=False, and re-exported at the top level."""
+    assert issubclass(ttk.Listbox, AutoStyleMixin)
+    assert issubclass(ttk.Listbox, tkinter.Listbox)
+    assert "Listbox" in ttk.__all__
+
+    themed = ttk.Listbox(root)
+    assert hasattr(themed, "_theme_version")          # painted by the theme
+
+    raw = ttk.Listbox(root, autostyle=False, background="#abcdef")
+    assert getattr(raw, "_tb_no_autostyle", False) is True
+    assert not hasattr(raw, "_theme_version")
+    assert raw.cget("background") == "#abcdef"
+
+
 def test_stock_tkinter_is_unpatched_by_default(root):
     """Importing ttkbootstrap must not mutate the stock tkinter classes.
 


### PR DESCRIPTION
Adds **Listbox** to the blessed tk-widget set (`Tk`/`Menu`/`Text`/`Canvas`/`TkFrame`/`TkLabel`/`LabelFrame`) so it's reachable as `ttk.Listbox` and auto-themed like the others.

Prereq for the upcoming widget API-reference docs, where Listbox is now in scope.

## Change
- Import `tkinter.Listbox as _tkListbox`; add `class Listbox(AutoStyleMixin, _tkListbox)`; add `"Listbox"` to `__all__`.
- No styling code needed — `StyleBuilderTK.update_listbox_style` already exists, so `AutoStyleMixin` paints it via `winfo_class()` dispatch.

## Behavior (verified)
- Themed by default (bg `#ffffff`, fg `#212529` in the light theme).
- `autostyle=False` opts out → raw `SystemWindow` background, no theme stamp.
- Core Listbox API (`insert`/`curselection`/`get`/`size`/…) unaffected.

## Tests
`tests/test_mixin_api.py` +1 — subclass check, themed-by-default, `autostyle=False` opt-out, top-level re-export. **Full suite: 649 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)