### PR TITLE
docs: complete the Widgets catalog — Canvas + Scrolled stub + coverage test

### DIFF
--- a/development/2_0_docs_design.md
+++ b/development/2_0_docs_design.md
@@ -393,7 +393,13 @@ tasks* (determinate/indeterminate `mode`, `mask`/`text`, `.start()/.stop()/
 .step()`, bind `variable`), cross-links to **API Reference › Floodgauge**. Style
 Reference is N/A (Canvas).
 
-### 5a-plan. Widgets-catalog authoring plan (LOCKED 2026-07-11)
+### 5a-plan. Widgets-catalog authoring plan (LOCKED 2026-07-11 — COMPLETE 2026-07-13)
+
+**STATUS: COMPLETE.** Every page authored across the family PRs; the final page
+(Canvas, robust) + the Scrolled thin stub + the no-gaps coverage sync test
+(`tests/test_widget_catalog_coverage.py`) landed 2026-07-13. Every `ttk.__all__`
+widget now has a catalog page or a justified allowlist entry.
+
 
 Coverage decided from a full inventory (19 native `BootMixin` + 8 shipped
 widgets). **~27 pages; 2 done (Button — to rewrite, Meter), ~25 to author.**

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -3,6 +3,41 @@
 > Living handoff for the 2.0 cleanup. Update at the end of each working session.
 > Pair with `development/2_0_plan.md` (the durable worklist) and `CLAUDE.md`.
 
