### PR TITLE
docs: Dialogs & overlays reference

### DIFF
--- a/docs/reference/api/index.rst
+++ b/docs/reference/api/index.rst
@@ -256,26 +256,6 @@ Show text, images, and custom graphics.
 
       The classic ``tk.Canvas`` drawing surface — items, tags, and their methods.
 
-Overlays
---------
-
-Transient popups layered over the UI.
-
-.. grid:: 1 2 2 2
-   :gutter: 3
-
-   .. grid-item-card:: ToastNotification
-      :link: toastnotification
-      :link-type: doc
-
-      A temporary popup alert.
-
-   .. grid-item-card:: ToolTip
-      :link: tooltip
-      :link-type: doc
-
-      A hover popup attached to a widget.
-
 .. toctree::
    :hidden:
    :maxdepth: 1
@@ -312,5 +292,3 @@ Transient popups layered over the UI.
    label
    tklabel
    canvas
-   toastnotification
-   tooltip

--- a/docs/reference/dialogs/dialog-classes.rst
+++ b/docs/reference/dialogs/dialog-classes.rst
@@ -1,0 +1,236 @@
+Dialog classes
+==============
+
+These are the dialog classes behind the :doc:`Messagebox </reference/dialogs/messagebox>`
+and :doc:`Querybox </reference/dialogs/querybox>` facades. Use them directly when
+you need full control over a dialog, or subclass ``Dialog`` to build your own.
+
+Dialog
+------
+
+``Dialog`` is the base for custom dialogs. Subclass it and implement
+:py:meth:`create_body` and :py:meth:`create_buttonbox`, set ``self._result``,
+then call :py:meth:`show`; the outcome is read from :py:attr:`result` after
+``show`` returns.
+
+Options
+~~~~~~~
+
+Construct with ``Dialog(parent=None, title="", alert=False)``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``parent``
+     - ``Widget``
+     - The window to center over and block while open. Defaults to the
+       application root.
+   * - ``title``
+     - ``str``
+     - The text shown on the dialog's title bar.
+   * - ``alert``
+     - ``bool``
+     - Ring the display bell when the dialog appears.
+
+Methods
+~~~~~~~
+
+.. py:method:: show(position=None, wait_for_result=True)
+   :noindex:
+
+   Build and display the dialog modally.
+
+   :param position: An ``(x, y)`` top-left screen position. Centered on
+      ``parent`` by default.
+   :param wait_for_result: Block until the dialog is closed. Default ``True``.
+   :returns: ``None``. Read :py:attr:`result` after it returns.
+
+.. py:method:: build()
+   :noindex:
+
+   Construct the dialog window and its body and button box. Called by
+   :py:meth:`show`.
+
+   :returns: ``None``.
+
+.. py:method:: close()
+   :noindex:
+
+   Close the dialog and release its grab.
+
+   :returns: ``None``.
+
+.. py:method:: create_body(master)
+   :noindex:
+
+   Override hook. Subclasses build the dialog's body widgets here.
+
+   :param master: The parent widget for the body content.
+   :returns: ``None``.
+
+.. py:method:: create_buttonbox(master)
+   :noindex:
+
+   Override hook. Subclasses build the button row here.
+
+   :param master: The parent widget for the button box.
+   :returns: ``None``.
+
+.. py:attribute:: result
+   :noindex:
+
+   The dialog's outcome, set by the subclass. Read it after :py:meth:`show`
+   returns.
+
+MessageDialog
+-------------
+
+``MessageDialog`` is a configurable message dialog — the class
+:doc:`Messagebox </reference/dialogs/messagebox>` builds. Use it directly for
+custom button sets and colors.
+
+Options
+~~~~~~~
+
+Construct with ``MessageDialog(message, title=" ", buttons=None, command=None,
+width=50, parent=None, alert=False, default=None, padding=(20, 20), icon=None)``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``message``
+     - ``str``
+     - The message text.
+   * - ``title``
+     - ``str``
+     - The text shown on the dialog's title bar.
+   * - ``buttons``
+     - ``list``
+     - The button labels, each optionally ``"label:bootstyle"`` to color it
+       (e.g. ``"OK:success"``). The clicked label becomes :py:attr:`result`.
+   * - ``command``
+     - ``callable``
+     - A callback invoked when a button is pressed.
+   * - ``width``
+     - ``int``
+     - The message wrap width in characters.
+   * - ``parent``
+     - ``Widget``
+     - The window to center over and block while open.
+   * - ``alert``
+     - ``bool``
+     - Ring the display bell when the dialog appears.
+   * - ``default``
+     - ``str``
+     - The label of the button focused by default.
+   * - ``padding``
+     - ``int | tuple``
+     - Padding around the content.
+   * - ``icon``
+     - ``str``
+     - A Bootstrap Icons glyph name shown beside the message.
+
+Methods
+~~~~~~~
+
+.. py:method:: show(position=None, wait_for_result=True)
+   :noindex:
+
+   Build and display the dialog modally.
+
+   :param position: An ``(x, y)`` top-left screen position. Centered on
+      ``parent`` by default.
+   :param wait_for_result: Block until the dialog is closed. Default ``True``.
+   :returns: ``None``. Read :py:attr:`result` after it returns.
+
+.. py:attribute:: result
+   :noindex:
+
+   The clicked button's text, or ``None`` if the dialog is closed.
+
+QueryDialog
+-----------
+
+``QueryDialog`` is a configurable input dialog — the class
+:doc:`Querybox </reference/dialogs/querybox>` builds. It collects a typed value,
+or a choice from a list.
+
+Options
+~~~~~~~
+
+Construct with ``QueryDialog(prompt, title=" ", initialvalue="", minvalue=None,
+maxvalue=None, width=65, datatype=str, padding=(20, 20), parent=None,
+items=None)``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``prompt``
+     - ``str``
+     - The label shown above the input.
+   * - ``title``
+     - ``str``
+     - The text shown on the dialog's title bar.
+   * - ``initialvalue``
+     - ``any``
+     - The value the input starts with.
+   * - ``minvalue``
+     - ``any``
+     - The smallest accepted value (numeric datatypes).
+   * - ``maxvalue``
+     - ``any``
+     - The largest accepted value (numeric datatypes).
+   * - ``width``
+     - ``int``
+     - The entry width in characters.
+   * - ``datatype``
+     - ``type``
+     - The type the input is validated and cast to (``str``, ``int``,
+       ``float``).
+   * - ``padding``
+     - ``int | tuple``
+     - Padding around the content.
+   * - ``parent``
+     - ``Widget``
+     - The window to center over and block while open.
+   * - ``items``
+     - ``list``
+     - If given, the user chooses from this list instead of typing.
+
+Methods
+~~~~~~~
+
+.. py:method:: show(position=None, wait_for_result=True)
+   :noindex:
+
+   Build and display the dialog modally.
+
+   :param position: An ``(x, y)`` top-left screen position. Centered on
+      ``parent`` by default.
+   :param wait_for_result: Block until the dialog is closed. Default ``True``.
+   :returns: ``None``. Read :py:attr:`result` after it returns.
+
+.. py:attribute:: result
+   :noindex:
+
+   The entered or chosen value cast to ``datatype``, or ``None`` if cancelled.
+
+See also
+--------
+
+- :doc:`Dialogs </user-guide/feature-guides/dialogs>` — how to use them, with
+  examples.
+- :doc:`Messagebox </reference/dialogs/messagebox>` — the message-dialog facade.
+- :doc:`Querybox </reference/dialogs/querybox>` — the input-and-picker facade.

