### PR TITLE
docs: Windows reference — App and Toplevel

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,11 @@ exclude_patterns = [
     # Include-only styling partials pulled into each widget's API page; not
     # standalone documents.
     "reference/api/_style",
+    # Include-only window-method partials shared by the App/Toplevel/Tk pages.
+    "reference/windows/_wm-1.rst",
+    "reference/windows/_wm-2.rst",
+    "reference/windows/_theme.rst",
+    "reference/windows/_positioning.rst",
     "Thumbs.db",
     ".DS_Store",
 ]

--- a/docs/reference/api/tk.rst
+++ b/docs/reference/api/tk.rst
@@ -5,15 +5,15 @@ Tk
 re-exported as ``ttk.Tk``. It is the main window of an application and the top of
 the widget tree; creating it also starts the Tcl/Tk interpreter.
 
-.. admonition:: Prefer ``ttk.Window``
+.. admonition:: Prefer ``App``
    :class: tip
 
-   For applications, use :doc:`ttk.Window </user-guide/feature-guides/windows>`
-   (also exported as ``App``) instead of ``ttk.Tk``. ``Window`` folds size,
-   position, icon, and constraints into one constructor call and applies a theme
-   for you, so you rarely call the raw window-manager methods below. Keep **one**
-   root per program (the single-root rule); every other window is a
-   :doc:`Toplevel </user-guide/feature-guides/windows>`.
+   For applications, use :doc:`App </reference/windows/app>` (also exported as
+   ``Window``) instead of ``ttk.Tk``. ``App`` folds size, position, icon, and
+   constraints into one constructor call and applies a theme for you, so you
+   rarely call the raw window-manager methods below. Keep **one** root per program
+   (the single-root rule); every other window is a
+   :doc:`Toplevel </reference/windows/toplevel>`.
 
 Options
 -------
@@ -85,75 +85,14 @@ The root window takes the same surface options as a
 Window management
 -----------------
 
-The root window carries the full window-manager (``wm``) protocol — the same
-methods a :doc:`Toplevel </user-guide/feature-guides/windows>` has. The
-:doc:`Windows guide </user-guide/feature-guides/windows>` teaches these by
-building; the table below is the index.
+As the application's root window, ``Tk`` carries the full window-manager
+(``wm``) protocol below -- the same surface a :doc:`Toplevel
+</reference/windows/toplevel>` has. The :doc:`Windows guide
+</user-guide/feature-guides/windows>` teaches these by building.
 
-.. rubric:: Title, icon, and menu
+.. include:: /reference/windows/_wm-1.rst
 
-.. list-table::
-   :widths: 30 70
-
-   * - ``title(string=None)``
-     - Get or set the window title.
-   * - ``iconphoto(default, *images)``
-     - Set the window/taskbar icon from one or more ``PhotoImage`` objects.
-   * - ``iconbitmap(bitmap=None, default=None)``
-     - Set the window icon from a bitmap file.
-   * - ``iconname(newName=None)``
-     - Get or set the icon-window name.
-
-.. rubric:: Size and position
-
-.. list-table::
-   :widths: 30 70
-
-   * - ``geometry(newGeometry=None)``
-     - Get or set the window geometry as ``"WxH+X+Y"``.
-   * - ``minsize(width=None, height=None)``
-     - Get or set the minimum size.
-   * - ``maxsize(width=None, height=None)``
-     - Get or set the maximum size.
-   * - ``resizable(width=None, height=None)``
-     - Whether the user can resize the window horizontally / vertically.
-   * - ``aspect(...)``
-     - Constrain the window's width-to-height ratio.
-   * - ``grid(...)``
-     - Constrain the window to size in grid units.
-
-.. rubric:: State
-
-.. list-table::
-   :widths: 30 70
-
-   * - ``deiconify()``
-     - Show the window (restore from minimized/withdrawn).
-   * - ``iconify()``
-     - Minimize the window to an icon.
-   * - ``withdraw()``
-     - Remove the window from the screen without destroying it.
-   * - ``state(newstate=None)``
-     - Get or set the window state (``"normal"``, ``"iconic"``, ``"withdrawn"``,
-       ``"zoomed"``).
-   * - ``attributes(*args)``
-     - Get or set platform window attributes (``-alpha``, ``-topmost``,
-       ``-fullscreen``, …).
-   * - ``overrideredirect(boolean=None)``
-     - Remove the window's border and title bar (a bare window).
-
-.. rubric:: Relationships and protocols
-
-.. list-table::
-   :widths: 30 70
-
-   * - ``protocol(name=None, func=None)``
-     - Register a handler for a window-manager protocol, most often
-       ``"WM_DELETE_WINDOW"`` (the close button).
-   * - ``transient(master=None)``
-     - Mark the window as a transient (a dialog) of another.
-   * - ``group(pathName=None)``
-     - Assign the window to a window group.
+.. include:: /reference/windows/_wm-2.rst
 
 Shared capabilities
 -------------------
