### PR TITLE
docs: accuracy & quality pass across the feature guides

### DIFF
--- a/docs/user-guide/feature-guides/custom-styles.rst
+++ b/docs/user-guide/feature-guides/custom-styles.rst
@@ -98,8 +98,30 @@ widget* — the ``icon=`` keyword, the imperative ``apply_icon``, or the standal
 What belongs *here* is placing a glyph inside a style **layout** you build
 yourself: ``icon_element`` creates a ttk image element whose per-state image is a
 glyph, so a custom indicator (a checkbox, a toggle) can be drawn from the font
-instead of a raster asset. Use it the same way as the ``image_element`` shown
-above, swapping in the glyph name.
+instead of a raster asset. Unlike ``image_element`` it takes glyph *names* (not
+pre-rendered images), a required ``size=``, and an element name of the form
+``<ttkstyle>.<element>`` — the glyph color follows that style's foreground. Give a
+``default`` glyph plus a ``states`` map of state → glyph:
+
+.. code-block:: python
+
+   from ttkbootstrap import icon_element, layout, El
+
+   icon_element(
+       style,
+       "Star.TCheckbutton.indicator",
+       size=18,
+       default={"name": "star", "color": "warning"},
+       states={"selected": "star-fill"},
+       sticky="w",
+   )
+
+   layout(style, "Star.TCheckbutton",
+       El("Star.TCheckbutton.indicator", side="left", children=[
+           El("Checkbutton.label", side="left", expand=True)])
+   )
+
+   ttk.Checkbutton(app, text="Favorite", style="Star.TCheckbutton").pack()
 
 Creating theme-aware styles
 ---------------------------
@@ -111,7 +133,7 @@ against the new theme's ``style.colors``:
 
 .. code-block:: python
 
-   from ttkbootstrap import theme_aware
+   from ttkbootstrap import theme_aware, Assets, El, layout, image_element
 
    @theme_aware        # runs once now, and again after every theme change
    def build_pill(style):
@@ -135,3 +157,12 @@ Now ``ttk.Button(app, style="Pill.TButton")`` stays correct through
 level, before the app exists — the build is queued and runs when the app is
 created. Use ``on_theme_change(fn)`` for the plain-function form, and
 ``remove_theme_change_callback(fn)`` to unregister.
+
+.. seealso::
+
+   - :doc:`Styling reference </reference/styling>` — the ``Assets`` / ``El`` /
+     ``layout`` / ``image_element`` / ``register_style`` API.
+   - :doc:`Theming & Colors </user-guide/feature-guides/theming>` — the
+     ``style.colors`` palette custom styles draw from.
+   - :doc:`Icons </user-guide/feature-guides/icons>` — putting a glyph *on* a
+     widget, rather than inside a style layout.

--- a/docs/user-guide/feature-guides/dialogs.rst
+++ b/docs/user-guide/feature-guides/dialogs.rst
@@ -9,15 +9,15 @@ user answers) and hands its result straight back from the call — there are no
 callbacks to wire up.
 
 ttkbootstrap ships themed dialogs that replace tkinter's plain stdlib ones,
-reached through two facades:
+reached through **Messagebox** and **Querybox**:
 
 - **Messagebox** — *tell* the user something, or *ask* a question with fixed
   buttons (OK, yes/no, retry/cancel).
 - **Querybox** — *get a value* back: a string, a number, a date, a font, a color,
   or a file path.
 
-Both are re-exported at the top level, so ``ttk.Messagebox`` and
-``from ttkbootstrap import Messagebox`` both work.
+Reach both as ``ttk.Messagebox`` / ``ttk.Querybox``, or import them directly
+(``from ttkbootstrap import Messagebox``).
 
 Asking a question — Messagebox
 ------------------------------
@@ -57,8 +57,8 @@ Pick the method for the buttons your question needs:
    * - Method
      - Buttons / use
    * - ``show_info`` / ``show_warning`` / ``show_error`` / ``show_question``