--- a/docs/reference/dialogs/index.rst
+++ b/docs/reference/dialogs/index.rst
@@ -1,0 +1,56 @@
+Dialogs & overlays
+==================
+
+Modal dialogs for messages, input, and pickers, plus the transient overlays —
+toasts and tooltips. The :doc:`Dialogs guide </user-guide/feature-guides/dialogs>`
+teaches them by building; these pages are the lookup.
+
+.. grid:: 1 2 2 2
+   :gutter: 3
+
+   .. grid-item-card:: Messagebox
+      :link: messagebox
+      :link-type: doc
+
+      Show a message and get the clicked button.
+
+   .. grid-item-card:: Querybox
+      :link: querybox
+      :link-type: doc
+
+      Ask for a string, number, date, color, font, or file.
+
+   .. grid-item-card:: Dialog classes
+      :link: dialog-classes
+      :link-type: doc
+
+      ``MessageDialog``, ``QueryDialog``, and the ``Dialog`` base for custom
+      dialogs.
+
+   .. grid-item-card:: Pickers
+      :link: pickers
+      :link-type: doc
+
+      The date, font, and color dialogs.
+
+   .. grid-item-card:: ToastNotification
+      :link: toast
+      :link-type: doc
+
+      A temporary popup alert.
+
+   .. grid-item-card:: ToolTip
+      :link: tooltip
+      :link-type: doc
+
+      A hover popup attached to a widget.
+
+.. toctree::
+   :hidden:
+
+   messagebox
+   querybox
+   dialog-classes
+   pickers
+   toast
+   tooltip

