### PR TITLE
docs: show the dependent (cascading) dropdown use of combobox postcommand

### DIFF
--- a/docs/widgets/combobox.rst
+++ b/docs/widgets/combobox.rst
@@ -71,6 +71,20 @@ list scrolls:
 
    combo = ttk.Combobox(app, textvariable=color, postcommand=refresh, height=8)
 
+Because ``postcommand`` runs each time the list is about to open, it can build the
+choices from the *current* state — including another widget's selection. That's how
+you make a **dependent (cascading) dropdown**, e.g. a city list filtered by the
+selected country:
+
+.. code-block:: python
+
+   cities = {"France": ["Paris", "Lyon"], "Japan": ["Tokyo", "Osaka"]}
+
+   def city_choices():
+       city_combo.configure(values=cities.get(country.get(), []))
+
+   city_combo = ttk.Combobox(app, textvariable=city, postcommand=city_choices)
+
 Pick-only vs. editable
 ----------------------
 


### PR DESCRIPTION
Builds on the combobox `postcommand` section. Since `postcommand` fires each time *before* the dropdown opens, it can rebuild `values` from the current state — including **another widget's selection**. That's the idiomatic way to make a **dependent (cascading) dropdown** (e.g. a city list filtered by the selected country), so the section now shows that example alongside the recent/live-list one.

Verified headlessly that reading a second variable in `postcommand` and calling `configure(values=…)` filters the list as expected. Build `-W` clean. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)