### PR TITLE
docs: standardize the Reference / See also sections across the widget catalog

### DIFF
--- a/docs/widgets/button.rst
+++ b/docs/widgets/button.rst
@@ -194,20 +194,12 @@ automatically — the theme handles the visuals. You set ``disabled`` yourself (
 `Enabling and disabling`_); the rest follow the pointer and keyboard. To style a
 state differently, see :ref:`the button's styling options <button-styling>`.
 
-API & reference
----------------
+Reference
+---------
 
-``Button`` is the native ``ttk.Button`` — ttkbootstrap adds the ``bootstyle=`` and
-``icon=`` keywords but no other Python API. For its constructor and options
-(``text``, ``command``, ``width``, ``compound``, ``default``, ``state``, …) and the
-``invoke()`` method that fires the command from code, see the
-`tkinter.ttk.Button <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Button>`__
-reference.
+``Button`` is the native ``ttk.Button``; ttkbootstrap adds the ``bootstyle`` and
+``icon=`` keywords.
 
-.. seealso::
-
-   Want to restyle the button yourself? The
-   :ref:`button's styling options <button-styling>` cover the hand-styling
-   surface — the ``bootstyle`` → ttk style-name mapping, element layout,
-   configurable options, and supported states — alongside the
-   :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
+- :doc:`Button API reference </reference/api/button>` — every option and method.
+- :ref:`Button styling options <button-styling>` — restyle it yourself, with the
+  :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.

--- a/docs/widgets/canvas.rst
+++ b/docs/widgets/canvas.rst
@@ -313,29 +313,20 @@ To keep tkinter's default look and take over styling entirely, pass
 
    ttk.Canvas(app, autostyle=False, background="white")
 
-API & reference
----------------
+Reference
+---------
 
-``Canvas`` is tkinter's ``tk.Canvas`` — ttkbootstrap themes it but adds no Python
-API beyond ``autostyle``. Its surface is large: item constructors
-(``create_line``/``create_rectangle``/``create_oval``/``create_arc``/
-``create_polygon``/``create_text``/``create_image``/``create_window``), geometry
-(``coords``, ``move``, ``moveto``, ``scale``, ``bbox``), configuration
-(``itemconfigure``, ``itemcget``, ``type``), finding items (``find_all``,
-``find_withtag``, ``find_closest``, ``find_overlapping``), tagging
-(``gettags``, ``addtag_withtag``, ``dtag``), stacking (``tag_raise``,
-``tag_lower``), item events (``tag_bind``), and scrolling
-(``xview``/``yview``, ``canvasx``/``canvasy``, ``scan_mark``/``scan_dragto``).
+``Canvas`` is tkinter's ``tk.Canvas``; ttkbootstrap themes it but adds no Python
+API beyond ``autostyle``. The standard library doesn't document it in full.
 
-The standard library reference doesn't document the canvas in full. The
-:doc:`Canvas reference </reference/api/canvas>` documents its options and methods,
-and the canonical, complete upstream reference is the
-`Tk canvas manual page <https://www.tcl-lang.org/man/tcl8.6/TkCmd/canvas.htm>`__ —
-written in Tcl, so a subcommand like ``itemconfigure`` maps directly to the
-Python method of the same name.
+- :doc:`Canvas reference </reference/api/canvas>` — its options and methods (item
+  constructors, geometry, tagging, stacking, scrolling).
+- `Tk canvas manual page <https://www.tcl-lang.org/man/tcl8.6/TkCmd/canvas.htm>`__
+  — the canonical upstream reference (Tcl 8.6; a subcommand like ``itemconfigure``
+  maps to the Python method of the same name).
 
 .. seealso::
 
-   :doc:`Text <text>` for the other big tk-native widget, and
-   :doc:`Scroll long content </user-guide/how-to/scrollable>` for scrollable
-   regions built from ordinary widgets.
+   - :doc:`Text <text>` — the other big tk-native widget.
+   - :doc:`Scroll long content </user-guide/how-to/scrollable>` — scrollable
+     regions built from ordinary widgets.

--- a/docs/widgets/checkbutton.rst
+++ b/docs/widgets/checkbutton.rst
@@ -125,20 +125,18 @@ that is only partly on:
    Bind a ``variable=``, or clear it with ``check.state(["!alternate"])``, to start
    it unchecked.
 
-API & reference
----------------
+Reference
+---------
 
-``Checkbutton`` is the native ``ttk.Checkbutton`` — ttkbootstrap adds ``bootstyle=``
-but no other Python API. For its constructor and options (``variable``, ``text``,
-``command``, ``onvalue``, ``offvalue``, ``state``, …) see the
-`tkinter.ttk.Checkbutton <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Checkbutton>`__
-reference.
+``Checkbutton`` is the native ``ttk.Checkbutton``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Checkbutton API reference </reference/api/checkbutton>` — every option and
+  method.
+- :ref:`Checkbutton styling options <checkbutton-styling>` — restyle it yourself
+  (these cover the switch/toggle look too), with the
+  :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Radiobutton <radiobutton>` for a mutually exclusive group of choices.
-   Want to restyle the checkbutton yourself? The
-   :ref:`checkbutton's styling options <checkbutton-styling>` (which also cover
-   the switch/toggle look) and its companion
-   :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide document
-   the hand-styling surface.
+   - :doc:`Radiobutton <radiobutton>` — a mutually exclusive group of choices.