--- a/docs/reference/dialogs/messagebox.rst
+++ b/docs/reference/dialogs/messagebox.rst
@@ -1,0 +1,121 @@
+Messagebox
+==========
+
+``Messagebox`` shows a modal message dialog and returns which button the user
+clicked. Every method is a **static method** — call it on the class, no instance
+needed (``Messagebox.show_info("Saved.")``). Each blocks until the user responds
+and returns the clicked button's text, or ``None`` if the dialog is closed.
+
+Common parameters
+-----------------
+
+Every method takes ``message`` and ``title`` positionally, plus these
+keyword-only options:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 16 66
+
+   * - Option
+     - Type
+     - Description
+   * - ``parent``
+     - ``Widget``
+     - The window to center over and block while open. Defaults to the
+       application root.
+   * - ``alert``
+     - ``bool``
+     - Ring the display bell when the dialog appears.
+   * - ``position``
+     - ``tuple``
+     - An ``(x, y)`` top-left screen position. Centered on ``parent`` by default.
+   * - ``buttons``
+     - ``list``
+     - Override the buttons — a list of labels, each optionally ``"label:bootstyle"``
+       to color it (e.g. ``"OK:success"``). The label is also what the method
+       returns.
+   * - ``icon``
+     - ``str``
+     - A Bootstrap Icons glyph name shown beside the message.
+   * - ``localize``
+     - ``bool``
+     - Translate the standard button labels through the message catalog. Default
+       ``True``.
+
+Methods
+-------
+
+.. py:staticmethod:: show_info(message, title=" ", *, parent=None, alert=False, position=None, buttons=None, icon=None, localize=True)
+   :noindex:
+
+   An informational message with an info icon and an **OK** button.
+
+   :returns: the clicked button's text, or ``None``.
+
+.. py:staticmethod:: show_warning(message, title=" ", *, parent=None, alert=True, position=None, buttons=None, icon=None, localize=True)
+   :noindex:
+
+   A warning message with a warning icon and an **OK** button. Rings the bell by
+   default.
+
+   :returns: the clicked button's text, or ``None``.
+
+.. py:staticmethod:: show_error(message, title=" ", *, parent=None, alert=True, position=None, buttons=None, icon=None, localize=True)
+   :noindex:
+
+   An error message with an error icon and an **OK** button. Rings the bell by
+   default.
+
+   :returns: the clicked button's text, or ``None``.
+
+.. py:staticmethod:: show_question(message, title=" ", *, parent=None, alert=False, position=None, buttons=None, icon=None, localize=True)
+   :noindex:
+
+   A message with a question icon and an **OK** button. Pass ``buttons`` for a
+   different choice set.
+
+   :returns: the clicked button's text, or ``None``.
+
+.. py:staticmethod:: ok(message, title=" ", *, parent=None, alert=False, position=None, buttons=None, icon=None, localize=True)
+   :noindex:
+
+   A message with a single **OK** button.
+
+   :returns: ``"OK"``, or ``None`` if closed.
+
+.. py:staticmethod:: okcancel(message, title=" ", *, parent=None, alert=False, position=None, buttons=None, icon=None, localize=True)
+   :noindex:
+
+   A message with **OK** and **Cancel** buttons.
+
+   :returns: ``"OK"`` or ``"Cancel"``, or ``None`` if closed.
+
+.. py:staticmethod:: yesno(message, title=" ", *, parent=None, alert=False, position=None, buttons=None, icon=None, localize=True)
+   :noindex:
+
+   A message with **Yes** and **No** buttons.
+
+   :returns: ``"Yes"`` or ``"No"``, or ``None`` if closed.
+
+.. py:staticmethod:: yesnocancel(message, title=" ", *, parent=None, alert=False, position=None, buttons=None, icon=None, localize=True)
+   :noindex:
+
+   A message with **Yes**, **No**, and **Cancel** buttons.
+
+   :returns: ``"Yes"``, ``"No"``, or ``"Cancel"``, or ``None`` if closed.
+
+.. py:staticmethod:: retrycancel(message, title=" ", *, parent=None, alert=False, position=None, buttons=None, icon=None, localize=True)
+   :noindex:
+
+   A message with **Retry** and **Cancel** buttons.
+
+   :returns: ``"Retry"`` or ``"Cancel"``, or ``None`` if closed.
+
+See also
+--------
+
+- :doc:`Dialogs </user-guide/feature-guides/dialogs>` — how to use them, with
+  examples.
+- :doc:`Querybox </reference/dialogs/querybox>` — the input-and-picker facade.
+- :doc:`MessageDialog </reference/dialogs/dialog-classes>` — the dialog class
+  ``Messagebox`` builds, for full control.