+_Last updated: 2026-07-13 (**The WIDGETS CATALOG (docs Workstream H, `docs/widgets/`)
+is now COMPLETE.** The prior handoff's "remaining families" were stale — Containers
+(#1203878a), Range & misc (#27de4df6), Shipped indicators + interactive (#08425bbf/
+#091a50a0), and Text (#36adaeff) were **already merged into `2.0`**. This session
+authored the last two pages + the no-gaps mechanism on branch
+`docs/2.0-widgets-canvas`: **(1) `docs/widgets/canvas.rst`** — a robust, non-lite
+Canvas page (author steer: the earlier catalog pages ran "lite"; **mine the
+Tcl/Tk manual for concepts/caveats**, which the API-reference-first ordering
+enabled). Beyond basic drawing it teaches the coordinate system (float coords +
+`c`/`i`/`m`/`p` unit suffixes + normalised `coords`), ids vs. tags (the built-in
+`all`/`current` tags), the **display-list stacking model** (`tag_raise`/
+`tag_lower`; embedded windows always on top), **state-driven styling** (the
+`active*`/`disabled*` option triples give free hover styling — a gem lite pages
+miss), interactivity (`tag_bind`; *items are not widgets*; drag via
+`canvasx`/`canvasy`), per-item-type distinctive options (line `arrow`/`smooth`/
+`capstyle`, arc `start`/`extent`/`style`, polygon fill/hit-testing, text
+`width`-wrap/`angle`), embedding (`create_text`/`create_image` [live-ref caveat]/
+`create_window` [clipped by parent]), and scrolling (`scrollregion` =
+`bbox("all")`, `scan_mark`/`scan_dragto` pan, `confine`). Every snippet verified
+headlessly. **(2) `docs/widgets/scrolled.rst`** — the planned thin stub for
+`ScrolledFrame`/`ScrolledText` that cross-links the *Scroll long content* How-To
+(which owns the usage). **(3) `tests/test_widget_catalog_coverage.py`** — the
+no-gaps sync test: every public `tkinter.Widget` subclass in `ttk.__all__` (+ the
+non-tk shipped helpers `ToastNotification`/`ToolTip`) must have a
+`docs/widgets/<page>.rst` page or a justified `COVERED_ELSEWHERE` entry (Menu→guide,
+Tk*/LabelFrame→infra, ColorChooser→dialogs, Listbox→API ref, FloodgaugeLegacy→
+deprecated); a second test guards the allowlist from rot. Index cards + toctree
+updated (Canvas by Text, Scrolled among shipped). Build gate green
+(`sphinx -b html -W -q -E`, exit 0); suite **652 passed** (added 2; the 3
+`test_menu_api` "off_mac" failures are the known pristine-`2.0` macOS flakes).
+**With this, the Widgets catalog is DONE — every `ttk.__all__` widget is
+documented.** **NEXT docs-H threads:** the deferred **screenshot slice**
+(placeholders are in place across the catalog + guides) and any remaining
+Typography-guide follow-ups. Prior entry follows.**)_
+
 _Last updated: 2026-07-13 (**The self-authored API-REFERENCE layer is now COMPLETE
 — every planned Reference section authored and MERGED into `2.0`.** This was a
 large parallel sub-workstream tracked in its own doc,

--- a/docs/widgets/canvas.rst
+++ b/docs/widgets/canvas.rst
@@ -1,0 +1,341 @@
+Canvas
+======
+
+A **canvas** is a 2-D drawing surface — you place lines, shapes, text, images, and
+even other widgets on it, then move, restyle, and delete them individually.
+``Canvas`` is tkinter's ``tk.Canvas``; ttkbootstrap themes it to match the active
+theme automatically (there is no ``bootstyle`` — its background follows the
+theme). This page covers drawing items, the coordinate system, ids and tags, the
+stacking order, state-driven styling, making items interactive, embedding text and
+widgets, and scrolling a drawing larger than the window.
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   A canvas with a filled rectangle, an oval, a line, and a caption, in light and
+   dark themes.
+
+Usage
+-----
+
+Create it with a ``width`` and ``height`` in pixels, then draw with the
+``create_*`` methods. Each takes the item's coordinates first, then keyword
+options like ``fill`` and ``outline``:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
+   canvas = ttk.Canvas(app, width=300, height=200)
+   canvas.pack(padx=10, pady=10)
+
+   canvas.create_rectangle(20, 20, 120, 90, fill="#0d6efd", outline="")
+   canvas.create_oval(160, 20, 260, 120, fill="#20c997", outline="")
+   canvas.create_line(20, 150, 280, 150, width=3)
+   canvas.create_text(150, 180, text="Hello, canvas")
+
+   app.mainloop()
+
+Each item is an independent object living on the canvas — nothing is "painted"
+permanently. You keep drawing, then reach back and change, move, or remove any
+item you drew.
+
+The coordinate system
+---------------------
+
+Coordinates are measured from the **top-left corner**: ``x`` grows to the right,
+``y`` grows **downward**. Rectangles, ovals, and arcs are given by two opposite
+corners of a bounding box; lines and polygons by a run of points:
+
+.. code-block:: python
+
+   canvas.create_rectangle(x0, y0, x1, y1)     # top-left and bottom-right corners
+   canvas.create_line(x0, y0, x1, y1, x2, y2)  # a path through several points
+
+An oval fills the box you give it — pass a square box for a circle. Coordinates
+are stored as **floating-point** numbers, and any distance may be written with a
+unit suffix — ``"2c"`` (centimetres), ``"1i"`` (inch), ``"10m"`` (millimetres),
+``"72p"`` (points) — instead of bare pixels:
+
+.. code-block:: python
+
+   canvas.create_line("1c", "1c", "5c", "1c")   # a 4 cm line
+
+One quirk to know: querying a rectangle's or oval's ``coords`` returns them
+**normalised** to left-top-right-bottom order (and always in pixels), which may
+differ from the order you passed in.
+
+Item ids and tags
+-----------------
+
+Every ``create_*`` call returns an integer **id** that names that one item. Keep
+it to change the item later:
+
+.. code-block:: python
+
+   box = canvas.create_rectangle(20, 20, 120, 90, fill="#0d6efd", outline="")
+   canvas.itemconfigure(box, fill="#dc3545")    # recolor it
+
+To act on several items at once, give them a **tag** — a string label — with the
+``tags=`` option, then address the tag instead of an id. Any method that takes a
+``tagOrId`` accepts either; a tag may name **many** items at once:
+
+.. code-block:: python
+
+   canvas.create_oval(20, 20, 60, 60, fill="#adb5bd", outline="", tags="dot")
+   canvas.create_oval(80, 20, 120, 60, fill="#adb5bd", outline="", tags="dot")
+
+   canvas.itemconfigure("dot", fill="#0d6efd")  # recolor both dots at once
+
+An item can carry several tags, and ``gettags(item)`` lists them. Two tags are
+built in and always available:
+
+- ``"all"`` matches every item on the canvas — ``canvas.move("all", 0, 30)``
+  shifts the whole drawing.
+- ``"current"`` matches the single item under the mouse pointer (the topmost one),
+  or nothing when the pointer is over empty canvas. It is how bindings know which
+  item was clicked (see `Making items interactive`_).
+
+Tags let you treat a drawing as named groups of parts rather than a flat pile of
+ids. (A tag must not look like a plain integer — those are reserved for ids.)
+
+Stacking order
+--------------
+
+Items sit in a **display list**: earlier items are drawn first, later ones on top.
+A new item always goes on top of everything drawn before it. Reorder with
+``tag_raise`` (bring to front) and ``tag_lower`` (send to back), and note that
+``find_all`` reports ids in this bottom-to-top order:
+
+.. code-block:: python
+
+   back = canvas.create_rectangle(20, 20, 120, 90, fill="#0d6efd", outline="")
+   front = canvas.create_oval(60, 40, 160, 120, fill="#ffc107", outline="")
+
+   canvas.tag_raise(back)     # the rectangle now covers the oval
+   canvas.tag_lower(back)     # ...and back behind it
+
+Embedded widgets (`Text, images, and widgets`_) are the exception — they always
+draw on top of the graphics, regardless of the display list.
+
+Moving and changing items
+-------------------------
+
+Once an item exists you rarely recreate it — you adjust it in place:
+
+- ``move(tagOrId, dx, dy)`` shifts matching items by an offset.
+- ``coords(tagOrId, *new)`` sets an item's coordinates outright, or returns them
+  when called with just the id.
+- ``itemconfigure(tagOrId, **options)`` changes any of the item's options
+  (``fill``, ``outline``, ``width``, ``text``, ``state``, …).
+- ``delete(tagOrId)`` removes matching items; ``delete("all")`` clears the canvas.
+
+.. code-block:: python
+
+   ball = canvas.create_oval(20, 20, 60, 60, fill="#0d6efd", outline="")
+
+   canvas.move(ball, 40, 0)                  # nudge right
+   canvas.coords(ball, 100, 100, 160, 160)   # or reposition absolutely
+   x0, y0, x1, y1 = canvas.coords(ball)       # query the current box
+
+States and state-driven styling
+-------------------------------
+
+Every item has a **state** — ``"normal"``, ``"hidden"``, or ``"disabled"`` —
+which you set at creation or with ``itemconfigure``. ``"hidden"`` removes it from
+view without deleting it (great for toggling parts of a drawing on and off), and
+``"disabled"`` shows it but makes it **ignore all bindings**:
+
+.. code-block:: python
+
+   canvas.itemconfigure(ball, state="hidden")   # temporarily invisible
+   canvas.itemconfigure(ball, state="normal")   # back again
+
+The canvas also gives items **automatic hover styling** with no binding at all.
+Alongside ``fill``/``outline``/``width`` you can set ``active*`` variants that
+apply while the pointer is over the item, and ``disabled*`` variants for the
+disabled state. So a shape can light up on hover for free:
+
+.. code-block:: python
+
+   canvas.create_oval(
+       50, 50, 110, 110,
+       fill="#0d6efd", activefill="#dc3545",     # blue, red under the pointer
+       outline="", width=2, activewidth=4,
+   )
+
+``activefill``/``activeoutline``/``activewidth``/``activedash``/``activestipple``
+(and the matching ``disabled*`` set) cover the common cases without a single event
+handler.
+
+Making items interactive
+------------------------
+
+Canvas items are **not widgets** — they can't take focus, and ``bind`` is for the
+canvas as a whole. To respond to events on a specific item, use ``tag_bind``,
+which fires for every item matching the tag or id. The callback receives an event
+whose ``x``/``y`` are the pointer position:
+
+.. code-block:: python
+
+   dot = canvas.create_oval(50, 50, 90, 90, fill="#0d6efd", outline="", tags="target")
+
+   def flip_color(event):
+       canvas.itemconfigure("target", fill="#dc3545")
+
+   canvas.tag_bind("target", "<Button-1>", flip_color)
+
+Item bindings rely on the ``"current"`` tag (the topmost item under the pointer),
+so ``<Enter>`` / ``<Leave>`` work per item, and ``closeenough`` (a canvas option,
+default 1 pixel) sets how near counts as "over." To drag an item, move it to
+follow the pointer on ``<B1-Motion>`` — convert the event's window coordinates to
+canvas coordinates with ``canvasx``/``canvasy`` so it stays correct when the
+canvas is scrolled:
+
+.. code-block:: python
+
+   handle = canvas.create_oval(40, 40, 80, 80, fill="#20c997", outline="", tags="drag")
+
+   def on_drag(event):
+       x = canvas.canvasx(event.x)
+       y = canvas.canvasy(event.y)
+       canvas.coords("drag", x - 20, y - 20, x + 20, y + 20)
+
+   canvas.tag_bind("drag", "<B1-Motion>", on_drag)
+
+Shapes and lines
+----------------
+
+The shape items share ``fill``, ``outline``, and ``width``, and each adds a few of
+its own worth knowing:
+
+- **Line** (``create_line``) — ``arrow`` (``"first"``/``"last"``/``"both"``) puts
+  arrowheads on the ends, ``smooth=True`` renders it as a spline curve through the
+  points, ``dash`` makes it dashed, and ``capstyle``/``joinstyle`` shape the ends
+  and corners.
+- **Arc** (``create_arc``) — ``start`` and ``extent`` (both in degrees) set the
+  slice, and ``style`` picks ``"pieslice"`` (default), ``"chord"``, or ``"arc"``
+  (just the curved edge).
+- **Polygon** (``create_polygon``) — closes the path automatically and can
+  ``smooth``. Note a filled *and* an unfilled polygon both count as "solid" for
+  hit-testing; use a ``create_line`` if you want a click-through outline.
+- **Rectangle** and **oval** take only the shared options.
+
+.. code-block:: python
+
+   canvas.create_line(20, 20, 120, 20, arrow="last", width=2)
+   canvas.create_arc(20, 40, 120, 140, start=30, extent=120, style="pieslice", fill="#0d6efd")
+   canvas.create_polygon(60, 40, 100, 100, 20, 100, fill="#20c997", outline="")
+
+Text, images, and widgets
+-------------------------
+
+Beyond shapes, a canvas can hold text, images, and live widgets — each positioned
+at a point, with ``anchor`` deciding which part of the item sits on that point
+(``"nw"`` for the top-left, ``"center"`` by default):
+
+.. code-block:: python
+
+   canvas.create_text(20, 20, text="Top-left label", anchor="nw", justify="left")
+
+   logo = ttk.PhotoImage(file="logo.png")
+   canvas.create_image(150, 100, image=logo)      # keep a reference to `logo`
+
+   button = ttk.Button(app, text="Click me")
+   canvas.create_window(150, 170, window=button)
+
+A few specifics:
+
+- **Text** (``create_text``) — set ``width`` (pixels) to wrap long text at word
+  boundaries, ``justify`` to align the wrapped lines, and ``angle`` to rotate the
+  text. Text items are editable and support the character indices ``"insert"`` /
+  ``"end"`` with ``insert`` and ``dchars``.
+- **Image** (``create_image``) — needs a live reference to the ``PhotoImage``; if
+  it is garbage-collected the picture vanishes, so store it (e.g. on ``self``).
+- **Window** (``create_window``) — embeds any existing widget (not a toplevel).
+  Embedded widgets always draw on top of the graphics and are clipped by the
+  *parent* window, not the canvas border.
+
+Scrolling
+---------
+
+A canvas can be larger than the window it shows. Set ``scrollregion`` to the full
+drawing area — ``(left, top, right, bottom)`` in canvas coordinates — and wire a
+:doc:`Scrollbar <scrollbar>` to it, exactly as you would for a Text or Treeview:
+
+.. code-block:: python
+
+   canvas = ttk.Canvas(app, width=300, height=200)
+   vbar = ttk.Scrollbar(app, orient="vertical", command=canvas.yview)
+   canvas.configure(yscrollcommand=vbar.set)
+
+   canvas.pack(side="left", fill="both", expand=True)
+   vbar.pack(side="right", fill="y")
+
+   canvas.create_line(0, 0, 300, 1000, width=2)   # a tall drawing
+   canvas.configure(scrollregion=canvas.bbox("all"))
+
+``bbox("all")`` returns the box enclosing every item, so setting ``scrollregion``
+to it is the usual way to make the whole drawing reachable. ``confine=True`` (the
+default) keeps the view inside that region, and ``xscrollincrement`` /
+``yscrollincrement`` quantise scrolling to a fixed step. For a quick "grab and
+pan" gesture, wire ``scan_mark`` / ``scan_dragto`` to a mouse button:
+
+.. code-block:: python
+
+   canvas.bind("<Button-1>", lambda e: canvas.scan_mark(e.x, e.y))
+   canvas.bind("<B1-Motion>", lambda e: canvas.scan_dragto(e.x, e.y, gain=1))
+
+For a ready-made scrollable region that holds ordinary widgets rather than drawn
+items, use ``ScrolledFrame`` — see
+:doc:`Scroll long content </user-guide/how-to/scrollable>`.
+
+Appearance
+----------
+
+The canvas picks up the theme's background automatically and re-themes when you
+switch themes — you don't style it with ``bootstyle``. Items carry their own
+colors through their ``fill``/``outline`` options, so a drawing's palette is up to
+you; pull theme colors from the :doc:`Style </reference/styling>` if you want them
+to track the theme:
+
+.. code-block:: python
+
+   colors = app.style.colors
+   canvas.create_rectangle(20, 20, 120, 90, fill=colors.primary, outline="")
+
+To keep tkinter's default look and take over styling entirely, pass
+``autostyle=False`` — it opts out of the automatic theming:
+
+.. code-block:: python
+
+   ttk.Canvas(app, autostyle=False, background="white")
+
+API & reference
+---------------
+
+``Canvas`` is tkinter's ``tk.Canvas`` — ttkbootstrap themes it but adds no Python
+API beyond ``autostyle``. Its surface is large: item constructors
+(``create_line``/``create_rectangle``/``create_oval``/``create_arc``/
+``create_polygon``/``create_text``/``create_image``/``create_window``), geometry
+(``coords``, ``move``, ``moveto``, ``scale``, ``bbox``), configuration
+(``itemconfigure``, ``itemcget``, ``type``), finding items (``find_all``,
+``find_withtag``, ``find_closest``, ``find_overlapping``), tagging
+(``gettags``, ``addtag_withtag``, ``dtag``), stacking (``tag_raise``,
+``tag_lower``), item events (``tag_bind``), and scrolling
+(``xview``/``yview``, ``canvasx``/``canvasy``, ``scan_mark``/``scan_dragto``).
+
+The standard library reference doesn't document the canvas in full. The
+:doc:`Canvas reference </reference/api/canvas>` documents its options and methods,
+and the canonical, complete upstream reference is the
+`Tk canvas manual page <https://www.tcl-lang.org/man/tcl8.6/TkCmd/canvas.htm>`__ —
+written in Tcl, so a subcommand like ``itemconfigure`` maps directly to the
+Python method of the same name.
+
+.. seealso::
+
+   :doc:`Text <text>` for the other big tk-native widget, and
+   :doc:`Scroll long content </user-guide/how-to/scrollable>` for scrollable
+   regions built from ordinary widgets.

--- a/docs/widgets/index.rst
+++ b/docs/widgets/index.rst
@@ -97,6 +97,12 @@ where each page also documents the widget's hand-styling surface.
 
       A multi-line editor — tags, marks, search, and undo.
 
+   .. grid-item-card:: Canvas
+      :link: canvas
+      :link-type: doc
+
+      A drawing surface — shapes, text, images, and embedded widgets.
+
    .. grid-item-card:: Progressbar
       :link: progressbar
       :link-type: doc
@@ -175,6 +181,12 @@ where each page also documents the widget's hand-styling surface.
 
       A help popup that appears on hover.
 
+   .. grid-item-card:: Scrolled
+      :link: scrolled
+      :link-type: doc
+
+      Frame and text widgets with a scrollbar already wired in.
+
 .. toctree::
    :hidden:
 
@@ -192,6 +204,7 @@ where each page also documents the widget's hand-styling surface.
    panedwindow
    label
    text
+   canvas
    progressbar
    scale
    scrollbar
@@ -205,3 +218,4 @@ where each page also documents the widget's hand-styling surface.
    tableview
    toast
    tooltip
+   scrolled

--- a/docs/widgets/scrolled.rst
+++ b/docs/widgets/scrolled.rst
@@ -1,0 +1,38 @@
+Scrolled
+========
+
+When content outgrows its window, plain tkinter makes you pair a widget with a
+:doc:`Scrollbar <scrollbar>` and wire the two together by hand. ttkbootstrap
+ships two widgets that do that wiring for you:
+
+- ``ScrolledFrame`` — a frame with a scrollbar attached; pack or grid any widgets
+  into it and it scrolls when they overflow.
+- ``ScrolledText`` — a themed multi-line :doc:`Text <text>` with its scrollbar
+  attached; its underlying ``Text`` is exposed as ``.text``.
+
+Both take ``auto_hide=True`` to hide the scrollbar until the pointer enters the
+region.
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(title="Settings", size=(360, 300))
+
+   scroller = ttk.ScrolledFrame(app, auto_hide=True)
+   scroller.pack(fill="both", expand=True, padx=10, pady=10)
+
+   for i in range(40):
+       ttk.Checkbutton(scroller, text=f"Option {i + 1}", bootstyle="round toggle").pack(anchor="w", pady=2)
+
+   app.mainloop()
+
+The full walkthrough — a scrollable form, a live log, read-only text, and
+streaming output — lives in the How-To, which owns the usage:
+
+.. seealso::
+
+   :doc:`Scroll long content </user-guide/how-to/scrollable>` — the complete
+   guide to ``ScrolledFrame`` and ``ScrolledText``. For scrolling a drawing or a
+   single widget yourself, see :doc:`Canvas <canvas>` and :doc:`Scrollbar
+   <scrollbar>`.

--- a/tests/test_widget_catalog_coverage.py
+++ b/tests/test_widget_catalog_coverage.py
@@ -1,0 +1,81 @@
+"""No-gaps sync test for the Widgets catalog (docs Workstream H).
+
+The visual catalog (`docs/widgets/`) has one usage page per public widget. This
+test enforces that no public widget can be added to the API without either a
+catalog page or an explicit "covered elsewhere" allowlist entry -- so a new
+widget can't silently ship undocumented.
+
+The widget set is derived live from `ttkbootstrap.__all__`: every exported
+`tkinter.Widget` subclass, plus the two shipped helpers that are catalog widgets
+without being tk widgets (`ToastNotification`, `ToolTip`). Each must map to a
+`docs/widgets/<page>.rst` file or appear in `COVERED_ELSEWHERE`.
+
+The allowlists are themselves checked (`test_*_are_public_widgets`) so they
+can't rot: every key must still name a real public widget.
+"""
+import pathlib
+import tkinter
+
+import ttkbootstrap as ttk
+
+_REPO = pathlib.Path(__file__).resolve().parents[1]
+_WIDGETS_DIR = _REPO / "docs" / "widgets"
+
+# Shipped helpers that ARE catalog widgets but don't subclass tkinter.Widget.
+_EXTRA_WIDGETS = {"ToastNotification", "ToolTip"}
+
+# class name -> catalog page basename, where it isn't just the lowercased name.
+_PAGE_ALIASES = {
+    "ToastNotification": "toast",
+    "ScrolledFrame": "scrolled",
+    "ScrolledText": "scrolled",
+}
+
+# Public widget classes documented OUTSIDE the visual catalog, by design.
+_COVERED_ELSEWHERE = {
+    "Menu": "Menus feature guide",
+    "TkFrame": "window/infrastructure, not a catalog widget",
+    "TkLabel": "window/infrastructure, not a catalog widget",
+    "LabelFrame": "the tk LabelFrame; the catalog documents the ttk Labelframe",
+    "ColorChooser": "Dialogs & overlays reference",
+    "Listbox": "API reference; superseded for most uses by Treeview/Combobox",
+    "FloodgaugeLegacy": "deprecated alias, removed in 3.0",
+}
+
+
+def _public_widgets():
+    names = set(_EXTRA_WIDGETS)
+    for name in ttk.__all__:
+        obj = getattr(ttk, name)
+        if isinstance(obj, type) and issubclass(obj, tkinter.Widget):
+            names.add(name)
+    return names
+
+
+def test_every_public_widget_has_catalog_page_or_allowlist():
+    missing = []
+    for name in sorted(_public_widgets()):
+        if name in _COVERED_ELSEWHERE:
+            continue
+        page = _PAGE_ALIASES.get(name, name.lower())
+        if not (_WIDGETS_DIR / f"{page}.rst").exists():
+            missing.append(f"{name} (expected docs/widgets/{page}.rst)")
+    assert not missing, (
+        "Public widgets with no catalog page and no COVERED_ELSEWHERE entry:\n  "
+        + "\n  ".join(missing)
+        + "\n\nAuthor a docs/widgets/<name>.rst page, add a _PAGE_ALIASES entry, "
+        "or (if documented elsewhere by design) a _COVERED_ELSEWHERE entry."
+    )
+
+
+def test_allowlist_keys_are_public_widgets():
+    widgets = _public_widgets()
+    stale = sorted(
+        name
+        for name in (*_COVERED_ELSEWHERE, *_PAGE_ALIASES)
+        if name not in widgets
+    )
+    assert not stale, (
+        "Allowlist names that are no longer public widgets (remove them):\n  "
+        + "\n  ".join(stale)
+    )


### PR DESCRIPTION
Finishes docs Workstream H's **visual Widgets catalog** (`docs/widgets/`). The prior handoff listed several families as "remaining," but Containers / Range & misc / Shipped / Text were already merged into `2.0`. This PR lands the last two pages plus the no-gaps mechanism, so **every `ttk.__all__` widget is now documented**.

## What's here

- **`docs/widgets/canvas.rst`** — a robust, *non-lite* Canvas page. Per author steer ("the earlier pages ran lite; mine the Tcl/Tk manual for concepts and caveats"), it teaches beyond basic drawing:
  - coordinate system (float coords, `c`/`i`/`m`/`p` unit suffixes, normalised `coords`)
  - ids vs. tags, the built-in `all` / `current` tags
  - the **display-list stacking model** (`tag_raise`/`tag_lower`; embedded windows always on top)
  - **free hover styling** via the `active*`/`disabled*` option triples (a detail lite pages miss)
  - `tag_bind` interactivity (*items are not widgets*; drag via `canvasx`/`canvasy`)
  - per-item-type distinctive options (line `arrow`/`smooth`, arc `start`/`extent`/`style`, text `width`-wrap/`angle`, polygon hit-testing)
  - embedding caveats (`create_image` live-ref, `create_window` clipped by parent)
  - scrolling (`scrollregion = bbox("all")`, `scan_mark`/`scan_dragto` pan, `confine`)

  Every code snippet verified headlessly.
- **`docs/widgets/scrolled.rst`** — the planned thin stub for `ScrolledFrame`/`ScrolledText`, cross-linking the *Scroll long content* How-To (which owns the usage).
- **`tests/test_widget_catalog_coverage.py`** — the no-gaps sync test: every public `tkinter.Widget` subclass in `ttk.__all__` (plus the non-tk shipped helpers `ToastNotification`/`ToolTip`) must have a `docs/widgets/<page>.rst` page or a justified `COVERED_ELSEWHERE` entry. A second test guards the allowlist from rot.
- Index cards + toctree updated; handoff + design §5a-plan marked **COMPLETE**.

## Verification

- Build gate green: `sphinx -b html -W -q -E docs` → exit 0, no warnings.
- Suite **652 passed** (added 2). The 3 `test_menu_api` "off_mac" failures are the known pristine-`2.0` macOS flakes, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)