--- a/docs/widgets/combobox.rst
+++ b/docs/widgets/combobox.rst
@@ -132,20 +132,18 @@ With validation attached, a failed check also puts the field in the **invalid**
 state — what the ``danger`` border maps to. Validation sets and clears it for you;
 read it with ``combo.instate(["invalid"])``.
 
-API & reference
----------------
+Reference
+---------
 
-``Combobox`` is the native ``ttk.Combobox`` — ttkbootstrap adds ``bootstyle=`` but
-no other Python API. For its constructor and options (``values``,
-``textvariable``, ``state``, ``height``, ``postcommand``, …) and the ``get`` /
-``set`` / ``current`` methods, see the
-`tkinter.ttk.Combobox <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Combobox>`__
-reference.
+``Combobox`` is the native ``ttk.Combobox``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Combobox API reference </reference/api/combobox>` — every option and
+  method.
+- :ref:`Combobox styling options <combobox-styling>` — restyle it yourself, with
+  the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Entry <entry>` for a plain text field and :doc:`Spinbox <spinbox>` for a
-   stepper over an ordered range. Want to restyle the combobox yourself? The
-   :ref:`Combobox's styling options <combobox-styling>` and its
-   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+   - :doc:`Entry <entry>` — a plain single-line text field.
+   - :doc:`Spinbox <spinbox>` — a stepper over an ordered range.

--- a/docs/widgets/dateentry.rst
+++ b/docs/widgets/dateentry.rst
@@ -79,14 +79,14 @@ palette:
 
    DateEntry(app, bootstyle="success")
 
-API & reference
----------------
+Reference
+---------
 
-For the complete option list and methods, see the
-:doc:`DateEntry API reference </reference/api/dateentry>`.
+- :doc:`DateEntry API reference </reference/api/dateentry>` — every option and
+  method.
 
 .. seealso::
 
-   The date **picker dialog** (``Querybox.get_date``) in the
-   :doc:`Dialogs guide </user-guide/feature-guides/dialogs>` for asking a date
-   without a permanent field, and :doc:`Entry <entry>` for a plain text field.
+   - :doc:`Dialogs guide </user-guide/feature-guides/dialogs>` — the date picker
+     dialog (``Querybox.get_date``) for asking a date without a permanent field.
+   - :doc:`Entry <entry>` — a plain single-line text field.

--- a/docs/widgets/entry.rst
+++ b/docs/widgets/entry.rst
@@ -127,19 +127,17 @@ When you attach validation, a failed check adds a third state: **invalid**.
 Validation sets and clears it for you, and it is what the ``danger`` border maps
 to — read it with ``entry.instate(["invalid"])`` (see `Validating input`_).
 
-API & reference
----------------
+Reference
+---------
 
-``Entry`` is the native ``ttk.Entry`` — ttkbootstrap adds ``bootstyle=`` but no
-other Python API. For its constructor and options (``textvariable``, ``show``,
-``width``, ``justify``, ``state``, …) see the
-`tkinter.ttk.Entry <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Entry>`__
-reference.
+``Entry`` is the native ``ttk.Entry``; ttkbootstrap adds only the ``bootstyle``
+keyword.
+
+- :doc:`Entry API reference </reference/api/entry>` — every option and method.
+- :ref:`Entry styling options <entry-styling>` — restyle it yourself, with the
+  :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Combobox <combobox>` and :doc:`Spinbox <spinbox>` for entries with a
-   dropdown or numeric stepper. Want to restyle the entry yourself? The
-   :ref:`Entry's styling options <entry-styling>` and its
-   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+   - :doc:`Combobox <combobox>` — an entry with a dropdown of choices.
+   - :doc:`Spinbox <spinbox>` — an entry with a numeric stepper.

--- a/docs/widgets/floodgauge.rst
+++ b/docs/widgets/floodgauge.rst
@@ -75,13 +75,13 @@ Color
 
    Floodgauge(app, value=50, maximum=100, mask="{}%", bootstyle="success")
 
-API & reference
----------------
+Reference
+---------
 
-For the complete option list and methods, see the
-:doc:`Floodgauge API reference </reference/api/floodgauge>`.
+- :doc:`Floodgauge API reference </reference/api/floodgauge>` — every option and
+  method.
 
 .. seealso::
 
-   :doc:`Progressbar <progressbar>` for a plain bar without the value label, and
-   :doc:`Meter <meter>` for a radial indicator.
+   - :doc:`Progressbar <progressbar>` — a plain bar without the value label.
+   - :doc:`Meter <meter>` — a radial progress indicator.

--- a/docs/widgets/frame.rst
+++ b/docs/widgets/frame.rst
@@ -98,22 +98,19 @@ fixed size regardless of its contents, turn **geometry propagation** off:
 Use ``grid_propagate(False)`` instead when the frame's children are gridded. This
 is the usual answer to "why won't my frame stay the size I set?"
 
