### PR TITLE
docs: point guide links at our own reference (not python.org)

### DIFF
--- a/docs/user-guide/feature-guides/menus.rst
+++ b/docs/user-guide/feature-guides/menus.rst
@@ -295,5 +295,5 @@ cascade off macOS, so a Help menu is present everywhere.
    :doc:`Windows </user-guide/feature-guides/windows>` for the cross-platform
    windowing model this builds on, the :doc:`Events guide
    </user-guide/feature-guides/events>` for the event object and binding
-   conventions, and the `tkinter menu reference
-   <https://docs.python.org/3/library/tkinter.html>`_ for the full option set.
+   conventions, and the :doc:`Menu reference </reference/api/menu>` for the full
+   option set.

--- a/docs/user-guide/feature-guides/typography.rst
+++ b/docs/user-guide/feature-guides/typography.rst
@@ -154,7 +154,5 @@ when the app is destroyed, so you rarely call it yourself.
 
 .. seealso::
 
-   The named-font families are the standard tkinter fonts; for the underlying
-   options and the ``font.Font`` object, see
-   `tkinter.font <https://docs.python.org/3/library/tkinter.font.html>`__ on
-   python.org.
+   The named-font families are the standard tkinter fonts; for the ``Font``
+   object and the full options, see the :doc:`Fonts reference </reference/fonts>`.

--- a/docs/user-guide/feature-guides/variables.rst
+++ b/docs/user-guide/feature-guides/variables.rst
@@ -149,6 +149,5 @@ localization subsystem.
 .. seealso::
 
    :doc:`State & variables </user-guide/foundations/state-and-variables>` for the
-   binding basics. The variable classes are standard tkinter; for the base API see
-   `Variable classes <https://docs.python.org/3/library/tkinter.html#coupling-widget-variables>`__
-   on python.org.
+   binding basics, and the :doc:`Variables reference </reference/variables>` for
+   the ``StringVar`` / ``IntVar`` / … API and the numeric-coercion gotcha.

--- a/docs/user-guide/foundations/layout-with-grid.rst
+++ b/docs/user-guide/foundations/layout-with-grid.rst
@@ -147,8 +147,7 @@ Recap
   grow.
 - ``columnspan`` / ``rowspan`` let a widget cover several cells.
 
-For every option, see the
-`Grid reference <https://docs.python.org/3/library/tkinter.html#tkinter.Grid>`__.
+For every option, see the :doc:`Grid reference </reference/geometry/grid>`.
 
 .. seealso::
 

--- a/docs/user-guide/foundations/layout-with-pack.rst
+++ b/docs/user-guide/foundations/layout-with-pack.rst
@@ -81,8 +81,8 @@ That's the distinction worth remembering:
 
 The other options: ``anchor`` positions a widget within its space when it isn't
 filling (``anchor="w"`` left-aligns), ``padx``/``pady`` add space outside it, and
-``ipadx``/``ipady`` inside it. See the
-`Pack reference <https://docs.python.org/3/library/tkinter.html#tkinter.Pack>`__.
+``ipadx``/``ipady`` inside it. See the :doc:`Pack reference
+</reference/geometry/pack>`.
 
 Step 4 — combine managers by nesting frames
 -------------------------------------------
@@ -147,8 +147,7 @@ pinned to a corner, where neither ``pack`` nor ``grid`` fits:
 
    badge.place(relx=1.0, rely=0.0, anchor="ne")   # pin to the top-right corner
 
-See the
-`Place reference <https://docs.python.org/3/library/tkinter.html#tkinter.Place>`__.
+See the :doc:`Place reference </reference/geometry/place>`.
 
 Recap
 -----

--- a/docs/user-guide/foundations/the-widget-model.rst
+++ b/docs/user-guide/foundations/the-widget-model.rst
@@ -50,8 +50,7 @@ and read or change them afterward:
 ``configure()`` with no arguments returns *every* option the widget supports —
 a quick way to discover what you can set. For the full, per-widget option list,
 each widget's page in the :doc:`Widgets catalog </widgets/index>` and the
-`tkinter.ttk <https://docs.python.org/3/library/tkinter.ttk.html>`__ reference
-are the place to look.
+:doc:`Widgets reference </reference/api/index>` are the place to look.
 
 .. note::
 

--- a/docs/user-guide/how-to/index.rst
+++ b/docs/user-guide/how-to/index.rst
@@ -8,9 +8,8 @@ How-To
 
 Short, task-focused recipes for common jobs — the everyday tkinter tasks a
 newcomer arrives needing, written the ttkbootstrap way (ttkbootstrap widgets and
-idioms throughout, with links out to the `tkinter reference
-<https://docs.python.org/3/library/tkinter.html>`_ for the raw API). This band
-absorbs the recipes from the old cookbook.
+idioms throughout, with links to the :doc:`Reference </reference/index>` for the
+full API). This band absorbs the recipes from the old cookbook.
 
 Building interfaces
 -------------------

--- a/docs/user-guide/how-to/scrollable.rst
+++ b/docs/user-guide/how-to/scrollable.rst
@@ -70,8 +70,8 @@ for the standard Text API (``insert``, ``get``, ``delete``, tags):
 
    app.mainloop()
 
-- ``.text`` is the real ``Text`` widget — anything the `tkinter Text reference
-  <https://docs.python.org/3/library/tkinter.html>`_ documents works on it.
+- ``.text`` is the real ``Text`` widget — anything the :doc:`Text reference
+  </reference/api/text>` documents works on it.
 - Pass ``hbar=True`` for a horizontal scrollbar too (off by default); ``vbar`` is
   on by default.
 - ``see("end")`` keeps the newest content in view — the usual move for a log.


### PR DESCRIPTION
The guides linked **python.org** for things we now document ourselves. Retargets them:

- `layout-with-grid` / `layout-with-pack` — Grid / Pack / Place → the new **Geometry** reference
- `the-widget-model` — `tkinter.ttk` → our **Widgets** reference
- `how-to/scrollable` — tkinter Text → our **Text** reference
- `how-to/index` — "raw API" → our **Reference**
- `menus` (See also) — tkinter menu → our **Menu** reference
- `typography` (See also) — `tkinter.font` → our **Fonts** reference
- `variables` (See also) — Variable classes → the new **Variables** reference

**Deliberately kept** as legitimate upstream: `threads` (stdlib `threading`/`queue`) and `custom-styles`/`icons` (ttk's raw element/layout model, which we don't teach).

Follows the merged Geometry (#1208) + Variables (#1209) reference sections. Build gate green (`sphinx -W -q -E`, exit 0). Docs-only.

Follow-up PR will listify the multi-link See-also paragraphs across the guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)