### PR TITLE
docs(typography): teach setting a font on a widget

### DIFF
--- a/docs/user-guide/feature-guides/typography.rst
+++ b/docs/user-guide/feature-guides/typography.rst
@@ -5,8 +5,62 @@ Text in a tkinter app is styled through the **standard Tk named fonts** — a
 handful of fonts (``TkDefaultFont``, ``TkTextFont``, ``TkFixedFont``, …) that
 every interpreter ships and every widget reads by default. There is no separate
 ttkbootstrap font vocabulary: change a named font and every widget that uses it
-restyles at once. This guide covers the one-liner for the whole app, per-font
-tweaks, and registering your own named fonts.
+restyles at once. This guide covers setting a font on a single widget, the
+one-liner that restyles the whole app, per-font tweaks, and registering your own
+named fonts.
+
+Setting a font on a widget
+--------------------------
+
+Any widget that shows text takes a ``font=`` option, and tkinter accepts the value
+in several forms. Reach for a direct ``font=`` for a **one-off** — a single
+heading, one label in a particular size; for typography that stays consistent
+across the app, prefer the named fonts (the rest of this guide).
+
+**A (family, size, style) tuple** is the clearest form. The order is fixed —
+family, then size, then an optional style:
+
+.. code-block:: python
+
+   ttk.Label(app, text="Title",   font=("Helvetica", 16, "bold"))
+   ttk.Label(app, text="Caption", font=("Helvetica", 10, "italic"))
+   ttk.Label(app, text="Both",    font=("Helvetica", 12, "bold italic"))
+
+The style is optional and may combine ``bold``, ``italic``, ``underline``, and
+``overstrike``. Because the family is its own element, a multi-word name such as
+``"Segoe UI"`` needs no special handling.
+
+The **size is in points** — so it scales with the display — unless you make it
+negative, which means device pixels:
+
+.. code-block:: python
+
+   ("Helvetica", 12)     # 12 points (scales with the display's DPI)
+   ("Helvetica", -16)    # 16 pixels (fixed)
+
+**String forms** say the same thing and turn up throughout existing tkinter code.
+The ``-option value`` form is explicit, and you can set only the fields you want —
+the rest come from the default font:
+
+.. code-block:: python
+
+   ttk.Label(app, text="Heading", font="-size 16 -weight bold")   # default family
+   ttk.Label(app, text="Heading", font="-family Georgia -size 16 -weight bold")
+
+There is also a bare ``"family size style"`` string — ``"Helvetica 16 bold"`` —
+but it cannot express a multi-word family: ``"Segoe UI 16"`` fails, because Tk
+reads ``UI`` as the size. Use the tuple or ``-family`` when the family name has a
+space.
+
+Two more values work anywhere ``font=`` is accepted: a **named font** string
+(``"TkHeadingFont"``, or an alias you registered — the form to use when you want
+the value to follow the app's typography rather than stay fixed), and a
+:class:`~ttkbootstrap.Font` **object** (``ttk.Font(family="Helvetica", size=16,
+weight="bold")``), a live handle you can reconfigure later — see the
+:doc:`Fonts reference </reference/fonts>`.
+
+Each of these pins a font onto one widget. To restyle text everywhere from a single
+place, use the named fonts described next.
 
 The named fonts
 ---------------


### PR DESCRIPTION
## What

The typography guide covered the app-wide named-font approach well but never taught **how to set a font on a single widget** or the several `font=` spec forms (which are genuinely confusing — order matters, multiple syntaxes, the points-vs-pixels sign).

Adds a **"Setting a font on a widget"** section (before the named-fonts material) covering every form, each verified against a live widget:

- **The `(family, size, style)` tuple** — the clearest form: fixed order, combinable styles (`"bold italic"`), and multi-word families work because the family is its own element.
- **Points vs pixels** — positive size = points (scales with DPI), negative = pixels (fixed).
- **String forms** — explicit `-family Georgia -size 16 -weight bold` and the partial `-size 16 -weight bold` (inherits the default family — the form used in ttkbootstrap's own code), plus the bare `"Helvetica 16 bold"` string with the real gotcha: `"Segoe UI 16"` fails because Tk parses `UI` as the size, so use the tuple or `-family` for spaced families.
- **Named-font strings** and the **`ttk.Font` object**, bridging into the app-wide named-font approach.

Intro updated to advertise the section.

## Verification
- Docs build green: `sphinx -b html -W -q -E docs` → exit 0.
- Every `font=` form verified against a live widget (including the multi-word-family parse failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)