-API & reference
----------------
+Reference
+---------
 
-``Frame`` is the native ``ttk.Frame`` — ttkbootstrap adds ``bootstyle=`` but no
-other Python API. For its constructor and options (``padding``, ``width``,
-``height``, ``borderwidth``, ``relief``, …) see the
-`tkinter.ttk.Frame <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Frame>`__
-reference.
+``Frame`` is the native ``ttk.Frame``; ttkbootstrap adds only the ``bootstyle``
+keyword.
+
+- :doc:`Frame API reference </reference/api/frame>` — every option and method.
+- :ref:`Frame styling options <frame-styling>` — restyle it yourself, with the
+  :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Labelframe <labelframe>` for a frame with a titled border, and
-   :doc:`Notebook <notebook>` / :doc:`Panedwindow <panedwindow>` for tabbed and
-   split containers. For laying widgets out inside a frame, see
-   :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>`. Want to
-   restyle the frame yourself? The
-   :ref:`Frame's styling options <frame-styling>` and its
-   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
-   document the hand-styling surface.
+   - :doc:`Labelframe <labelframe>` — a frame with a titled border.
+   - :doc:`Notebook <notebook>` — a tabbed container.
+   - :doc:`Panedwindow <panedwindow>` — a split, resizable container.
+   - :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>` — laying out the contents.

--- a/docs/widgets/label.rst
+++ b/docs/widgets/label.rst
@@ -112,21 +112,17 @@ reference to images is covered in
 :doc:`Show images and icons </user-guide/how-to/working-with-images>`; type styling
 in the :doc:`Typography guide </user-guide/feature-guides/typography>`.
 
-API & reference
----------------
+Reference
+---------
 
-``Label`` is the native ``ttk.Label`` — ttkbootstrap adds ``bootstyle=`` but no
-other Python API. For its constructor and options (``text``, ``textvariable``,
-``font``, ``image``, ``compound``, ``wraplength``, ``justify``, ``anchor``,
-``width``, …) see the
-`tkinter.ttk.Label <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Label>`__
-reference.
+``Label`` is the native ``ttk.Label``; ttkbootstrap adds only the ``bootstyle``
+keyword.
+
+- :doc:`Label API reference </reference/api/label>` — every option and method.
+- :ref:`Label styling options <label-styling>` — restyle it yourself, with the
+  :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   The :doc:`Typography guide </user-guide/feature-guides/typography>` for fonts,
-   and :doc:`Show images and icons </user-guide/how-to/working-with-images>` for
-   the image side. Want to restyle the label yourself? The
-   :ref:`Label's styling options <label-styling>` and its
-   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
-   document the hand-styling surface.
+   - :doc:`Typography guide </user-guide/feature-guides/typography>` — fonts and type.
+   - :doc:`Show images and icons </user-guide/how-to/working-with-images>` — the image side.

--- a/docs/widgets/labeledscale.rst
+++ b/docs/widgets/labeledscale.rst
@@ -67,12 +67,12 @@ Color
 
    LabeledScale(app, variable=level, from_=0, to=100, bootstyle="success")
 
-API & reference
----------------
+Reference
+---------
 
-For the complete option list, see the
-:doc:`LabeledScale API reference </reference/api/labeledscale>`.
+- :doc:`LabeledScale API reference </reference/api/labeledscale>` — every option
+  and method.
 
 .. seealso::
 
-   :doc:`Scale <scale>` for the plain slider it builds on.
+   - :doc:`Scale <scale>` — the plain slider it builds on.

--- a/docs/widgets/labelframe.rst
+++ b/docs/widgets/labelframe.rst
@@ -71,20 +71,18 @@ use it to tie a section to a color, or to signal an important or dangerous group
 
    ttk.Labelframe(app, text="Danger zone", padding=12, bootstyle="danger")
 
-API & reference
----------------
+Reference
+---------
 