--- a/docs/reference/dialogs/pickers.rst
+++ b/docs/reference/dialogs/pickers.rst
@@ -1,0 +1,198 @@
+Pickers
+=======
+
+These are the dialog classes behind :py:meth:`Querybox.get_date`,
+:py:meth:`Querybox.get_color`, and :py:meth:`Querybox.get_font`. ``Querybox``
+constructs them for you and hands back the result, but you can construct any of
+them directly when you want more control over placement, styling, or lifecycle.
+
+DatePickerDialog
+----------------
+
+A calendar popup for choosing a date. It opens near the parent widget, lets the
+user page through months, and returns the selected day.
+
+Options
+~~~~~~~
+
+Set these on the constructor —
+``DatePickerDialog(parent=None, title=" ", first_weekday=6, start_date=None, bootstyle="primary", autoshow=True, show_outside_days=True)``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``parent``
+     - ``Widget``
+     - The window to position near and block. Defaults to the application root.
+   * - ``title``
+     - ``str``
+     - The text shown on the window's title bar.
+   * - ``first_weekday``
+     - ``int``
+     - The leftmost weekday column, ``0`` (Monday)–``6`` (Sunday). Default ``6``.
+   * - ``start_date``
+     - ``date``
+     - The date shown selected initially. Defaults to today.
+   * - ``bootstyle``
+     - ``str``
+     - The calendar's accent color. Default ``"primary"``.
+   * - ``autoshow``
+     - ``bool``
+     - Display immediately on construction. Default ``True``; pass ``False`` to
+       call :py:meth:`show` yourself.
+   * - ``show_outside_days``
+     - ``bool``
+     - Show days spilling in from the adjacent months. Default ``True``.
+
+Methods
+~~~~~~~
+
+.. py:method:: show(position=None, wait_for_result=True)
+   :noindex:
+
+   Display the dialog. Blocks until the user picks a date or cancels, then
+   stores the outcome on :py:attr:`result`.
+
+   :param position: An ``(x, y)`` top-left screen position. Positioned near
+      ``parent`` by default.
+   :param wait_for_result: Block until the dialog closes. Default ``True``.
+   :returns: ``None`` — read :py:attr:`result` after it returns.
+
+.. py:attribute:: result
+   :noindex:
+
+   The chosen ``datetime.date``, or ``None`` if cancelled.
+
+FontDialog
+----------
+
+A font selector for choosing a family, size, weight, slant, and effects, with a
+live preview of the current selection.
+
+Options
+~~~~~~~
+
+Set these on the constructor —
+``FontDialog(title="Font Selector", parent=None, default_font="TkDefaultFont")``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``title``
+     - ``str``
+     - The text shown on the window's title bar. Default ``"Font Selector"``.
+   * - ``parent``
+     - ``Widget``
+     - The window to center over and block. Defaults to the application root.
+   * - ``default_font``
+     - ``str``
+     - The named font shown selected initially. Default ``"TkDefaultFont"``.
+
+Methods
+~~~~~~~
+
+.. py:method:: show(position=None, wait_for_result=True)
+   :noindex:
+
+   Display the dialog. Blocks until the user picks a font or cancels, then
+   stores the outcome on :py:attr:`result`.
+
+   :param position: An ``(x, y)`` top-left screen position. Centered on
+      ``parent`` by default.
+   :param wait_for_result: Block until the dialog closes. Default ``True``.
+   :returns: ``None`` — read :py:attr:`result` after it returns.
+
+.. py:attribute:: result
+   :noindex:
+
+   The chosen ``Font``, or ``None`` if cancelled.
+
+ColorChooserDialog
+------------------
+
+A color picker with color-model sliders and a preview. The user can adjust the
+sliders, enter a value, or reach the eyedropper (:py:class:`ColorDropperDialog`)
+to sample a color from the screen.
+
+Options
+~~~~~~~
+
+Set these on the constructor —
+``ColorChooserDialog(parent=None, title="Color Chooser", initialcolor=None)``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``parent``
+     - ``Widget``
+     - The window to center over and block. Defaults to the application root.
+   * - ``title``
+     - ``str``
+     - The text shown on the window's title bar. Default ``"Color Chooser"``.
+   * - ``initialcolor``
+     - ``str``
+     - The color selected initially, a hex string like ``"#2b8cee"``.
+
+Methods
+~~~~~~~
+
+.. py:method:: show(position=None, wait_for_result=True)
+   :noindex:
+
+   Display the dialog. Blocks until the user picks a color or cancels, then
+   stores the outcome on :py:attr:`result`.
+
+   :param position: An ``(x, y)`` top-left screen position. Centered on
+      ``parent`` by default.
+   :param wait_for_result: Block until the dialog closes. Default ``True``.
+   :returns: ``None`` — read :py:attr:`result` after it returns.
+
+.. py:attribute:: result
+   :noindex:
+
+   The chosen color, or ``None`` if cancelled.
+
+ColorDropperDialog
+------------------
+
+An eyedropper that picks the color of any pixel on screen — the same dropper
+reachable from :py:class:`ColorChooserDialog`. It takes over the screen so the
+next click samples the color under the cursor.
+
+Methods
+~~~~~~~
+
+The constructor takes no arguments — ``ColorDropperDialog()``.
+
+.. py:method:: show()
+   :noindex:
+
+   Take over the screen; the next click picks the color under the cursor. A
+   right-click or ``Escape`` cancels. The outcome is stored on
+   :py:attr:`result`.
+
+   :returns: ``None`` — read :py:attr:`result` after it returns.
+
+.. py:attribute:: result
+   :noindex:
+
+   The picked color, or ``None`` if cancelled.
+
+See also
+--------
+
+- :doc:`Querybox </reference/dialogs/querybox>` — the input-and-picker facade.
+- :doc:`Dialogs </user-guide/feature-guides/dialogs>` — how to use them, with
+  examples.

