### PR TITLE
docs: enrich the Choice + Command usage pages (Tcl/Tk depth pass)

### DIFF
--- a/docs/widgets/checkbutton.rst
+++ b/docs/widgets/checkbutton.rst
@@ -108,6 +108,9 @@ with ``invoke`` (toggle) and ``instate`` (read):
    check.invoke()                  # toggle it programmatically
    check.instate(["selected"])     # read the checked state directly
 
+The widget keeps the ``selected`` state in sync with the variable (set whenever the
+variable equals ``onvalue``), so ``instate`` mirrors what ``.get()`` reports.
+
 The ``alternate`` state shows an indeterminate "mixed" mark — for a "select all"
 that is only partly on:
 

--- a/docs/widgets/optionmenu.rst
+++ b/docs/widgets/optionmenu.rst
@@ -55,6 +55,17 @@ value as its argument:
 
    ttk.OptionMenu(app, size, "Medium", "Small", "Medium", "Large", command=on_choice)
 
+Rebuilding the choices
+----------------------
+
+The choices are fixed at construction, but ``set_menu(default, *values)`` rebuilds
+the list later — repopulate it when your data changes:
+
+.. code-block:: python
+
+   menu = ttk.OptionMenu(app, size, "Medium", "Small", "Medium", "Large")
+   menu.set_menu("Large", "Large", "X-Large")   # new default + new choices
+
 Color
 -----
 
@@ -89,8 +100,8 @@ API & reference
 
 ``OptionMenu`` is the native ``ttk.OptionMenu`` — ttkbootstrap adds ``bootstyle=``
 but no other Python API. Its constructor is
-``OptionMenu(master, variable, default, *values, command=None, direction="below")``;
-see the
+``OptionMenu(master, variable, default, *values, command=None, direction="below")``,
+and ``set_menu(default, *values)`` rebuilds the choices; see the
 `tkinter.ttk.OptionMenu <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.OptionMenu>`__
 reference.
 

--- a/docs/widgets/radiobutton.rst
+++ b/docs/widgets/radiobutton.rst
@@ -100,11 +100,18 @@ variable, not a state:
    size.set("large")                   # select a button by its value
    radio.invoke()                      # select this button programmatically
 
+A radiobutton created without an explicit ``variable=`` starts in the
+indeterminate ``alternate`` state — its default variable is unset, so it looks
+unselected, the same mixed state a :doc:`Checkbutton <checkbutton>` shows. Bind a
+variable and set it to a button's ``value`` to select that button and clear the
+rest.
+
 .. note::
 
    The shared ``variable=`` is what links a group — selecting one button clears
-   the others. Give every button in the group the same variable; without it they
-   are unrelated buttons, not a mutually exclusive set.
+   the others. Give **each group its own variable**. Radiobuttons created *without*
+   an explicit ``variable=`` don't become independent: they all fall back to the
+   same built-in default variable and interfere as one accidental group.
 
 API & reference
 ---------------


### PR DESCRIPTION
Fourth PR of the per-family pass enriching the Widgets-catalog **usage pages** against the Tcl/Tk manuals (audit + plan: `development/2_0_docs_usage_enrichment.md`).

## Choice + Command

- **radiobutton** — **corrects a factual error**: the closing note claimed radiobuttons without `variable=` are "unrelated buttons." They aren't — they all fall back to Tk's default `::selectedButton` global and interfere as one accidental group (verified: two no-`variable` radiobuttons both report `::selectedButton`). Rewritten to "give each group its own variable." Also documents the indeterminate `alternate` state (a no-`variable` radiobutton starts unselected because its default variable is unset — verified `alternate=True` with no variable, `False` once a `StringVar` is bound, since tkinter variables are always set).
- **optionmenu** — `set_menu(default, *values)` to rebuild the choices after construction (the "it builds its own menu" concept, made dynamic).
- **checkbutton** (already solid) — one line: the `selected` state stays in sync with the variable, so `instate` mirrors `.get()`.
- **menubutton** — unchanged (audit confirmed it's solid; the menu is already built as a child of the button).

## Verification

Every claim verified headlessly against the live widgets (shared default global, `alternate` only when truly unset, `set_menu` signature/behavior); build gate green (`sphinx -b html -W -q -E docs`, exit 0). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)