-     - A message with the matching icon and a single **OK** button — a
-       notification, not a real question.
+     - A message with the matching icon and a single **OK** button by default
+       (any of them also accepts a custom ``buttons=`` list).
    * - ``ok`` / ``okcancel``
      - Confirm an action (returns ``"OK"`` / ``"Cancel"``).
    * - ``yesno`` / ``yesnocancel``
@@ -214,8 +214,8 @@ File dialogs
 Opening and saving files use the **native OS** dialog — the one standard dialog
 ttkbootstrap deliberately does *not* restyle, because the OS draws it and users
 expect their platform's file picker. They're still reached through ``Querybox``,
-so a path is fetched like any other value, and — like the rest of the facade —
-they return ``None`` on cancel:
+so a path is fetched like any other value, and — like the other ``Querybox``
+methods — they return ``None`` on cancel:
 
 .. code-block:: python
 
@@ -232,13 +232,13 @@ they return ``None`` on cancel:
    many    = Querybox.get_open_filenames(parent=app)   # a tuple of paths
 
 Each forwards its keyword arguments (``title``, ``filetypes``, ``initialdir``,
-``defaultextension``, …) to the underlying ``tkinter.filedialog`` function. That
-module is also re-exported as ``ttk.filedialog`` for a variant these four don't
+``defaultextension``, …) to the underlying ``tkinter.filedialog`` function. The
+full module is available as ``ttk.filedialog`` for a variant these four don't
 cover — for example ``askopenfile``, which returns an open file object:
 
 .. code-block:: python
 
-   ttk.filedialog.askopenfile(parent=app)     # the stdlib module, surfaced
+   ttk.filedialog.askopenfile(parent=app)     # returns an open file object, not a path
 
 .. note::
 
@@ -250,9 +250,9 @@ cover — for example ``askopenfile``, which returns an open file object:
 Driving the dialog classes directly
 -----------------------------------
 
-The facades are thin conveniences over two classes — ``MessageDialog`` and
-``QueryDialog`` — that you can use directly when you need more than a one-line
-call: to set a **default button**, **place** the dialog yourself, or run it
+``Messagebox`` and ``Querybox`` are thin conveniences over two classes —
+``MessageDialog`` and ``QueryDialog`` — that you can use directly when you need
+more than a one-line call: to set a **default button**, **place** the dialog yourself, or run it
 **without blocking**. The three-step shape becomes explicit: construct, ``show``,
 read ``.result``.
 

--- a/docs/user-guide/feature-guides/events.rst
+++ b/docs/user-guide/feature-guides/events.rst
@@ -148,8 +148,9 @@ moment you bind and generate it.
    the previous one.
 
 ``event_generate`` also synthesizes **physical** events, though it's less common
-— a bare ``<KeyRelease>`` needs the widget focused and the relevant fields
-supplied (``keysym``, ``x``/``y``) to behave like real input.
+— a bare ``<KeyRelease>`` needs the widget focused and the relevant fields for
+that event type supplied (``keysym`` for keys, ``x``/``y`` for pointer events) to
+behave like real input.
 
 To make a virtual event fire from the keyboard too, alias it to physical key
 sequences with ``event_add``:

--- a/docs/user-guide/feature-guides/icons.rst
+++ b/docs/user-guide/feature-guides/icons.rst
@@ -175,6 +175,8 @@ A small toolbar of icon-only buttons beside a labeled action:
 
 .. seealso::
 
+   - :doc:`Imaging </reference/imaging>` — the ``Icon`` / ``apply_icon`` /
+     ``icon_element`` reference.
    - :doc:`Windows </user-guide/feature-guides/windows>` — the *application*
      (window/taskbar) icon.
    - :doc:`Show images and icons </user-guide/how-to/working-with-images>` — raster

--- a/docs/user-guide/feature-guides/localization.rst
+++ b/docs/user-guide/feature-guides/localization.rst
@@ -78,9 +78,8 @@ every file matching the user's preferred locales and returns how many it loaded:
 Switching the locale
 --------------------
 
