### PR TITLE
docs(reference): Styling/Theming/Imaging/Utilities + ThemeDefinition mode rename

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -24,6 +24,7 @@
 | **Validation rules grouped under a `Validation` namespace** | API | this doc, below |
 | **Light/dark theme mode (settable `theme_mode`/`toggle_theme()`)** | New | this doc, below |
 | **Theme-aware custom styles (`on_theme_change` / `@theme_aware`)** | New | this doc, below |
+| **`ThemeDefinition`: `themetype`→`mode` (kwarg + `.type`→`.mode`)** | Deprecated | this doc, below |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
 | Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
@@ -118,6 +119,35 @@ skipped — one bad callback never breaks theming. Rides the existing theme walk
 
 **Scope note.** A *utility* over the existing theme walk, not new widget
 behavior. Purely additive; no migration required.
+
+---
+
+## `ThemeDefinition`: `themetype` → `mode`  *(Deprecated — no break)*
+
+**What.** `ThemeDefinition`'s light/dark selector is now spelled **`mode`**,
+both as the constructor argument and the stored attribute:
+
+- `ThemeDefinition(name, colors, mode="dark")` — the third positional arg is
+  unchanged (`ThemeDefinition(name, colors, "dark")` still works); only the
+  keyword spelling changed.
+- `definition.mode` replaces `definition.type`.
+
+The old spellings still work through 2.x with a one-time `DeprecationWarning`
+(removed in 3.0): passing `themetype=` normalizes to `mode`, and reading
+`.type` returns `.mode`. `load_user_theme(s)` JSON accepts either a `"mode"` or
+a legacy `"type"` key, so existing saved-theme files keep loading.
+
+**Why.** The value only ever holds `"light"`/`"dark"` — i.e. the theme *mode*,
+which is exactly what the rest of the 2.0 theme surface already calls it
+(`Style.theme_mode`, `toggle_theme()`, the `light_theme`/`dark_theme` kwargs,
+the `<name>-light`/`<name>-dark` naming). `themetype`/`.type` was the last
+pre-2.0 holdout, and the class was already internally inconsistent (the kwarg
+was `themetype` but it was stored as `.type`). `ThemeDefinition.mode` now lines
+up with `Style.theme_mode`.
+
+**Migration.** `ThemeDefinition(..., themetype=X)` → `ThemeDefinition(..., mode=X)`;
+`definition.type` → `definition.mode`. In 2.0 most custom themes go through
+`Theme(...).register()` rather than constructing `ThemeDefinition` directly.
 
 ---
 

--- a/development/2_0_docs_api_reference.md
+++ b/development/2_0_docs_api_reference.md
@@ -136,33 +136,42 @@ work is on **`docs/2.0-widget-api-reference`** off `2.0`:
 
 ## REMAINING (next session starts here)
 