--- a/docs/reference/dialogs/querybox.rst
+++ b/docs/reference/dialogs/querybox.rst
@@ -1,0 +1,125 @@
+Querybox
+========
+
+``Querybox`` prompts the user for a value and returns it. Every method is a
+**static method** — call it on the class (``Querybox.get_string("Name?")``). Each
+blocks until the user responds and returns the entered or chosen value, or
+``None`` if the dialog is cancelled.
+
+Two options are common to every method: ``parent`` (the window to center over and
+block; defaults to the application root) and the keyword-only ``position`` (an
+``(x, y)`` top-left screen position, centered on ``parent`` by default).
+
+Text and number input
+----------------------
+
+.. py:staticmethod:: get_string(prompt="", title=" ", initialvalue=None, parent=None, *, position=None)
+   :noindex:
+
+   Ask for a line of text.
+
+   :param prompt: the label shown above the entry.
+   :param initialvalue: the value the entry starts with.
+   :returns: the entered string, or ``None`` if cancelled.
+
+.. py:staticmethod:: get_integer(prompt="", title=" ", initialvalue=None, minvalue=None, maxvalue=None, parent=None, *, position=None)
+   :noindex:
+
+   Ask for a whole number, rejecting non-integer or out-of-range input.
+
+   :param minvalue: the smallest value accepted.
+   :param maxvalue: the largest value accepted.
+   :returns: the entered ``int``, or ``None`` if cancelled.
+
+.. py:staticmethod:: get_float(prompt="", title=" ", initialvalue=None, minvalue=None, maxvalue=None, parent=None, *, position=None)
+   :noindex:
+
+   Ask for a decimal number, rejecting non-numeric or out-of-range input.
+
+   :param minvalue: the smallest value accepted.
+   :param maxvalue: the largest value accepted.
+   :returns: the entered ``float``, or ``None`` if cancelled.
+
+.. py:staticmethod:: get_item(prompt="", title=" ", initialvalue=None, items=None, parent=None, *, position=None)
+   :noindex:
+
+   Ask the user to choose one value from a list.
+
+   :param items: the list of values to choose from.
+   :param initialvalue: the value selected initially.
+   :returns: the chosen item, or ``None`` if cancelled.
+
+Pickers
+-------
+
+.. py:staticmethod:: get_date(parent=None, title=" ", first_weekday=6, start_date=None, bootstyle="primary", *, show_outside_days=True, position=None)
+   :noindex:
+
+   Open a calendar popup to pick a date (see :doc:`DatePickerDialog
+   </reference/dialogs/pickers>`).
+
+   :param first_weekday: the leftmost weekday column, ``0`` (Monday)–``6`` (Sunday).
+   :param start_date: the date shown selected initially; defaults to today.
+   :param bootstyle: the calendar's accent color.
+   :param show_outside_days: show days spilling in from the adjacent months.
+   :returns: the chosen ``datetime.date``, or ``None`` if cancelled.
+
+.. py:staticmethod:: get_color(parent=None, title="Color Chooser", initialcolor=None, *, position=None)
+   :noindex:
+
+   Open the color chooser (see :doc:`ColorChooserDialog
+   </reference/dialogs/pickers>`).
+
+   :param initialcolor: the color selected initially (a hex string).
+   :returns: the chosen color, or ``None`` if cancelled.
+
+.. py:staticmethod:: get_font(parent=None, *, position=None)
+   :noindex:
+
+   Open the font selector (see :doc:`FontDialog </reference/dialogs/pickers>`).
+
+   :returns: the chosen ``Font``, or ``None`` if cancelled.
+
+Files
+-----
+
+These wrap :doc:`tkinter.filedialog </user-guide/how-to/index>`; extra keyword
+arguments (``initialdir``, ``filetypes``, ``defaultextension``, …) pass straight
+through. A cancelled dialog returns ``None``.
+
+.. py:staticmethod:: get_open_filename(parent=None, **kwargs)
+   :noindex:
+
+   Choose one existing file to open.
+
+   :returns: the file path, or ``None`` if cancelled.
+
+.. py:staticmethod:: get_open_filenames(parent=None, **kwargs)
+   :noindex:
+
+   Choose one or more existing files to open.
+
+   :returns: a tuple of file paths, or ``None`` if cancelled.
+
+.. py:staticmethod:: get_save_filename(parent=None, **kwargs)
+   :noindex:
+
+   Choose a file path to save to (prompting to confirm an overwrite).
+
+   :returns: the file path, or ``None`` if cancelled.
+
+.. py:staticmethod:: get_directory(parent=None, **kwargs)
+   :noindex:
+
+   Choose a directory.
+
+   :returns: the directory path, or ``None`` if cancelled.
+
+See also
+--------
+
+- :doc:`Dialogs </user-guide/feature-guides/dialogs>` — how to use them, with
+  examples.
+- :doc:`Messagebox </reference/dialogs/messagebox>` — the message-dialog facade.
+- :doc:`Pickers </reference/dialogs/pickers>` — the date, color, and font dialog
+  classes these build.

