### PR TITLE
docs: enrich the Range & misc usage pages (Tcl/Tk depth pass)

### DIFF
--- a/docs/widgets/label.rst
+++ b/docs/widgets/label.rst
@@ -78,6 +78,23 @@ wrapped lines:
 
    ttk.Label(app, text="A long paragraph that should wrap…", wraplength=200, justify="left")
 
+Aligning and sizing
+-------------------
+
+Two options are easy to confuse. ``justify=`` (above) aligns **multiple wrapped
+lines** against each other; ``anchor=`` positions the whole text/image block
+**within the label's own area** (``"w"`` left, ``"center"``, ``"e"`` right, plus
+the corners) — visible only when the label is bigger than its content. Give a
+label a fixed ``width=`` (in characters) so a column of field-name labels lines up
+its values:
+
+.. code-block:: python
+
+   ttk.Label(app, text="Name", width=12, anchor="e").pack()
+
+A ``relief=`` (``"solid"``, ``"groove"``, …) with some ``padding=`` turns a label
+into a bordered chip or badge — pair it with ``inverse-<color>`` for a filled tag.
+
 Fonts and images
 ----------------
 
@@ -89,7 +106,9 @@ Set ``font=`` to change the type — a Tk font spec, a named font, or a
    ttk.Label(app, text="Heading", font="-size 18 -weight bold")
 
 A label can also show an image (with or without text) via ``image=`` and
-``compound=``. Building and keeping a reference to images is covered in
+``compound=``, which places the image relative to the text (``"left"``, ``"top"``,
+``"center"``, or ``"image"`` / ``"text"`` to show just one). Building and keeping a
+reference to images is covered in
 :doc:`Show images and icons </user-guide/how-to/working-with-images>`; type styling
 in the :doc:`Typography guide </user-guide/feature-guides/typography>`.
 

--- a/docs/widgets/progressbar.rst
+++ b/docs/widgets/progressbar.rst
@@ -32,8 +32,9 @@ progress; bind ``variable=`` to drive it from your code as the work advances:
 
    app.mainloop()
 
-``bar.step(amount)`` advances the value by ``amount`` (default 1) without a
-variable — handy in a loop that processes items.
+``bar.step(amount)`` advances the value by ``amount`` (default ``1.0``) without a
+variable — handy in a loop that processes items. If you set both ``variable=`` and
+``value=``, the variable wins and ``value`` is ignored.
 
 Indeterminate: work is happening
 --------------------------------
@@ -49,7 +50,9 @@ back and forth. ``start()`` begins the animation and ``stop()`` ends it:
    spinner.start()                   # animate while a task runs…
    spinner.stop()                    # …then stop
 
-``start()`` takes an optional interval in milliseconds between steps.
+``start(interval)`` steps every ``interval`` milliseconds (default 50). In
+indeterminate mode the value wraps around ``maximum``, so ``maximum`` sets the
+length of one bounce cycle — raise it to slow the sweep.
 
 Striped and vertical
 --------------------

--- a/docs/widgets/scale.rst
+++ b/docs/widgets/scale.rst
@@ -39,6 +39,26 @@ Like a :doc:`Spinbox <spinbox>`, ``from_`` has a trailing underscore because
    A scale's value is a **float**, even over an integer-looking range. Round it
    (``round(volume.get())``) or bind an ``IntVar`` if you need a whole number.
 
+Setting the value from code
+---------------------------
+
+``scale.set(value)`` moves the handle and **clips** to the ``from_``/``to`` range.
+Setting the bound variable directly does **not** clip — the handle can then show a
+value past the ends — so prefer ``.set()`` (or clamp the value yourself) when the
+source might be out of bounds:
+
+.. code-block:: python
+
+   scale.set(150)          # clipped to `to` (100)
+   volume.set(150)         # NOT clipped — the handle overshoots the track
+
+Unlike ``tk.Scale``, ``ttk.Scale`` has no ``resolution``, ``tickinterval``,
+``showvalue``, or ``label`` options — use ``round()`` / an ``IntVar`` for stepping
+and the ``LabeledScale`` widget for a value readout. ``scale.coords(value)``
+returns the pixel position of a value along the trough (and ``scale.get(x, y)``
+maps a pixel back to a value) — how ``LabeledScale`` parks its label over the
+handle.
+
 Reacting as it moves
 --------------------
 