@@ -165,8 +104,6 @@ binding, lifecycle, focus, and introspection. These are documented under
 See also
 --------
 
-- :doc:`Windows </user-guide/feature-guides/windows>` — how to build and manage
-  windows with ``ttk.Window`` / ``ttk.Toplevel`` (the recommended API).
-- `Tk toplevel <https://www.tcl-lang.org/man/tcl8.6/TkCmd/toplevel.htm>`__ and
-  `wm <https://www.tcl-lang.org/man/tcl8.6/TkCmd/wm.htm>`__ manual pages — the
-  canonical upstream reference (Tcl 8.6).
+- :doc:`App </reference/windows/app>` / :doc:`Toplevel </reference/windows/toplevel>`
+  — the ttkbootstrap window classes (the recommended API), and
+  :doc:`Windows </user-guide/feature-guides/windows>` for how to use them.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -14,6 +14,13 @@ The lookup layer:
       native ttk widgets, the ones ttkbootstrap ships, and the classic tk
       widgets, grouped by what they do.
 
+   .. grid-item-card:: Windows
+      :link: windows/index
+      :link-type: doc
+
+      The application window classes — ``App`` (the root) and ``Toplevel`` — and
+      their constructor, theme, and window-management surface.
+
    .. grid-item-card:: Capabilities
       :link: capabilities/index
       :link-type: doc
@@ -40,6 +47,7 @@ The lookup layer:
    :hidden:
 
    api/index
+   windows/index
    capabilities/index
    events/index
    cursors

--- a/docs/reference/windows/_positioning.rst
+++ b/docs/reference/windows/_positioning.rst
@@ -1,0 +1,12 @@
+.. The ttkbootstrap positioning helper, included on the App and Toplevel pages
+   right after the inherited Size and position methods (so it reads as part of
+   that group). Not a standalone document.
+
+.. py:method:: place_window_center()
+   :noindex:
+
+   Center the window on the screen — the monitor under the cursor when
+   ``screeninfo`` is installed — clamped to stay fully visible. A ttkbootstrap
+   convenience over :py:meth:`geometry`. Alias: ``position_center()``.
+
+   :returns: ``None``.

--- a/docs/reference/windows/_theme.rst
+++ b/docs/reference/windows/_theme.rst
@@ -1,0 +1,48 @@
+.. Shared ttkbootstrap theme methods, included by the App and Toplevel reference
+   pages. Not a standalone document.
+
+.. py:attribute:: style
+   :noindex:
+
+   The application's ``Style`` engine (a property) — drop to it for colors,
+   ``configure``, registering themes, and the custom-style toolkit (see
+   :doc:`Custom styles </user-guide/feature-guides/custom-styles>`).
+
+.. py:method:: theme_use(themename=None)
+   :noindex:
+
+   Switch to ``themename``, or return the current theme name when called with no
+   argument.
+
+   :param themename: the theme to switch to.
+   :returns: the current theme name.
+
+.. py:method:: theme_names()
+   :noindex:
+
+   List every registered theme name.
+
+   :returns: a list of theme names.
+
+.. py:attribute:: theme_mode
+   :noindex:
+
+   The active theme mode (a property). Assign ``"light"`` or ``"dark"`` to switch
+   to the corresponding theme of the configured pair.
+
+.. py:method:: set_theme_modes(light=None, dark=None)
+   :noindex:
+
+   Designate the light/dark theme pair that :py:attr:`theme_mode` and
+   :py:meth:`toggle_theme` switch between.
+
+   :param light: the light theme name.
+   :param dark: the dark theme name.
+   :returns: ``None``.
+
+.. py:method:: toggle_theme()
+   :noindex:
+
+   Toggle between the configured light and dark themes.
+
+   :returns: the new mode (``"light"`` or ``"dark"``).

