### PR TITLE
docs: use "secondary ghost" for the button toolbar example

### DIFF
--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -98,7 +98,7 @@ For a **toolbar**, pack icon-only buttons side by side in a frame:
    toolbar.pack(fill=X)
 
    for name, action in [("save", save), ("printer", print_doc), ("trash", delete)]:
-       button = ttk.Button(toolbar, icon=name, icon_only=True, command=action, bootstyle="secondary link")
+       button = ttk.Button(toolbar, icon=name, icon_only=True, command=action, bootstyle="secondary ghost")
        button.pack(side=LEFT)
 
 The default button


### PR DESCRIPTION
Swaps the toolbar example on `docs/widgets/button.rst` from `secondary link` to `secondary ghost` — the ghost variant (borderless until hovered) reads better for a row of icon-only toolbar buttons.

Verified `secondary ghost` resolves to a real style (`secondary.Ghost.TButton`) and the docs build `-W` clean. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)