--- a/docs/widgets/scrollbar.rst
+++ b/docs/widgets/scrollbar.rst
@@ -46,6 +46,20 @@ is so the thumb tracks (``set``). Wire both:
    wiring for you — reach for a bare ``Scrollbar`` when you attach one to a
    ``Listbox``, ``Canvas``, or ``Treeview`` yourself.
 
+How it talks to the widget
+--------------------------
+
+The two sides speak in **fractions** from ``0.0`` (top / left of the content) to
+``1.0`` (the end). The widget calls ``set(first, last)`` with the visible slice,
+and ``scroll.get()`` reads that ``(first, last)`` pair back. When the whole
+content fits, the widget sends ``set(0.0, 1.0)`` and the scrollbar **disables
+itself** — the thumb fills the track and greys out. That's expected, not a dead
+scrollbar; it re-enables once there's something to scroll.
+
+Wiring a scrollbar to a view Tk doesn't scroll for you (a ``Canvas`` or a custom
+widget) means handling the ``command`` calls yourself — they arrive as
+``("moveto", fraction)`` or ``("scroll", number, "units" | "pages")``.
+
 Color and variants
 ------------------
 

--- a/docs/widgets/separator.rst
+++ b/docs/widgets/separator.rst
@@ -32,7 +32,9 @@ its space:
    app.mainloop()
 
 A horizontal separator needs ``fill=X`` (a vertical one ``fill=Y``) to stretch —
-otherwise it collapses to nothing.
+otherwise it collapses to nothing. ``orient=`` defaults to ``horizontal``, and a
+separator is purely decorative — it takes no focus and has no methods beyond
+styling.
 
 Color
 -----

--- a/docs/widgets/sizegrip.rst
+++ b/docs/widgets/sizegrip.rst
@@ -33,6 +33,15 @@ A sizegrip is a visual affordance — the window is resizable from its edges
 regardless — so add one when a corner handle makes the resize obvious, typically
 beside a status bar.
 
+A sizegrip only resizes from the **south-east**, which is why it belongs at the
+bottom-right with ``anchor=SE``. Two caveats:
+
+- It **won't resize a window whose position was set relative to the right or
+  bottom edge** — a ``geometry("WxH-x-y")`` with minus signs. Windows placed with
+  ``+x+y`` work normally.
+- On macOS the window already draws its own resize corner, so a ``Sizegrip`` there
+  is redundant (harmless, but the native grip sits on top).
+
 Color
 -----
 


### PR DESCRIPTION
Second PR of the per-family pass enriching the Widgets-catalog **usage pages** against the Tcl/Tk manuals (audit + plan: `development/2_0_docs_usage_enrichment.md`).

## Range & misc

- **label** — the `anchor` vs `justify` distinction (block position vs wrapped-line alignment, the most-confused pair on labels), `width=` for aligning a column of field-name labels, `relief`+`padding` badge/chip, the `compound=` placement values.
- **progressbar** — `variable=` overrides `value=`; `step` default `1.0`; `start(interval)` default 50 ms; in indeterminate mode `value` wraps around `maximum` (so `maximum` sets the bounce-cycle length).
- **scale** — the footgun that `.set()` clips to the range but assigning the bound variable **doesn't**; no `resolution`/`tickinterval`/`label` vs `tk.Scale` (migrator note); `coords(value)`/`get(x,y)` pixel↔value mapping (how `LabeledScale` places its label).
- **scrollbar** — the `0.0`–`1.0` fraction model; `get()` → `(first, last)`; the **auto-disable** when everything fits ("not a dead scrollbar"); the `command` subcommands (`moveto`/`scroll`) you handle when wiring a `Canvas`/custom view.
- **separator** — default `orient` horizontal; purely decorative.
- **sizegrip** — SE-only (why bottom-right + `anchor=SE`); the **negative-geometry** no-resize caveat (`geometry("WxH-x-y")`); redundant on macOS (native grip).

## Verification

Every API-bearing snippet verified headlessly (`set` clipping vs variable bypass, `coords`/`get`, `scroll.get`, default orient all confirmed); build gate green (`sphinx -b html -W -q -E docs`, exit 0). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)