-:func:`~ttkbootstrap.set_locale` sets the active locale. Like the typography
-helpers it rides the **deferred-config seam**: call it at the top of a file
-before the root exists and it is queued until ``App()`` comes up; call it
+:func:`~ttkbootstrap.set_locale` sets the active locale. Call it at the top of a
+file before the root exists and it is queued until ``App()`` comes up; call it
 against a live root and it applies immediately, firing a ``<<LocaleChanged>>``
 event:
 
@@ -114,9 +113,9 @@ widget follows the language live — no rebuild:
    ttk.Button(app, text="Español",
               command=lambda: ttk.set_locale("es")).pack()   # label switches instantly
 
-Under the hood it is the observer pattern: every ``LocaleVar`` listens for the
-``<<LocaleChanged>>`` event that ``set_locale`` fires and re-runs its own
-translation. Replace the source string (and any format args) with
+Every ``LocaleVar`` listens for the ``<<LocaleChanged>>`` event that
+``set_locale`` fires and re-runs its own translation. Replace the source string
+(and any format args) with
 ``set_source(src, *args)``; call ``stop_tracking()`` to freeze one at its current
 text while keeping it alive.
 

--- a/docs/user-guide/feature-guides/menus.rst
+++ b/docs/user-guide/feature-guides/menus.rst
@@ -249,9 +249,10 @@ and users expect *About*, *Preferences…*, and *Quit* to live there — not und
 *File*. ``Menu`` builds these native slots for you: :meth:`add_application_menu`,
 :meth:`add_window_menu`, and :meth:`add_help_menu` create the standard macOS
 menus, and :meth:`on_preferences` / :meth:`on_quit` wire the standard commands.
-Every one of them is a **no-op on Windows and Linux** — the ``add_*_menu``
-helpers return ``None`` there — so a single code path builds a native-feeling bar
-on every platform:
+``add_application_menu`` and ``add_window_menu`` return ``None`` off macOS (there
+is no application menu there), and ``on_preferences`` / ``on_quit`` are no-ops;
+``add_help_menu`` builds an ordinary Help cascade on every platform. So a single
+code path builds a native-feeling bar everywhere:
 
 .. code-block:: python
 

--- a/docs/user-guide/feature-guides/theming.rst
+++ b/docs/user-guide/feature-guides/theming.rst
@@ -26,8 +26,7 @@ Pass ``theme=`` to the app. The default is ``bootstrap-light``:
 
 .. note::
 
-   ``themename=`` is an accepted alias for ``theme=`` (the pre-2.0 spelling); use
-   whichever you prefer.
+   ``themename=`` also works as an alias for ``theme=`` (the pre-2.0 spelling).
 
 Switching at runtime
 --------------------
@@ -122,9 +121,12 @@ hard-coding hex.
 
 Each value is an ordinary hex string, so it drops into any tkinter color option.
 ``c.get(name)`` looks a color up by name and returns ``None`` if it isn't one —
-handy when the name is dynamic. Redraw on ``<<ThemeChanged>>`` (see
-:doc:`Events </user-guide/feature-guides/events>`) so custom drawing follows a
-theme switch.
+handy when the name is dynamic. These are snapshots of the *current* theme, so
+keep custom drawing on-theme by re-reading them after a switch: register a
+callback with :func:`~ttkbootstrap.on_theme_change` (or the ``@theme_aware``
+decorator), or bind the raw ``<<ThemeChanged>>`` event — see
+:doc:`Custom styles </user-guide/feature-guides/custom-styles>` and
+:doc:`Events </user-guide/feature-guides/events>`.
 
 Color ramps
 -----------
@@ -193,19 +195,19 @@ and foreground. Registration needs a running app (a style must exist first):
    app = ttk.App()
 
    ttk.Theme(
-       name="pulse",
+       name="brand",
        primary="#593196", success="#13b955", info="#009cdc",
        warning="#efa31d", danger="#fc3939",
        light=dict(background="#ffffff", foreground="#17141f"),
        dark=dict(background="#17141f", foreground="#e9ecef"),
    ).register()
 
