### PR TITLE
docs: enrich the Shipped usage pages (source-grounded depth pass)

### DIFF
--- a/docs/widgets/dateentry.rst
+++ b/docs/widgets/dateentry.rst
@@ -41,7 +41,19 @@ Create a ``DateEntry`` and read the chosen date with ``get_date()`` — it retur
 
 The widget exposes its parts as ``picker.entry`` (the text field) and
 ``picker.button`` (the calendar button), and ``enable()`` / ``disable()`` toggle
-interaction.
+interaction. The ``value`` property is a shorthand for get/set.
+
+``get_date()`` parses the **live entry text**, so typed keyboard edits are honored,
+and an unparseable entry is flagged ``invalid`` when the field loses focus. If the
+text is empty or can't be parsed it falls back to the last date set — it does
+**not** return ``None`` here, unlike the ``Querybox.get_date`` *dialog*, which
+returns ``None`` on cancel.
+
+To run code when the user picks from the calendar, bind ``<<DateEntrySelected>>``:
+
+.. code-block:: python
+
+   picker.bind("<<DateEntrySelected>>", lambda event: print(picker.get_date()))
 
 Format and calendar
 -------------------
@@ -53,6 +65,9 @@ sets the leftmost column (``0`` = Monday … ``6`` = Sunday):
 .. code-block:: python
 
    DateEntry(app, date_format="%Y-%m-%d", start_date=datetime(2025, 1, 1), first_weekday=6)
+
+``show_outside_days=False`` hides the adjacent-month days the calendar uses to pad
+the first and last weeks.
 
 Color
 -----

--- a/docs/widgets/floodgauge.rst
+++ b/docs/widgets/floodgauge.rst
@@ -38,6 +38,11 @@ variable to drive it as work advances:
 
 For a fixed caption instead of the value, pass ``text`` instead of ``mask``.
 
+``mask`` formats the value as an **integer** (``int(value)``), so a fractional
+value shows truncated in the label even while the fill stays exact. Size the gauge
+with ``length`` (the long axis, default 200) and ``thickness`` (the short axis,
+default 50), and set the label's ``font`` if you want.
+
 Indeterminate mode
 ------------------
 

--- a/docs/widgets/labeledscale.rst
+++ b/docs/widgets/labeledscale.rst
@@ -33,8 +33,20 @@ variable's value and follows the handle as it moves:
 
    app.mainloop()
 
-Read the chosen value from the bound variable's ``.get()``. The label shows whole
-numbers, so bind an ``IntVar`` for a clean readout.
+Read the chosen value from the bound variable's ``.get()``. The label renders the
+value cleanly — it drops a trailing ``.0`` (so ``4.0`` shows as ``4``) but keeps a
+real fraction (``3.7`` shows as ``3.7``).
+
+The widget exposes its parts as ``ls.scale`` and ``ls.label`` for fine-tuning, and
+its ``value`` property reads or sets the current number directly. A
+``LabeledScale`` is horizontal only — there is no ``orient``:
+
+.. code-block:: python
+
+   ls = LabeledScale(app, variable=level, from_=0, to=100)
+   ls.pack(fill="x")
+   ls.scale.configure(length=240)       # reach the underlying Scale
+   print(ls.value)                       # read the current number directly
 
 Where the label sits
 --------------------

--- a/docs/widgets/meter.rst
+++ b/docs/widgets/meter.rst
@@ -37,8 +37,26 @@ dial), or with ``configure``; ``step`` nudges it by an amount:
 .. code-block:: python
 
    meter.amount_used_var.get()          # -> the current value
+   meter.value                           # -> the same, via the read/write property
    meter.configure(amount_used=80)      # set it
-   meter.step(5)                        # advance by 5
+   meter.step(5)                        # advance by 5 (bounces at the ends)
+
+``step`` **bounces** back when it reaches the minimum or maximum, reversing
+direction rather than clamping — it's for a looping animation, not a plain
+increment.
+
+The center label
+----------------
+
+The big number is formatted by ``amount_format`` (a ``str.format`` template,
+default ``"{:.0f}"``), and ``text_left`` / ``text_right`` flank it with a unit — a
+``$`` prefix or a ``%`` suffix. ``amount_min`` shifts where the range starts, for a
+dial that runs from something other than zero:
+
+.. code-block:: python
+
+   Meter(app, amount_used=42, amount_format="{:.1f}", text_right="%",
+         amount_min=0, subtext="CPU")
 
 Full or semicircle
 ------------------
@@ -82,6 +100,9 @@ progress look:
 .. code-block:: python
 
    Meter(app, amount_used=65, stripe_thickness=10, bootstyle="info")
+
+``wedge_size`` instead draws the indicator as a moving wedge over the base ring,
+rather than a filled arc — a pointer look for a live reading.
 
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder

--- a/docs/widgets/tableview.rst
+++ b/docs/widgets/tableview.rst
@@ -61,6 +61,10 @@ the columns that need one. The common keys are ``text`` (the heading),
 
    Tableview(app, coldata=coldata, rowdata=rows)
 
+At the table level, ``height`` sets how many rows are visible at once (distinct
+from ``pagesize``, which is the page length), and ``autofit=True`` sizes the
+columns to their content.
+
 Search and pagination
 ---------------------
 
@@ -109,6 +113,7 @@ column equals a value:
 .. code-block:: python
 
    table.search_table_data("Engineer")               # match anywhere
+   table.search_table_data("Ada", 0)                 # or limit to given columns
    table.filter_column_to_value(cid=1, value="Admiral")   # match one column
 
    filtered = table.get_rows(filtered=True)          # the rows now showing
@@ -130,14 +135,19 @@ just the selected rows:
 
    selected = table.get_rows(selected=True)
 
