### PR TITLE
docs: Migrating to 2.0 guide + backfill early breaking changes

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -27,7 +27,11 @@
 | **`ThemeDefinition`: `themetype`→`mode` (kwarg + `.type`→`.mode`)** | Deprecated | this doc, below |
 | Canonical `bootstyle` grammar (closed vocab, strict mode) | API | `development/2_0_bootstyle_grammar_design.md` |
 | Character-based icons removed (`ttkbootstrap.icons`) | API | `development/2_0_icon_drop_design.md` (PR #1094) |
-| Delivery API (mixins, no import-time monkey-patch) | API | handoff / PR #1075 |
+| **Delivery API: no import-time monkey-patch; `bootstyle`/`autostyle` via `ttk.*` classes or `enable_global_api()`** | API | this doc, below (backfill) |
+| **Single application root enforced (`RuntimeError` on a second `Window`)** | API | this doc, below (backfill) |
+| **`Publisher` no longer fires on theme change (use `<<ThemeChanged>>`)** | API | this doc, below (backfill) |
+| **Removed shim modules (`ttkbootstrap.scrolled`/`tableview`/`toast`/`tooltip`, `dialogs/dialogs.py`)** | Removed | this doc, below (backfill) |
+| **`FloodgaugeLegacy` warns on use; `publisher`/`utility` helpers moved to `internal/`** | Deprecated | this doc, below (backfill) |
 | **Fluent geometry (`pack`/`grid`/`place` return the widget)** | New | this doc, below |
 | **`TkLabel` blessed tk.Label + ColorChooser default-mode fix** | New/Fix | this doc, below |
 | **`neutral` color** | New | this doc, below |
@@ -52,6 +56,122 @@
 | **Inputs: focus color on focus only (not hover)** | Visual | this doc, below |
 | **`card` / `highlight` frames: hairline border (`RAISED`, no bevel)** | Visual | this doc, below |
 | **Control-height parity + check/radio/menubutton focus rings** | Visual | this doc, below |
+
+---
+
+# Engine & delivery foundations (early 2.0 PRs — backfilled)
+
+> This log began mid-initiative, so the foundational engine/delivery breaks from
+> the first wave of 2.0 PRs (#1068–#1077) were not captured inline. They are the
+> changes an upgrader is *most* likely to hit, so they are backfilled here from a
+> grounded diff review.
+
+## Delivery API — no import-time monkey-patch  *(API — the headline 2.0 change)*
+
+**What.** Importing `ttkbootstrap` no longer monkey-patches stock `tkinter` /
+`tkinter.ttk` at import time (the old `Bootstyle.setup_ttkbootstrap_api()`
+import-time call is gone). The `bootstyle=` / `autostyle=` keywords are now
+carried by the **concrete widget subclasses** re-exported from the package
+(`class Button(BootMixin, ttk.Button)`, `class Tk(AutoStyleMixin, tk.Tk)`, …),
+not injected into tkinter's own classes.
+
+- **Unaffected (the common case):** code written as
+  `import ttkbootstrap as ttk; ttk.Button(root, bootstyle="success")` resolves to
+  the blessed subclass and works exactly as before.
+- **Breaks:** after `import ttkbootstrap`, a **vanilla** `tkinter.ttk.Button(root,
+  bootstyle="success")` or `tkinter.Frame(root, autostyle=False)` no longer
+  accepts those keywords — Tk raises `unknown option "-bootstyle"`.
+
+**Migration.** Prefer the `ttkbootstrap.*` widget classes (recommended). To keep
+using raw `tkinter`/`ttk` widget classes with the styling keywords, call the new
+opt-in **`enable_global_api()`** once at startup — it restores the global patch
+(and also makes `pack`/`grid`/`place` return the widget on stock/native/third-party
+widgets). For a one-off foreign class, **`bootify(cls)`** returns a styled subclass
+and **`apply_bootstyle(widget, bootstyle)`** styles an existing instance.
+
+**Also:** the `BootMixin` / `AutoStyleMixin` classes and the `bootify` /
+`apply_bootstyle` / `enable_global_api` helpers are re-exported from
+`ttkbootstrap` and `ttkbootstrap.style`. The blessed tk set is `Tk`, `Menu`,
+`Text`, `Canvas`, `TkFrame` (tk `Frame`), `TkLabel`, and `LabelFrame`. The
+~54 KB `__init__.pyi` type stub was deleted (typing now lives on the concrete
+classes) — affects only tooling that imported the stub directly, not runtime.
+
+**Why.** The import-time monkey-patch mutated tkinter's own classes for the whole
+process — surprising, order-dependent, and hostile to apps mixing themed and
+un-themed widgets. Concrete subclasses make the styled widgets ordinary classes
+with an explicit, opt-in global escape hatch (PR #1075).
+
+---
+
+## Single application root enforced  *(API — behavioral break)*
+
+**What.** `Window.__init__` now enforces one application root per process
+(the `Style` engine is a singleton bound to the first root). Creating a **second,
+concurrent** `ttk.Window` while another live root exists raises
+`RuntimeError("ttkbootstrap supports a single application root window…")`.
+
+- **Sequential roots are fine** — `Window.destroy()` clears the singleton, so
+  create-an-app-after-another still works.
+- **Only `Window` triggers the check**; a plain `ttk.Toplevel` does not (it is not
+  a root). Secondary windows should be `Toplevel`.
+
+**Migration.** Use **one** `Window` per process and add extra windows as
+`Toplevel`; or destroy the first root before creating another. In 1.x a second
+root silently mis-bound the `Style` singleton and left theming broken with no
+error — this converts that silent failure into a loud one (PR #1073).
+
+---
+
+## `Publisher` no longer fires on theme change  *(API — behavioral break)*
+
+**What.** The old `Publisher` / `Channel` subscribe-on-theme-change mechanism is
+no longer used by the engine. Theme switching is now a version-stamped theme walk
+and **does not publish to `Channel.STD`**. `ttkbootstrap.internal.publisher`
+still exists and `Publisher.subscribe(...)` still registers a callback, but the
+engine **never fires it on `theme_use()` anymore**, so any code that subscribed to
+be notified on a theme change silently stops receiving callbacks.
+
+**Migration.** Bind the standard Tk **`<<ThemeChanged>>`** virtual event instead
+(or, for custom styles, register `ttk.on_theme_change(...)` / `@theme_aware`).
+`ttkbootstrap.publisher` is also now a deprecation shim (see below) (PR #1073/#1069).
+
+---
+
+## Removed shim modules  *(Removed — import paths)*
+
+**What.** Five legacy top-level import paths were deleted outright (they had been
+deprecation shims):
+
+- `ttkbootstrap.scrolled`, `ttkbootstrap.tableview`, `ttkbootstrap.toast`,
+  `ttkbootstrap.tooltip` → import from **`ttkbootstrap.widgets`** (e.g.
+  `from ttkbootstrap.widgets.tooltip import ToolTip`, or `ttk.ToolTip`).
+- `ttkbootstrap.dialogs.dialogs` → import from **`ttkbootstrap.dialogs`** (e.g.
+  `from ttkbootstrap.dialogs import Messagebox, Querybox`, or `ttk.Messagebox`).
+
+**Migration.** Update the import path. All the classes themselves are unchanged
+and are additionally re-exported at the top level (`ttk.ToolTip`, `ttk.Tableview`,
+`ttk.ToastNotification`, `ttk.Messagebox`, …) (PR #1068).
+
+---
+
+## `FloodgaugeLegacy` warns; `publisher` / `utility` helpers moved  *(Deprecated — still work)*
+
+**What.** Deprecations that keep working through 2.x (removed in 3.0):
+
+- **`FloodgaugeLegacy(...)`** now emits a `DeprecationWarning` on every
+  instantiation. Migrate to the canvas-based `ttk.Floodgauge` (PR #1071).
+- **`ttkbootstrap.publisher`** is a warn-and-reexport shim to
+  `ttkbootstrap.internal.publisher` (`Channel`/`Subscriber`/`Publisher`) — still
+  importable, warns once (PR #1069). (And per the entry above, the engine no
+  longer fires it on theme change.)
+- **`ttkbootstrap.utility.get_image_name` / `center_on_parent`** moved to
+  `ttkbootstrap.internal.utility`; reaching them via the old path still works via
+  a module `__getattr__` forwarder but warns. Public `enable_high_dpi_awareness`
+  / `scale_size` are unchanged (PR #1069).
+
+**Why.** The 2.0 `internal/` convention: implementation-detail plumbing moves under
+`ttkbootstrap.internal.*` (no back-compat guarantee), with warn-and-forward shims
+at the old public paths, removed in 3.0.
 
 ---
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -111,6 +111,35 @@ html[data-theme="dark"] .tb-dialog-screenshot {
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
 }
 
+/* Screenshot placeholders. Until the real light/dark captures land (Windows is
+   the canonical capture box), each `:class: screenshot-placeholder` admonition
+   renders as a clearly-provisional dashed box so unfinished pages are obvious. */
+.admonition.screenshot-placeholder,
+div.admonition.screenshot-placeholder {
+    border: 2px dashed var(--pst-color-border);
+    border-left: 2px dashed var(--pst-color-border);
+    border-radius: 6px;
+    background: repeating-linear-gradient(
+        45deg,
+        var(--pst-color-surface),
+        var(--pst-color-surface) 12px,
+        var(--pst-color-on-background) 12px,
+        var(--pst-color-on-background) 24px);
+    box-shadow: none;
+    color: var(--pst-color-text-muted);
+}
+.admonition.screenshot-placeholder > .admonition-title {
+    background: transparent;
+    color: var(--pst-color-text-muted);
+    font-weight: 600;
+}
+.admonition.screenshot-placeholder > .admonition-title::after {
+    display: none;  /* drop the pydata note/icon glyph */
+}
+.admonition.screenshot-placeholder p {
+    font-style: italic;
+}
+
 /* Promo home page: a prominent lead line and a row of hero call-to-action
    buttons (the sphinx-design button directives are block-level, so wrap them in
    a flex container to sit side by side). */

--- a/docs/user-guide/getting-started/migrating.rst
+++ b/docs/user-guide/getting-started/migrating.rst
@@ -1,19 +1,309 @@
 Migrating to 2.0
 ================
 
-.. note::
+ttkbootstrap 2.0 is a cleanup and consolidation release. It removes long-standing
+cruft, standardizes the API, and overhauls the theme engine and docs — but it is
+still the same styling extension for tkinter you already know. Most apps need only
+a handful of small edits.
 
-   This guide is being written for the 2.0 release. It will fold in the theme
-   and icon migration notes staged in ``development/2_0_theme_migration.md``.
+This guide sorts every change into four kinds so you can tell at a glance what
+needs your attention:
 
-ttkbootstrap 2.0 is a cleanup and consolidation release. This page will cover
-the breaking changes and their migration paths:
+- **Breaking** — existing code stops working and you must change it.
+- **Deprecated** — the old form still works but prints a ``DeprecationWarning``;
+  update it before 3.0, which removes it.
+- **Notable** — behavior or appearance differs, but no code change is required.
+- **New** — an optional addition. These are covered in the feature guides, not
+  here; this page only lists them so you know they exist.
 
-- **bootstyle strings** — the canonical single-string grammar; tuple/list forms
-  are deprecated.
-- **Theme names** — the semantic-anchor catalog (default ``bootstrap-light``);
-  legacy Bootswatch names auto-register on first use.
-- **Removed shims** — top-level module shims retired in favor of
-  ``ttkbootstrap.widgets`` / ``ttkbootstrap.dialogs``.
-- **Icons** — the character/emoji ``ttkbootstrap.icons`` catalog is removed;
-  dialog and widget glyphs now render from the built-in icon font.
+The fastest path is to run your app once: fix anything that errors (the breaking
+changes), then turn on warnings to catch the deprecations::
+
+   python -W once::DeprecationWarning your_app.py
+
+
+Breaking changes
+----------------
+
+These require an edit. There are only a few, and most apps hit at most one or two.
+
+Styling keywords need a ttkbootstrap widget
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Importing ttkbootstrap no longer reaches into tkinter and adds ``bootstyle=`` /
+``autostyle=`` to *every* widget class in the process. Those keywords now belong to
+ttkbootstrap's own widget classes — the ones you get from ``import ttkbootstrap as
+ttk``.
+
+If your code already looks like this, nothing changes:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+   ttk.Button(app, text="Save", bootstyle="success").pack()
+
+What breaks is passing the keyword to a **raw** ``tkinter`` widget after importing
+ttkbootstrap:
+
+.. code-block:: python
+
+   import tkinter.ttk as ttk_native
+   import ttkbootstrap                       # no longer patches tkinter
+
+   ttk_native.Button(app, bootstyle="success")   # TclError: unknown option "-bootstyle"
+
+You have three ways forward:
+
+- **Use ttkbootstrap's widgets** — construct from ``ttk.Button``, ``ttk.Frame``,
+  and so on. This is the recommended fix.
+- **Opt the whole process back in** — call :func:`~ttkbootstrap.enable_global_api`
+  once at startup to restore the global patch, so raw ``tkinter`` / ``ttk`` widgets
+  accept the styling keywords again (it also makes ``pack``/``grid``/``place``
+  return the widget everywhere).
+- **Style one foreign class** — :func:`~ttkbootstrap.bootify` returns a styled
+  subclass, and :func:`~ttkbootstrap.apply_bootstyle` styles an instance you already
+  have.
+
+One application root
+~~~~~~~~~~~~~~~~~~~~~~
+
+The style engine is a singleton bound to the first root window, so an app has one
+application root. Creating a **second** ``ttk.App`` (or ``ttk.Window``) while the
+first is still alive now raises ``RuntimeError`` instead of silently leaving the
+second window unthemed.
+
+Give every extra window a ``Toplevel``, which is what secondary windows are:
+
+.. code-block:: python
+
+   app = ttk.App()
+   editor = ttk.Toplevel()         # attaches to the root; not a second App/Window
+
+Creating one root after another (each destroyed before the next) is unaffected.
+
+Removed import paths
+~~~~~~~~~~~~~~~~~~~~~~
+
+Five old top-level module paths are gone. The classes themselves are unchanged —
+reach them from the top-level ``ttk`` namespace, the same way you reach every other
+widget and dialog.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - 1.x import
+     - 2.0
+   * - ``import ttkbootstrap.scrolled``
+     - ``ttk.ScrolledText`` / ``ttk.ScrolledFrame``
+   * - ``from ttkbootstrap.tableview import Tableview``
+     - ``ttk.Tableview``
+   * - ``from ttkbootstrap.toast import ToastNotification``
+     - ``ttk.ToastNotification``
+   * - ``from ttkbootstrap.tooltip import ToolTip``
+     - ``ttk.ToolTip``
+   * - ``from ttkbootstrap.dialogs.dialogs import Messagebox``
+     - ``ttk.Messagebox`` / ``ttk.Querybox``
+
+If you prefer explicit imports, the full paths still work too —
+``from ttkbootstrap.widgets.tableview import Tableview`` and
+``from ttkbootstrap.dialogs import Messagebox``.
+
+Character-icon constants removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``ttkbootstrap.icons`` module of named character constants (``Emoji`` and
+``Icon``) is removed. Those constants were just Unicode characters, and a character
+only appears if the user's system font happens to include that glyph — so they were
+never reliable across platforms, which is why the catalog is gone.
+
+You can still use a literal character yourself if you want to — any widget accepts
+``text=`` — with the same font-dependent caveat:
+
+.. code-block:: python
+
+   ttk.Label(app, text="🔔").pack()   # shows only where the system font has it
+
+For an icon that renders the same everywhere and follows the theme, use ``icon=``
+instead, which draws from a bundled Bootstrap Icons font:
+
+.. code-block:: python
+
+   ttk.Button(app, text="Add", icon="plus-lg", bootstyle="success").pack()
+
+If you passed a character to ``ToastNotification(icon=...)``, give it a Bootstrap
+Icons glyph name instead (for example ``icon="bell-fill"``).
+
+Keyword-only constructors and renamed options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The shipped widgets and dialogs were normalized to a consistent signature: options
+are passed by keyword after the first positional argument, and multi-word option
+names are ``snake_case``. Most option renames keep a deprecated alias that warns, so
+they land in the deprecations list below — but two shapes cannot be shimmed and are
+hard breaks:
+
+- **Constructors are keyword-only** after the leading positional(s). Pass widget and
+  window options by keyword — ``ttk.Window("Title", size=(800, 600))``, not a long
+  positional argument list. Affects ``Window`` / ``Toplevel`` and the shipped
+  widgets (``Meter``, ``DateEntry``, ``Floodgauge``, ``ScrolledText`` /
+  ``ScrolledFrame``, ``LabeledScale``, ``ToolTip``, ``ToastNotification``).
+- **Value-carrying widgets are DoubleVar-backed** (were ``IntVar``). ``Meter``,
+  ``Floodgauge``, and ``LabeledScale`` now return a ``float`` from ``value`` /
+  ``cget("value")`` where you previously got an ``int`` — fractional values are
+  honored instead of truncated.
+
+See the widget reference pages for each widget's final option names.
+
+``get_date`` returns ``None`` when cancelled
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``Querybox.get_date`` (and the ``DateEntry`` calendar) previously always returned a
+``date``, so a cancelled dialog was indistinguishable from a real pick. It now
+returns ``None`` on cancel. Guard the result if you used it unconditionally:
+
+.. code-block:: python
+
+   picked = ttk.Querybox.get_date()
+   if picked is not None:
+       ...
+
+The other ``Querybox.get_*`` methods likewise return ``None`` on cancel.
+
+
+Deprecated (still works, warns)
+-------------------------------
+
+These keep working through the 2.x series and print a one-time
+``DeprecationWarning`` naming the replacement. Update them at your leisure; they are
+removed in 3.0.
+
+- **Tuple and list bootstyle** — the canonical form is a single string.
+  ``bootstyle=("primary", "outline")`` becomes ``bootstyle="primary outline"``. See
+  :doc:`Styling with bootstyle </user-guide/foundations/bootstyle-grammar>`.
+- **Legacy theme names** — ``"darkly"``, ``"cosmo"``, ``"litera"``, and the rest of
+  the pre-2.0 Bootswatch names still work; naming one registers it on demand with a
+  warning. See *Theme names changed* below.
+- **Validation helpers** — the flat ``add_*_validation`` functions moved under a
+  namespace: ``add_numeric_validation(w)`` becomes ``ttk.Validation.numeric(w)``.
+  See :doc:`Validation </user-guide/feature-guides/validation>`.
+- **Utility import paths** — ``ttkbootstrap.utility`` and ``ttkbootstrap.colorutils``
+  are now the ``ttkbootstrap.utils`` package; the old paths forward with a warning.
+  The helpers are also on ``ttk`` directly (``ttk.scale_size``,
+  ``ttk.contrast_color``).
+- **Window kwarg spellings** — ``hdpi`` → ``high_dpi``, ``overrideredirect`` →
+  ``override_redirect``, ``windowtype`` → ``window_type``, ``toolwindow`` →
+  ``tool_window`` on ``Window`` / ``Toplevel``.
+- **Widget option spellings** — renamed options such as ``Meter``'s ``metersize`` →
+  ``meter_size`` or ``DateEntry``'s ``startdate`` → ``start_date`` keep a warning
+  alias.
+- **ThemeDefinition selector** — ``themetype=`` → ``mode=`` (and ``.type`` →
+  ``.mode``).
+- **FloodgaugeLegacy** — ``FloodgaugeLegacy(...)`` warns on use; migrate to
+  ``ttk.Floodgauge``.
+- **The publisher module** — ``ttkbootstrap.publisher`` forwards to
+  ``ttkbootstrap.internal.publisher`` with a warning (and see *Theme-change
+  notifications* under Notable changes — the engine no longer fires it).
+
+
+Notable changes
+---------------
+
+No code change is required for these, but the app looks or behaves differently than
+it did in 1.x.
+
+Theme names changed
+~~~~~~~~~~~~~~~~~~~~~
+
+The built-in catalog is now 15 curated **families**, each generating a matched
+``-light`` and ``-dark`` pair (30 themes total), and the default theme is now
+``bootstrap-light`` (was ``litera``). Prefer a curated name in new code:
+
+.. code-block:: python
+
+   app = ttk.App(theme="bootstrap-dark")
+
+.. admonition:: Coming from 1.x
+   :class: note
+
+   Your existing ``App(themename="darkly")`` still works — naming a legacy theme
+   registers it on demand with a warning. To register the whole pre-2.0 set at once
+   (say, to list them in a theme picker), call
+   :func:`~ttkbootstrap.install_legacy_themes`. Legacy themes keep their authored
+   colors; only their inconsistent plumbing is regenerated. There is no one-to-one
+   legacy-to-curated mapping (``darkly`` is not ``bootstrap-dark``), so pick a
+   curated theme deliberately rather than expecting an automatic swap.
+
+See :doc:`Theming & Colors </user-guide/feature-guides/theming>` for the theme model
+and how to author your own.
+
+Theme-change notifications
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Switching themes no longer notifies the old ``Publisher`` mechanism. If you
+subscribed to it to rebuild something on a theme change, bind the standard Tk
+``<<ThemeChanged>>`` virtual event instead, or register a callback with
+:func:`~ttkbootstrap.on_theme_change`:
+
+.. code-block:: python
+
+   ttk.on_theme_change(lambda style: rebuild_my_chart(style))
+
+Bare buttons are quiet by default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ``ttk.Button`` or ``ttk.Menubutton`` with no ``bootstyle`` now renders in a calm,
+theme-adaptive ``neutral`` look instead of the ``primary`` accent — a plain button
+is not a call to action. Add ``bootstyle="primary"`` to the buttons that should draw
+attention, or restore the old default globally:
+
+.. code-block:: python
+
+   app = ttk.App(default_button="primary")
+
+Appearance refinements
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+2.0 regenerates each theme's palette from its accents for consistent contrast, and
+restyles several widgets. You may notice: solid buttons gain a subtle hairline
+border; scrollbars are restyled; an input shows its accent color on **focus** only,
+not on hover; and the date picker opens as a frameless popover that dismisses on an
+outside click or ``Escape``. None of these need a code change. Pin exact 1.x colors,
+if you need them, by authoring your own theme.
+
+
+New in 2.0
+----------
+
+Optional additions worth knowing about — each has a feature guide:
+
+- **Light/dark mode toggle** — ``app.toggle_theme()`` and a settable
+  ``app.theme_mode`` flip between a family's light and dark variants.
+- **Fluent geometry** — ``pack``/``grid``/``place`` return the widget, so you can
+  construct and place in one expression.
+- **Themed icons** — ``icon=`` puts a theme-aware Bootstrap Icons glyph on a widget;
+  ``icon_only=True`` makes a compact icon button. See
+  :doc:`Icons </user-guide/feature-guides/icons>`.
+- **Typography** — ``ttk.set_global_family("Inter")`` and the ``ttk.Fonts`` manager.
+  See :doc:`Typography </user-guide/feature-guides/typography>`.
+- **Localization** — ``ttk.L``, ``ttk.LocaleVar``, and ``ttk.set_locale`` for
+  runtime language switching. See
+  :doc:`Localization </user-guide/feature-guides/localization>`.
+- **File dialogs** — ``ttk.Querybox.get_open_filename`` and friends, plus
+  ``ttk.filedialog``. See :doc:`Dialogs </user-guide/feature-guides/dialogs>`.
+- **Custom-style toolkit** — ``Assets``, ``El``/``layout``, and
+  ``register_style`` for building your own styles. See
+  :doc:`Custom styles </user-guide/feature-guides/custom-styles>`.
+
+
+See also
+--------
+
+- :doc:`Styling with bootstyle </user-guide/foundations/bootstyle-grammar>` — the
+  canonical string grammar that replaces tuples.
+- :doc:`Theming & Colors </user-guide/feature-guides/theming>` — the new theme model
+  and authoring your own.
+- :doc:`The delivery model </user-guide/foundations/delivery-model>` — how the
+  styling keywords reach widgets, and ``enable_global_api``.


### PR DESCRIPTION
## What

Fills the last thin spot in the Getting Started band and completes the breaking-changes record.

### 1. `Migrating to 2.0` guide (`docs/user-guide/getting-started/migrating.rst`)
From a stub to a full guide, authored against a complete 1.x→2.0 inventory. Every change is sorted into one of four clearly-labeled categories so an upgrader can tell at a glance what needs action:

- **Breaking** — must edit code (styling-keyword delivery, single root, removed imports, character-icon constants, keyword-only/DoubleVar signatures, `get_date`→`None`).
- **Deprecated** — works now, warns, removed in 3.0 (tuple bootstyle, legacy theme names, `Validation.*`, utils paths, kwarg renames, `themetype`→`mode`, `FloodgaugeLegacy`, `publisher`).
- **Notable** — behaves/looks different, no code change (default theme, quiet default button, appearance refinements, theme-change notifications).
- **New** — optional additions, with pointers to the feature guides.

### 2. Backfilled `development/2_0_breaking_changes.md`
The running log began mid-initiative. A grounded diff review of the early PRs (#1068–#1077) recovered **five foundational engine/delivery breaks** never documented inline:

- Delivery API — no import-time monkey-patch; `bootstyle`/`autostyle` need ttkbootstrap's widgets or `enable_global_api()` (#1075)
- Single application root — a second `Window` raises `RuntimeError` (#1073)
- `Publisher` no longer fires on theme change — use `<<ThemeChanged>>`
- Removed shim modules — `ttkbootstrap.scrolled`/`tableview`/`toast`/`tooltip`, `dialogs/dialogs.py` (#1068)
- `FloodgaugeLegacy`/`publisher`/`utility` deprecations (#1069/#1071)

Added index rows + an "Engine & delivery foundations (backfilled)" section, so the log is complete end-to-end.

### 3. Styled screenshot placeholders (`docs/_static/custom.css`)
Each `:class: screenshot-placeholder` admonition now renders as a dashed, hatched, muted box so unfinished pages read as visibly provisional until the (Windows-canonical) captures land.

## Verification
- Docs build green: `sphinx -b html -W -q -E docs` → exit 0.
- Every runnable snippet in the guide verified headlessly, with `DeprecationWarning` promoted to an error so no recommended example steers users onto a deprecated path.
- Swept the page for nested inline markup (`` ``code`` `` inside `**bold**`, which `-W` doesn't catch) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)