### PR TITLE
docs: listify the multi-link See-also blocks across the guides

### DIFF
--- a/docs/user-guide/feature-guides/dialogs.rst
+++ b/docs/user-guide/feature-guides/dialogs.rst
@@ -311,8 +311,9 @@ accept them.
 
 .. seealso::
 
-   :doc:`Windows </user-guide/feature-guides/windows>` for the focus,
-   modality, and lifecycle mechanics the dialogs are built on;
-   :doc:`Input validation </user-guide/feature-guides/validation>` for validating
-   fields in a form dialog; and :doc:`Open a second window
-   </user-guide/how-to/multiple-windows>` for rolling your own.
+   - :doc:`Windows </user-guide/feature-guides/windows>` — the focus, modality,
+     and lifecycle mechanics the dialogs are built on.
+   - :doc:`Input validation </user-guide/feature-guides/validation>` — validating
+     fields in a form dialog.
+   - :doc:`Open a second window </user-guide/how-to/multiple-windows>` — rolling
+     your own.

--- a/docs/user-guide/feature-guides/events.rst
+++ b/docs/user-guide/feature-guides/events.rst
@@ -168,7 +168,7 @@ sequences with ``event_add``:
 
 .. seealso::
 
-   :doc:`Events & callbacks </user-guide/foundations/events-and-callbacks>` for
-   the basics, and the :doc:`Event reference </reference/events/index>` for the
-   complete catalog — every event type, modifier, key symbol, and event
-   attribute.
+   - :doc:`Events & callbacks </user-guide/foundations/events-and-callbacks>` —
+     the basics.
+   - :doc:`Event reference </reference/events/index>` — the complete catalog:
+     every event type, modifier, key symbol, and event attribute.

--- a/docs/user-guide/feature-guides/icons.rst
+++ b/docs/user-guide/feature-guides/icons.rst
@@ -175,7 +175,7 @@ A small toolbar of icon-only buttons beside a labeled action:
 
 .. seealso::
 
-   For the *application* (window/taskbar) icon, see
-   :doc:`Windows </user-guide/feature-guides/windows>`. For
-   raster images and Pillow, see
-   :doc:`Show images and icons </user-guide/how-to/working-with-images>`.
+   - :doc:`Windows </user-guide/feature-guides/windows>` — the *application*
+     (window/taskbar) icon.
+   - :doc:`Show images and icons </user-guide/how-to/working-with-images>` — raster
+     images and Pillow.

--- a/docs/user-guide/feature-guides/localization.rst
+++ b/docs/user-guide/feature-guides/localization.rst
@@ -158,7 +158,7 @@ anything that must switch live is bound to a ``LocaleVar``.
 
 .. seealso::
 
-   :doc:`Variables </user-guide/feature-guides/variables>` for how variable
-   objects bind to widgets — ``LocaleVar`` is a specialized ``StringVar`` — and
-   :doc:`Events </user-guide/feature-guides/events>` for the ``<<LocaleChanged>>``
-   virtual event that drives it.
+   - :doc:`Variables </user-guide/feature-guides/variables>` — how variable objects
+     bind to widgets (``LocaleVar`` is a specialized ``StringVar``).
+   - :doc:`Events </user-guide/feature-guides/events>` — the ``<<LocaleChanged>>``
+     virtual event that drives it.

--- a/docs/user-guide/feature-guides/menus.rst
+++ b/docs/user-guide/feature-guides/menus.rst
@@ -292,8 +292,8 @@ cascade off macOS, so a Help menu is present everywhere.
 
 .. seealso::
 
-   :doc:`Windows </user-guide/feature-guides/windows>` for the cross-platform
-   windowing model this builds on, the :doc:`Events guide
-   </user-guide/feature-guides/events>` for the event object and binding
-   conventions, and the :doc:`Menu reference </reference/api/menu>` for the full
-   option set.
+   - :doc:`Windows </user-guide/feature-guides/windows>` — the cross-platform
+     windowing model this builds on.
+   - :doc:`Events guide </user-guide/feature-guides/events>` — the event object and
+     binding conventions.
+   - :doc:`Menu reference </reference/api/menu>` — the full option set.

--- a/docs/user-guide/feature-guides/validation.rst
+++ b/docs/user-guide/feature-guides/validation.rst
@@ -186,9 +186,9 @@ fields unflagged.
 
 .. seealso::
 
-   :doc:`Variables </user-guide/feature-guides/variables>` for reacting to input
-   changes generally with traces,
-   :doc:`Events </user-guide/feature-guides/events>` for the binding system these
-   validation callbacks are built on, and
-   :doc:`Dialogs </user-guide/feature-guides/dialogs>` for the ``Messagebox`` used
-   above.
+   - :doc:`Variables </user-guide/feature-guides/variables>` — reacting to input
+     changes generally, with traces.
+   - :doc:`Events </user-guide/feature-guides/events>` — the binding system these
+     validation callbacks are built on.
+   - :doc:`Dialogs </user-guide/feature-guides/dialogs>` — the ``Messagebox`` used
+     above.