-``insert_row`` adds a row and ``delete_row`` removes one by ``iid``. Both change
-the underlying data; call ``load_table_data()`` afterward to redraw:
+``insert_row`` adds a row and ``delete_row`` removes one by ``iid``:
 
 .. code-block:: python
 
    table.insert_row("end", ["Katherine Johnson", "Mathematician", 101])
    table.delete_row(iid="I001")
    table.load_table_data()
+
+``insert_row`` redraws by default (``reload=True``); pass ``reload=False`` when
+adding many rows, then call ``load_table_data()`` once at the end. Row ids are
+generated unless you set ``iid_field=`` (a column index or heading) at
+construction — that keys each row to your own id, for a stable
+``delete_row(iid=…)`` / ``get_row(iid=…)``.
 
 To replace the whole dataset at once, call
 ``build_table_data(coldata, rowdata)`` — it rebuilds the columns and rows from

--- a/docs/widgets/toast.rst
+++ b/docs/widgets/toast.rst
@@ -40,18 +40,25 @@ Unlike most widgets you don't ``pack`` a toast — you build it with a ``title``
    app.mainloop()
 
 ``duration`` is in milliseconds; **omit it** and the toast stays until it is
-clicked. ``hide_toast()`` dismisses one early.
+clicked. ``show_toast()`` returns the toast, so keep the reference to dismiss it
+early with ``.hide()`` (in the example above the toast is a local, so hold onto it
+if you need to close it yourself).
 
 Where it appears
 ----------------
 
 ``position`` is an ``(x, y, anchor)`` tuple — the ``x``/``y`` offset from the
-corner named by ``anchor`` (``"ne"``, ``"se"``, ``"sw"``, ``"nw"``). The default is
-the bottom-right:
+corner or edge named by ``anchor``, which accepts any of the eight compass points
+(``"n"``, ``"e"``, ``"s"``, ``"w"``, ``"nw"``, ``"ne"``, ``"sw"``, ``"se"``). The
+default is **platform-specific** — bottom-right (``"se"``) on Windows and Linux,
+top-right (``"ne"``) on macOS:
 
 .. code-block:: python
 
    ToastNotification(title="Done", message="Export finished.", position=(10, 60, "ne"))
+
+Toasts anchored to the same corner **stack** automatically instead of overlapping,
+and reflow when one is dismissed.
 
 Color and icon
 --------------

--- a/docs/widgets/tooltip.rst
+++ b/docs/widgets/tooltip.rst
@@ -39,12 +39,23 @@ Delay and wrapping
 ------------------
 
 ``delay`` is how long (in milliseconds) the pointer must rest before the tip shows
-(default 500); ``wraplength`` (in pixels) wraps a long tip onto multiple lines:
+(default 250); ``wraplength`` (in pixels) wraps a long tip onto multiple lines:
 
 .. code-block:: python
 
    ToolTip(save, text="A longer explanation that should wrap onto a few lines.",
-           delay=250, wraplength=200)
+           delay=400, wraplength=200)
+
+By default the tip **follows the pointer**. Pass ``position=`` to anchor it to the
+widget instead — ``"top"``, ``"bottom"``, ``"left"``, ``"right"``, ``"center"``,
+or a pair like ``"top left"``:
+
+.. code-block:: python
+
+   ToolTip(save, text="Save the file", position="top")
+
+A ``ToolTip`` isn't fire-and-forget — ``configure()`` changes its ``text``,
+``bootstyle``, and other options later, and a visible tip updates in place.
 
 Color
 -----


### PR DESCRIPTION
Sixth and **final** PR of the per-family pass enriching the Widgets-catalog **usage pages** (audit + plan: `development/2_0_docs_usage_enrichment.md`). The shipped widgets have no Tcl/Tk manual, so these findings are grounded against the widget **source**. Fixes three factual errors.

## Shipped

- **labeledscale** — **fixes** "the label shows whole numbers": it uses `:g`, so `4.0` shows `"4"` but `3.7` shows `"3.7"` (verified). Adds `.scale`/`.label` part access, the `value` property, horizontal-only (no `orient`).
- **toast** — **fixes** the `anchor` list (8 compass points, not 4) and the default position ("bottom-right" is only true off macOS — it's SE on win32/x11, **NE on aqua**); `show_toast()` returns the toast as a dismiss handle; concurrent toasts auto-stack.
- **tooltip** — **fixes** the `delay` default (**250**, not 500); adds `position=` (anchor to the widget vs follow the pointer) and live `configure()`.
- **meter** — `text_left`/`text_right` + `amount_format` + `amount_min` (the center label); the `value` property; the `step()`-**bounces**-at-the-ends caveat; `wedge_size`.
- **floodgauge** — `mask` formats `int(value)` (a fractional value shows truncated); `length`/`thickness` sizing; `font`.
- **dateentry** — `<<DateEntrySelected>>`; `get_date()` parses live text + blur-validates + falls back (never `None` here, unlike the `Querybox.get_date` dialog); `value`; `show_outside_days`.
- **tableview** — `iid_field` for stable ids; `insert_row` redraws by default (`reload=`); `autofit`/`height`; column-scoped `search_table_data(criteria, *columns)`.

## Verification

Every snippet/claim verified headlessly against the live widgets (the `:g` label, toast returning self + anchor `"n"`, `insert_row(reload=False)`, `iid_field`, etc.); build gate green (`sphinx -b html -W -q -E docs`, exit 0). Docs-only.

**This completes the usage-guide enrichment pass** — all six families (Containers #1196, Range & misc #1197, Inputs #1198, Choice + Command #1199, Button + Treeview #1200, Shipped) done; five factual errors fixed across the set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)