### PR TITLE
docs: enrich the Button + Treeview usage pages (Tcl/Tk depth pass)

### DIFF
--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -104,19 +104,23 @@ For a **toolbar**, pack icon-only buttons side by side in a frame:
 The default button
 ------------------
 
-A dialog usually has a **default** action that fires on :kbd:`Return`. There is no
-"default" flag on ``ttk.Button``; make one by giving it focus and binding the key:
+A dialog usually has a **default** action that fires on :kbd:`Return`. Mark the
+button as the default with ``default="active"`` — on platforms that draw a default
+ring (macOS, for one) it gets the highlight. That flag only *marks* the button,
+though; it does not wire the key, so also bind :kbd:`Return`, calling ``invoke()``
+so the button shows its pressed feedback as it fires:
 
 .. code-block:: python
 
-   submit = ttk.Button(app, text="Submit", command=on_submit, bootstyle="primary")
+   submit = ttk.Button(app, text="Submit", command=on_submit, bootstyle="primary", default="active")
    submit.pack(pady=10)
    submit.focus_set()                         # start focused
-   app.bind("<Return>", lambda event: on_submit())
+   app.bind("<Return>", lambda event: submit.invoke())
 
 Now :kbd:`Return` triggers the action from anywhere in the window, and the button
-already has the focus ring. (For the shipped dialogs, ``default=`` does this for
-you — see the :doc:`Dialogs guide </user-guide/feature-guides/dialogs>`.)
+already has the focus ring. (The shipped dialogs wire up their default button — the
+ring plus the :kbd:`Return` binding — for you; see the
+:doc:`Dialogs guide </user-guide/feature-guides/dialogs>`.)
 
 Enabling and disabling
 ----------------------
@@ -195,7 +199,8 @@ API & reference
 
 ``Button`` is the native ``ttk.Button`` — ttkbootstrap adds the ``bootstyle=`` and
 ``icon=`` keywords but no other Python API. For its constructor and options
-(``text``, ``command``, ``width``, ``compound``, ``state``, …) see the
+(``text``, ``command``, ``width``, ``compound``, ``default``, ``state``, …) and the
+``invoke()`` method that fires the command from code, see the
 `tkinter.ttk.Button <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Button>`__
 reference.
 

--- a/docs/widgets/treeview.rst
+++ b/docs/widgets/treeview.rst
@@ -64,7 +64,10 @@ data beside it, and ``show=`` chooses which parts are visible:
 
 Name the columns yourself in ``columns=`` and refer to each by that name in
 ``heading`` / ``column`` / ``values``. ``values`` fills the data columns in order;
-``text`` fills the ``"#0"`` tree column.
+``text`` fills the ``"#0"`` tree column. ``displaycolumns=`` reorders or hides the
+data columns for display without changing ``columns=``, and ``column(name,
+stretch=False)`` pins a column's width when the widget is resized (columns stretch
+to share extra space by default).
 
 Reading and changing items
 --------------------------
@@ -90,6 +93,15 @@ it, and ``delete(id)`` removes it (along with its children):
    tree.move(item_id, new_parent, 0)
    tree.delete(item_id)
 
+To hide a row temporarily without losing it — filtering, say — ``detach(id)``
+unlinks it from the tree (keeping its data), and ``reattach(id, parent, index)``
+puts it back:
+
+.. code-block:: python
+
+   tree.detach(item_id)                    # remove from view, keep the item
+   tree.reattach(item_id, "", "end")       # restore it at the top level
+
 Reacting to a selection
 -----------------------
 
@@ -105,7 +117,38 @@ changes; ``selection()`` returns the selected item ids:
    tree.bind("<<TreeviewSelect>>", on_select)
 
 ``selection_set(id)`` selects an item from code, and ``focus(id)`` moves the