--- a/docs/reference/dialogs/toast.rst
+++ b/docs/reference/dialogs/toast.rst
@@ -6,8 +6,7 @@ ToastNotification
 alerts. It is **not a widget**: you construct it, then call
 :py:meth:`show_toast` to display it. A toast either closes itself after
 ``duration`` milliseconds or waits to be clicked. Concurrent toasts anchored to
-the same corner stack without overlapping. This page is the
-complete lookup reference.
+the same corner stack without overlapping.
 
 Options
 -------

--- a/docs/reference/dialogs/tooltip.rst
+++ b/docs/reference/dialogs/tooltip.rst
@@ -5,8 +5,7 @@ ToolTip
 semi-transparent popup that shows text while the pointer hovers over a target
 widget, and hides on leave or click. It is **not a widget**: you attach one to a
 target by passing that widget to the constructor, and it manages its own hover
-events thereafter. This page is the complete lookup
-reference.
+events thereafter.
 
 Options
 -------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -21,6 +21,13 @@ The lookup layer:
       The application window classes — ``App`` (the root) and ``Toplevel`` — and
       their constructor, theme, and window-management surface.
 
+   .. grid-item-card:: Dialogs & overlays
+      :link: dialogs/index
+      :link-type: doc
+
+      Message, input, and picker dialogs — ``Messagebox``, ``Querybox``, and the
+      dialog classes — plus toasts and tooltips.
+
    .. grid-item-card:: Capabilities
       :link: capabilities/index
       :link-type: doc
