### PR TITLE
feat(window): App/Toplevel on_close handler + getting-started finishes

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -17,6 +17,7 @@
 | **User theme store removed; ttkcreator exports a `Theme(...).register()` snippet** | Removed | this doc, below |
 | **Legacy theme names auto-register on use (no hard-stop)** | Fix/Deprecated | this doc, below (Slice 1) |
 | **`App` (canonical) / `Window` alias; `theme` / `themename` alias** | New | this doc, below (Slice 2) |
+| **`on_close` window close handler (`App`/`Toplevel` method + kwarg)** | New | this doc, below |
 | **`utils/` package; `utility`/`colorutils` → warn-and-forward shims** | Deprecated | this doc, below (Slice 0) |
 | **Deferred-config seam + `ttk.set_default_button()` pre-root setter** | New | this doc, below (Slice 5) |
 | **Localization: msgcat bug fixes + `L()` / `LocaleVar` / `set_locale`** | Fix/New | this doc, below (Slice 3) |
@@ -1719,3 +1720,46 @@ This is additive — no existing call changes; `tkinter.filedialog` still works.
 **Scope.** `dialogs/query.py` (four `Querybox` methods + `filedialog` import),
 `__init__.py` (`ttk.filedialog` re-export), `tests/test_dialogs_api.py` (+3), the
 Dialogs feature guide.