--- a/docs/user-guide/feature-guides/variables.rst
+++ b/docs/user-guide/feature-guides/variables.rst
@@ -148,6 +148,7 @@ localization subsystem.
 
 .. seealso::
 
-   :doc:`State & variables </user-guide/foundations/state-and-variables>` for the
-   binding basics, and the :doc:`Variables reference </reference/variables>` for
-   the ``StringVar`` / ``IntVar`` / … API and the numeric-coercion gotcha.
+   - :doc:`State & variables </user-guide/foundations/state-and-variables>` — the
+     binding basics.
+   - :doc:`Variables reference </reference/variables>` — the ``StringVar`` /
+     ``IntVar`` / … API and the numeric-coercion gotcha.

--- a/docs/user-guide/feature-guides/windows.rst
+++ b/docs/user-guide/feature-guides/windows.rst
@@ -365,9 +365,11 @@ possible, but they affect what you can rely on:
 
 .. seealso::
 
-   :doc:`Structuring an app </user-guide/getting-started/app-structures>` for the
-   single-root rule, :doc:`Theming & Colors </user-guide/feature-guides/theming>`
-   for themes and light/dark, :doc:`Widget & screen info </reference/winfo>` for
-   the ``winfo_*`` size/position accessors, and
-   :doc:`Open a second window </user-guide/how-to/multiple-windows>` for the
-   second-window recipe.
+   - :doc:`Structuring an app </user-guide/getting-started/app-structures>` — the
+     single-root rule.
+   - :doc:`Theming & Colors </user-guide/feature-guides/theming>` — themes and
+     light/dark.
+   - :doc:`Widget & screen info </reference/winfo>` — the ``winfo_*`` size/position
+     accessors.
+   - :doc:`Open a second window </user-guide/how-to/multiple-windows>` — the
+     second-window recipe.

--- a/docs/user-guide/foundations/events-and-callbacks.rst
+++ b/docs/user-guide/foundations/events-and-callbacks.rst
@@ -111,6 +111,6 @@ label — no blocking, the window stays responsive throughout:
 
 .. seealso::
 
-   The :doc:`Events guide </user-guide/feature-guides/events>` for binding scope,
-   stopping events, and dispatching your own; the
-   :doc:`Event reference </reference/events/index>` for the complete catalog.
+   - :doc:`Events guide </user-guide/feature-guides/events>` — binding scope,
+     stopping events, and dispatching your own.
+   - :doc:`Event reference </reference/events/index>` — the complete catalog.

--- a/docs/user-guide/foundations/how-a-tkinter-app-runs.rst
+++ b/docs/user-guide/foundations/how-a-tkinter-app-runs.rst
@@ -139,6 +139,7 @@ blocking it:
 
 .. seealso::
 
-   :doc:`Events & callbacks </user-guide/foundations/events-and-callbacks>` for
-   binding handlers, and :doc:`Widget & screen info </reference/winfo>` for why
-   sizes aren't known until the loop runs.
+   - :doc:`Events & callbacks </user-guide/foundations/events-and-callbacks>` —
+     binding handlers.
+   - :doc:`Widget & screen info </reference/winfo>` — why sizes aren't known until
+     the loop runs.

--- a/docs/user-guide/foundations/state-and-variables.rst
+++ b/docs/user-guide/foundations/state-and-variables.rst
@@ -82,6 +82,7 @@ the box is checked:
 
 .. seealso::
 
-   The :doc:`Variables guide </user-guide/feature-guides/variables>` for the full
-   picture, and :doc:`Localization </user-guide/feature-guides/localization>` for
-   ``LocaleVar``, a variable that re-translates itself when the locale changes.
+   - :doc:`Variables guide </user-guide/feature-guides/variables>` — the full
+     picture.
+   - :doc:`Localization </user-guide/feature-guides/localization>` — ``LocaleVar``,
+     a variable that re-translates itself when the locale changes.

--- a/docs/user-guide/foundations/the-widget-model.rst
+++ b/docs/user-guide/foundations/the-widget-model.rst
@@ -116,6 +116,7 @@ A small tree, configured, with a state toggled:
 
 .. seealso::
 
-   :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
-   for the loop that drives callbacks, and :doc:`Cursors </reference/cursors>` for
-   the platform-dependent ``cursor`` option.
+   - :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
+     — the loop that drives callbacks.
+   - :doc:`Cursors </reference/cursors>` — the platform-dependent ``cursor``
+     option.

--- a/docs/user-guide/getting-started/build-your-first-app.rst
+++ b/docs/user-guide/getting-started/build-your-first-app.rst
@@ -64,9 +64,9 @@ apps stay organized as they grow.
 
 .. seealso::
 