--- a/docs/reference/windows/_wm-1.rst
+++ b/docs/reference/windows/_wm-1.rst
@@ -1,0 +1,139 @@
+.. Shared window-manager (wm) specs, part 1 (title/icon + size/position),
+   included by the App, Toplevel, and Tk pages. The window pages slot
+   place_window_center in after this, under Size and position. Not standalone.
+
+.. rubric:: Title, icon, and taskbar
+
+.. py:method:: title(string=None)
+   :noindex:
+
+   Set the window's title-bar text, or return the current title when called with
+   no argument.
+
+   :param string: the new title.
+   :returns: the current title when queried, otherwise ``None``.
+
+.. py:method:: iconphoto(default=False, *images)
+   :noindex:
+
+   Set the title-bar / taskbar icon from one or more ``PhotoImage`` objects (Tk
+   picks the best size). Pass ``default=True`` to make it the default icon for
+   this window and every toplevel created afterward.
+
+   :param default: make this the application-wide default icon.
+   :param images: one or more ``PhotoImage`` objects.
+   :returns: ``None``.
+
+.. py:method:: iconbitmap(bitmap=None, default=None)
+   :noindex:
+
+   Set the window icon from a bitmap. On Windows, ``default`` accepts a ``.ico``
+   path and applies it to this window and its future toplevels. Called with no
+   argument, returns the current icon bitmap.
+
+   :param bitmap: the bitmap for this window.
+   :param default: (Windows) a ``.ico`` path applied as the default icon.
+   :returns: the current bitmap when queried, otherwise ``None``.
+
+.. py:method:: iconname(newName=None)
+   :noindex:
+
+   Set the name shown with the window's icon (when minimized), or return it.
+
+   :returns: the current icon name when queried, otherwise ``None``.
+
+.. py:method:: iconmask(bitmap=None)
+   :noindex:
+
+   Set the mask bitmap that controls which pixels of the icon are drawn, or
+   return the current mask.
+
+   :returns: the current mask when queried, otherwise ``None``.
+
+.. py:method:: iconposition(x=None, y=None)
+   :noindex:
+
+   Hint to the window manager where to place the window's icon. Advisory — many
+   window managers ignore it.
+
+   :returns: ``None``.
+
+.. py:method:: iconwindow(pathName=None)
+   :noindex:
+
+   Use another window as the icon for this one, or return the current icon
+   window. Rarely supported on modern desktops.
+
+   :returns: the current icon window when queried, otherwise ``None``.
+
+.. rubric:: Size and position
+
+.. py:method:: geometry(newGeometry=None)
+   :noindex:
+
+   Set the window's size and position as a ``"WxH+X+Y"`` string (any part may be
+   omitted, e.g. ``"400x300"`` or ``"+100+100"``), or return the current geometry.
+
+   :param newGeometry: a geometry string such as ``"640x480+200+120"``.
+   :returns: the current geometry string when queried, otherwise ``None``.
+
+.. py:method:: minsize(width=None, height=None)
+   :noindex:
+
+   Set the smallest size the user may resize the window to, or return the current
+   minimum as ``(width, height)``.
+
+   :returns: the current minimum when queried, otherwise ``None``.
+
+.. py:method:: maxsize(width=None, height=None)
+   :noindex:
+
+   Set the largest size the user may resize the window to, or return the current
+   maximum as ``(width, height)``.
+
+   :returns: the current maximum when queried, otherwise ``None``.
+
+.. py:method:: resizable(width=None, height=None)
+   :noindex:
+
+   Set whether the user may resize the window horizontally and vertically (two
+   booleans), or return the current pair.
+
+   :param width: allow horizontal resizing.
+   :param height: allow vertical resizing.
+   :returns: the current ``(width, height)`` flags when queried, otherwise ``None``.
+
+.. py:method:: aspect(minNumer=None, minDenom=None, maxNumer=None, maxDenom=None)
+   :noindex:
+
+   Constrain the window's width-to-height ratio between ``minNumer/minDenom`` and
+   ``maxNumer/maxDenom``, or return the current constraint. Call with no arguments
+   to clear it.
+
+   :returns: the current aspect constraint when queried, otherwise ``None``.
+
+.. py:method:: grid(baseWidth=None, baseHeight=None, widthInc=None, heightInc=None)
+   :noindex:
+
+   Ask the window manager to report and constrain the window's size in **grid
+   units** of ``widthInc`` × ``heightInc`` pixels (used by text-grid apps like a
+   terminal), or return the current setting.
+
+   :returns: the current grid setting when queried, otherwise ``None``.
+
+.. py:method:: sizefrom(who=None)
+   :noindex:
+
+   Set who is considered to have specified the window's size — ``"program"`` or
+   ``"user"`` — or return the current value. Affects how the window manager treats
+   the size.
+
+   :returns: the current value when queried, otherwise ``None``.
+
+.. py:method:: positionfrom(who=None)
+   :noindex:
+
+   Set who is considered to have specified the window's position — ``"program"``
+   or ``"user"`` — or return the current value.
+
+   :returns: the current value when queried, otherwise ``None``.

