### PR TITLE
docs: enrich the Containers usage pages (Tcl/Tk depth pass)

### DIFF
--- a/development/2_0_docs_usage_enrichment.md
+++ b/development/2_0_docs_usage_enrichment.md
@@ -1,0 +1,150 @@
+# 2.0 Docs — Widgets-catalog usage-guide enrichment (audit + plan)
+
+Author steer (2026-07-13): the existing catalog usage pages were authored *before*
+the "don't write lite pages — mine the Tcl/Tk manuals for concepts/caveats" rule
+([[feedback_mine_tcltk_manuals_for_usage]]). This pass re-evaluates every existing
+`docs/widgets/*.rst` page against its `ttk_*`/`tk` manual (shipped widgets against
+their real source/API) and enriches the thin ones. Canvas (just authored) and Text
+(already robust) are excluded.
+
+**Method:** 6 parallel audit agents, one per family, each read the full page +
+fetched the manual + verified names against the live API. Findings below are their
+grounded output. **Execution:** one PR per family (same structure as the original
+catalog PRs), every new snippet verified headlessly, build gate `sphinx -W -q -E`
+exit 0. Depth stays *usage* depth — teach the real patterns/caveats, not an
+exhaustive option dump (the API reference is the depth home).
+
+**Five factual errors to fix (independent of enrichment):** radiobutton
+"unrelated buttons" note (backwards — shared `::selectedButton`), button "no
+default flag" (false — `default=` exists), labeledscale "shows whole numbers"
+(`:g`), toast default-position + 4-anchor list (OS-specific; 8 anchors), tooltip
+`delay` default (250 not 500).
+
+---
+
+## PR 1 — Containers (frame, labelframe, notebook, panedwindow)
+
+- **frame** (OK→minor): geometry-propagation caveat (`width`/`height` ignored once
+  children packed; `pack_propagate(False)`/`grid_propagate(False)` to force); note
+  `relief` needs non-zero `borderwidth` + prefer `card`/`highlight` over raw relief;
+  frames are non-interactive.
+- **labelframe** (MODERATE): `labelanchor=` (12 forms, where the caption sits);
+  `labelwidget=` (replace caption text with a widget, e.g. a checkbutton that
+  enables the group — overrides `text=`, must be child/ancestor); `underline=`
+  mnemonic.
+- **notebook** (MODERATE): `enable_traversal()` (Ctrl-Tab / Alt-mnemonic; needs all
+  pages as direct children) + tab `underline=`; tab display options on `add`/`tab`
+  (`image`/`compound`/`underline`/`sticky`/`padding`); tab-id forms
+  (index/widget/`@x,y`/`current`/`end`); `state="hidden"` third state; `tabs()` +
+  `identify(x,y)`; `<<NotebookTabChanged>>` also fires on initial map (matters for
+  lazy-load).
+- **panedwindow** (MODERATE): `insert(pos,child,weight=)` / `forget(child)`;
+  `panes()` + `pane(child, weight=)` to reconfigure; multi-sash monotonic clamp;
+  `sashpos` only after mapped (`update_idletasks()`); `orient` is configurable
+  (page implies construction-only); no per-pane `minsize` (unlike tk.PanedWindow).
+
+## PR 2 — Range & misc (label, progressbar, scale, scrollbar, separator, sizegrip)
+
+- **label** (MODERATE): `anchor=` vs `justify=` distinction (block position vs
+  wrapped-line alignment); `width=` (char width, negative=min, for aligning form
+  label columns); `relief=`+`padding=` (badge/chip look); `compound=` values;
+  `disabled` greys text.
+- **progressbar** (MODERATE-light): indeterminate `value` wraps modulo `maximum`
+  (so maximum sets cycle length); `variable` overrides `value`; `step` default
+  `1.0`; `start(interval)` default 50 ms; read-only `phase` drives stripes.
+- **scale** (MODERATE): `.set()` clips to range but assigning the variable directly
+  bypasses clipping (footgun); `command` receives the value as a **string**
+  (explains the `float()` cast); `.coords(value)` + `.get(x,y)` (pixel↔value, how
+  LabeledScale places its label); no `resolution`/`tickinterval`/`showvalue`/`label`
+  vs tk.Scale (migrator note); `to<from_` inverts.
+- **scrollbar** (MODERATE): auto-disable when whole range visible (set gets
+  `0.0 1.0`) — "dead scrollbar" surprise; fraction model 0.0–1.0; `.get()` →
+  `(first,last)`; `command` subcommands (`moveto`/`scroll n units|pages`) for
+  custom/canvas wiring.
+- **separator** (OK): optional — default `orient` horizontal; purely decorative.
+- **sizegrip** (MODERATE): negative-geometry caveat (window positioned with
+  `-x-y` won't resize — the marquee bug); SE-only (why bottom-right + `anchor=SE`);
+  macOS draws a native grip already.
+
+## PR 3 — Inputs (entry, combobox, spinbox)
+
+- **entry** (MODERATE): index vocab (`insert`/`sel.first`/`sel.last`/`@x`;
+  out-of-range rounds); `icursor()`; selection methods (`selection_range`/`_clear`/
+  `_present`, `index()`); `show=` copies mask chars caveat; validatecommand `%`
+  substitutions pointer (`%P`/`%s`/`%S`/`%d`/`%V`) + `invalidcommand`; ttk caveat:
+  validation NOT re-triggered on programmatic `textvariable` change; `invalid`
+  state auto-set.
+- **combobox** (MODERATE): `current()` as getter (index or `-1` if typed value not
+  in list) — detect pick-vs-typed; `postcommand=` (refresh `values` before
+  dropdown); `height=`; `<<ComboboxSelected>>` fires only on pick, not typed edits
+  (trace the var too); dropdown list is a classic `listbox`, NOT ttk-styled
+  (option-database only) — the look-mismatch surprise; readonly still settable via
+  dropdown/`.set()`.
+- **spinbox** (MODERATE): `format="%.2f"` (kills float noise on fractional
+  `increment`); `values=` overrides `from_`/`to`/`increment`; keyboard
+  `<Up>`/`<Down>` + `<<Increment>>`/`<<Decrement>>` events; `command` on spin only
+  (typed edits via var trace); `wrap` works for numeric ranges too; `.set()` exists
+  but NO `current()` (unlike Combobox).
+
+## PR 4 — Choice + Command (checkbutton, radiobutton, menubutton, optionmenu)
+
+- **checkbutton** (OK): one line — `selected` state tracks the variable
+  automatically.
+- **radiobutton** (MODERATE, **correctness**): FIX the note — without `variable=`
+  they share the default global `::selectedButton` (interfere), not independent;
+  add `alternate`/tristate state (variable unset → mixed look); `selected` tracks
+  variable.
+- **menubutton** (OK): optional one line — build the menu as a child of the
+  menubutton.
+- **optionmenu** (MODERATE): `set_menu(default=None, *values)` to rebuild choices
+  after construction (the "it builds its own menu" concept, made dynamic).
+
+## PR 5 — Button + Treeview
+
+- **button** (MODERATE, **correctness**): FIX "no default flag" — `default=`
+  (`normal`/`active`/`disabled`) is real; teach `Button(default="active")` for the
+  platform default-ring + still show the `<Return>` binding; add `invoke()`; name
+  the `active` state.
+- **treeview** (MODERATE, additive): `selectmode=` (extended/browse/none; code
+  selection ignores browse); `selection_add`/`_remove`/`_toggle`;
+  `<<TreeviewOpen>>`/`<<TreeviewClose>>` (lazy-load children); `detach`/`reattach`
+  (hide/filter without delete); hit-testing `identify_region`/`_column`/`_row` +
+  `bbox` (context menus); `see(item)`; focus vs selection distinction; hierarchy
+  nav (`parent`/`children`/`index`/`next`/`prev`/`exists`); `displaycolumns=`;
+  `column(stretch=False)` pin + tag priority = creation order + `foreground`/`font`
+  tag options.
+
+## PR 6 — Shipped (meter, floodgauge, labeledscale, dateentry, tableview, toast, tooltip)
+
+- **meter** (MODERATE): `text_left`/`text_right` (`$`/`%` affixes); `amount_format`
+  (`"{:.1f}"`); `amount_min` (negative/offset ranges); `value` property;
+  `step()` bounces at min/max (reverses, not clamp); `wedge_size` look.
+- **floodgauge** (OK-minor): `length`/`thickness` sizing; `mask` formats
+  `int(value)` (fractional shows truncated); `font`.
+- **labeledscale** (MODERATE, **correctness**): FIX "whole numbers" (`:g` →
+  `3.7` shows `3.7`); `.scale`/`.label` sub-widget access; `value` read/write
+  property (variable optional); horizontal-only (no `orient`).
+- **dateentry** (MODERATE): `<<DateEntrySelected>>` event; typed-text + blur
+  validation (`get_date()` parses live entry text; unparseable → `invalid` on
+  focus-out); `get_date()` never returns None here (vs `Querybox.get_date` dialog
+  which does); `value` property; `show_outside_days`.
+- **tableview** (OK-minor): `iid_field` (natural-key iids, for stable
+  `delete_row(iid=)`/`get_row(iid=)`); `insert_row(reload=True)` already redraws;
+  `autofit`/`height` (viewport rows ≠ `pagesize`); column-scoped
+  `search_table_data(criteria, *columns)`.
+- **toast** (MODERATE, **correctness**): `show_toast()` returns the toast as a
+  dismiss handle; FIX anchor list (8 compass points); FIX default position
+  (SE win32/x11, NE aqua); auto-stacking of concurrent toasts; `hide()` canonical.
+- **tooltip** (MODERATE, **correctness**): FIX `delay` default (250 not 500);
+  `position=` ("top left"/…) anchors to widget vs following pointer;
+  `configure()`/`cget()` live reconfig; `justify`/`image`/`padding`.
+
+## PR 7 (optional, small) — Text
+
+- One line: inline `image_create(index, image=)` / `window_create(index, window=)`
+  to embed pictures/widgets between characters. Low priority; API ref is depth home.
+
+---
+
+**Status:** audit COMPLETE 2026-07-13. PRs pending — execute in order, each its own
+branch off `2.0`, snippets verified headlessly, `-W` green, suite green.

--- a/docs/widgets/frame.rst
+++ b/docs/widgets/frame.rst
@@ -67,6 +67,10 @@ a card glow while an entry inside it is focused:
    entry.bind("<FocusIn>",  lambda event: card.state(["focus"]))
    entry.bind("<FocusOut>", lambda event: card.state(["!focus"]))
 
+Prefer ``card`` and ``highlight`` over a raw ``relief=``/``borderwidth=`` border:
+plain ttk relief is theme-dependent and needs a non-zero ``borderwidth`` to show
+at all, while the ``card`` hairline matches the rest of the theme.
+
 Colored background
 ------------------
 
@@ -77,6 +81,22 @@ reads against the fill (as the header in `Usage`_ does):
 .. code-block:: python
 
    ttk.Frame(app, padding=10, bootstyle="secondary")
+
+Fixing a frame's size
+---------------------
+
+A frame sizes itself to fit its children, so ``width=`` and ``height=`` are
+**ignored** the moment you pack or grid anything into it. To make a frame hold a
+fixed size regardless of its contents, turn **geometry propagation** off:
+
+.. code-block:: python
+
+   panel = ttk.Frame(app, width=200, height=120)
+   panel.pack()
+   panel.pack_propagate(False)      # keep 200x120 even after adding children
+
+Use ``grid_propagate(False)`` instead when the frame's children are gridded. This
+is the usual answer to "why won't my frame stay the size I set?"
 
 API & reference
 ---------------

--- a/docs/widgets/labelframe.rst
+++ b/docs/widgets/labelframe.rst
@@ -37,6 +37,30 @@ as their ``master``. It is the natural container for a **section of a form**:
 Like a plain :doc:`Frame <frame>`, use ``padding=`` to inset the contents; arrange
 the children with any geometry manager.
 
+Positioning and replacing the caption
+-------------------------------------
+
+``labelanchor=`` moves the caption around the border — ``"nw"`` (top-left),
+``"n"`` (top-centre), ``"w"`` (down the left edge), through the twelve compass
+positions:
+
+.. code-block:: python
+
+   ttk.Labelframe(app, text="Contact", labelanchor="nw", padding=12)
+
+For a caption that's more than plain text, pass a **widget** as the label with
+``labelwidget=`` — a label with an icon, or a checkbutton that enables the whole
+group. It replaces ``text=``, and must be a child of the labelframe or one of its
+ancestors:
+
+.. code-block:: python
+
+   enabled = ttk.Checkbutton(app, text="Shipping address", bootstyle="round-toggle")
+   section = ttk.Labelframe(app, labelwidget=enabled, padding=12)
+   section.pack(fill=X, padx=10, pady=10)
+
+``underline=`` underlines one character of a text caption as a keyboard mnemonic.
+
 Color
 -----
 

--- a/docs/widgets/notebook.rst
+++ b/docs/widgets/notebook.rst
@@ -37,6 +37,24 @@ tab ``text``. Build a frame per page, fill it, and add it:
 
    app.mainloop()
 
+Tab labels and keyboard traversal
+---------------------------------
+
+``add`` (and ``tab``) take more than ``text``. ``image=`` with ``compound=`` puts
+an icon on the tab, ``underline=`` marks a mnemonic character, and ``sticky=``
+controls how the page fills its tab area. Call ``enable_traversal()`` once to turn
+on keyboard navigation — Control-Tab and Control-Shift-Tab cycle the tabs, and
+Alt+mnemonic jumps straight to one:
+
+.. code-block:: python
+
+   notebook.add(advanced, text="Advanced", underline=0)   # Alt+A jumps here
+   notebook.enable_traversal()
+
+Traversal only reaches pages that are **direct children** of the notebook. To show
+an icon, pass a ``PhotoImage`` as ``image=`` (see
+:doc:`Show images and icons </user-guide/how-to/working-with-images>`).
+
 Switching tabs
 --------------
 
@@ -49,6 +67,11 @@ The user clicks a tab to switch; ``select`` switches programmatically, and
    notebook.select(0)                       # or by index
    current = notebook.index(notebook.select())   # -> the selected tab's index
 
+Methods that address a tab — ``select``, ``tab``, ``hide``, ``forget``, ``index``
+— accept the same tab-id forms: the page widget, an integer index, ``"current"``,
+or ``"@x,y"`` (the tab at a point). ``tabs()`` returns every page widget in tab
+order, handy for iterating.
+
 Reacting to a tab change
 ------------------------
 
@@ -58,6 +81,10 @@ To run code when the page changes — lazy-load its contents, say — bind the
 .. code-block:: python
 
    notebook.bind("<<NotebookTabChanged>>", lambda event: print("now on", notebook.index("current")))
+
+This also fires once when the notebook first appears and selects its initial tab —
+so a handler that lazy-loads a page's contents runs for the starting tab too,
+which is usually what you want.
 
 Disabling and removing tabs
 ---------------------------
@@ -92,9 +119,11 @@ API & reference
 ---------------
 
 ``Notebook`` is the native ``ttk.Notebook`` — ttkbootstrap adds ``bootstyle=`` but
-no other Python API. For its constructor and the tab-management methods
-(``add``, ``insert``, ``select``, ``tab``, ``hide``, ``forget``, ``index``,
-``tabs``) see the
+no other Python API. Its own methods manage tabs: ``add`` / ``insert(pos, …)`` to
+append or insert a page, ``select`` / ``tab`` / ``index`` / ``tabs`` to query and
+switch, ``hide`` / ``forget`` to remove, ``enable_traversal`` for keyboard
+navigation, and ``identify(x, y)`` to hit-test the tab bar. For the full signatures
+see the
 `tkinter.ttk.Notebook <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Notebook>`__
 reference.
 

--- a/docs/widgets/panedwindow.rst
+++ b/docs/widgets/panedwindow.rst
@@ -47,12 +47,35 @@ Sharing space
 pane with ``weight=4`` grows four times as fast as one with ``weight=1``, so the
 content pane above stays dominant while the sidebar stays slim.
 
-For the starting split, set a sash position explicitly with ``sashpos`` (after the
-window is laid out). The user can always drag the sash to override it:
+For the starting split, set a sash position explicitly with ``sashpos``. The user
+can always drag the sash to override it:
 
 .. code-block:: python
 
    paned.sashpos(0, 200)                    # put the first sash 200px from the start
+
+``sashpos`` only works once the panedwindow has been laid out, so call it after an
+``update_idletasks()`` (or from an idle callback) — right after ``add`` it is a
+no-op. With three or more panes, sash *N* sits between panes *N* and *N+1* and the
+positions stay ordered, so moving one sash can nudge its neighbours.
+
+Adding and removing panes
+-------------------------
+
+Panes aren't fixed at construction — manage them at runtime. ``insert`` adds a
+pane at a position, ``forget`` removes one (the widget itself survives), and
+``pane`` re-reads or changes a pane's settings, so you can freeze a pane by giving
+it ``weight=0``:
+
+.. code-block:: python
+
+   paned.insert(0, sidebar, weight=1)       # add a pane at the front
+   paned.pane(sidebar, weight=0)            # freeze it: no share of extra space
+   paned.forget(sidebar)                    # remove it again
+
+``panes()`` returns the managed pane widgets in order. Unlike the classic
+``tk.PanedWindow``, there is no per-pane ``minsize`` — a pane's minimum is driven
+by its children's requested size.
 
 Color
 -----


### PR DESCRIPTION
First PR of a per-family pass re-evaluating the existing Widgets-catalog **usage pages** for "lite" treatment and gaps, mining the Tcl/Tk manuals for the concepts and caveats a self-sufficient page should teach. Full audit + plan for all families: `development/2_0_docs_usage_enrichment.md`.

## Containers

- **frame** — the geometry-propagation gotcha (`width`/`height` are ignored once children are packed; `pack_propagate(False)`/`grid_propagate(False)` to force a fixed size — the #1 "why won't my frame stay this size?" question), and a note to prefer `card`/`highlight` over a raw `relief=` border (theme-dependent, needs non-zero `borderwidth`).
- **labelframe** — `labelanchor=` (where the caption sits), `labelwidget=` (replace the text caption with a widget — e.g. a checkbutton that enables the whole group), `underline=` mnemonic.
- **notebook** — tab labels (`image`/`compound`/`underline`/`sticky`) + `enable_traversal()` keyboard nav; the shared tab-id vocabulary (widget / index / `current` / `@x,y`) + `tabs()`; the `<<NotebookTabChanged>>` initial-map fire (matters for lazy-load); the API block now teaches the methods instead of deferring to python.org.
- **panedwindow** — `sashpos` timing (only after `update_idletasks()`) + multi-sash ordering; runtime `insert`/`forget`/`pane(weight=0)` + `panes()`; no per-pane `minsize` (vs `tk.PanedWindow`).

## Verification

Every snippet verified headlessly (`verify_containers.py`); build gate green (`sphinx -b html -W -q -E docs`, exit 0, no warnings). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)