-   :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
-   for the event loop and why ``mainloop()`` comes last, and
-   :doc:`Structuring an app <app-structures>` for the root and single-root rule.
+   - :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
+     — the event loop and why ``mainloop()`` comes last.
+   - :doc:`Structuring an app <app-structures>` — the root and single-root rule.
 
 Step 2 — a form with ``grid``
 -----------------------------

--- a/docs/user-guide/getting-started/quickstart.rst
+++ b/docs/user-guide/getting-started/quickstart.rst
@@ -55,6 +55,7 @@ style engine:
 
 .. seealso::
 
-   :doc:`Styling with bootstyle </user-guide/foundations/bootstyle-grammar>` for the
-   full styling vocabulary, and :doc:`Theming </user-guide/feature-guides/theming>`
-   for the color model behind the themes.
+   - :doc:`Styling with bootstyle </user-guide/foundations/bootstyle-grammar>` —
+     the full styling vocabulary.
+   - :doc:`Theming </user-guide/feature-guides/theming>` — the color model behind
+     the themes.

--- a/docs/user-guide/how-to/clipboard.rst
+++ b/docs/user-guide/how-to/clipboard.rst
@@ -77,6 +77,7 @@ through the same call instead:
 
 .. seealso::
 
-   The :doc:`Events guide </user-guide/feature-guides/events>` for binding the
-   copy/paste shortcuts, and the ``<<Copy>>`` / ``<<Paste>>`` / ``<<Cut>>``
-   virtual events that Entry and Text already handle for you.
+   - :doc:`Events guide </user-guide/feature-guides/events>` — binding the
+     copy/paste shortcuts.
+   - The ``<<Copy>>`` / ``<<Paste>>`` / ``<<Cut>>`` virtual events that Entry and
+     Text already handle for you.

--- a/docs/user-guide/how-to/error-handling.rst
+++ b/docs/user-guide/how-to/error-handling.rst
@@ -65,7 +65,7 @@ or validate the field instead — see
 
 .. seealso::
 
-   The :doc:`Variables guide </user-guide/feature-guides/variables>` for the
-   numeric-variable coercion gotcha, and
-   :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
-   for the event loop that these callbacks run inside.
+   - :doc:`Variables guide </user-guide/feature-guides/variables>` — the
+     numeric-variable coercion gotcha.
+   - :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
+     — the event loop that these callbacks run inside.

--- a/docs/user-guide/how-to/feedback.rst
+++ b/docs/user-guide/how-to/feedback.rst
@@ -77,6 +77,6 @@ and marshal results back with ``after``, so the UI stays responsive.
 
 .. seealso::
 
-   :doc:`Cursors </reference/cursors>` for the pointer names, and the
-   :doc:`Windows guide </user-guide/feature-guides/windows>` for window-level
-   behavior.
+   - :doc:`Cursors </reference/cursors>` — the pointer names.
+   - :doc:`Windows guide </user-guide/feature-guides/windows>` — window-level
+     behavior.

--- a/docs/user-guide/how-to/multiple-windows.rst
+++ b/docs/user-guide/how-to/multiple-windows.rst
@@ -92,6 +92,7 @@ Hide an expensive window and bring it back rather than recreating it:
 
 .. seealso::
 
-   :doc:`Focus, modality & lifecycle </user-guide/feature-guides/windows>` for
-   the concepts, and :doc:`Structuring an app
-   </user-guide/getting-started/app-structures>` for the single-root rule.
+   - :doc:`Focus, modality & lifecycle </user-guide/feature-guides/windows>` — the
+     concepts.
+   - :doc:`Structuring an app </user-guide/getting-started/app-structures>` — the
+     single-root rule.

--- a/docs/user-guide/how-to/scrollable.rst
+++ b/docs/user-guide/how-to/scrollable.rst
@@ -89,6 +89,7 @@ for the standard Text API (``insert``, ``get``, ``delete``, tags):
 
 .. seealso::
 
-   :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>` for
-   packing and gridding content, and :doc:`Run background work <threads>` for
-   streaming output into a ``ScrolledText`` without freezing the UI.
+   - :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>` — packing
+     and gridding content.
+   - :doc:`Run background work <threads>` — streaming output into a
+     ``ScrolledText`` without freezing the UI.


### PR DESCRIPTION
The final piece of the guide-references cleanup, matching the widget-catalog standardization: run-on **See also** paragraphs (2+ cross-links) become scannable bulleted lists, each `link — short description`, reusing the descriptions already in the prose. Single-link See-alsos are left as prose (a one-item list reads odd).

19 guide pages across feature-guides, foundations, getting-started, and how-to.

**Stacked on #1210** — base is `docs/2.0-guide-retargets`; retarget to `2.0` once that merges. Build gate green (`sphinx -W -q -E`, exit 0). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)