--- a/docs/reference/windows/_wm-2.rst
+++ b/docs/reference/windows/_wm-2.rst
@@ -1,0 +1,151 @@
+.. Shared window-manager (wm) specs, part 2 (state/attributes/relationships/
+   embedding), included after the size/position group. Not standalone.
+
+.. rubric:: State and visibility
+
+.. py:method:: deiconify()
+   :noindex:
+
+   Show the window, restoring it from a minimized or withdrawn state and raising
+   it.
+
+   :returns: ``None``.
+
+.. py:method:: iconify()
+   :noindex:
+
+   Minimize the window to an icon.
+
+   :returns: ``None``.
+
+.. py:method:: withdraw()
+   :noindex:
+
+   Remove the window from the screen without destroying it (unmapped). Restore it
+   with :py:meth:`deiconify`.
+
+   :returns: ``None``.
+
+.. py:method:: state(newstate=None)
+   :noindex:
+
+   Set the window state — ``"normal"``, ``"iconic"`` (minimized), ``"withdrawn"``,
+   or ``"zoomed"`` (maximized, Windows/macOS) — or return the current state.
+
+   :returns: the current state when queried, otherwise ``None``.
+
+.. py:method:: overrideredirect(boolean=None)
+   :noindex:
+
+   Set whether the window manager ignores the window — a truthy value removes the
+   border and title bar (a bare window, e.g. a splash) — or return the current
+   flag. Ignored on macOS, where it destabilizes Tk.
+
+   :param boolean: ``True`` for a borderless window.
+   :returns: the current flag when queried, otherwise ``None``.
+
+.. rubric:: Attributes
+
+.. py:method:: attributes(*args)
+   :noindex:
+
+   Get or set platform window attributes. Call ``attributes("-alpha")`` to read
+   one, or ``attributes("-alpha", 0.9)`` to set it. Common options:
+
+   - ``-alpha`` — opacity, ``0.0``–``1.0``.
+   - ``-topmost`` — keep above all other windows.
+   - ``-fullscreen`` — fill the screen with no chrome.
+   - ``-disabled`` — block input to the window.
+   - ``-toolwindow`` — (Windows) a thin tool-window title bar, no taskbar entry.
+   - ``-type`` — (X11) the window type, e.g. ``"dialog"`` or ``"splash"``.
+
+   :returns: the requested attribute value when reading, otherwise ``None``.
+
+.. rubric:: Relationships and protocols
+
+.. py:method:: protocol(name=None, func=None)
+   :noindex:
+
+   Register ``func`` as the handler for a window-manager protocol — most often
+   ``"WM_DELETE_WINDOW"`` (the close button), letting you confirm or veto a close.
+   Call with only ``name`` to return the current handler.
+
+   :param name: the protocol, e.g. ``"WM_DELETE_WINDOW"`` or ``"WM_TAKE_FOCUS"``.
+   :param func: the callback to run when the protocol fires.
+   :returns: the current handler name when queried, otherwise ``None``.
+
+.. py:method:: transient(master=None)
+   :noindex:
+
+   Mark the window as a **transient** of ``master`` — a dependent window (a dialog
+   or picker) that stays above its owner and minimizes with it — or return the
+   current master.
+
+   :param master: the owning window.
+   :returns: the current master when queried, otherwise ``None``.
+
+.. py:method:: group(pathName=None)
+   :noindex:
+
+   Add the window to the window group led by ``pathName`` so a window manager can
+   treat the group as a unit, or return the current group leader.
+
+   :returns: the current group leader when queried, otherwise ``None``.
+
+.. py:method:: client(name=None)
+   :noindex:
+
+   Set the ``WM_CLIENT_MACHINE`` property (the host name the app runs on) for
+   remote-display setups, or return it. X11 only.
+
+   :returns: the current value when queried, otherwise ``None``.
+
+.. py:method:: command(value=None)
+   :noindex:
+
+   Set the ``WM_COMMAND`` property — the command line that could restart the app,
+   used by session managers — or return it. X11 only.
+
+   :returns: the current value when queried, otherwise ``None``.
+
+.. py:method:: colormapwindows(*wlist)
+   :noindex:
+
+   Set the ``WM_COLORMAP_WINDOWS`` list — the child windows whose colormaps the
+   window manager should install — or return the current list. X11, rarely needed.
+
+   :returns: the current list when queried, otherwise ``None``.
+
+.. py:method:: focusmodel(model=None)
+   :noindex:
+
+   Set the window's focus model — ``"active"`` or ``"passive"`` — or return it.
+   Governs how the window accepts keyboard focus from the window manager.
+
+   :returns: the current model when queried, otherwise ``None``.
+
+.. rubric:: Embedding (advanced)
+
+.. py:method:: frame()
+   :noindex:
+
+   Return the platform window identifier of the outermost decorative frame the
+   window manager drew around this window (or the window's own id if none).
+
+   :returns: a platform window id (a string).
+
+.. py:method:: manage(widget)
+   :noindex:
+
+   Turn a previously :py:meth:`forget`-ten or embedded ``widget`` into a managed
+   toplevel window.
+
+   :returns: ``None``.
+
+.. py:method:: forget(window)
+   :noindex:
+
+   Unmap a managed toplevel and hand it back to its parent's geometry manager (the
+   inverse of :py:meth:`manage`).
+
+   :returns: ``None``.

