### PR TITLE
docs: correct Text appearance + surface direct color-setting on Label

### DIFF
--- a/docs/widgets/label.rst
+++ b/docs/widgets/label.rst
@@ -46,26 +46,45 @@ status (``success``, ``danger``, ``secondary`` for muted):
    ttk.Label(app, text="Failed", bootstyle="danger")
 
 To put a label on a **colored fill** (inside a colored :doc:`Frame <frame>`, say),
-use ``inverse-<color>`` — it paints the background the color and the text to read
-against it:
+use ``inverse-<color>`` — it paints the background a palette color and the text to
+read against it:
 
 .. code-block:: python
 
    ttk.Label(app, text="Header", bootstyle="inverse-primary")
 
-.. note::
+Setting colors directly
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   ``Label`` is one of the few ttk widgets that also accepts ``foreground``,
-   ``background``, and ``font`` **directly** as options — most ttk widgets take
-   their colors only from a style. A value set this way overrides the
-   ``bootstyle`` color, which is handy for a one-off:
+``bootstyle`` and ``inverse-`` both draw from the theme palette. For any **other**
+color, ``Label`` is one of the few ttk widgets that accept ``foreground`` and
+``background`` directly (most take their colors only from a style); a value set this
+way overrides the ``bootstyle`` color. Pass a raw color, or read one from the active
+theme through ``style.colors`` — an accent, an interface role, or a ramp step:
 
-   .. code-block:: python
+.. code-block:: python
 
-      ttk.Label(app, text="Note", foreground="#b02a37", background="#fff3cd")
+   colors = app.style.colors
 
-   Prefer ``bootstyle`` for anything themed, though — a hard-coded color here does
-   not follow a theme switch.
+   ttk.Label(app, text="Note",    foreground="#b02a37", background="#fff3cd")
+   ttk.Label(app, text="Balance", foreground=colors.success)
+   ttk.Label(app, text="Tag",     foreground=colors.primary, background=colors.primary[100])
+
+A :doc:`color helper </reference/utilities>` can compute one — ``contrast_color``
+picks black or white to read against a background:
+
+.. code-block:: python
+
+   from ttkbootstrap import contrast_color
+
+   bg = colors.info
+   ttk.Label(app, text="Info", background=bg, foreground=contrast_color(bg, "hex"))
+
+A direct color — raw or read from ``style.colors`` — is a **fixed snapshot**: it
+stays as you set it across theme switches but does not adapt to the new theme. Use
+``bootstyle`` / ``inverse-`` for theme-following colors; see
+:doc:`Theming & Colors </user-guide/feature-guides/theming>` for the palette and
+rebuilding on a theme change.
 
 Wrapping long text
 ------------------

--- a/docs/widgets/text.rst
+++ b/docs/widgets/text.rst
@@ -163,26 +163,34 @@ was last saved — handy for a "you have unsaved changes" prompt.
 Appearance
 ----------
 
-The text widget picks up the theme's colors automatically and re-themes when you
-switch themes — you don't style it with ``bootstyle``. To customize, pass the
-usual tk options directly: ``font`` for the editor font, ``foreground`` /
-``background`` for the text and page colors, ``insertbackground`` for the cursor,
-``padx`` / ``pady`` for an inner margin, and ``wrap`` (``"word"``, ``"char"``, or
-``"none"``) for line wrapping:
+The text widget picks up the theme's colors automatically and re-themes on a theme
+switch — you don't style it with ``bootstyle``.
+
+Options the theme doesn't manage you set directly, and they stick — the editor
+``font``, ``wrap`` (``"word"``, ``"char"``, or ``"none"``), the ``width`` /
+``height``, and line spacing:
 
 .. code-block:: python
 
-   ttk.Text(app, font=("Consolas", 11), wrap="word", padx=8, pady=8)
+   ttk.Text(app, font=("Consolas", 11), wrap="word")
+
+The **colors and inner margin are theme-managed**, though — ``foreground`` /
+``background``, ``insertbackground`` (the cursor), ``selectbackground`` /
+``selectforeground``, and ``padx`` / ``pady``. Colors you pass are overridden by
+the theme, and any you set later are undone on the next theme switch. To own them,
+pass ``autostyle=False`` — it opts the widget out of theming so your values persist:
+
+.. code-block:: python
+
+   ttk.Text(app, autostyle=False, background="white", foreground="black",
+            padx=8, pady=8)
+
+``autostyle`` is specific to the tk-based widgets ttkbootstrap themes (``Text``,
+``Canvas``, and the like); ttk widgets such as :doc:`Label <label>` take
+``foreground`` / ``background`` directly instead.
 
 For color that varies *within* the text — a highlighted span, a colored keyword —
 use tags, as above.
-
-To keep tkinter's default look and style the widget entirely yourself, pass
-``autostyle=False`` — it opts out of the automatic theming:
-
-.. code-block:: python
-
-   ttk.Text(app, autostyle=False, background="white", foreground="black")
 
 Scrolling
 ---------


### PR DESCRIPTION
## What

Two related corrections about setting colors on themed widgets, grounded in live probes.

### Text guide — Appearance section
The guide told readers to "pass the usual tk options directly" and listed `foreground`/`background`/`padx`/`pady` among them — but on a themed `tk.Text` those are **theme-managed**: overridden at construction and re-applied on every theme switch. (The old example `ttk.Text(app, font=(...), wrap="word", padx=8, pady=8)` silently had `padx`/`pady=8` become `5`.)

Rewritten to:
- split the options the theme leaves alone (`font`, `wrap`, `width`/`height`, spacing — set directly, they stick) from the theme-managed colors + inner margin;
- give the correct fix — **`autostyle=False`** — with an example that keeps `padx=8`/`background="white"`;
- note that `autostyle` is tk-widget-specific (ttk widgets take colors directly), cross-linked to Label.

### Label guide — Color section
Direct `foreground`/`background` was buried in a `.. note::` after the prominent `inverse-<color>` example, so readers could think `inverse-` is the only way to color a label. Promoted into a **"Setting colors directly"** subsection showing three routes:
- **raw hex**,
- the **theme palette** via `style.colors` (accent, interface role, and a ramp step `primary[100]`),
- a **color helper** (`contrast_color(bg, "hex")` for a readable foreground),

with the accurate caveat that a direct color is a **fixed snapshot** — it survives a theme switch but doesn't adapt (use `bootstyle`/`inverse-` for theme-following).

## The mechanism (probed)
- On a themed `tk.Text`, a direct color is **overridden** by the theme unless `autostyle=False` (tk widgets have no style layer, so ttkbootstrap writes colors onto the widget and rewrites them on theme switch).
- On a `ttk.Label`, an instance `foreground`/`background` **overrides the style and survives** theme switches (ttk instance options win over the rebuilt style) — no `autostyle` needed, and `ttk.Label` rejects `autostyle`.

## Verification
- Docs build green: `sphinx -b html -W -q -E docs` → exit 0.
- Every snippet verified headlessly (incl. the `autostyle=False` Text keeping `padx=8`, and the palette/ramp/`contrast_color` calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)