-DONE: **Windows** (#1189, merged), **Dialogs & overlays** (#1190, merged), and
-**autodoc slice 1** — Validation, Fonts, Localization — as **PR #1191 (OPEN** on
-`docs/2.0-reference-autodoc`). **First: confirm #1191 merged, then branch off the
-updated `2.0`.**
+DONE: **Windows** (#1189, merged), **Dialogs & overlays** (#1190, merged),
+**autodoc slice 1** — Validation, Fonts, Localization (#1191, merged), and
+**autodoc slice 2** — **Styling · Theming · Imaging · Utilities** — on
+`docs/2.0-reference-styling-theming` (branched off `2.0`, PR pending). With slice
+2 **every planned Reference section is authored.**
 
-Reference-landing IA now: **Widgets · Windows · Dialogs & overlays · Localization
-· Fonts · Validation · Capabilities · Events · Cursors**. Target full order:
-Widgets · Windows · Dialogs & overlays · **Styling · Theming · Imaging** ·
-Localization · Fonts · Validation · **Utilities** · Capabilities · Events ·
-Cursors — insert the new cards accordingly.
+Reference-landing IA is now the full target order: **Widgets · Windows · Dialogs &
+overlays · Styling · Theming · Imaging · Localization · Fonts · Validation ·
+Utilities · Capabilities · Events · Cursors.**
 
-Still to author:
+### Slice 2 — what landed + two scope decisions (READ before a follow-up)
 
-1. **Styling** (autodoc): `Style`, `Bootstyle`, toolkit (`Assets`/`El`/`layout`/
-   `StyleName`/`register_style`/`statespec`/`state_map`/`image_element`). Strip
-   `Examples:` from `style/layout.py` (×6) + `engine.py` (×1) first.
-2. **Theming** (autodoc): `Theme`, `ThemeDefinition`, `Colors`,
-   `install_legacy_themes`. Strip `Examples:` from `theme.py` (×3).
-3. **Imaging**: `PhotoImage` (hand-write — tk primitive, thin upstream) + `Icon`/
-   `apply_icon`/`icon_element` (autodoc). Consider re-exporting + documenting
-   `BitmapImage` (PhotoImage's sibling) here for image-surface completeness.
-4. **Utilities** (autodoc): `ttkbootstrap.utils` / `colorutils` — a grab-bag
-   (color fns `HEX`/`HSL`/`RGB`/`color_to_*`/`contrast_color`/
-   `conform_color_model`, `enable_high_dpi_awareness`, `on_theme_change`/
-   `remove_theme_change_callback`, `config`); curate the genuinely-public surface,
-   skip internals.
-5. Card + toctree into `docs/reference/index.rst` for each.
+Pages: `docs/reference/{styling,theming,imaging,utilities}.rst`, cards + toctree
+in `docs/reference/index.rst`. `Examples:` stripped from `style/layout.py` (×6),
+`engine.py` (×1), `theme.py` (×3); a handful of Markdown-ism `-W` errors fixed in
+the newly-autodoc'd members (`` `El`s ``/`` `ThemeDefinition`s `` unclosed spans;
+`_delta_`-style italics in `Colors.update_hsv`). Build gate green (exit 0, `-W`),
+suite 647 passed (the 3 `test_menu_api` "off_mac" failures are **pre-existing on
+pristine `2.0`** — they fail on real macOS, unrelated).
+
+- **`Bootstyle` class was NOT autodoc'd** (handoff had listed it). Its own
+  docstring says "typical end users will not call these methods directly" and its
+  members are internal resolver plumbing (`override_*`, `patch_geometry_managers`,
+  …); it also references deprecated tuple syntax. Instead the Styling page
+  documents the genuinely-public delivery surface — **`bootify` / `apply_bootstyle`
+  / `enable_global_api`** — under "Applying styles to any widget." Revisit if the
+  author wants the class itself surfaced.
+- **`BitmapImage` was skipped** (the optional "consider" item). It's a
+  near-obsolete XBM primitive with no methods of its own; adding a top-level
+  re-export for it wasn't judged worth the surface. Imaging documents `PhotoImage`
+  (hand-written, PNG/GIF) + the `Icon`/`apply_icon`/`icon_element` glyph engine.
+
+Note: inline ```` ```python ```` fences in `bootify`/`apply_bootstyle`/`Icon`/
+`icon_element` docstrings were **left in place** (the fence shim renders them; the
+strip rule as operationalized only targets `Examples:` blocks, matching the prior
+slices). A future strict-no-examples sweep could remove them.
 
 ### Autodoc page pattern (ESTABLISHED — replicate)
 

--- a/docs/reference/imaging.rst
+++ b/docs/reference/imaging.rst
@@ -1,0 +1,118 @@
+Imaging
+=======
+
+Two kinds of image reach a widget's ``image`` option. ``PhotoImage`` is Tk's
+own image primitive — load a PNG or GIF from a file or base-64 data, or draw one
+pixel by pixel, then pass it to a ``Button``, ``Label``, or any widget that
+takes an image. The icon engine renders a named `Bootstrap Icons
+<https://icons.getbootstrap.com/>`_ glyph as a theme-colored image, so you can
+put a crisp, recolorable icon on a widget without shipping image files. The
+:doc:`Icons </user-guide/feature-guides/icons>` guide shows the icon engine in
+use.
+
+Photo images
+------------
+
+.. py:class:: PhotoImage(name=None, cnf={}, master=None, *, data=None, file=None, format=None, width=0, height=0)
+   :noindex:
+
+   A full-color image you can display on a widget. Create an empty canvas by
+   giving ``width``/``height``, or load one from ``file`` (a PNG or GIF path) or
+   ``data`` (the image bytes, or base-64 text). Hold a reference to the object
+   for as long as the widget shows it — Tk does not, and a garbage-collected
+   ``PhotoImage`` blanks the widget.
+
+   :param file: path to a PNG or GIF image to load.
+   :param data: the image as bytes or a base-64 string (an alternative to ``file``).
+   :param format: the image format, when it can't be inferred (e.g. ``"gif"``).
+   :param width: the width in pixels of a blank image.
+   :param height: the height in pixels of a blank image.
+
+.. py:method:: width()
+   :noindex:
+
+   Return the image width in pixels.
+
+.. py:method:: height()
+   :noindex:
+
+   Return the image height in pixels.
+
+.. py:method:: get(x, y)
+   :noindex:
+
+   Return the color of the pixel at ``(x, y)`` as an ``(r, g, b)`` tuple.
+
+.. py:method:: put(data, to=None)
+   :noindex:
+
+   Write colors into the image. ``data`` is a color string or a nested
+   sequence of color rows; ``to`` is the ``(x, y)`` corner (or an ``(x1, y1,
+   x2, y2)`` box) to write into.
+
+   :param data: a color, or rows of colors, to write.
+   :param to: where to write — a corner or a bounding box.
+
+.. py:method:: blank()
+   :noindex:
+
+   Clear the image to transparent, keeping its size.
+
+.. py:method:: copy()
+   :noindex:
+
+   Return a new ``PhotoImage`` with the same contents.
+
+   :rtype: PhotoImage
+
+.. py:method:: zoom(x, y=None)
+   :noindex:
+
+   Return a copy magnified by integer factor ``x`` horizontally and ``y``
+   vertically (``y`` defaults to ``x``).
+
+   :rtype: PhotoImage
+
+.. py:method:: subsample(x, y=None)
+   :noindex:
+
+   Return a copy reduced by integer factor ``x`` horizontally and ``y``
+   vertically (``y`` defaults to ``x``).
+
+   :rtype: PhotoImage
+
+.. py:method:: write(filename, format=None, from_coords=None)
+   :noindex:
+
+   Save the image to ``filename``.
+
+   :param filename: the path to write to.
+   :param format: the output format (e.g. ``"png"``).
+   :param from_coords: an optional region of the image to save.
+
+.. py:method:: configure(**options)
+   :noindex:
+
+   Get or set image options (``width``, ``height``, ``data``, ``file``, …).
+   Alias: ``config``.
+
+.. py:method:: cget(option)
+   :noindex:
+
+   Return the value of one image option.
+
+Icons
+-----
+
+.. autofunction:: ttkbootstrap.Icon
+
+.. autofunction:: ttkbootstrap.apply_icon
+
+.. autofunction:: ttkbootstrap.icon_element
+
+See also
+--------
+
+- :doc:`Icons </user-guide/feature-guides/icons>` — how to use icons on widgets,
+  with examples.
+- :doc:`styling` — the ``Assets`` toolkit that ``icon_element`` builds on.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -28,6 +28,27 @@ The lookup layer:
       Message, input, and picker dialogs — ``Messagebox``, ``Querybox``, and the
       dialog classes — plus toasts and tooltips.
 
+   .. grid-item-card:: Styling
+      :link: styling
+      :link-type: doc
+
+      The style engine and the tools to build your own styles — ``Style``,
+      the ``bootstyle`` delivery helpers, and the custom-style toolkit.
+
+   .. grid-item-card:: Theming
+      :link: theming
+      :link-type: doc
+
+      Declare and consume color themes — ``Theme``, ``ThemeDefinition``,
+      ``Colors``, and the legacy-theme bridge.
+
+   .. grid-item-card:: Imaging
+      :link: imaging
+      :link-type: doc
+
+      Images on widgets — the ``PhotoImage`` primitive and the Bootstrap Icons
+      glyph engine (``Icon``, ``apply_icon``, ``icon_element``).
+
    .. grid-item-card:: Localization
       :link: localization
       :link-type: doc
@@ -47,6 +68,13 @@ The lookup layer:
 
       Attach input validation to entries — ready-made checks plus custom
       validators.
+
+   .. grid-item-card:: Utilities
+      :link: utilities
+      :link-type: doc
+
+      Standalone helpers — color conversion and contrast, high-DPI awareness
+      and scaling, and theme-change hooks.
 
    .. grid-item-card:: Capabilities
       :link: capabilities/index
@@ -76,9 +104,13 @@ The lookup layer:
    api/index
    windows/index
    dialogs/index
+   styling
+   theming
+   imaging
    localization
    fonts
    validation
+   utilities
    capabilities/index
    events/index
    cursors

--- a/docs/reference/styling.rst
+++ b/docs/reference/styling.rst
@@ -1,0 +1,77 @@
+Styling
+=======
+
+Styling in ttkbootstrap runs through one engine and reaches widgets three ways.
+The ``Style`` engine owns the active theme and builds ttk styles on demand. The
+shipped widgets carry the ``bootstyle`` keyword; to put that keyword on a widget
+ttkbootstrap does not ship, use the delivery helpers below. And when a name in
+the ``bootstyle`` vocabulary can't describe the look you want, the toolkit builds
+a ttk style by hand. The :doc:`Custom styles
+</user-guide/feature-guides/custom-styles>` guide shows the toolkit in use.
+
+The style engine
+----------------
+
+``Style`` is a process-wide singleton, bound to the first application window and
+reachable as its ``style`` attribute (or ``Style.get_instance()``). It holds the
+theme definitions, switches the active theme, and exposes the current theme's
+colors.
+
+.. autoclass:: ttkbootstrap.Style
+   :members:
+
+Applying styles to any widget
+-----------------------------
+
+The widgets ttkbootstrap ships already accept ``bootstyle``. These helpers extend
+that keyword to widgets it does not ship — a third-party ttk widget, or a plain
+``tkinter.ttk`` widget you created yourself.
+
+.. autofunction:: ttkbootstrap.bootify
+
+.. autofunction:: ttkbootstrap.apply_bootstyle
+
+.. autofunction:: ttkbootstrap.enable_global_api
+
+Building custom styles
+----------------------
+
+For a look ``bootstyle`` can't name, compose a ttk style from **assets**,
+**elements**, a **state map**, and a **layout** — each a small toolkit call.
+``Assets`` renders cached images, ``image_element`` turns one into a named ttk
+element, ``state_map`` is a validated ``style.map``, and ``layout`` arranges the
+elements into the widget's element tree and registers the style. See the
+:doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide for a
+worked example.
+
+.. autoclass:: ttkbootstrap.Assets
+   :members:
+
+.. autofunction:: ttkbootstrap.image_element
+
+.. autofunction:: ttkbootstrap.state_map
+
+.. autofunction:: ttkbootstrap.statespec
+
+.. autofunction:: ttkbootstrap.layout
+
+.. autoclass:: ttkbootstrap.El
+   :members:
+
+.. autofunction:: ttkbootstrap.register_style
+
+.. autoclass:: ttkbootstrap.StyleName
+   :members:
+
+.. note::
+
+   To render a glyph as an element in a custom layout, see
+   :func:`~ttkbootstrap.icon_element` on the :doc:`Imaging <imaging>` page.
+
+See also
+--------
+
+- :doc:`Custom styles </user-guide/feature-guides/custom-styles>` — how to build
+  and apply your own styles, with examples.
+- :doc:`Theming & Colors </user-guide/feature-guides/theming>` — the theme model
+  behind the engine.

--- a/docs/reference/theming.rst
+++ b/docs/reference/theming.rst
@@ -1,0 +1,37 @@
+Theming
+=======
+
+A theme is a named color scheme the engine turns into widget styles.
+``Theme`` declares a theme *family* in code from a handful of anchor colors;
+``ThemeDefinition`` is the per-mode container the engine consumes; and
+``Colors`` is the resolved palette you read off the active theme (through
+``Style.colors``). ``install_legacy_themes`` brings the pre-2.0 theme names
+back for migration. The :doc:`Theming & Colors
+</user-guide/feature-guides/theming>` guide shows them in use.
+
+Declaring a theme
+-----------------
+
+.. autoclass:: ttkbootstrap.Theme
+   :members:
+
+.. autoclass:: ttkbootstrap.style.ThemeDefinition
+   :members:
+
+The color palette
+-----------------
+
+.. autoclass:: ttkbootstrap.style.Colors
+   :members:
+
+Legacy themes
+-------------
+
+.. autofunction:: ttkbootstrap.install_legacy_themes
+
+See also
+--------
+
+- :doc:`Theming & Colors </user-guide/feature-guides/theming>` — how to pick,
+  switch, and build themes, with examples.
+- :doc:`styling` — the ``Style`` engine that consumes these themes.

--- a/docs/reference/utilities.rst
+++ b/docs/reference/utilities.rst
@@ -1,0 +1,63 @@
+Utilities
+=========
+
+A small set of standalone helpers that don't belong to any one widget: color
+conversion and contrast, high-DPI awareness and size scaling, and hooks that run
+your code when the theme changes. They live in ``ttkbootstrap.utils`` and are
+re-exported at the top level (``ttkbootstrap.contrast_color``, …).
+
+Color
+-----
+
+Convert a color between models and derive readable pairings. A *model* is one of
+the strings ``"hex"``, ``"rgb"``, ``"hsl"``, or ``"name"`` (exposed as the
+constants ``HEX``/``RGB``/``HSL``/``NAME``); ``RGB`` is ``(r, g, b)`` with each
+channel ``0–255`` and ``HSL`` is ``(hue, saturation, luminance)``.
+
+.. autofunction:: ttkbootstrap.utils.color_to_hex
+
+.. autofunction:: ttkbootstrap.utils.color_to_rgb
+
+.. autofunction:: ttkbootstrap.utils.color_to_hsl
+
+.. autofunction:: ttkbootstrap.utils.conform_color_model
+
+.. autofunction:: ttkbootstrap.utils.update_hsl_value
+
+.. autofunction:: ttkbootstrap.utils.contrast_color
+
+High-DPI and scaling
+--------------------
+
+.. autofunction:: ttkbootstrap.utils.enable_high_dpi_awareness
+
+.. autofunction:: ttkbootstrap.utils.scale_size
+
+.. autofunction:: ttkbootstrap.utils.windowing_system
+
+Reacting to theme changes
+-------------------------
+
+A custom style built by hand is not rebuilt when the theme switches. Register a
+callback to re-run your build after every switch — or mark the builder with the
+``theme_aware`` decorator, which registers it and runs it once.
+
+.. autofunction:: ttkbootstrap.utils.on_theme_change
+
+.. autofunction:: ttkbootstrap.utils.remove_theme_change_callback
+
+.. autofunction:: ttkbootstrap.utils.theme_aware
+
+Defaults
+--------
+
+.. autofunction:: ttkbootstrap.utils.set_default_button
+
+See also
+--------
+
+- :doc:`Fonts <fonts>` and :doc:`Localization <localization>` — the font and
+  message-catalog helpers are also re-exported from ``ttkbootstrap.utils`` but
+  are documented on their own pages.
+- :doc:`Custom styles </user-guide/feature-guides/custom-styles>` — where the
+  theme-change hooks are put to use.

--- a/examples/features/custom_themes.py
+++ b/examples/features/custom_themes.py
@@ -6,7 +6,7 @@ root = Window()
 # create custom theme
 theme = ThemeDefinition(
     name="custom",
-    themetype="dark",
+    mode="dark",
     colors={
         "primary": "#4bb731",
         "secondary": "#444444",

--- a/src/ttkbootstrap/style/builders_tk.py
+++ b/src/ttkbootstrap/style/builders_tk.py
@@ -42,7 +42,7 @@ class StyleBuilderTK:
     @property
     def is_light_theme(self) -> bool:
         """Returns `True` if the theme is _light_, otherwise `False`."""
-        return self.style.theme.type == LIGHT
+        return self.style.theme.mode == LIGHT
 
     def update_tk_style(self, widget: tk.Tk):
         """Update the window style.

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -68,7 +68,7 @@ class StyleBuilderTTK:
     @property
     def is_light_theme(self) -> bool:
         """Whether the current theme is light."""
-        return self.style.theme.type == LIGHT
+        return self.style.theme.mode == LIGHT
 
     @property
     def assets(self) -> Assets:

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -26,23 +26,6 @@ class Style(ttk.Style):
     inherits all of it's methods and properties. However, in
     ttkbootstrap, this class is implemented as a singleton. Subclassing
     is not recommended and may have unintended consequences.
-
-    Examples:
-
-        ```python
-        # instantiate the style with default theme
-        style = Style()
-
-        # instantiate the style with another theme
-        style = Style(theme='bootstrap-dark')
-
-        # check all available themes
-        for theme in style.theme_names():
-            print(theme)
-        ```
-
-    See the [Python documentation](https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Style)
-    on this class for more details.
     """
 
     instance = None

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -302,10 +302,10 @@ class Style(ttk.Style):
             style.theme_mode           # -> "light"
             style.theme_mode = "dark"  # switch
 
-        Reads the active theme's type; `None` before a theme is applied.
+        Reads the active theme's mode; `None` before a theme is applied.
         """
         theme = getattr(self, "theme", None)
-        return theme.type if theme is not None else None
+        return theme.mode if theme is not None else None
 
     @theme_mode.setter
     def theme_mode(self, mode: str) -> None:
@@ -335,9 +335,9 @@ class Style(ttk.Style):
             if name not in self._theme_names:
                 raise ValueError(f"{name!r} is not a registered theme name.")
             definition = self._theme_definitions.get(name)
-            if definition is not None and definition.type != mode:
+            if definition is not None and definition.mode != mode:
                 warnings.warn(
-                    f"designating {name!r} (a {definition.type} theme) as the "
+                    f"designating {name!r} (a {definition.mode} theme) as the "
                     f"{mode} theme; toggling will not change appearance the way "
                     "a matching-type theme would.",
                     UserWarning,
@@ -487,7 +487,7 @@ class Style(ttk.Style):
             copied_def = ThemeDefinition(
                 name=themename,
                 colors=parent_def.colors,
-                themetype=parent_def.type
+                mode=parent_def.mode
             )
             self._theme_definitions[themename] = copied_def
             self._theme_names.add(themename)
@@ -746,7 +746,7 @@ class Style(ttk.Style):
                 self.register_theme(
                     ThemeDefinition(
                         name=name,
-                        themetype=definition["type"],
+                        mode=definition.get("mode") or definition["type"],
                         colors=definition["colors"],
                     )
                 )

--- a/src/ttkbootstrap/style/layout.py
+++ b/src/ttkbootstrap/style/layout.py
@@ -30,12 +30,6 @@ def statespec(spec):
 
     Tokens are space-separated; each may be negated with a leading `!`
     ("!selected"). An unknown token raises `ValueError`.
-
-    Examples:
-        ```python
-        statespec("disabled selected")  # -> ("disabled", "selected")
-        statespec("!selected")          # -> ("!selected",)
-        ```
     """
     tokens = tuple(spec.split())
     for token in tokens:
@@ -49,20 +43,12 @@ def statespec(spec):
 
 
 class El:
-    """A ttk layout element: a name, layout options, and child `El`s.
+    """A ttk layout element: a name, layout options, and child elements.
 
     `layout()` lowers an `El` tree to ttk's nested `(name, {opts, "children":
     [...]})` form. Mirrors bootstack's `Element.spec()`, but takes children as a
     constructor `children=[...]` kwarg (unambiguous; reads as the tree it builds)
     rather than fluent positional parenting.
-
-    Examples:
-        ```python
-        El("Radiobutton.padding", sticky=NSEW, children=[
-            El(f"{ttk_style}.indicator", side=LEFT),
-            El("Radiobutton.focus", side=LEFT, children=[
-                El("Radiobutton.label", sticky=NSEW)])])
-        ```
     """
 
     __slots__ = ("name", "options", "children")
@@ -100,12 +86,6 @@ def register_style(style, ttk_style):
     `map`) does not register it on its own; call this (or `layout()`, which calls
     it for you) so `style="<ttk_style>"` resolves to what you built.
 
-    Examples:
-        ```python
-        state_map(style, "My.TButton", background={"pressed": "#333"})
-        register_style(style, "My.TButton")   # now style="My.TButton" resolves
-        ```
-
     Registration is per *active* theme (it mirrors the built-in builders). A
     hand-built style is not auto-rebuilt on a theme switch, so re-build + re
     -register it if you change themes -- engine-managed theme-follow for custom
@@ -138,14 +118,6 @@ def image_element(style, name, *, default, states=None, **options):
     explicit. Each state string is validated by `statespec` (a typo raises
     instead of silently never matching). `options` (width, border, sticky, ...)
     pass through to `element_create`.
-
-    Examples:
-        ```python
-        image_element(style, f"{ttk_style}.indicator", default=on,
-            states={"disabled selected": on_disabled, "disabled": disabled,
-                    "!selected": off},
-            width=20, border=4, sticky=W)
-        ```
     """
     args = [default]
     if states:
@@ -161,11 +133,6 @@ def state_map(style, ttk_style, **options):
     dict `{state_string: value}` (or an iterable of `(state_string, value)`
     pairs). State strings are validated by `statespec`. Replaces bare
     `foreground=[("disabled", fg)]` lists.
-
-    Examples:
-        ```python
-        state_map(style, ttk_style, foreground={"disabled": disabled_fg})
-        ```
     """
     mapping = {}
     for option, spec in options.items():
@@ -189,14 +156,6 @@ class StyleName:
       .element    the element-name prefix with the class token's leading "T"
                   dropped ("info.Horizontal.TScale" -> "info.Horizontal.Scale"),
                   matching the old `h_ttkstyle.replace(".TS", ".S")` dance.
-
-    Examples:
-        ```python
-        sn = StyleName("TScale", colorname, orient="Horizontal")
-        sn.colorname    # PRIMARY when colorname was DEFAULT/"", else as given
-        sn.ttk_style     # "Horizontal.TScale" or "primary.Horizontal.TScale"
-        sn.element      # "Horizontal.Scale"
-        ```
     """
 
     __slots__ = ("colorname", "ttk_style", "element")

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -15,6 +15,7 @@ from PIL import ImageColor
 
 from ttkbootstrap import utils
 from ttkbootstrap.constants import *
+from ttkbootstrap.style._compat import warn_deprecated
 
 
 _TINT_WEIGHTS = {
@@ -665,7 +666,7 @@ class ThemeDefinition:
     styles and images for the active theme.
     """
 
-    def __init__(self, name, colors, themetype=LIGHT):
+    def __init__(self, name, colors, mode=LIGHT, **kwargs):
         """
         Parameters:
 
@@ -675,18 +676,33 @@ class ThemeDefinition:
             colors (Colors or dict):
                 A Colors instance or a dict of color values.
 
-            themetype (str):
+            mode (str):
                 Specifies whether the theme is **light** or **dark**.
         """
+        themetype = kwargs.pop("themetype", None)
+        if themetype is not None:
+            warn_deprecated("the 'themetype' ThemeDefinition argument", "'mode'")
+            mode = themetype
+        if kwargs:
+            raise TypeError(
+                "ThemeDefinition() got unexpected keyword argument(s): "
+                f"{', '.join(map(repr, sorted(kwargs)))}"
+            )
         self.name = name
         self.colors = colors if isinstance(colors, Colors) else Colors(**colors)
-        self.type = themetype
+        self.mode = mode
+
+    @property
+    def type(self):
+        """Deprecated alias for `mode` (removed in 3.0)."""
+        warn_deprecated("the 'ThemeDefinition.type' attribute", "'mode'")
+        return self.mode
 
     def __repr__(self):
         return " ".join(
             [
                 f"name={self.name},",
-                f"type={self.type},",
+                f"mode={self.mode},",
                 f"colors={self.colors}",
             ]
         )
@@ -846,7 +862,7 @@ class Theme:
             mode, anchors, self.neutral,
             block["background"], block["foreground"], self.secondary,
         )
-        return ThemeDefinition(name=f"{self.name}-{mode}", colors=colors, themetype=mode)
+        return ThemeDefinition(name=f"{self.name}-{mode}", colors=colors, mode=mode)
 
     def to_definitions(self):
         """Return the generated per-mode `ThemeDefinition` objects (light, then dark).

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -240,46 +240,9 @@ class Colors:
     be accessed through the `Style.colors` property for the
     current theme.
 
-    Examples:
-
-        ```python
-        style = Style()
-
-        # dot-notation
-        style.colors.primary
-
-        # get method
-        style.colors.get('primary')
-        ```
-
-        This class is an iterator, so you can iterate over the main
-        style color labels (primary, secondary, success, info, warning,
-        danger, light, dark):
-
-        ```python
-        for color_label in style.colors:
-            color = style.colors.get(color_label)
-            print(color_label, color)
-        ```
-
-        If, for some reason, you need to iterate over all theme color
-        labels, then you can use the `Colors.label_iter` method. This
-        will include all theme colors.
-
-        ```python
-        for color_label in style.colors.label_iter():
-            color = style.colors.get(color_label)
-            print(color_label, color)
-        ```
-
-        If you want to adjust the hsv values of an existing color by a
-        specific percentage (delta), you can use the `Colors.update_hsv`
-        method, which is static. In the example below, the "value delta"
-        or `vd` is increased by 15%, which will lighten the color:
-
-        ```python
-        Colors.update_hsv("#9954bb", vd=0.15)
-        ```
+    This class is an iterator over the main style color labels (primary,
+    secondary, success, info, warning, danger, light, dark); `label_iter`
+    iterates over every theme color label.
     """
 
     def __init__(
@@ -640,7 +603,7 @@ class Colors:
     @staticmethod
     def update_hsv(color, hd=0, sd=0, vd=0):
         """Modify the hue, saturation, and/or value of a given hex
-        color value by specifying the _delta_.
+        color value by specifying the delta.
 
         Parameters:
 
@@ -648,13 +611,13 @@ class Colors:
                 A hexadecimal color value to adjust.
 
             hd (float):
-                % change in hue, _hue delta_.
+                % change in hue, the hue delta.
 
             sd (float):
-                % change in saturation, _saturation delta_.
+                % change in saturation, the saturation delta.
 
             vd (float):
-                % change in value, _value delta_.
+                % change in value, the value delta.
 
         Returns:
 
@@ -835,18 +798,6 @@ class Theme:
     `<name>-dark`). The per-mode ramp step for solids, borders, and inputs is
     chosen automatically -- there is no per-mode shade boilerplate.
 
-    Examples:
-
-        ```python
-        Theme(
-            name="pulse",
-            primary="#593196", success="#13b955", info="#009cdc",
-            warning="#efa31d", danger="#fc3939",
-            light=dict(background="#ffffff", foreground="#17141f"),
-            dark=dict(background="#17141f", foreground="#e9ecef"),
-        ).register()   # registers pulse-light + pulse-dark on the live Style
-        ```
-
     Parameters:
 
         name (str):
@@ -898,7 +849,7 @@ class Theme:
         return ThemeDefinition(name=f"{self.name}-{mode}", colors=colors, themetype=mode)
 
     def to_definitions(self):
-        """Return the generated per-mode `ThemeDefinition`s (light, then dark).
+        """Return the generated per-mode `ThemeDefinition` objects (light, then dark).
 
         A family that declares only one block yields a single definition.
         """
@@ -934,12 +885,6 @@ class Theme:
 
         Every token not overridden is inherited from `base`, so a built-in can
         be re-branded by changing just its `primary` (and anything else).
-
-        Examples:
-
-            ```python
-            Theme.from_existing(BOOTSTRAP, name="acme", primary="#ff5722")
-            ```
         """
         unknown = set(overrides) - {f.name for f in fields(cls)}
         if unknown:

--- a/src/ttkbootstrap/themes/legacy.py
+++ b/src/ttkbootstrap/themes/legacy.py
@@ -70,7 +70,7 @@ def theme_from_legacy_dict(name, spec) -> ThemeDefinition:
         inputbg=inputbg,
         active=active,
     )
-    return ThemeDefinition(name=name, colors=colors, themetype=mode)
+    return ThemeDefinition(name=name, colors=colors, mode=mode)
 
 
 def install_legacy_themes(style=None) -> None:

--- a/tests/widget_styles/test_builder_registry.py
+++ b/tests/widget_styles/test_builder_registry.py
@@ -183,7 +183,7 @@ def test_new_theme_keeps_nondefault_recipes_lazy(root):
         ThemeDefinition(
             name=name,
             colors=style.theme.colors,
-            themetype=style.theme.type,
+            mode=style.theme.mode,
         )
     )
     style.theme_use(name)

--- a/tests/widget_styles/test_theme_anchor.py
+++ b/tests/widget_styles/test_theme_anchor.py
@@ -13,6 +13,7 @@ import ttkbootstrap as ttk
 from ttkbootstrap.style.theme import (
     Colors,
     Theme,
+    ThemeDefinition,
     _accent_on_color,
     _color_ramp,
     _color_to_hsl,
@@ -39,7 +40,7 @@ def sample_theme():
 def test_theme_generates_light_and_dark_definitions():
     defs = sample_theme().to_definitions()
     assert [d.name for d in defs] == ["sample-light", "sample-dark"]
-    assert [d.type for d in defs] == ["light", "dark"]
+    assert [d.mode for d in defs] == ["light", "dark"]
     assert all(isinstance(d.colors, Colors) for d in defs)
 
 
@@ -166,7 +167,7 @@ def test_legacy_adapter_preserves_identity_regenerates_plumbing():
     # buggy plumbing regenerated off bg
     assert c.inputbg != legacy["inputbg"]
     assert c.border != legacy["border"]
-    assert d.type == "dark"
+    assert d.mode == "dark"
 
 
 def test_user_theme_spec_builds_and_registers(root):
@@ -205,6 +206,26 @@ def test_from_existing_overrides_and_rejects_unknown_tokens():
     assert derived.success == BOOTSTRAP.success  # inherited
     with pytest.raises(ValueError, match="Unknown Theme token"):
         Theme.from_existing(BOOTSTRAP, name="acme", bogus="x")
+
+
+def test_theme_definition_mode_is_canonical():
+    colors = sample_theme().to_definitions()[0].colors
+    definition = ThemeDefinition("x", colors, mode="dark")
+    assert definition.mode == "dark"
+
+
+def test_theme_definition_themetype_kwarg_is_deprecated_alias():
+    colors = sample_theme().to_definitions()[0].colors
+    with pytest.warns(DeprecationWarning, match="themetype"):
+        definition = ThemeDefinition("x", colors, themetype="dark")
+    assert definition.mode == "dark"
+
+
+def test_theme_definition_type_attribute_is_deprecated_alias():
+    colors = sample_theme().to_definitions()[0].colors
+    definition = ThemeDefinition("x", colors, mode="dark")
+    with pytest.warns(DeprecationWarning, match="type"):
+        assert definition.type == "dark"
 
 
 def test_legacy_theme_use_lazy_registers_then_bulk_opt_in(root):


### PR DESCRIPTION
Two related pieces of theming/styling work.

## 1. Final four Reference sections

Authors the last four **Reference** sections, completing the API-reference
workstream's planned surface (all autodoc except hand-written `PhotoImage`):

- **`styling.rst`** — the `Style` engine, the bootstyle delivery helpers
  (`bootify`/`apply_bootstyle`/`enable_global_api`), and the custom-style
  toolkit (`Assets`/`El`/`layout`/`image_element`/`state_map`/`statespec`/
  `register_style`/`StyleName`).
- **`theming.rst`** — `Theme`, `ThemeDefinition`, `Colors`, `install_legacy_themes`.
- **`imaging.rst`** — `PhotoImage` (hand-written) + the
  `Icon`/`apply_icon`/`icon_element` glyph engine.
- **`utilities.rst`** — `ttkbootstrap.utils`: color conversion/contrast,
  high-DPI + scaling, and theme-change hooks.

Cards + hidden toctree wired into `reference/index.rst` in the target order.
`Examples:` stripped from the newly-autodoc'd members (`style/layout.py` ×6,
`engine.py` ×1, `theme.py` ×3) and the Markdown-ism inline-rST `-W` errors they
surfaced fixed.

Scope decisions (rationale in `development/2_0_docs_api_reference.md`): the
internal `Bootstyle` resolver class and the near-obsolete `BitmapImage` primitive
were deliberately left undocumented.

## 2. `ThemeDefinition`: `themetype` → `mode`  *(deprecated, no break)*

Documenting `ThemeDefinition` surfaced its last pre-2.0 naming holdout — and an
internal inconsistency: the constructor kwarg was `themetype` but it was stored
as `.type`. The light/dark selector is now `mode` everywhere, aligning with
`Style.theme_mode` / `toggle_theme` / `light_theme`/`dark_theme` / the
`<name>-light`/`<name>-dark` naming.

- `mode=` replaces `themetype=` (third positional arg unchanged); `themetype=`
  still accepted via `**kwargs` with a one-time `DeprecationWarning` (removed in
  3.0), matching the Meter/Window compat pattern. Unexpected kwargs now raise
  `TypeError`.
- `.mode` replaces `.type`; `.type` kept as a deprecated read-only property alias.
- `load_user_theme(s)` JSON accepts a `"mode"` **or** legacy `"type"` key, so
  saved-theme files keep loading.
- Logged in `development/2_0_breaking_changes.md`.

## Verification

- Docs build gate green: `sphinx -b html -W -q -E docs` → exit 0, no warnings;
  all four pages render (the deprecated `themetype` no longer appears in the
  `ThemeDefinition` signature).
- Suite **650 passed** (incl. 3 new `ThemeDefinition` alias tests). The 3
  `test_menu_api` "off_mac" failures are pre-existing on pristine `2.0` (they
  fail on real macOS), confirmed by stash-testing the base — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)