--- a/docs/reference/windows/app.rst
+++ b/docs/reference/windows/app.rst
@@ -1,0 +1,133 @@
+App
+===
+
+``App`` is the ttkbootstrap application **root window** (also exported as
+``Window``). It wraps tkinter's ``tk.Tk`` — folding the theme, title, icon, size,
+position, and window constraints into a single constructor — and starts the
+Tcl/Tk interpreter.
+
+Keep **one** ``App`` per process. The style engine is a process-wide singleton
+bound to the first root, so a second root would silently stop theming. Every
+other window is a
+:doc:`Toplevel </reference/windows/toplevel>`.
+
+Options
+-------
+
+Set these on the constructor — ``App(title="ttkbootstrap", theme=None,
+**options)``, where ``title`` and ``theme`` may be passed positionally and every
+other option is keyword-only.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``title``
+     - ``str``
+     - The text shown on the window's title bar. Default ``"ttkbootstrap"``.
+   * - ``theme`` (``themename``)
+     - ``str``
+     - The ttkbootstrap theme to apply. Defaults to ``bootstrap-light``.
+   * - ``light_theme``
+     - ``str``
+     - The light theme the :py:meth:`toggle_theme` / :py:attr:`theme_mode` pair
+       switches to.
+   * - ``dark_theme``
+     - ``str``
+     - The dark theme the light/dark toggle switches to.
+   * - ``default_button``
+     - ``str``
+     - The color a bare ``Button``/``Menubutton`` (no ``bootstyle``) uses.
+       Default ``"neutral"``; pass ``"primary"`` for the pre-2.0 accented default.
+   * - ``iconphoto``
+     - ``str``
+     - Path to the title-bar / taskbar icon image, applied application-wide.
+       ``""`` (default) uses the ttkbootstrap brand icon; ``None`` leaves the
+       icon untouched so you can call ``iconphoto``/``iconbitmap`` yourself.
+   * - ``size``
+     - ``tuple``
+     - The window's ``(width, height)`` in pixels.
+   * - ``position``
+     - ``tuple``
+     - The window's ``(x, y)`` position relative to the top-left. Negative values
+       are edge-relative — ``(-10, -10)`` sits near the bottom-right.
+   * - ``minsize``
+     - ``tuple``
+     - The minimum ``(width, height)`` the user may resize the window to.
+   * - ``maxsize``
+     - ``tuple``
+     - The maximum ``(width, height)`` the user may resize the window to.
+   * - ``resizable``
+     - ``tuple``
+     - A ``(horizontal, vertical)`` pair of booleans controlling whether the user
+       may resize each dimension.
+   * - ``high_dpi``
+     - ``bool``
+     - Enable high-DPI awareness (Windows). Default ``True``.
+   * - ``scaling``
+     - ``float``
+     - The Tk scaling factor — pixels per point — for converting physical units
+       to pixels.
+   * - ``transient``
+     - ``Widget``
+     - Mark the window as transient with respect to another window.
+   * - ``override_redirect``
+     - ``bool``
+     - Remove the border and title bar (a bare window). Ignored on macOS, where
+       it destabilizes Tk. Default ``False``.
+   * - ``alpha``
+     - ``float``
+     - The window's opacity, ``0.0``–``1.0``. Default ``1.0`` (opaque).
+
+Theming
+-------
+
+``App`` adds application-wide theme control; drop to :py:attr:`style` for the
+full engine.
+
+.. include:: /reference/windows/_theme.rst
+
+Lifecycle
+---------
+
+.. py:method:: destroy()
+   :noindex:
+
+   Destroy the window and all its children. As the application root, this also
+   resets the ttkbootstrap style engine and named-font cache, so a later root
+   rebinds them cleanly.
+
+   :returns: ``None``.
+
+Window management
+-----------------
+
+Every window carries the full window-manager (``wm``) protocol below — its title,
+icon, size, position, state, and relationships. The common ones fold into the
+constructor above; the :doc:`Windows guide </user-guide/feature-guides/windows>`
+teaches them by building.
+
+.. include:: /reference/windows/_wm-1.rst
+
+.. include:: /reference/windows/_positioning.rst
+
+.. include:: /reference/windows/_wm-2.rst
+
+Shared capabilities
+-------------------
+
+``App`` also has the methods every widget inherits — configuration, event
+binding, lifecycle, focus, and introspection. These are documented under
+:doc:`Capabilities </reference/capabilities/index>`.
+
+See also
+--------
+
+- :doc:`Toplevel </reference/windows/toplevel>` — every window other than the root.
+- :doc:`Windows </user-guide/feature-guides/windows>` — how to build and manage
+  windows, step by step.
+- :doc:`Tk </reference/api/tk>` — the classic ``tk.Tk`` root and its full
+  window-manager surface.