-``Labelframe`` is the native ``ttk.Labelframe`` — ttkbootstrap adds ``bootstyle=``
-but no other Python API. For its constructor and options (``text``, ``padding``,
-``labelanchor``, ``labelwidget``, ``width``, ``height``, …) see the
-`tkinter.ttk.Labelframe <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Labelframe>`__
-reference.
+``Labelframe`` is the native ``ttk.Labelframe``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Labelframe API reference </reference/api/labelframe>` — every option and
+  method.
+- :ref:`Labelframe styling options <labelframe-styling>` — restyle it yourself,
+  with the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Frame <frame>` for a plain container, and
-   :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>` for laying
-   out the widgets inside. Want to restyle the labelframe yourself? The
-   :ref:`Labelframe's styling options <labelframe-styling>` and
-   its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+   - :doc:`Frame <frame>` — a plain container.
+   - :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>` — laying out the contents.

--- a/docs/widgets/menubutton.rst
+++ b/docs/widgets/menubutton.rst
@@ -85,20 +85,18 @@ menu:
    menubutton.state(["disabled"])      # greyed out, won't open
    menubutton.state(["!disabled"])     # re-enable
 
-API & reference
----------------
+Reference
+---------
 
-``Menubutton`` is the native ``ttk.Menubutton`` — ttkbootstrap adds ``bootstyle=``
-but no other Python API. For its constructor and options (``text``, ``menu``,
-``direction``, ``state``, ``image``, ``compound``, …) see the
-`tkinter.ttk.Menubutton <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Menubutton>`__
-reference.
+``Menubutton`` is the native ``ttk.Menubutton``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Menubutton API reference </reference/api/menubutton>` — every option and
+  method.
+- :ref:`Menubutton styling options <menubutton-styling>` — restyle it yourself,
+  with the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`OptionMenu <optionmenu>` when the menu is just a list of values to pick
-   one from, and the :doc:`Menus guide </user-guide/feature-guides/menus>` for
-   building the menu itself. Want to restyle the menubutton yourself? The
-   :ref:`Menubutton's styling options <menubutton-styling>` and
-   its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+   - :doc:`OptionMenu <optionmenu>` — when the menu is just a list of values.
+   - :doc:`Menus guide </user-guide/feature-guides/menus>` — building the menu itself.

--- a/docs/widgets/meter.rst
+++ b/docs/widgets/meter.rst
@@ -124,13 +124,12 @@ Color
    A row of meters in primary, success, info, warning, and danger, in light and
    dark themes.
 
-API & reference
----------------
+Reference
+---------
 
-For the complete option list and methods, see the
-:doc:`Meter API reference </reference/api/meter>`.
+- :doc:`Meter API reference </reference/api/meter>` — every option and method.
 
 .. seealso::
 
-   :doc:`Floodgauge <floodgauge>` for a linear progress indicator with a value,
-   and :doc:`Progressbar <progressbar>` for a plain bar.
+   - :doc:`Floodgauge <floodgauge>` — a linear progress indicator with a value.
+   - :doc:`Progressbar <progressbar>` — a plain progress bar.

--- a/docs/widgets/notebook.rst
+++ b/docs/widgets/notebook.rst
@@ -115,23 +115,19 @@ palette:
 
    ttk.Notebook(app, bootstyle="primary")
 
-API & reference
----------------
+Reference
+---------
 
-``Notebook`` is the native ``ttk.Notebook`` — ttkbootstrap adds ``bootstyle=`` but
-no other Python API. Its own methods manage tabs: ``add`` / ``insert(pos, …)`` to
-append or insert a page, ``select`` / ``tab`` / ``index`` / ``tabs`` to query and
-switch, ``hide`` / ``forget`` to remove, ``enable_traversal`` for keyboard
-navigation, and ``identify(x, y)`` to hit-test the tab bar. For the full signatures
-see the
-`tkinter.ttk.Notebook <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Notebook>`__
-reference.
+``Notebook`` is the native ``ttk.Notebook``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Notebook API reference </reference/api/notebook>` — every option and
+  method (``add`` / ``insert`` / ``select`` / ``tab`` / ``hide`` /
+  ``enable_traversal`` …).
+- :ref:`Notebook styling options <notebook-styling>` — restyle it yourself, with
+  the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Frame <frame>` for the page containers, and
-   :doc:`Panedwindow <panedwindow>` for a split rather than tabbed layout. Want to
-   restyle the notebook yourself? The
-   :ref:`Notebook's styling options <notebook-styling>` and its
-   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
-   document the hand-styling surface.
+   - :doc:`Frame <frame>` — the page containers.
+   - :doc:`Panedwindow <panedwindow>` — a split rather than tabbed layout.

--- a/docs/widgets/optionmenu.rst
+++ b/docs/widgets/optionmenu.rst
@@ -95,21 +95,22 @@ Toggle the ``disabled`` state to grey the control out and block it from opening:
    option.state(["disabled"])          # greyed out, won't open
    option.state(["!disabled"])         # re-enable
 
-API & reference
----------------
+Reference
+---------
 
-``OptionMenu`` is the native ``ttk.OptionMenu`` — ttkbootstrap adds ``bootstyle=``
-but no other Python API. Its constructor is
+``OptionMenu`` is the native ``ttk.OptionMenu``; ttkbootstrap adds only the
+``bootstyle`` keyword. Its constructor is
 ``OptionMenu(master, variable, default, *values, command=None, direction="below")``,