@@ -48,6 +55,7 @@ The lookup layer:
 
    api/index
    windows/index
+   dialogs/index
    capabilities/index
    events/index
    cursors

--- a/docs/widgets/toast.rst
+++ b/docs/widgets/toast.rst
@@ -70,7 +70,7 @@ API & reference
 ---------------
 
 For the complete option list, see the
-:doc:`ToastNotification API reference </reference/api/toastnotification>`.
+:doc:`ToastNotification API reference </reference/dialogs/toast>`.
 
 .. seealso::
 

--- a/docs/widgets/tooltip.rst
+++ b/docs/widgets/tooltip.rst
@@ -60,7 +60,7 @@ API & reference
 ---------------
 
 For the complete option list, see the
-:doc:`ToolTip API reference </reference/api/tooltip>`.
+:doc:`ToolTip API reference </reference/dialogs/tooltip>`.
 
 .. seealso::
 


### PR DESCRIPTION
Adds the **Dialogs & overlays** section to the API reference (Workstream H) — the modal dialogs plus the transient overlays, hand-written and fully documented.

## What's here

New `docs/reference/dialogs/` section, added as a top-level Reference card + toctree:

- **messagebox.rst** — the `Messagebox` facade (9 static methods: `show_info`/`show_warning`/`show_error`/`show_question`/`ok`/`okcancel`/`yesno`/`yesnocancel`/`retrycancel`) with a shared common-parameters table (`parent`/`alert`/`position`/`buttons`/`icon`/`localize`).
- **querybox.rst** — the `Querybox` facade (11 static methods), grouped into text/number input, pickers, and files.
- **dialog-classes.rst** — `Dialog` (the base for custom dialogs), `MessageDialog`, and `QueryDialog` — Options tables + `show()` / `result` specs.
- **pickers.rst** — `DatePickerDialog`, `FontDialog`, `ColorChooserDialog`, `ColorDropperDialog`.
- **toast.rst / tooltip.rst** — moved here from the Widgets reference (they are overlay helpers, not widgets). The Widgets index's Overlays category is removed and the catalog links repointed.

Reference landing now reads: Widgets · Windows · Dialogs & overlays · Capabilities · Events · Cursors.

Grounded against the live dialog classes — constructors, static-method signatures, `show(position=None, wait_for_result=True)`, and the `result` property.

## Verification

- `sphinx -b html -W -q -E docs` — clean (exit 0).

Follows #1189 (merged). Remaining reference sections (Styling, Theming, Imaging, Localization, Fonts, Validation, Utilities — autodoc, after an `Examples:`-strip on the docstrings) tracked in `development/2_0_docs_api_reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)