-keyboard focus to it.
+keyboard focus to it. ``selectmode=`` sets how many rows the user can select —
+``"extended"`` (the default: multi-select with Shift/Ctrl), ``"browse"`` (one at a
+time), or ``"none"``. Adjust a multi-selection from code with ``selection_add`` /
+``selection_remove`` / ``selection_toggle`` (``selection_set`` replaces it).
+**Focus and selection are separate**: ``focus(id)`` sets the single active row the
+keyboard drives, which needn't be part of the selection.
+
+Bind ``<<TreeviewOpen>>`` / ``<<TreeviewClose>>`` to react when a parent is
+expanded or collapsed — the hook for **lazy-loading** a node's children the first
+time it opens (``tree.focus()`` is the row being opened):
+
+.. code-block:: python
+
+   tree.bind("<<TreeviewOpen>>", lambda event: load_children(tree.focus()))
+
+Finding what was clicked
+------------------------
+
+To turn a click into a target — for a right-click context menu, say — map the
+pointer to a row and region. ``identify_row(y)`` returns the item id under a pixel,
+and ``identify_region(x, y)`` says which part was hit (``"heading"``, ``"cell"``,
+``"tree"``, or ``"separator"``):
+
+.. code-block:: python
+
+   def on_right_click(event):
+       row = tree.identify_row(event.y)
+       if row:
+           tree.selection_set(row)         # select the row under the pointer
+       # ...then pop your context menu
+
+   tree.bind("<Button-3>", on_right_click)  # <Button-2> on macOS
 
 Sorting on a heading
 --------------------
@@ -147,8 +190,10 @@ to color, highlight, or re-font every row that carries it:
 
    tree.insert("", "end", values=("Invoice #12", "past due"), tags=("overdue",))
 
-Tags are the way to give rows conditional appearance — flagged rows, groups,
-alternating stripes — without touching the widget's base style.
+A tag can set ``foreground`` and ``font`` too, not only ``background``. When a row
+carries two tags with conflicting styles, the one **configured first** takes
+priority. Tags are the way to give rows conditional appearance — flagged rows,
+groups, alternating stripes — without touching the widget's base style.
 
 Color
 -----
@@ -175,8 +220,9 @@ API & reference
 
 ``Treeview`` is the native ``ttk.Treeview`` — ttkbootstrap adds ``bootstyle=`` but
 no other Python API. For the full set of methods (``insert``, ``item``, ``set``,
-``move``, ``delete``, ``heading``, ``column``, ``selection``, ``tag_configure``,
-``see``, ``bbox``, …) and options, see the
+``move``, ``detach`` / ``reattach``, ``delete``, ``heading``, ``column``,
+``selection`` / ``selection_add`` / ``selection_remove``, ``identify_row`` /
+``identify_region``, ``see``, ``bbox``, …) and options, see the
 `tkinter.ttk.Treeview <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Treeview>`__
 reference.
 


### PR DESCRIPTION
Fifth PR of the per-family pass enriching the Widgets-catalog **usage pages** against the Tcl/Tk manuals (audit + plan: `development/2_0_docs_usage_enrichment.md`).

## Button + Treeview

- **button** — **corrects a factual error**: the page said "There is no 'default' flag on `ttk.Button`." The `default=` option (`normal`/`active`/`disabled`) is real (verified: defaults to `"normal"`, settable to `"active"`). Now teaches `default="active"` to mark the default button (platform ring), still bind `<Return>`, and fire it via `invoke()` (verified `invoke()` runs the command); `default`/`invoke` added to the API block.
- **treeview** (already rich — additive) — `selectmode=` + `selection_add`/`selection_remove`/`selection_toggle`; the **focus vs selection** distinction; `<<TreeviewOpen>>`/`<<TreeviewClose>>` for lazy-loading children; `detach`/`reattach` to hide/filter a row without deleting it; `identify_row`/`identify_region` for right-click hit-testing (context menus); `displaycolumns=` + `column(stretch=False)`; tag `foreground`/`font` and the first-configured-wins priority rule.

## Verification

Every snippet verified headlessly (button `default`/`invoke`; treeview `detach`/`reattach` reordering, selection API, `identify_row`/`identify_region`, tag options); build gate green (`sphinx -b html -W -q -E docs`, exit 0). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)