### PR TITLE
docs: enrich the Inputs usage pages (Tcl/Tk depth pass)

### DIFF
--- a/docs/widgets/combobox.rst
+++ b/docs/widgets/combobox.rst
@@ -51,6 +51,26 @@ virtual event:
 
    combo.bind("<<ComboboxSelected>>", on_pick)
 
+``<<ComboboxSelected>>`` fires only when the user **picks** from the list — not
+when they type into an editable combobox. To catch typed values too, also trace
+the variable. ``combo.current()`` with no argument returns the index of the
+selected value, or ``-1`` if the current text isn't one of ``values`` — the clean
+way to tell a picked value from a typed-in one.
+
+Keeping the list fresh
+----------------------
+
+Pass ``postcommand=`` to refresh ``values`` just before the dropdown opens — for a
+recent-items or live list — and ``height=`` to cap how many rows show before the
+list scrolls:
+
+.. code-block:: python
+
+   def refresh():
+       combo.configure(values=["Red", "Green", "Blue"])
+
+   combo = ttk.Combobox(app, textvariable=color, postcommand=refresh, height=8)
+
 Pick-only vs. editable
 ----------------------
 
@@ -76,6 +96,11 @@ constant color across styles.
 .. code-block:: python
 
    ttk.Combobox(app, values=["Red", "Green", "Blue"], bootstyle="success")
+
+The open dropdown is a classic ``tk`` listbox, not a ttk widget. ttkbootstrap
+colors it to match the current theme, but it does **not** take the combobox's
+``bootstyle`` accent — so a colored field shows a neutral dropdown, which is
+expected.
 
 States
 ------

--- a/docs/widgets/entry.rst
+++ b/docs/widgets/entry.rst
@@ -45,6 +45,18 @@ position; ``delete(first, last)`` removes the characters between two:
    entry.insert("end", "!")            # append after the last
    entry.delete(0, "end")              # remove everything from 0 to the end
 
+Positions beyond ``0`` and ``"end"`` let you work relative to the cursor and the
+selection: ``"insert"`` is the cursor, ``"sel.first"`` / ``"sel.last"`` bound the
+current selection, and ``"@x"`` is the character under pixel *x*. Out-of-range
+indices round to the nearest legal position, so bounds checks are rarely needed:
+
+.. code-block:: python
+
+   entry.icursor("end")                # move the cursor to the end
+   entry.selection_range(0, "end")     # select all the text
+   if entry.selection_present():       # is anything selected?
+       entry.delete("sel.first", "sel.last")
+
 A password field
 ----------------
 
@@ -54,7 +66,8 @@ A password field
 
    ttk.Entry(app, show="•", bootstyle="primary")
 
-The variable still holds the real text — only the display is masked.
+The variable still holds the real text — only the display is masked. (Text the
+user *copies* out of a masked field is the mask characters, not the real value.)
 
 Validating input
 ----------------
@@ -75,8 +88,12 @@ stays until the value becomes valid again — so the field flags itself only aft
 the user leaves it, not on every keystroke. Pass ``when=`` to validate at a
 different time (for example ``when="key"`` to check as they type).
 
-The full rule set, custom rules, and the ``when=`` options are covered in the
-:doc:`Input validation guide </user-guide/feature-guides/validation>`.
+Two things worth knowing: a failed check puts the entry in the ``invalid`` state —
+the state the ``danger`` border maps to, readable with
+``entry.instate(["invalid"])`` — and validation does **not** re-run when you change
+the value through the bound ``textvariable`` from code (only user edits and focus
+trigger it). The full rule set, custom rules, and the ``when=`` options are covered
+in the :doc:`Input validation guide </user-guide/feature-guides/validation>`.
 
 Color
 -----

--- a/docs/widgets/spinbox.rst
+++ b/docs/widgets/spinbox.rst
@@ -35,6 +35,13 @@ arrow click), and bind the value to a variable:
 and ``increment`` do not. Read the value with the bound variable's ``.get()`` or
 the spinbox's own ``.get()`` (which returns a string).
 
+When the range steps by a fraction, set ``format=`` so the field shows a clean
+number instead of float noise like ``0.30000000000000004``:
+
+.. code-block:: python
+
+   ttk.Spinbox(app, from_=0, to=1, increment=0.1, format="%.2f")
+
 Stepping through a list
 -----------------------
 
@@ -44,6 +51,10 @@ Pass ``values=`` instead of a range to step through a fixed list. Add
 .. code-block:: python
 
    ttk.Spinbox(app, values=["Small", "Medium", "Large"], wrap=True)
+
+``values=`` overrides ``from_`` / ``to`` / ``increment`` — use one mode or the
+other, not both. ``wrap=True`` works for a numeric range too, cycling ``to`` back
+around to ``from_``.
 
 Reacting to the arrows
 ----------------------
@@ -60,7 +71,12 @@ something as the value steps:
 
 ``command`` fires only for the arrows, not for typing; to react to typed edits too,
 trace the variable (see :doc:`State & variables
-</user-guide/foundations/state-and-variables>`).
+</user-guide/foundations/state-and-variables>`). The arrows also respond to the
+``<Up>`` / ``<Down>`` keys, and the widget emits ``<<Increment>>`` /
+``<<Decrement>>`` virtual events on a step — a binding point distinct from
+``command``. Spinbox has ``.set(value)`` to set the field directly but, unlike
+:doc:`Combobox <combobox>`, no ``current()`` method — select by value with
+``.set()`` or the variable.
 
 Color
 -----


### PR DESCRIPTION
Third PR of the per-family pass enriching the Widgets-catalog **usage pages** against the Tcl/Tk manuals (audit + plan: `development/2_0_docs_usage_enrichment.md`). The Inputs family was already above-average; these are genuine conceptual/method gaps, not nitpicks.

## Inputs

- **entry** — the fuller index vocabulary (`"insert"` / `"sel.first"` / `"sel.last"` / `"@x"`, out-of-range rounds) plus `icursor` / `selection_range` / `selection_present`; the `show=` copies-mask-characters caveat; two validation gotchas (a failed check sets the `invalid` state — what the `danger` border maps to; validation does **not** re-run on a programmatic `textvariable` change).
- **combobox** — `current()` as a getter (index, or `-1` if the text isn't in `values`) to tell a pick from a typed value; `<<ComboboxSelected>>` fires **only** on a pick (trace the var for typed edits); `postcommand=` + `height=`; the dropdown is a classic `tk` listbox that ttkbootstrap themes but that does **not** take the `bootstyle` accent (grounded in `update_combobox_popdown_style`, not just the Tk manual).
- **spinbox** — `format=` to kill float noise on fractional `increment`; `values=` overrides `from_`/`to`/`increment`; the `<Up>`/`<Down>` keys + `<<Increment>>`/`<<Decrement>>` events; `.set()` exists but there is **no** `current()` (unlike Combobox).

## Verification

Every snippet verified headlessly (selection methods, `current()` returning `1` then `-1`, spinbox-has-no-`current`); build gate green (`sphinx -b html -W -q -E docs`, exit 0). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)