-and ``set_menu(default, *values)`` rebuilds the choices; see the
-`tkinter.ttk.OptionMenu <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.OptionMenu>`__
-reference.
+and ``set_menu(default, *values)`` rebuilds the choices.
+
+- :doc:`OptionMenu API reference </reference/api/optionmenu>` — every option and
+  method.
+- :ref:`OptionMenu styling options <optionmenu-styling>` — an option menu renders
+  as a menubutton, so it shares that customization surface, with the
+  :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Menubutton <menubutton>` when you need a full menu (commands,
-   separators, submenus) rather than a list of values, :doc:`Combobox <combobox>`
-   for a version the user can also type into, and :doc:`Radiobutton <radiobutton>`
-   for a visible group. An option menu renders as a menubutton, so its
-   customization surface is the
-   :ref:`menubutton styling options <optionmenu-styling>`.
+   - :doc:`Menubutton <menubutton>` — for a full menu (commands, separators, submenus).
+   - :doc:`Combobox <combobox>` — a version the user can also type into.
+   - :doc:`Radiobutton <radiobutton>` — the same choice as a visible group.

--- a/docs/widgets/panedwindow.rst
+++ b/docs/widgets/panedwindow.rst
@@ -86,20 +86,18 @@ Color
 
    ttk.Panedwindow(app, orient=VERTICAL, bootstyle="secondary")
 
-API & reference
----------------
+Reference
+---------
 
-``Panedwindow`` is the native ``ttk.Panedwindow`` — ttkbootstrap adds ``bootstyle=``
-but no other Python API. For its constructor and pane methods (``add``,
-``insert``, ``forget``, ``sashpos``, ``pane``) see the
-`tkinter.ttk.Panedwindow <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Panedwindow>`__
-reference.
+``Panedwindow`` is the native ``ttk.Panedwindow``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Panedwindow API reference </reference/api/panedwindow>` — every option and
+  method.
+- :ref:`Panedwindow styling options <panedwindow-styling>` — restyle it yourself,
+  with the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Notebook <notebook>` for a tabbed rather than split layout, and
-   :doc:`Frame <frame>` for the pane containers. Want to restyle the panedwindow
-   yourself? The
-   :ref:`Panedwindow's styling options <panedwindow-styling>`
-   and its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+   - :doc:`Notebook <notebook>` — a tabbed rather than split layout.
+   - :doc:`Frame <frame>` — the pane containers.

--- a/docs/widgets/progressbar.rst
+++ b/docs/widgets/progressbar.rst
@@ -74,21 +74,18 @@ Color
 
    ttk.Progressbar(app, value=50, bootstyle="warning")
 
-API & reference
----------------
+Reference
+---------
 
-``Progressbar`` is the native ``ttk.Progressbar`` — ttkbootstrap adds ``bootstyle=``
-but no other Python API. For its constructor and options (``mode``, ``maximum``,
-``value``, ``variable``, ``orient``, ``length``) and the ``start`` / ``stop`` /
-``step`` methods, see the
-`tkinter.ttk.Progressbar <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Progressbar>`__
-reference.
+``Progressbar`` is the native ``ttk.Progressbar``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Progressbar API reference </reference/api/progressbar>` — every option and
+  method.
+- :ref:`Progressbar styling options <progressbar-styling>` — restyle it yourself,
+  with the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   the ``Floodgauge`` widget for a progress indicator that also shows a
-   value/label, and :doc:`Meter <meter>` for a radial one. Want to restyle the
-   progressbar yourself? The
-   :ref:`Progressbar's styling options <progressbar-styling>`
-   and its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+   - :doc:`Floodgauge <floodgauge>` — a progress bar that shows its value as text.
+   - :doc:`Meter <meter>` — a radial progress indicator.

--- a/docs/widgets/radiobutton.rst
+++ b/docs/widgets/radiobutton.rst
@@ -113,21 +113,20 @@ rest.
    an explicit ``variable=`` don't become independent: they all fall back to the
    same built-in default variable and interfere as one accidental group.
 
-API & reference
----------------
+Reference
+---------
 
-``Radiobutton`` is the native ``ttk.Radiobutton`` — ttkbootstrap adds ``bootstyle=``
-but no other Python API. For its constructor and options (``variable``, ``value``,
-``text``, ``command``, ``state``, …) see the
-`tkinter.ttk.Radiobutton <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Radiobutton>`__
-reference.
+``Radiobutton`` is the native ``ttk.Radiobutton``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Radiobutton API reference </reference/api/radiobutton>` — every option and
+  method.
+- :ref:`Radiobutton styling options <radiobutton-styling>` (and the
+  :ref:`toolbutton style <button-styling>` for the segmented look) — restyle it
+  yourself, with the :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
+  guide.
 
 .. seealso::
 
-   :doc:`Checkbutton <checkbutton>` for an independent on/off toggle, and
-   :doc:`Combobox <combobox>` when a dropdown fits better than a visible group.
-   Want to restyle the radiobutton yourself? The
-   :ref:`radiobutton's styling options <radiobutton-styling>` (and the
-   :ref:`toolbutton style <button-styling>` for the segmented look) and its
-   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+   - :doc:`Checkbutton <checkbutton>` — an independent on/off toggle.
+   - :doc:`Combobox <combobox>` — a dropdown when a visible group is too big.

--- a/docs/widgets/scale.rst
+++ b/docs/widgets/scale.rst
@@ -91,20 +91,17 @@ palette:
 
    ttk.Scale(app, from_=0, to=100, variable=volume, bootstyle="info")
 
-API & reference
----------------
+Reference
+---------
 