--- a/docs/reference/windows/index.rst
+++ b/docs/reference/windows/index.rst
@@ -1,0 +1,30 @@
+Windows
+=======
+
+The application window classes. ``App`` is the root — one per process, paired
+with the style engine — and ``Toplevel`` is every window after it. Both wrap
+their tkinter counterparts and fold the theme, icon, size, position, and window
+constraints into one constructor. The :doc:`Windows guide
+</user-guide/feature-guides/windows>` teaches them by building; these pages are
+the lookup.
+
+.. grid:: 1 2 2 2
+   :gutter: 3
+
+   .. grid-item-card:: App
+      :link: app
+      :link-type: doc
+
+      The application root window (also exported as ``Window``).
+
+   .. grid-item-card:: Toplevel
+      :link: toplevel
+      :link-type: doc
+
+      A secondary window — dialogs, pickers, tool windows.
+
+.. toctree::
+   :hidden:
+
+   app
+   toplevel

--- a/docs/reference/windows/toplevel.rst
+++ b/docs/reference/windows/toplevel.rst
@@ -1,0 +1,108 @@
+Toplevel
+========
+
+``Toplevel`` is a secondary window — every application window other than the
+:doc:`App </reference/windows/app>` root. It wraps tkinter's ``tk.Toplevel``,
+inherits the application theme and icon, and folds size, position, constraints,
+and platform window hints into a single constructor.
+
+Options
+-------
+
+Set these on the constructor — ``Toplevel(title="ttkbootstrap", **options)``,
+where ``title`` may be passed positionally and every other option is keyword-only.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``title``
+     - ``str``
+     - The text shown on the window's title bar. Default ``"ttkbootstrap"``.
+   * - ``iconphoto``
+     - ``str``
+     - Path to the title-bar icon image for this window. ``""`` (default)
+       inherits the application icon; ``None`` leaves the icon untouched.
+   * - ``size``
+     - ``tuple``
+     - The window's ``(width, height)`` in pixels.
+   * - ``position``
+     - ``tuple``
+     - The window's ``(x, y)`` position relative to the top-left. Negative values
+       are edge-relative — ``(-10, -10)`` sits near the bottom-right.
+   * - ``minsize``
+     - ``tuple``
+     - The minimum ``(width, height)`` the user may resize the window to.
+   * - ``maxsize``
+     - ``tuple``
+     - The maximum ``(width, height)`` the user may resize the window to.
+   * - ``resizable``
+     - ``tuple``
+     - A ``(horizontal, vertical)`` pair of booleans controlling whether the user
+       may resize each dimension.
+   * - ``transient``
+     - ``Widget``
+     - Mark the window as transient with respect to another window (typical for a
+       dialog owned by the main window).
+   * - ``override_redirect``
+     - ``bool``
+     - Remove the border and title bar (a bare window). Ignored on macOS. Default
+       ``False``.
+   * - ``window_type``
+     - ``str``
+     - A window-type hint. On X11 it sets the ``-type`` attribute (``"dialog"``,
+       ``"splash"``, ``"utility"``, …); on macOS the borderless types
+       (``"tooltip"``, ``"splash"``, ``"utility"``, ``"dock"``) map to a native
+       window class with a real shadow and no title bar.
+   * - ``topmost``
+     - ``bool``
+     - Keep the window above all others. Default ``False``.
+   * - ``tool_window``
+     - ``bool``
+     - On Windows, use the tool-window style (a thin title bar, no taskbar entry).
+       Default ``False``.
+   * - ``iconify``
+     - ``bool``
+     - Start the window minimized. Default ``False``.
+   * - ``alpha``
+     - ``float``
+     - The window's opacity, ``0.0``–``1.0``. Default ``1.0`` (opaque).
+
+Theming
+-------
+
+A ``Toplevel`` shares the application-wide theme control of
+:doc:`App </reference/windows/app>` — switching the theme from any window
+re-themes them all.
+
+.. include:: /reference/windows/_theme.rst
+
+Window management
+-----------------
+
+Every window carries the full window-manager (``wm``) protocol below. The common
+ones fold into the constructor above; the :doc:`Windows guide
+</user-guide/feature-guides/windows>` teaches them by building.
+
+.. include:: /reference/windows/_wm-1.rst
+
+.. include:: /reference/windows/_positioning.rst
+
+.. include:: /reference/windows/_wm-2.rst
+
+Shared capabilities
+-------------------
+
+``Toplevel`` also has the methods every widget inherits — configuration, event
+binding, lifecycle, focus, and introspection. These are documented under
+:doc:`Capabilities </reference/capabilities/index>`.
+
+See also
+--------
+
+- :doc:`App </reference/windows/app>` — the application root window.
+- :doc:`Windows </user-guide/feature-guides/windows>` — how to build and manage
+  windows, step by step.


