### PR TITLE
docs: deepen the widget model + refocus variables on reactivity

### DIFF
--- a/docs/user-guide/feature-guides/events.rst
+++ b/docs/user-guide/feature-guides/events.rst
@@ -108,7 +108,7 @@ ttkbootstrap emits two you will use:
 
 - ``<<LocaleChanged>>`` — fires when the app's locale changes; this is what
   drives :class:`~ttkbootstrap.LocaleVar` (see
-  :doc:`State & variables </user-guide/foundations/state-and-variables>`).
+  :doc:`Variables & reactivity </user-guide/foundations/state-and-variables>`).
 
 .. admonition:: Prefer the callback helpers for theme changes
 

--- a/docs/user-guide/feature-guides/menus.rst
+++ b/docs/user-guide/feature-guides/menus.rst
@@ -136,7 +136,7 @@ name. :meth:`add_checkbutton` toggles a ``BooleanVar``; a group of
 
 The menu keeps the variable in sync as the user toggles items — read
 ``wrap.get()`` / ``theme.get()`` in your callbacks, or trace the variable to react
-immediately (see :doc:`State & variables
+immediately (see :doc:`Variables & reactivity
 </user-guide/foundations/state-and-variables>`).
 
 Enabling, disabling, and rebuilding

--- a/docs/user-guide/feature-guides/variables.rst
+++ b/docs/user-guide/feature-guides/variables.rst
@@ -4,16 +4,17 @@ Variables
 A **variable object** is tkinter's link between your data and your widgets: bind
 a widget to a variable and the two stay in sync — set the variable and the widget
 updates, edit the widget and the variable updates. The
-:doc:`State & variables </user-guide/foundations/state-and-variables>` foundations
-page covers binding and reading; this guide goes deeper into the variable types,
+:doc:`Variables & reactivity </user-guide/foundations/state-and-variables>`
+foundations page covers binding and reading; this guide goes deeper into the
+variable types,
 **traces** (reacting to changes), and the patterns they enable.
 
 The variable classes
 --------------------
 
-Four classes cover the value types, re-exported from ttkbootstrap (they are the
-tkinter classes — import from ``tkinter`` if you prefer). The class you choose
-decides what ``.get()`` returns:
+Four classes cover the value types — the standard tkinter classes, available as
+``ttk.StringVar`` and friends (or import them from ``tkinter`` directly). The class
+you choose decides what ``.get()`` returns:
 
 .. list-table::
    :header-rows: 1
@@ -129,6 +130,45 @@ Submit button that enables only when a box is checked:
 dedicated helpers rather than hand-rolled traces — see
 :doc:`Input validation </user-guide/feature-guides/validation>`.
 
+Named variables
+---------------
+
+Every variable object wraps a **named Tcl variable**. Normally that name is
+auto-generated (``PY_VAR0``, …) and you never see it — you hold the object and call
+``.get()`` / ``.set()``. But you can give a variable an explicit name and then
+address that value *by name*, which is occasionally handy for loosely-coupled parts
+of an app that read or write a shared value without holding the object.
+
+Give the variable a ``name=`` and **keep the object alive** (store it on your app or
+another long-lived place). Then bind widgets with the **name string**, and read or
+write it by name with a widget's ``getvar`` / ``setvar``:
+
+.. code-block:: python
+
+   username = ttk.StringVar(name="username", value="Ada")   # keep this reference
+
+   ttk.Entry(app, textvariable="username")   # bind by name, not by object
+   app.setvar("username", "Grace")           # write by name; bound widgets update
+   app.getvar("username")                    # -> "Grace"
+
+.. warning::
+
+   Two rules make named variables sharp-edged:
+
+   - **Keep exactly one owning reference.** The Variable object *owns* its Tcl
+     variable — when the object is garbage-collected, the Tcl variable is unset and
+     reads by name fail. A ``ttk.StringVar(name="x")`` whose result you don't store
+     vanishes immediately, and a second same-named object is **not** a safe alias
+     (collecting either one unsets the shared variable). Hold one object and share
+     its *name*.
+   - **Name access skips type conversion.** ``getvar`` / ``setvar`` read and write
+     raw Tcl values, so ``app.setvar("count", "oops")`` on an ``IntVar`` succeeds and
+     the next ``count.get()`` raises ``TclError``. Prefer the object's ``.get()`` /
+     ``.set()`` for typed, validated access.
+
+   Reach for name access only when you genuinely need to address state by name;
+   otherwise pass the variable object.
+
 ``LocaleVar`` — a variable that re-translates
 ---------------------------------------------
 
@@ -148,7 +188,7 @@ localization subsystem.
 
 .. seealso::
 
-   - :doc:`State & variables </user-guide/foundations/state-and-variables>` — the
-     binding basics.
+   - :doc:`Variables & reactivity </user-guide/foundations/state-and-variables>` —
+     the binding basics.
    - :doc:`Variables reference </reference/variables>` — the ``StringVar`` /
      ``IntVar`` / … API and the numeric-coercion gotcha.

--- a/docs/user-guide/foundations/state-and-variables.rst
+++ b/docs/user-guide/foundations/state-and-variables.rst
@@ -9,10 +9,6 @@ updates. That two-way link — plus running code when a value changes — is
 **reactivity**: your interface follows your data instead of you wiring every
 update by hand.
 
-This is your application's *data* — the values your widgets show. It is separate
-from a widget's ttk **state** flags (``disabled``, ``focus``, ``selected``, …),
-which the :doc:`widget model </user-guide/foundations/the-widget-model>` covers.
-
 .. note::
 
    This page covers the essentials. For the variable types in depth, traces (read

--- a/docs/user-guide/foundations/state-and-variables.rst
+++ b/docs/user-guide/foundations/state-and-variables.rst
@@ -1,11 +1,17 @@
-State & variables
-=================
+Variables & reactivity
+======================
 
 Widgets that hold a value — entries, checkbuttons, radiobuttons, scales — can be
 bound to a **variable object** instead of you reading and writing the widget
 directly. A variable is the single source of truth for that value: set the
 variable and the widget updates; the user edits the widget and the variable
-updates. This two-way link is how tkinter keeps your data and your UI in sync.
+updates. That two-way link — plus running code when a value changes — is
+**reactivity**: your interface follows your data instead of you wiring every
+update by hand.
+
+This is your application's *data* — the values your widgets show. It is separate
+from a widget's ttk **state** flags (``disabled``, ``focus``, ``selected``, …),
+which the :doc:`widget model </user-guide/foundations/the-widget-model>` covers.
 
 .. note::
 
@@ -30,9 +36,9 @@ selection controls (Checkbutton, Radiobutton, Scale). Read and write with
 
    name.set("Grace")                          # entry and label both update
 
-The variable classes are re-exported from ttkbootstrap — ``ttk.StringVar``,
-``ttk.IntVar``, ``ttk.BooleanVar``, ``ttk.DoubleVar`` — and the class you pick
-determines what ``.get()`` returns:
+ttkbootstrap provides four variable classes — ``ttk.StringVar``, ``ttk.IntVar``,
+``ttk.BooleanVar``, ``ttk.DoubleVar`` — and the class you pick determines what
+``.get()`` returns:
 
 - ``StringVar`` — text (entries, labels).
 - ``IntVar`` — whole numbers; a Checkbutton's on/off value; a Radiobutton choice.

--- a/docs/user-guide/foundations/state-and-variables.rst
+++ b/docs/user-guide/foundations/state-and-variables.rst
@@ -58,27 +58,27 @@ the :doc:`Variables guide </user-guide/feature-guides/variables>`.
 A worked example
 ----------------
 
-A checkbutton drives a boolean, and a trace enables the submit button only when
-the box is checked:
+Reactivity in one screen: an entry feeds a variable, a trace recomputes a second
+variable from it, and a label bound to that one updates live as you type — no
+widget is read or refreshed by hand.
 
 .. code-block:: python
 
    import ttkbootstrap as ttk
 
-   app = ttk.App(title="Terms")
+   app = ttk.App(title="Reactivity")
 
-   agree = ttk.BooleanVar()
-   submit = ttk.Button(app, text="Continue", bootstyle="primary")
-   submit.state(["disabled"])                 # ttk state flags — see The widget model
+   name = ttk.StringVar()
+   greeting = ttk.StringVar(value="Hello there!")
 
-   def refresh(*_):
-       submit.state(["!disabled" if agree.get() else "disabled"])
+   def greet(*_):
+       who = name.get().strip()
+       greeting.set(f"Hello, {who}!" if who else "Hello there!")
 
-   agree.trace_add("write", refresh)
+   name.trace_add("write", greet)            # recompute whenever name changes
 
-   ttk.Checkbutton(app, text="I accept the terms", variable=agree,
-                   bootstyle="round toggle").pack(padx=20, pady=(20, 10))
-   submit.pack(padx=20, pady=(0, 20))
+   ttk.Entry(app, textvariable=name).pack(padx=20, pady=(20, 8))
+   ttk.Label(app, textvariable=greeting, bootstyle="primary").pack(padx=20, pady=(0, 20))
 
    app.mainloop()
 

--- a/docs/user-guide/foundations/the-widget-model.rst
+++ b/docs/user-guide/foundations/the-widget-model.rst
@@ -2,9 +2,10 @@ The widget model
 ================
 
 Everything you put on screen is a **widget** — a button, a label, a frame — and
-they all follow the same three rules: every widget lives in a **tree** under a
-parent, every widget is configured through **options**, and ttk widgets carry a
-set of **states**. Learn these once and every widget behaves predictably.
+they all follow the same handful of rules: every widget lives in a **tree** under a
+parent, is configured through **options**, carries a set of **states**, and moves
+through a **lifecycle** you manage. Learn these once and every widget behaves
+predictably.
 
 The widget tree
 ---------------
@@ -62,11 +63,11 @@ each widget's page in the :doc:`Widgets catalog </widgets/index>` and the
 States (the ttk way)
 --------------------
 
-Coming from classic tkinter you might expect a ``state="disabled"`` option. **ttk
-widgets work differently**: they carry a set of **state flags** —
+ttk keeps the familiar classic-tkinter ``state="disabled"`` option as a shortcut,
+but underneath, **every ttk widget carries a set of state flags** —
 ``disabled``, ``active``, ``pressed``, ``focus``, ``selected``, ``readonly``,
-``invalid`` — that you turn on and off. This is what lets a theme restyle a
-widget per state automatically.
+``invalid`` — that you turn on and off. This flag set is the real model: it is what
+lets a theme restyle a widget per state automatically.
 
 Set a flag with ``state([...])``, clear it by prefixing ``!``, and test one with
 ``instate([...])``:
@@ -81,6 +82,64 @@ Set a flag with ``state([...])``, clear it by prefixing ``!``, and test one with
 
 The same flags drive both behavior *and* appearance, which is why you never
 hand-color a disabled or focused widget — the theme already maps every state.
+
+The ``state="disabled"`` option is a coarse shortcut over these flags: it
+understands only ``normal``/``disabled`` (and ``readonly`` on entry-style
+widgets), so ``state([...])`` is the way to reach the rest (``active``,
+``pressed``, ``invalid``, …). One caveat that follows from this: ``cget("state")``
+reports only what the *option* was last set to, not the live flags — so after
+``widget.state(["disabled"])`` it can still read ``"normal"``. To ask whether a
+flag is set, use ``instate([...])``, never ``cget("state")``.
+
+Lifecycle
+---------
+
+A widget passes through three stages: it is **created**, **displayed**, and
+eventually **destroyed**.
+
+**Creating** a widget places it in the tree but does not draw it. It exists right
+away — you can configure and query it — yet it stays invisible until a geometry
+manager maps it onto the screen:
+
+.. code-block:: python
+
+   btn = ttk.Button(app, text="Save")   # exists now, but nothing is drawn
+   btn.winfo_ismapped()                 # -> False
+   btn.pack()                           # display it
+   btn.winfo_ismapped()                 # -> True
+
+That gap is deliberate — you build a whole subtree, then lay it out. It is also
+why a widget's **master is fixed at creation**: you cannot reparent a widget later.
+To move one, destroy it and rebuild it under the new parent.
+
+**Destroying** a widget removes it for good with ``destroy()``. The call
+**cascades** — destroying a container destroys every widget under it, so tearing
+down a screen is a single call on its frame. Afterward the widget is gone and its
+methods raise ``TclError``, so guard with ``winfo_exists()`` when a widget might
+already be destroyed:
+
+.. code-block:: python
+
+   panel.destroy()            # removes the panel and all of its children
+   panel.winfo_exists()       # -> False
+   # panel.configure(...)     # would raise TclError: invalid command name
+
+**Cleaning up.** ``destroy()`` frees the widget, but not the things you attached
+*around* it — a repeating ``after`` timer, a variable ``trace``, a binding on
+another widget. Those keep firing into a widget that no longer exists. Release them
+as the widget is torn down; the ``<Destroy>`` event fires for exactly this:
+
+.. code-block:: python
+
+   job = app.after(1000, tick)                       # a repeating timer
+   widget.bind("<Destroy>", lambda e: app.after_cancel(job))
+
+You rarely write this by hand: ttkbootstrap's shipped widgets already release their
+own timers and traces on destroy, and :doc:`on_close
+</user-guide/getting-started/app-structures>` gives the whole app a place to shut
+down cleanly. Reach for ``<Destroy>`` cleanup only for long-lived resources you
+create yourself. See :doc:`Events & callbacks
+</user-guide/feature-guides/events>` for ``after`` and traces in depth.
 
 Putting it together
 -------------------
@@ -118,5 +177,7 @@ A small tree, configured, with a state toggled:
 
    - :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
      — the loop that drives callbacks.
+   - :doc:`Events & callbacks </user-guide/feature-guides/events>` — ``after``
+     timers, variable traces, and the ``<Destroy>`` event.
    - :doc:`Cursors </reference/cursors>` — the platform-dependent ``cursor``
      option.

--- a/docs/user-guide/getting-started/build-your-first-app.rst
+++ b/docs/user-guide/getting-started/build-your-first-app.rst
@@ -150,7 +150,7 @@ Giving ``category`` an initial ``value`` preselects "Friend" in the combobox.
 
 .. seealso::
 
-   :doc:`State & variables </user-guide/foundations/state-and-variables>`
+   :doc:`Variables & reactivity </user-guide/foundations/state-and-variables>`
    and the :doc:`Variables </user-guide/feature-guides/variables>` feature guide
    for tracing changes and the other variable types.
 

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -75,7 +75,7 @@ respond to input, and how ttkbootstrap styles them.
       The three geometry managers and when to use each — start here, then the
       grid and pack tutorials.
 
-   .. grid-item-card:: State & variables
+   .. grid-item-card:: Variables & reactivity
       :link: foundations/state-and-variables
       :link-type: doc
 

--- a/docs/widgets/spinbox.rst
+++ b/docs/widgets/spinbox.rst
@@ -70,7 +70,7 @@ something as the value steps:
    ttk.Spinbox(app, from_=0, to=100, increment=5, textvariable=quantity, command=on_step)
 
 ``command`` fires only for the arrows, not for typing; to react to typed edits too,
-trace the variable (see :doc:`State & variables
+trace the variable (see :doc:`Variables & reactivity
 </user-guide/foundations/state-and-variables>`). The arrows also respond to the
 ``<Up>`` / ``<Down>`` keys, and the widget emits ``<<Increment>>`` /
 ``<<Decrement>>`` virtual events on a step — a binding point distinct from


### PR DESCRIPTION
## What

A Foundations review pass. The widget-model page was lite (no lifecycle at all), and the variables pages muddled ttk **state** (the flags) with variable-backed **values**. This separates the two concerns and fills the gaps.

### Widget model (`the-widget-model.rst`)
- **New Lifecycle section** — create ≠ display (`winfo_ismapped`), destroy **cascades** to children (`winfo_exists`, methods raise `TclError` after), and `<Destroy>` cleanup of `after` timers / traces. Every fact verified against a live widget.
- **Enriched States** — acknowledges the `state="disabled"` *option* as a coarse shortcut over the flag set, teaches flags as the real model, and adds the gotcha that **`cget("state")` isn't authoritative** (it reports the last option write, not live flags — use `instate()`).
- Intro reframed to four aspects; Events cross-links added.

### Reactivity (`state-and-variables.rst`)
- **Retitled "State & variables" → "Variables & reactivity"** and refocused on the reactive data model, with a pointer that widget **state flags** live in the widget-model page — so "state" has one clear home.
- Dropped an implementation-detail "re-exported" aside.

### Variables guide (`variables.rst`)
- **New "Named variables" section** — `name=`, bind-by-name, `getvar`/`setvar` — taught with **both footguns**: the **GC lifetime** trap (the object owns the Tcl variable; dropping the reference unsets it, and same-name "aliasing" is unsafe) and the **`getvar`/`setvar` type-bypass**. Dropped another "re-exported" aside.

### Link-text updates
`index.rst`, `events.rst`, `menus.rst`, `build-your-first-app.rst`, `spinbox.rst` retargeted to the new title.

## Verification
- Docs build green: `sphinx -b html -W -q -E docs` → exit 0.
- Every snippet verified headlessly — the lifecycle facts, the option-vs-flags `cget` behavior, and the named-variable GC/type-bypass traps were all confirmed against live widgets (the GC footgun was found *during* verification and folded into the guidance).
- Nested-inline-markup swept clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)