-``Scale`` is the native ``ttk.Scale`` — ttkbootstrap adds ``bootstyle=`` but no
-other Python API. For its constructor and options (``from_``, ``to``,
-``variable``, ``command``, ``orient``, ``length``, ``value``) see the
-`tkinter.ttk.Scale <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Scale>`__
-reference.
+``Scale`` is the native ``ttk.Scale``; ttkbootstrap adds only the ``bootstyle``
+keyword.
+
+- :doc:`Scale API reference </reference/api/scale>` — every option and method.
+- :ref:`Scale styling options <scale-styling>` — restyle it yourself, with the
+  :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   the ``LabeledScale`` widget for a scale with a value label that tracks the
-   handle, and :doc:`Spinbox <spinbox>` for a stepped numeric entry. Want to
-   restyle the scale yourself? The
-   :ref:`Scale's styling options <scale-styling>` and its
-   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
-   document the hand-styling surface.
+   - :doc:`LabeledScale <labeledscale>` — a scale with a value label on the handle.
+   - :doc:`Spinbox <spinbox>` — a stepped numeric entry.

--- a/docs/widgets/scrollbar.rst
+++ b/docs/widgets/scrollbar.rst
@@ -71,19 +71,17 @@ gives it rounded ends, and ``thin`` makes it a slim track for dense UIs:
    ttk.Scrollbar(app, orient=VERTICAL, command=text.yview, bootstyle="primary round")
    ttk.Scrollbar(app, orient=VERTICAL, command=text.yview, bootstyle="secondary thin")
 
-API & reference
----------------
+Reference
+---------
 
-``Scrollbar`` is the native ``ttk.Scrollbar`` — ttkbootstrap adds ``bootstyle=``
-but no other Python API. For its constructor and options (``orient``, ``command``)
-and the ``set`` method, see the
-`tkinter.ttk.Scrollbar <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Scrollbar>`__
-reference.
+``Scrollbar`` is the native ``ttk.Scrollbar``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Scrollbar API reference </reference/api/scrollbar>` — every option and
+  method.
+- :ref:`Scrollbar styling options <scrollbar-styling>` — restyle it yourself, with
+  the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Scroll long content </user-guide/how-to/scrollable>` for the ready-made
-   ``ScrolledText`` / ``ScrolledFrame``. Want to restyle the scrollbar yourself?
-   The :ref:`Scrollbar's styling options <scrollbar-styling>`
-   and its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+   - :doc:`Scroll long content </user-guide/how-to/scrollable>` — the ready-made ``ScrolledText`` / ``ScrolledFrame``.

--- a/docs/widgets/scrolled.rst
+++ b/docs/widgets/scrolled.rst
@@ -32,7 +32,7 @@ streaming output — lives in the How-To, which owns the usage:
 
 .. seealso::
 
-   :doc:`Scroll long content </user-guide/how-to/scrollable>` — the complete
-   guide to ``ScrolledFrame`` and ``ScrolledText``. For scrolling a drawing or a
-   single widget yourself, see :doc:`Canvas <canvas>` and :doc:`Scrollbar
-   <scrollbar>`.
+   - :doc:`Scroll long content </user-guide/how-to/scrollable>` — the complete
+     guide to ``ScrolledFrame`` and ``ScrolledText``.
+   - :doc:`Canvas <canvas>` / :doc:`Scrollbar <scrollbar>` — scrolling a drawing or
+     a single widget yourself.

--- a/docs/widgets/separator.rst
+++ b/docs/widgets/separator.rst
@@ -46,17 +46,13 @@ border tone that suits most dividers:
 
    ttk.Separator(app, orient=HORIZONTAL, bootstyle="primary")
 
-API & reference
----------------
+Reference
+---------
 
-``Separator`` is the native ``ttk.Separator`` — ttkbootstrap adds ``bootstyle=``
-but no other Python API. For its constructor see the
-`tkinter.ttk.Separator <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Separator>`__
-reference.
+``Separator`` is the native ``ttk.Separator``; ttkbootstrap adds only the
+``bootstyle`` keyword.
 
-.. seealso::
-
-   Want to restyle the separator yourself? The
-   :ref:`Separator's styling options <separator-styling>` and
-   its companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+- :doc:`Separator API reference </reference/api/separator>` — every option and
+  method.
+- :ref:`Separator styling options <separator-styling>` — restyle it yourself, with
+  the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.

--- a/docs/widgets/sizegrip.rst
+++ b/docs/widgets/sizegrip.rst
@@ -51,18 +51,17 @@ Color
 
    ttk.Sizegrip(app, bootstyle="secondary")
 
-API & reference
----------------
+Reference
+---------
 
-``Sizegrip`` is the native ``ttk.Sizegrip`` — ttkbootstrap adds ``bootstyle=`` but
-no other Python API. For its constructor see the
-`tkinter.ttk.Sizegrip <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Sizegrip>`__
-reference.
+``Sizegrip`` is the native ``ttk.Sizegrip``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Sizegrip API reference </reference/api/sizegrip>` — every option and
+  method.
+- :ref:`Sizegrip styling options <sizegrip-styling>` — restyle it yourself, with
+  the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Windows </user-guide/feature-guides/windows>` for window geometry and
-   resizing. Want to restyle the sizegrip yourself? The
-   :ref:`Sizegrip's styling options <sizegrip-styling>` and its
-   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide
-   document the hand-styling surface.
+   - :doc:`Windows </user-guide/feature-guides/windows>` — window geometry and resizing.

