### PR TITLE
docs: list the invalid state in the input States sections

### DIFF
--- a/docs/widgets/combobox.rst
+++ b/docs/widgets/combobox.rst
@@ -114,6 +114,10 @@ pick-only control:
    combo.state(["readonly"])           # pick-only, not typeable
    combo.state(["!disabled"])          # re-enable
 
+With validation attached, a failed check also puts the field in the **invalid**
+state — what the ``danger`` border maps to. Validation sets and clears it for you;
+read it with ``combo.instate(["invalid"])``.
+
 API & reference
 ---------------
 

--- a/docs/widgets/entry.rst
+++ b/docs/widgets/entry.rst
@@ -123,6 +123,10 @@ it:
    entry.state(["readonly"])           # selectable, not editable
    entry.state(["!disabled", "!readonly"])   # back to normal
 
+When you attach validation, a failed check adds a third state: **invalid**.
+Validation sets and clears it for you, and it is what the ``danger`` border maps
+to — read it with ``entry.instate(["invalid"])`` (see `Validating input`_).
+
 API & reference
 ---------------
 

--- a/docs/widgets/spinbox.rst
+++ b/docs/widgets/spinbox.rst
@@ -102,6 +102,10 @@ the value but blocks typing:
    spin.state(["readonly"])            # arrows work, not typeable
    spin.state(["!disabled", "!readonly"])   # back to normal
 
+With validation attached, a failed check also puts the field in the **invalid**
+state — what the ``danger`` border maps to. Validation sets and clears it for you;
+read it with ``spin.instate(["invalid"])``.
+
 API & reference
 ---------------
 


### PR DESCRIPTION
The `invalid` validation state was documented in the validation prose (and the danger-border colour note) but not in the **States** sections of the validatable inputs — where a reader looks for "what states does this widget have."

Adds it to **entry**, **combobox**, and **spinbox**: validation sets and clears it automatically, it's what the `danger` border maps to, and it's read with `instate(["invalid"])`.

Verified the state is real and readable on all three, and that a failed validation sets it. Build `-W` clean. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)