+
+## `on_close` — a window close handler on `App`/`Toplevel`  *(New)*
+
+**What.** A first-class way to run code when the user closes a window, replacing
+the raw `protocol("WM_DELETE_WINDOW", ...)` idiom. Available as a method on the
+shared `_BaseWindow` (so both `App`/`Window` and `Toplevel` have it) and as an
+`on_close=` constructor keyword:
+
+```python
+def save_and_exit():
+    ...                     # persist state, stop threads, close connections
+
+app = ttk.App(on_close=save_and_exit)   # or app.on_close(save_and_exit)
+```
+
+- The callback is a **plain zero-argument callable** (same shape as
+  `MessageDialog.command`). After it runs, the window is **destroyed
+  automatically** — no `destroy()` call needed.
+- **Return `False` to veto** the close and keep the window open (e.g. after an
+  unsaved-changes prompt); returning `None`/anything else lets it close.
+- The auto-destroy is wrapped in `try/except tkinter.TclError`, so a callback
+  that calls `destroy()` itself doesn't double-fire.
+- Registering again replaces the previous handler; the callback is returned, so
+  `on_close` also works as a decorator.
+
+**Cross-platform.** Rides `WM_DELETE_WINDOW`, so it fires for the title-bar close
+button on Windows, macOS, and Linux (and `Alt+F4`). On macOS the application-menu
+**Quit** (`⌘Q`) / Dock quit is a separate, app-wide gesture that does *not* go
+through this per-window handler — that path is `tk::mac::Quit`, already surfaced as
+`Menu.on_quit`. `on_close` deliberately does **not** wire `tk::mac::Quit` (it is
+app-global and would behave differently on a `Toplevel`, and would collide with
+`Menu.on_quit`); the docs cross-reference the two.
+
+**Why.** Intercepting the close is one of the few common uses of `protocol`, and
+the raw form has two footguns the wrapper removes: forgetting to call `destroy()`
+(so the window won't close) and double-destroy errors. A per-window, portable
+`on_close` with an explicit veto path covers the real cases (including the
+unsaved-changes confirmation) cleanly.
+
+**Scope.** `window.py` (`_BaseWindow.on_close` + `on_close=` on both constructors);
+`tests/test_window_api.py` (+7); docs: the *Structuring an app* "Shut down cleanly"
+section, the Windows guide "Lifecycle" section, and the `App`/`Toplevel` reference
+pages (shared `_lifecycle.rst` include). Additive — no existing signature changed.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,6 +129,7 @@ exclude_patterns = [
     "reference/windows/_wm-1.rst",
     "reference/windows/_wm-2.rst",
     "reference/windows/_theme.rst",
+    "reference/windows/_lifecycle.rst",
     "reference/windows/_positioning.rst",
     "Thumbs.db",
     ".DS_Store",

--- a/docs/reference/windows/_lifecycle.rst
+++ b/docs/reference/windows/_lifecycle.rst
@@ -1,0 +1,23 @@
+.. Include-only: the on_close lifecycle handler shared by App and Toplevel.
+
+.. py:method:: on_close(callback)
+   :noindex:
+
+   Run ``callback`` when the user closes the window — the title-bar close button
+   on Windows, macOS, and Linux (and ``Alt+F4``) — then destroy the window
+   automatically. You do not call :py:meth:`destroy` yourself. Registering a new
+   handler replaces the previous one, and the callback is returned so ``on_close``
+   also works as a decorator. Also available as the ``on_close=`` constructor
+   argument.
+
+   :param callback: a zero-argument callable. Return ``False`` from it to cancel
+      the close and keep the window open (for example, after an unsaved-changes
+      prompt); return ``None`` — or anything else — to let it close.
+   :returns: ``callback``.
+
+   .. note::
+
+      On macOS the application-menu **Quit** (``⌘Q``), the Dock's Quit, and the
+      app menu are a separate, app-wide gesture that does not trigger this
+      per-window handler. Wire that with :py:meth:`ttkbootstrap.Menu.on_quit` on
+      the native application menu.

--- a/docs/reference/windows/app.rst
+++ b/docs/reference/windows/app.rst
@@ -102,6 +102,8 @@ Lifecycle
 
    :returns: ``None``.
 
+.. include:: /reference/windows/_lifecycle.rst
+
 Window management
 -----------------
 

--- a/docs/reference/windows/toplevel.rst
+++ b/docs/reference/windows/toplevel.rst
@@ -80,6 +80,11 @@ re-themes them all.
 
 .. include:: /reference/windows/_theme.rst
 
+Lifecycle
+---------
+
+.. include:: /reference/windows/_lifecycle.rst
+
 Window management
 -----------------
 

--- a/docs/user-guide/feature-guides/windows.rst
+++ b/docs/user-guide/feature-guides/windows.rst
@@ -244,17 +244,23 @@ Lifecycle
 any ``after`` timers or variable traces first, or they fire against dead widgets.
 
 Clicking the window's close button (**✕**) does not call ``destroy()`` directly —
-it fires the ``WM_DELETE_WINDOW`` protocol, which *defaults* to destroying the
-window. Register a handler to confirm or veto the close instead:
+it asks the window to close. Handle that with ``on_close`` (on ``App`` and every
+``Toplevel``): your callback runs, then the window is destroyed for you. Return
+``False`` to cancel the close and keep the window open:
 
 .. code-block:: python
 
-   def on_close():
-       if user_confirms():
-           win.destroy()      # closing happens only if you call it
-       # returning without destroy() cancels the close
+   def confirm_close():
+       if not user_confirms():
+           return False       # stay open
+       # otherwise the window closes — no destroy() call needed
 
-   win.protocol("WM_DELETE_WINDOW", on_close)
+   win.on_close(confirm_close)
+
+Pass the same callable as ``App(on_close=...)`` / ``Toplevel(on_close=...)`` to set
+it at construction. ``on_close`` handles the close button on Windows, macOS, and
+Linux; on macOS, the application menu's **Quit** (``⌘Q``) is a separate, app-wide
+action — wire it with :meth:`ttkbootstrap.Menu.on_quit`.
 
 Application icon
 ----------------

--- a/docs/user-guide/getting-started/app-structures.rst
+++ b/docs/user-guide/getting-started/app-structures.rst
@@ -1,25 +1,186 @@
 Structuring an app
 ==================
 
-.. note::
+The :doc:`Quickstart <quickstart>` shows the smallest possible window, and
+:doc:`Build your first app <build-your-first-app>` walks through one complete
+program. This page steps back to the decisions that keep an app organized as it
+grows: which root to use, how to enforce a single root, how to split the interface
+into components, and how to shut down cleanly.
 
-   This guide is being written for 2.0.
+The application root
+--------------------
 
-Where :doc:`Quickstart <quickstart>` shows the smallest possible window, this
-guide covers how to structure a real application:
+Every app has one **root window**. Use :class:`~ttkbootstrap.App` for it — the
+enhanced root that creates the window *and* installs a theme in one step:
 
-- **App vs Tk.** ``App`` (also exported as ``ttk.Window``) is the enhanced
-  root — it owns the theme and sets title, geometry, icon, alpha, and DPI in one
-  constructor. Use it for new code; a bare ``tk.Tk`` still works if you attach a
-  :class:`~ttkbootstrap.style.Style` yourself.
-- **The single-root rule.** ttkbootstrap enforces one application root per
-  process (the ``Style`` engine is a singleton bound to it). Extra windows are
-  ``ttk.Toplevel``, not a second ``App``.
-- **An app skeleton.** Subclassing ``ttk.App`` (or a ``ttk.Frame``) into a
-  class-based layout, wiring ``mainloop``, and cleaning up on ``destroy``.
+.. code-block:: python
 
-.. seealso::
+   import ttkbootstrap as ttk
 
-   :doc:`Windows </user-guide/feature-guides/windows>` for the
-   full ``App``/``Toplevel`` surface (positioning, icons, ``window_type``,
-   light/dark mode).
+   app = ttk.App(title="My App", theme="bootstrap-light", size=(600, 400))
+   app.mainloop()
+
+``App`` is a drop-in replacement for ``tkinter.Tk``. (It is also exported under its
+longtime alias ``ttk.Window`` — both name the same class.) If you must keep a bare
+``tkinter.Tk`` root — say, in existing code — attach the styling engine to it by
+creating a :class:`~ttkbootstrap.style.Style`; the engine binds to whichever root
+exists. Prefer ``App`` for new code.
+
+``mainloop()`` always comes last: it hands control to tkinter's event loop, which
+draws the window and dispatches events until the user closes it.
+
+One root, many windows
+----------------------
+
+The styling engine is a singleton bound to that first root, so an app has **one**
+application root. Creating a second ``App`` while the first is alive raises
+``RuntimeError``. Extra windows are :class:`~ttkbootstrap.Toplevel` windows, which
+attach to the root you already have:
+
+.. code-block:: python
+
+   class MyApp(ttk.Frame):
+       def open_settings(self):
+           win = ttk.Toplevel(title="Settings")
+           ttk.Label(win, text="Settings go here", padding=20).pack()
+
+A ``Toplevel`` is a full window — title, geometry, close button — that shares the
+app's theme and event loop. Reach for one whenever you need a second window: a
+dialog, a tool palette, a detail view.
+
+Put the interface in a frame
+----------------------------
+
+Rather than piling widgets directly onto the root, build your interface inside a
+:class:`~ttkbootstrap.Frame` subclass. A frame is a container; subclassing it keeps
+a screen's widgets and the state they share together in one object, so the app
+stays organized as it grows:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   from ttkbootstrap.constants import *
+
+
+   class MyApp(ttk.Frame):
+       def __init__(self, master):
+           super().__init__(master, padding=16)
+           self.pack(fill=BOTH, expand=YES)
+           self._build_ui()
+
+       def _build_ui(self):
+           ttk.Label(self, text="Ready", font="-size 14").pack()
+
+
+   app = ttk.App(title="My App", theme="bootstrap-light", size=(600, 400))
+   MyApp(app)
+   app.mainloop()
+
+This is the shape :doc:`Build your first app <build-your-first-app>` uses: the root
+is a plain ``App``, and the interface lives in a ``Frame`` subclass that packs
+itself into that root.
+
+Compose components
+------------------
+
+An app's interface is a tree of frames. Give each distinct part — a sidebar, a
+toolbar, a content panel — its own ``Frame`` subclass, then let a parent frame
+assemble them. Each component owns its widgets and stays testable and reusable on
+its own:
+
+.. code-block:: python
+
+   class Sidebar(ttk.Frame):
+       def __init__(self, master):
+           super().__init__(master, padding=8, bootstyle="secondary")
+           ttk.Button(self, text="Home").pack(fill=X, pady=2)
+           ttk.Button(self, text="Settings").pack(fill=X, pady=2)
+
+
+   class Content(ttk.Frame):
+       def __init__(self, master):
+           super().__init__(master, padding=16)
+           ttk.Label(self, text="Content area", font="-size 16").pack(anchor=NW)
+
+
+   class MyApp(ttk.Frame):
+       def __init__(self, master):
+           super().__init__(master)
+           self.pack(fill=BOTH, expand=YES)
+           Sidebar(self).pack(side=LEFT, fill=Y)
+           Content(self).pack(side=LEFT, fill=BOTH, expand=YES)
+
+.. admonition:: 📷 Screenshot (placeholder)
+   :class: screenshot-placeholder
+
+   The composed skeleton: a narrow ``secondary`` sidebar with two buttons on the
+   left and a content panel filling the rest of the window.
+
+Subclass a frame, not the root
+------------------------------
+
+Building the interface in a ``Frame`` subclass and leaving ``App`` as a plain root
+(as above) keeps your UI independent of the window — easy to drop into a
+``Toplevel``, reuse elsewhere, or test on its own.
+
+Subclassing ``App`` directly also works, and can read well for a single-window app,
+but it ties the interface to the root:
+
+.. code-block:: python
+
+   class MyApp(ttk.App):
+       def __init__(self):
+           super().__init__(title="My App", theme="bootstrap-light", size=(600, 400))
+           ttk.Label(self, text="Built on App directly", padding=16).pack()
+
+
+   MyApp().mainloop()
+
+Prefer the frame-subclass pattern unless you have a reason not to.
+
+Shut down cleanly
+-----------------
+
+``mainloop()`` returns when the last window closes. If your app holds resources —
+a file, a database connection, a background thread — release them on the way out.
+Pass a handler to ``on_close`` (available on ``App`` and every ``Toplevel``); it
+runs when the user closes the window, and the window is destroyed for you
+afterward:
+
+.. code-block:: python
+
+   def save_and_exit():
+       # persist settings, stop background work, close connections...
+       ...
+
+   app = ttk.App(title="My App", on_close=save_and_exit)
+   app.mainloop()
+
+The handler takes no arguments, and you do not call ``destroy()`` yourself. To
+prompt before closing — say, when there are unsaved changes — return ``False`` to
+cancel the close and keep the window open:
+
+.. code-block:: python
+
+   def confirm_close():
+       if self.unsaved and ttk.Messagebox.yesno("Discard unsaved changes?") != "Yes":
+           return False   # user chose No — stay open
+
+   app.on_close(confirm_close)
+
+``on_close`` covers the title-bar close button on Windows, macOS, and Linux. On
+macOS the application menu's **Quit** (``⌘Q``) is a separate, app-wide action; wire
+it with :meth:`ttkbootstrap.Menu.on_quit`. Individual widgets that start timers or
+traces release them in their own ``destroy()`` — ttkbootstrap's shipped widgets
+already do.
+
+See also
+--------
+
+- :doc:`Build your first app <build-your-first-app>` — the frame-subclass pattern
+  applied to a complete program.
+- :doc:`Windows </user-guide/feature-guides/windows>` — the full ``App`` /
+  ``Toplevel`` surface: positioning, icons, ``window_type``, and light/dark mode.
+- :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>` —
+  the event loop behind ``mainloop()``.
+- :doc:`Migrating to 2.0 <migrating>` — the single-root rule as an upgrade note.

--- a/docs/user-guide/getting-started/build-your-first-app.rst
+++ b/docs/user-guide/getting-started/build-your-first-app.rst
@@ -146,9 +146,7 @@ Create the variables in ``__init__`` (before building the form) and attach them:
                            values=["Friend", "Family", "Work"], state="readonly")
    category.grid(row=2, column=1, sticky=EW, pady=4)
 
-``ttk.StringVar()`` (also plain :class:`tkinter.StringVar`) is re-exported on
-the package for convenience. Giving ``category`` an initial ``value`` preselects
-"Friend" in the combobox.
+Giving ``category`` an initial ``value`` preselects "Friend" in the combobox.
 
 .. seealso::
 
@@ -221,7 +219,7 @@ and column controls built in. We give it column headings and start it empty:
 
 .. seealso::
 
-   The :doc:`Tableview widget page </widgets/index>` for its full API —
+   The :doc:`Tableview widget page </widgets/tableview>` for its full API —
    pagination, column configuration, exporting, and programmatic selection.
 
 Step 6 — wire the button to a callback

--- a/docs/user-guide/getting-started/quickstart.rst
+++ b/docs/user-guide/getting-started/quickstart.rst
@@ -43,15 +43,23 @@ whichever root exists. Prefer ``ttk.App`` for new code.
 Choosing a theme
 ----------------
 
-ttkbootstrap ships 30 themes as light/dark pairs. Switch at runtime through the
-style engine:
+ttkbootstrap ships 30 themes as 15 light/dark pairs. You picked one with ``theme=``
+above; you can also switch at runtime straight from the app:
 
 .. code-block:: python
 
-   from ttkbootstrap import Style
+   app.theme_use("bootstrap-dark")   # switch to any theme by name
 
-   style = Style.get_instance()
-   style.theme_use("bootstrap-dark")
+Because every family comes as a light/dark pair, ``App`` gives you a shortcut for
+the common case — flipping between the two:
+
+.. code-block:: python
+
+   app.theme_mode = "dark"   # set the mode directly ("light" or "dark")
+   app.toggle_theme()        # or flip to the other mode
+
+Read ``app.theme_names()`` for the full list, and ``app.theme_mode`` to see the
+active mode.
 
 .. seealso::
 

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -11,7 +11,7 @@ import sys
 import tkinter
 import warnings
 from pathlib import Path
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 from ttkbootstrap import utils
 from ttkbootstrap.constants import *
@@ -230,6 +230,38 @@ class _BaseWindow:
         """Toggle between the light and dark theme; returns the new mode."""
         return self.style.toggle_theme()
 
+    # -- lifecycle ---------------------------------------------------------
+
+    def on_close(self, callback: Callable[[], Any]) -> Callable[[], Any]:
+        """Run `callback` when the user closes this window, then destroy it.
+
+        `callback` takes no arguments. The window is destroyed for you after it
+        runs -- there is no need to call `destroy()` yourself. Return `False`
+        from `callback` to cancel the close and keep the window open (for
+        example, after a "discard unsaved changes?" prompt); return `None`, or
+        anything else, to let it close.
+
+        This registers the `WM_DELETE_WINDOW` protocol, so it fires for the
+        title-bar close button on Windows, macOS, and Linux (and `Alt+F4`).
+        Calling it again replaces the previous handler. The returned `callback`
+        makes it usable as a decorator.
+
+        Note:
+            On macOS the application-menu **Quit** (`Cmd+Q`), the Dock's Quit,
+            and closing from the app menu are an application-wide gesture that
+            does *not* trigger this per-window handler. Wire that separately
+            with `Menu.on_quit` on the native application menu.
+        """
+        def _handler() -> None:
+            if callback() is False:
+                return  # vetoed -- leave the window open
+            try:
+                self.destroy()
+            except tkinter.TclError:
+                pass  # already destroyed by the callback itself
+        self.protocol("WM_DELETE_WINDOW", _handler)
+        return callback
+
     # -- setup helpers -----------------------------------------------------
 
     def _setup_icon(self, iconphoto: Optional[str], default_data: Optional[str] = None) -> None:
@@ -428,6 +460,7 @@ class App(_BaseWindow, tkinter.Tk):
             transient: Optional[tkinter.Misc] = None,
             override_redirect: bool = False,
             alpha: float = 1.0,
+            on_close: Optional[Callable[[], Any]] = None,
             **kwargs: Any,
     ) -> None:
         """
@@ -513,6 +546,11 @@ class App(_BaseWindow, tkinter.Tk):
                 except on X11 where it is deferred until the window becomes
                 visible.
 
+            on_close (Callable):
+                A zero-argument callback run when the user closes the window;
+                the window is then destroyed automatically. Return `False` from
+                it to cancel the close. Sugar for `App.on_close`.
+
             **kwargs:
                 Any other keyword arguments that are passed through to tkinter.Tk() constructor
                 List of available keywords available at: https://docs.python.org/3/library/tkinter.html#tkinter.Tk
@@ -566,6 +604,9 @@ class App(_BaseWindow, tkinter.Tk):
             theme, default_button=default_button,
             light_theme=light_theme, dark_theme=dark_theme,
         )
+
+        if on_close is not None:
+            self.on_close(on_close)
 
     @staticmethod
     def _set_app_user_model_id() -> None:
@@ -624,6 +665,7 @@ class Toplevel(_BaseWindow, tkinter.Toplevel):
             tool_window: bool = False,
             iconify: bool = False,
             alpha: float = 1.0,
+            on_close: Optional[Callable[[], Any]] = None,
             **kwargs: Any,
     ) -> None:
         """
@@ -711,6 +753,11 @@ class Toplevel(_BaseWindow, tkinter.Toplevel):
                 except on X11 where it is deferred until the window becomes
                 visible.
 
+            on_close (Callable):
+                A zero-argument callback run when the user closes the window;
+                the window is then destroyed automatically. Return `False` from
+                it to cancel the close. Sugar for `Toplevel.on_close`.
+
             **kwargs (Dict):
                 Other optional keyword arguments.
         """
@@ -763,6 +810,9 @@ class Toplevel(_BaseWindow, tkinter.Toplevel):
             self.attributes("-toolwindow", 1)
 
         self._setup_alpha(alpha)
+
+        if on_close is not None:
+            self.on_close(on_close)
 
 
 #: Permanent, fully-supported alias for `App`. `App` is the canonical name (one

--- a/tests/test_window_api.py
+++ b/tests/test_window_api.py
@@ -369,3 +369,91 @@ def test_window_kwargs_are_warning_free_for_new_names():
     # theme is the second positional; themename is keyword-only.
     assert params["theme"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
     assert params["themename"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+# --------------------------------------------------------------------------
+# on_close lifecycle handler
+# --------------------------------------------------------------------------
+
+def _fire_close(win):
+    """Invoke the WM_DELETE_WINDOW handler the way the window manager would."""
+    cmd = win.tk.call("wm", "protocol", win._w, "WM_DELETE_WINDOW")
+    win.tk.call(cmd)
+
+
+def test_on_close_runs_callback_then_destroys(root):
+    top = ttk.Toplevel(title="closes")
+    calls = []
+    top.on_close(lambda: calls.append(1))
+    _fire_close(top)
+    assert calls == [1]
+    assert not top.winfo_exists()  # auto-destroyed, no manual destroy() needed
+
+
+def test_on_close_returns_callback_for_decorator_use(root):
+    top = ttk.Toplevel(title="deco")
+    cb = lambda: None
+    assert top.on_close(cb) is cb
+    top.destroy()
+
+
+def test_on_close_veto_keeps_window_open(root):
+    top = ttk.Toplevel(title="veto")
+    calls = []
+
+    def veto():
+        calls.append(1)
+        return False
+
+    top.on_close(veto)
+    _fire_close(top)
+    assert calls == [1]
+    assert top.winfo_exists()  # returning False cancels the close
+    top.destroy()
+
+
+def test_on_close_constructor_kwarg(root):
+    calls = []
+    top = ttk.Toplevel(title="kw", on_close=lambda: calls.append(1))
+    _fire_close(top)
+    assert calls == [1]
+    assert not top.winfo_exists()
+
+
+def test_on_close_tolerates_callback_self_destroy(root):
+    top = ttk.Toplevel(title="selfdestruct")
+    top.on_close(lambda: top.destroy())
+    _fire_close(top)  # the auto-destroy must not raise on an already-dead window
+    assert not top.winfo_exists()
+
+
+def test_on_close_replaces_previous_handler(root):
+    top = ttk.Toplevel(title="replace")
+    order = []
+
+    def first():
+        order.append("first")
+        return False  # veto so the window survives for the second handler
+
+    top.on_close(first)
+    _fire_close(top)
+    assert order == ["first"] and top.winfo_exists()
+
+    top.on_close(lambda: order.append("second"))
+    _fire_close(top)
+    assert order == ["first", "second"] and not top.winfo_exists()
+
+
+def test_on_close_on_app_root_veto(root):
+    # `root` is the shared App fixture, so only exercise the veto path (which
+    # keeps it alive); this covers on_close on App as well as Toplevel.
+    calls = []
+
+    def veto():
+        calls.append(1)
+        return False
+
+    root.on_close(veto)
+    _fire_close(root)
+    assert calls == [1] and root.winfo_exists()
+    root.protocol("WM_DELETE_WINDOW", "")  # reset so the shared root is untouched


### PR DESCRIPTION
## What

Adds **`on_close`**, a first-class window close handler, and finishes the Getting Started band. Bundled together because `on_close` rewrites the *Structuring an app* shutdown section.

### Feature — `on_close`
A first-class replacement for the raw `protocol("WM_DELETE_WINDOW", ...)` idiom, on the shared `_BaseWindow` (so `App`/`Window` **and** `Toplevel` get it) plus an `on_close=` constructor kwarg.

```python
def save_and_exit():
    ...                     # persist state, stop threads

app = ttk.App(on_close=save_and_exit)   # or app.on_close(save_and_exit)
```

- Zero-arg callback runs, then the window is **destroyed automatically** — no `destroy()` call needed.
- **Return `False` to veto** the close (e.g. an unsaved-changes prompt) and keep the window open.
- Auto-destroy guarded with `try/except tkinter.TclError`, so a callback that destroys the window itself doesn't double-fire; the callback runs **outside** that guard, so real callback bugs still propagate.
- Returns the callback (usable as a decorator); registering again replaces the handler.

**Cross-platform:** rides `WM_DELETE_WINDOW` (title-bar close on Windows/macOS/Linux + Alt+F4). It deliberately does **not** wire macOS `tk::mac::Quit` (⌘Q) — that's an app-wide gesture, would behave differently on a `Toplevel`, and would collide with the existing `Menu.on_quit`. Docs cross-reference the two.

### Getting Started finishes
- **Structuring an app** — authored (App-vs-Tk, single-root rule, frame-subclass pattern, composing components, clean shutdown via `on_close`).
- **Quickstart** — "Choosing a theme" rewritten to the high-level `App` delegates (`app.theme_use` / `app.theme_mode` / `app.toggle_theme`) instead of reaching into `Style.get_instance()`.
- **Build your first app** — fixed a mis-targeted Tableview link and removed an implementation-detail aside.

## Docs
- *Structuring an app* "Shut down cleanly" + *Windows* guide "Lifecycle" rewritten onto `on_close`.
- Shared `_lifecycle.rst` reference include added to the `App`/`Toplevel` pages (excluded in `conf.py`, matching the existing partial pattern).
- Logged as **New** in `2_0_breaking_changes.md`.

## Verification
- `tests/test_window_api.py` **+7** (callback+auto-destroy, veto, kwarg, self-destroy tolerance, handler replacement, decorator return, App-root veto). Full suite **659 passed** — the 3 `test_menu_api` `*_off_mac` failures are pre-existing on macOS, unrelated.
- Docs build green: `sphinx -b html -W -q -E docs` → exit 0.
- Every doc snippet and the full first-app program verified headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)