--- a/docs/widgets/spinbox.rst
+++ b/docs/widgets/spinbox.rst
@@ -106,20 +106,17 @@ With validation attached, a failed check also puts the field in the **invalid**
 state — what the ``danger`` border maps to. Validation sets and clears it for you;
 read it with ``spin.instate(["invalid"])``.
 
-API & reference
----------------
+Reference
+---------
 
-``Spinbox`` is the native ``ttk.Spinbox`` — ttkbootstrap adds ``bootstyle=`` but
-no other Python API. For its constructor and options (``from_``, ``to``,
-``increment``, ``values``, ``wrap``, ``textvariable``, ``command``, ``format``,
-…) see the
-`tkinter.ttk.Spinbox <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Spinbox>`__
-reference.
+``Spinbox`` is the native ``ttk.Spinbox``; ttkbootstrap adds only the ``bootstyle``
+keyword.
+
+- :doc:`Spinbox API reference </reference/api/spinbox>` — every option and method.
+- :ref:`Spinbox styling options <spinbox-styling>` — restyle it yourself, with the
+  :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Entry <entry>` for a plain text field and :doc:`Combobox <combobox>` for
-   a dropdown of choices. Want to restyle the spinbox yourself? The
-   :ref:`Spinbox's styling options <spinbox-styling>` and its
-   companion :doc:`Custom styles </user-guide/feature-guides/custom-styles>`
-   guide document the hand-styling surface.
+   - :doc:`Entry <entry>` — a plain single-line text field.
+   - :doc:`Combobox <combobox>` — a dropdown of choices.