### PR DESCRIPTION
Adds the **Windows** section to the API reference (Workstream H) — the application window classes, hand-written and fully documented.

## What's here

New `docs/reference/windows/` section (**App** — the root, aka `Window` — and **Toplevel**), added as a top-level card + toctree on the Reference landing. Each page documents, in full:

- **Options** — the keyword-only constructor as a flat typed table (matching the widget pages' heading).
- **Theming** — the ttkbootstrap-added `style` / `theme_use` / `theme_names` / `theme_mode` / `set_theme_modes` / `toggle_theme`.
- **Lifecycle** (App) — the `destroy` override that resets the style engine + font cache.
- **Window management** — the complete 30-method `wm` protocol (`title`/`geometry`/`state`/`attributes`/`protocol`/`iconify`/`transient`/…) as full `py:method` specs, authored here rather than deferred to tcl/tk, with `place_window_center` slotted into the **Size and position** group.

Shared surfaces are factored into include-only partials (`_theme`, `_wm-1`, `_wm-2`, `_positioning`) so App/Toplevel are each complete without duplication, and `tk.rst` pulls the same `wm` specs (its previous compact index + tcl/tk "canonical reference" pointer are gone — we document these ourselves now). `tk.rst`'s "Prefer `App`" admonition / See also now point at the new pages.

Grounded against the live `window.py` (constructors, keyword-only params, the `themename`/`override_redirect`/`window_type`/`tool_window` aliases, macOS `window_type` behavior, the single-root rule) and `tkinter.Wm` (the 30-method surface + signatures).

## Verification

- `sphinx -b html -W -q -E docs` — clean (exit 0).

Stacked context: follows #1188 (already merged). Remaining reference sections (Dialogs & overlays, Styling, Theming, Imaging, Localization, Fonts, Validation, Utilities) are tracked in `development/2_0_docs_api_reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)