-   app.theme_use("pulse-light")   # registered as pulse-light and pulse-dark
+   app.theme_use("brand-light")   # registered as brand-light and brand-dark
    app.mainloop()
 
 Registering a theme generates a ``<name>-light`` and ``<name>-dark`` variant for
 whichever surfaces you declared, so it drops straight into the light/dark
-switching above — ``app.toggle_theme()`` flips ``pulse-light`` ↔ ``pulse-dark``.
+switching above — ``app.toggle_theme()`` flips ``brand-light`` ↔ ``brand-dark``.
 
 Re-branding a built-in
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user-guide/feature-guides/validation.rst
+++ b/docs/user-guide/feature-guides/validation.rst
@@ -180,9 +180,11 @@ fields unflagged.
 
 .. note::
 
-   The ready-made rules pass on an **empty** field, so ``validate()`` returns
-   ``True`` for a required field the user left blank. Add your own emptiness check
-   in ``submit`` (``if not name.get(): …``) when a field is mandatory.
+   The ``text``, ``numeric``, and ``range`` rules pass on an **empty** field, so
+   ``validate()`` returns ``True`` for such a field left blank — add your own
+   emptiness check in ``submit`` (``if not name.get(): …``) when a field is
+   mandatory. (``regex``, ``options``, and ``phonenumber`` instead *fail* an empty
+   field.)
 
 .. seealso::
 


### PR DESCRIPTION
## What

A grounded accuracy + quality pass over the **eight feature guides** that hadn't had a rigorous one (dialogs, validation, localization, theming, custom-styles, events, icons, menus). Each was audited by a dedicated agent that probed every claim against the live 2.0 API + the Tcl/Tk manuals and checked the standing docs rules.

**Verdict from the audits: all eight are fundamentally sound** — no broken snippets, signatures/behaviors match. The fixes are accuracy slips, jargon/impl-detail asides, and small quality gaps.

### Accuracy fixes
- **menus** — self-contradiction: `add_help_menu` builds a real Help cascade on *every* platform; only `add_application_menu`/`add_window_menu` return `None` off macOS (the page said all of them do, then said the opposite 30 lines later).
- **validation** — the empty-field note was too broad: only `text`/`numeric`/`range` pass on empty; `regex`/`options`/`phonenumber` *fail* it (probed).
- **events** — a synthesized `<KeyRelease>` needs `keysym`, not `x`/`y` (those are pointer fields).
- **theming** — the "build your own theme" example named the theme `pulse`, a **shipped catalog family**, so copying it silently overwrote `pulse-light`/`pulse-dark`; renamed to `brand`.
- **custom-styles** — `icon_element` was described as a drop-in for `image_element`; it actually takes glyph *names* (not images), a required `size=`, and a `<ttkstyle>.<element>` name. Corrected with a verified working example.

### Jargon / impl-detail asides removed (standing rule)
- **localization** — "Under the hood ... the observer pattern"; "deferred-config seam".
- **dialogs** — "re-exported" (×2), "the stdlib module, surfaced", "facade(s)" (×3).
- **validation** / **theming** — a "re-exported" aside; softened the `themename=` "use whichever you prefer" against the `theme=` rule.

### Quality gaps
- **dialogs** — `show_question` labelled "not a real question" then used as one → reworded (any `show_*` takes `buttons=`).
- **theming** — theme-aware redraw now points at `on_theme_change`/`@theme_aware`, not only the raw `<<ThemeChanged>>`.
- **icons** / **custom-styles** — added the missing See-also / Imaging + Styling reference links; made the `@theme_aware` snippet self-contained.

## Verification
- Docs build green: `sphinx -b html -W -q -E docs` → exit 0.
- Every new/renamed snippet verified headlessly (the `icon_element` custom checkbutton, the `brand` theme registration).
- Nested-inline-markup swept clean across all eight files.

Next up: finishing the **how-to guides**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)