--- a/docs/widgets/tableview.rst
+++ b/docs/widgets/tableview.rst
@@ -206,16 +206,18 @@ alternating row tint (pass ``None`` for a part you don't want to change):
    Tableview(app, coldata=cols, rowdata=rows,
              bootstyle="info", stripecolor=("#f2f2f2", None))
 
-API & reference
----------------
+Reference
+---------
 
 ``Tableview`` has a large API beyond this page — ``TableColumn`` / ``TableRow``
 objects, per-column show/hide, row and column moves, and more filtering and
-export variants. For the complete list, see the
-:doc:`Tableview API reference </reference/api/tableview>`.
+export variants.
+
+- :doc:`Tableview API reference </reference/api/tableview>` — the complete option
+  and method list.
 
 .. seealso::
 
-   :doc:`Build your first app </user-guide/getting-started/build-your-first-app>`
-   builds a form that feeds a ``Tableview``, and the ``Treeview`` widget for the
-   native tree/table it is built on.
+   - :doc:`Build your first app </user-guide/getting-started/build-your-first-app>`
+     — builds a form that feeds a ``Tableview``.
+   - :doc:`Treeview <treeview>` — the native tree/table it's built on.

--- a/docs/widgets/text.rst
+++ b/docs/widgets/text.rst
@@ -205,24 +205,20 @@ use it just like a ``Text``:
 wire a plain :doc:`Scrollbar <scrollbar>` to a bare ``Text`` yourself, see
 :doc:`Scroll long content </user-guide/how-to/scrollable>`.
 
-API & reference
----------------
+Reference
+---------
 
-``Text`` is tkinter's ``tk.Text`` — ttkbootstrap themes it but adds no Python
-API. Its methods cover editing (``insert``, ``delete``, ``replace``, ``get``),
-positions (``index``, ``see``, ``bbox``), tags (``tag_add``, ``tag_configure``,
-``tag_bind``, ``tag_remove``, ``tag_names``), marks (``mark_set``, ``mark_gravity``,
-``mark_unset``), search (``search``), and the undo stack (``edit_undo``,
-``edit_redo``, ``edit_separator``, ``edit_modified``).
+``Text`` is tkinter's ``tk.Text``; ttkbootstrap themes it but adds no Python API.
+The standard library doesn't document it in full.
 
-The standard library reference doesn't document the text widget in full. The
-canonical, complete reference is the
-`Tk text manual page <https://www.tcl-lang.org/man/tcl8.6/TkCmd/text.htm>`__ —
-it's written in Tcl, so a subcommand like ``tag configure`` is the Python method
-``tag_configure`` (spaces become underscores).
+- :doc:`Text reference </reference/api/text>` — its options and methods (editing,
+  indices, tags, marks, search, undo).
+- `Tk text manual page <https://www.tcl-lang.org/man/tcl8.6/TkCmd/text.htm>`__ —
+  the canonical upstream reference (Tcl 8.6; a subcommand like ``tag configure`` is
+  the Python method ``tag_configure``).
 
 .. seealso::
 
-   :doc:`Entry <entry>` for a single-line field, and
-   :doc:`Scroll long content </user-guide/how-to/scrollable>` for adding a
-   scrollbar.
+   - :doc:`Entry <entry>` — a single-line text field.
+   - :doc:`Scroll long content </user-guide/how-to/scrollable>` — adding a
+     scrollbar.

--- a/docs/widgets/toast.rst
+++ b/docs/widgets/toast.rst
@@ -73,14 +73,13 @@ glyph shown beside the text (a Bootstrap Icons name):
 
 Set ``alert=True`` to also ring the system bell when the toast appears.
 
-API & reference
----------------
+Reference
+---------
 
-For the complete option list, see the
-:doc:`ToastNotification API reference </reference/dialogs/toast>`.
+- :doc:`ToastNotification API reference </reference/dialogs/toast>` — every option
+  and method.
 
 .. seealso::
 
-   The :doc:`Dialogs guide </user-guide/feature-guides/dialogs>` for a
-   ``Messagebox`` when you need the user to acknowledge or answer, rather than a
-   toast that fades on its own.
+   - :doc:`Dialogs guide </user-guide/feature-guides/dialogs>` — a ``Messagebox``
+     when you need the user to acknowledge or answer, not a toast that fades.

--- a/docs/widgets/tooltip.rst
+++ b/docs/widgets/tooltip.rst
@@ -67,13 +67,13 @@ tip to the kind of control (``danger`` for a destructive action, say):
 
    ToolTip(delete_button, text="This cannot be undone", bootstyle="danger")
 
-API & reference
----------------
+Reference
+---------
 
-For the complete option list, see the
-:doc:`ToolTip API reference </reference/dialogs/tooltip>`.
+- :doc:`ToolTip API reference </reference/dialogs/tooltip>` — every option and
+  method.
 
 .. seealso::
 
-   :doc:`Toast <toast>` for a temporary notification that appears on its own
-   rather than on hover.
+   - :doc:`Toast <toast>` — a temporary notification that appears on its own, not
+     on hover.

--- a/docs/widgets/treeview.rst
+++ b/docs/widgets/treeview.rst
@@ -215,21 +215,18 @@ States
    tree.state(["disabled"])            # greyed out
    tree.state(["!disabled"])           # re-enable
 
-API & reference
----------------
+Reference
+---------
 
-``Treeview`` is the native ``ttk.Treeview`` — ttkbootstrap adds ``bootstyle=`` but
-no other Python API. For the full set of methods (``insert``, ``item``, ``set``,
-``move``, ``detach`` / ``reattach``, ``delete``, ``heading``, ``column``,
-``selection`` / ``selection_add`` / ``selection_remove``, ``identify_row`` /
-``identify_region``, ``see``, ``bbox``, …) and options, see the
-`tkinter.ttk.Treeview <https://docs.python.org/3/library/tkinter.ttk.html#tkinter.ttk.Treeview>`__
-reference.
+``Treeview`` is the native ``ttk.Treeview``; ttkbootstrap adds only the
+``bootstyle`` keyword.
+
+- :doc:`Treeview API reference </reference/api/treeview>` — every option and
+  method (``insert`` / ``item`` / ``set`` / ``selection`` / ``detach`` /
+  ``identify_row`` …).
+- :ref:`Treeview styling options <treeview-styling>` — restyle it yourself, with
+  the :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide.
 
 .. seealso::
 
-   :doc:`Tableview <tableview>` for a ready-made data table built on the
-   treeview. Want to restyle it yourself? The
-   :ref:`Treeview's styling options <treeview-styling>` and the
-   :doc:`Custom styles </user-guide/feature-guides/custom-styles>` guide document
-   the hand-styling surface.
+   - :doc:`Tableview <tableview>` — a ready-made data table built on the treeview.


### PR DESCRIPTION
Started from the observation that the native-widget catalog pages linked **python.org's `tkinter.ttk`** in their "API & reference" section — they were written *before* our own self-authored API reference existed. Widened (per discussion) into a consistency sweep of the bottom of every catalog page.

## The standard (approved)

Two scannable lists, replacing the old run-on paragraphs:

**Reference** (was "API & reference") — a short lead + bulleted reference links:
- **Native ttk pages** → our `docs/reference/api/<widget>` page + the styling options (`:ref:`<widget>-styling``) with the Custom styles guide. (No more python.org.)
- **Shipped pages** → our API reference page.
- **tk pages (Canvas/Text)** → our reference page **plus** the Tcl/Tk manual as a supplementary bullet. The **Text** page previously linked *only* the Tcl manual — it now links our Text reference too.

**See also** — the paragraph becomes a bulleted list, each `link — short description`, matching the voice of the catalog grid cards.

## Example (combobox)

```
Reference
---------
Combobox is the native ttk.Combobox; ttkbootstrap adds only the bootstyle keyword.

- Combobox API reference — every option and method.
- Combobox styling options — restyle it yourself, with the Custom styles guide.

.. seealso::
   - Entry — a plain single-line text field.
   - Spinbox — a stepper over an ordered range.
```

## Verification

- No `docs.python.org` links remain in `docs/widgets/`; every page links a reference.
- All 28 content pages use a `Reference` heading; `scrolled` (a stub) keeps just a listified See-also.
- Build gate green (`sphinx -b html -W -q -E docs`, exit 0). 29 files, net −63 lines. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)