### PR TITLE
docs: finish the How-To band (audit pass + 3 new recipes)

### DIFF
--- a/docs/reference/cursors.rst
+++ b/docs/reference/cursors.rst
@@ -19,7 +19,7 @@ widget inherits its parent's cursor.
    is platform-dependent** — the same name can look different on Windows, macOS,
    and Linux, and several names map to the same system pointer. For a busy
    pointer over a whole window, prefer the ``busy`` helper — see
-   :doc:`Beep and show busy </user-guide/how-to/feedback>`.
+   :doc:`Mark a window busy </user-guide/how-to/busy>`.
 
 Common cursors
 --------------
@@ -78,7 +78,7 @@ it. Force the pointer to update before the work starts:
    do_slow_work()
    app.configure(cursor="")      # restore
 
-See :doc:`Beep and show busy </user-guide/how-to/feedback>` for the ``busy``
+See :doc:`Mark a window busy </user-guide/how-to/busy>` for the ``busy``
 helper, which does this for a whole window (and disables input) in one call.
 
 All portable names

--- a/docs/user-guide/foundations/how-a-tkinter-app-runs.rst
+++ b/docs/user-guide/foundations/how-a-tkinter-app-runs.rst
@@ -66,7 +66,7 @@ time freezes the whole UI — nothing redraws or responds until it returns:
 The fix is never to do long work directly in a callback. Break it into small
 steps scheduled with ``after`` (below), or run it on a background thread and send
 the result back to the loop. For a quick "working…" state while a short step
-blocks, see :doc:`Beep and show busy </user-guide/how-to/feedback>`.
+blocks, see :doc:`Mark a window busy </user-guide/how-to/busy>`.
 
 Scheduling with ``after``
 -------------------------

--- a/docs/user-guide/how-to/animate-gif.rst
+++ b/docs/user-guide/how-to/animate-gif.rst
@@ -1,0 +1,146 @@
+Animate a GIF
+=============
+
+An animated GIF is a stack of still frames. Tk shows one image at a time, so
+animating one means loading each frame, then swapping the ``Label`` image on a
+timer. This recipe builds a spinner that starts and stops.
+
+Load the frames
+---------------
+
+``PhotoImage`` reads a single GIF frame at a time. Ask for a frame by number
+with the ``format`` option — ``"gif -index 0"`` is the first frame:
+
+.. code-block:: python
+
+   import tkinter
+   import ttkbootstrap as ttk
+
+   app = ttk.App(theme="bootstrap-light")
+
+   first = tkinter.PhotoImage(file="spinner.gif", format="gif -index 0", master=app)
+
+There is no "how many frames?" call. Tk raises ``TclError`` once you ask for an
+index past the end, which is the loop's stopping condition:
+
+.. code-block:: python
+
+   def load_frames(path, master):
+       frames = []
+       while True:
+           try:
+               frames.append(tkinter.PhotoImage(
+                   file=path, format=f"gif -index {len(frames)}", master=master))
+           except tkinter.TclError:
+               return frames
+
+   frames = load_frames("spinner.gif", app)
+
+The list doubles as the reference that keeps the images alive — an image with no
+Python reference is garbage collected and the widget goes blank. See
+:doc:`Show images and icons <working-with-images>` for that gotcha in full.
+
+Cycle through them
+------------------
+
+``after`` schedules the next frame; each frame schedules the one after it. Keep
+the job id ``after`` returns so the animation can be stopped:
+
+.. code-block:: python
+
+   label = ttk.Label(app, image=frames[0])
+   label.pack(padx=20, pady=20)
+
+   index = 0
+   job = None
+
+   def next_frame():
+       global index, job
+       index = (index + 1) % len(frames)
+       label.configure(image=frames[index])
+       job = app.after(80, next_frame)
+
+The ``% len(frames)`` wraps back to frame 0, so the animation loops forever.
+The ``80`` is the delay in milliseconds — roughly 12 frames per second.
+
+Start and stop it
+-----------------
+
+Starting is one ``after`` call; stopping cancels the pending job so no new frame
+is ever scheduled:
+
+.. code-block:: python
+
+   def start():
+       global job
+       if job is None:
+           job = app.after(80, next_frame)
+
+   def stop():
+       global job
+       if job is not None:
+           app.after_cancel(job)
+           job = None
+
+   ttk.Button(app, text="Start", command=start, bootstyle="success").pack(side="left")
+   ttk.Button(app, text="Stop", command=stop, bootstyle="secondary").pack(side="left")
+
+   app.mainloop()
+
+.. note::
+
+   Cancel the job before the window closes. A pending ``after`` that fires
+   against a destroyed widget raises ``TclError``. If the animation outlives its
+   own widget, cancel it on ``<Destroy>``:
+
+   .. code-block:: python
+
+      label.bind("<Destroy>", lambda e: stop())
+
+Use each frame's own delay
+--------------------------
+
+The single ``80`` above gives every frame the same delay. A GIF can specify a
+different delay per frame, and Tk does not expose it — Pillow does. Read the
+durations once, then use the current frame's:
+
+.. code-block:: python
+
+   from PIL import Image
+
+   def load_delays(path):
+       delays = []
+       with Image.open(path) as im:
+           for n in range(im.n_frames):
+               im.seek(n)
+               delays.append(im.info.get("duration", 80))
+       return delays
+
+   delays = load_delays("spinner.gif")
+
+   def next_frame():
+       global index, job
+       index = (index + 1) % len(frames)
+       label.configure(image=frames[index])
+       job = app.after(delays[index], next_frame)
+
+Pillow is already a ttkbootstrap dependency, so this costs no extra install. It
+is also the way to animate formats Tk cannot read at all, such as animated WebP
+or APNG — load the frames with ``ImageTk.PhotoImage`` instead and swap them on
+the same timer.
+
+.. seealso::
+
+   - :doc:`Show images and icons <working-with-images>` — loading images, Pillow
+     formats, and the keep-a-reference gotcha.
+   - :doc:`Run background work <threads>` — ``after`` for scheduling, and why
+     long work must leave the main loop free.
+   - :doc:`Events guide </user-guide/feature-guides/events>` — ``<Destroy>`` and
+     the rest of the binding model.
+
+Reference
+---------
+
+- :doc:`Label </reference/api/label>` — the ``image`` option this recipe swaps.
+- :doc:`after and the event loop </reference/capabilities/after>` — ``after``,
+  ``after_cancel``, and job ids.

--- a/docs/user-guide/how-to/application-icon.rst
+++ b/docs/user-guide/how-to/application-icon.rst
@@ -1,0 +1,124 @@
+Set the app icon
+================
+
+The icon your app shows in the titlebar, the taskbar, and the app switcher.
+Out of the box a ttkbootstrap app wears the ttkbootstrap logo; this recipe
+replaces it with your own.
+
+Set it on the root
+------------------
+
+Pass ``iconphoto`` a path when you create the ``App``:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(theme="bootstrap-light", iconphoto="assets/logo.png")
+
+That is the whole job for one window. The icon set on the root is the
+application-wide default, so every dialog and ``Toplevel`` you open afterwards
+inherits it — you do not repeat yourself per window.
+
+.. note::
+
+   PNG is the format to use. Tk reads PNG and GIF natively, and PNG keeps its
+   transparency. A square source of 512×512 gives every platform enough pixels
+   to scale down from.
+
+The three values ``iconphoto`` accepts are worth knowing apart:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Value
+     - Result
+   * - a path
+     - Load that image and use it as the icon.
+   * - ``""`` (the default)
+     - The ttkbootstrap logo.
+   * - ``None``
+     - Leave the icon alone — you get Tk's own feather.
+
+A bad path is not fatal: ttkbootstrap warns and falls back to the default icon
+rather than crashing your app on startup.
+
+Give one window its own icon
+----------------------------
+
+A ``Toplevel`` inherits the app icon, which is usually what you want. Pass its
+own ``iconphoto`` when it shouldn't — the override applies to that window only
+and leaves the rest of the app alone:
+
+.. code-block:: python
+
+   report = ttk.Toplevel(title="Report", iconphoto="assets/report.png")
+
+Windows: use an .ico
+--------------------
+
+Windows draws the icon at several sizes at once — small in the titlebar, larger
+in the taskbar and Alt-Tab — and a single PNG gets scaled to all of them, which
+looks soft. A multi-resolution ``.ico`` carries a purpose-made image for each
+size. Pass one and ttkbootstrap applies it the Windows way:
+
+.. code-block:: python
+
+   app = ttk.App(theme="bootstrap-light", iconphoto="assets/logo.ico")
+
+.. note::
+
+   ``.ico`` files are only honored on Windows. To ship one app for every
+   platform, pick the file at startup:
+
+   .. code-block:: python
+
+      import sys
+
+      icon = "assets/logo.ico" if sys.platform == "win32" else "assets/logo.png"
+      app = ttk.App(theme="bootstrap-light", iconphoto=icon)
+
+You can build the ``.ico`` from your PNG with Pillow, which ttkbootstrap already
+depends on:
+
+.. code-block:: python
+
+   from PIL import Image
+
+   sizes = [(16, 16), (32, 32), (48, 48), (64, 64), (128, 128), (256, 256)]
+   Image.open("assets/logo.png").save("assets/logo.ico", sizes=sizes)
+
+Change the icon later
+---------------------
+
+The icon is not fixed at construction. ``iconphoto`` is also a method — pass it
+a ``PhotoImage`` and a first argument of ``True`` to change the app-wide
+default:
+
+.. code-block:: python
+
+   import tkinter
+
+   badge = tkinter.PhotoImage(file="assets/unread.png", master=app)
+   app.iconphoto(True, badge)
+
+.. warning::
+
+   Keep a reference to the ``PhotoImage``. A local that goes out of scope is
+   garbage collected and the icon reverts. Assign it to an attribute
+   (``app.badge = badge``) or any other name that outlives the call — the same
+   gotcha covered in :doc:`Show images and icons <working-with-images>`.
+
+.. seealso::
+
+   - :doc:`Show images and icons <working-with-images>` — loading images, Pillow
+     formats, and themed glyphs.
+   - :doc:`Windows guide </user-guide/feature-guides/windows>` — titles,
+     geometry, and window state.
+
+Reference
+---------
+
+- :doc:`App </reference/windows/app>` — the ``iconphoto`` option and method.
+- :doc:`Toplevel </reference/windows/toplevel>` — per-window icon overrides.

--- a/docs/user-guide/how-to/bell.rst
+++ b/docs/user-guide/how-to/bell.rst
@@ -1,0 +1,83 @@
+Ring the system bell
+====================
+
+A beep is the cheapest way to get a user's attention — a flag for an invalid
+action, or a nudge that a long job has finished.
+
+Beep with ``bell``
+------------------
+
+``bell()`` rings the system alert sound. Every widget has it, so call it on
+``app`` or on whatever widget is at hand:
+
+.. code-block:: python
+
+   app.bell()
+
+It plays the platform's default alert; there is no volume or tone control.
+
+Beep on a rejected action
+-------------------------
+
+The usual job: the user did something the app can't accept, and you want to say
+so without a dialog. Beep, and put the reason on screen:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(title="Bell", size=(320, 140))
+
+   amount = ttk.Entry(app)
+   amount.pack(padx=20, pady=(20, 4), fill="x")
+   message = ttk.Label(app, text="", bootstyle="danger")
+   message.pack()
+
+   def submit():
+       if not amount.get().isdigit():
+           app.bell()
+           message.configure(text="Enter a number")
+           return
+       message.configure(text="")
+       save(amount.get())
+
+   ttk.Button(app, text="Save", command=submit, bootstyle="primary").pack(pady=10)
+
+   app.mainloop()
+
+The beep is the alert; the label is the explanation. A beep on its own tells the
+user something was wrong but not what — so pair it with something visible.
+
+.. note::
+
+   Use it sparingly. A beep on every keystroke gets old fast, and a user who has
+   silenced their system alert sound hears nothing at all — so never let a beep
+   be the *only* way you report something.
+
+Let a dialog beep for you
+-------------------------
+
+The shipped dialogs and toasts can ring the bell themselves. ``Messagebox``
+error dialogs already do; ``ToastNotification`` takes ``alert=True``:
+
+.. code-block:: python
+
+   ttk.ToastNotification(
+       title="Export finished",
+       message="Your report is ready.",
+       alert=True,
+   ).show_toast()
+
+.. seealso::
+
+   - :doc:`Mark a window busy <busy>` — the other half of telling the user what
+     is going on.
+   - :doc:`Dialogs guide </user-guide/feature-guides/dialogs>` — ``Messagebox``
+     and ``Querybox``, which beep on error for you.
+   - :doc:`Validation guide </user-guide/feature-guides/validation>` — rejecting
+     bad input before it reaches your handler.
+
+Reference
+---------
+
+- :doc:`Toast </widgets/toast>` — ``ToastNotification`` and its ``alert`` option.

--- a/docs/user-guide/how-to/busy.rst
+++ b/docs/user-guide/how-to/busy.rst
@@ -1,27 +1,5 @@
-Beep and show busy
-==================
-
-Two small built-in ways to tell the user something happened: a beep for
-attention, and a busy state that blocks a window while it works.
-
-Beep with ``bell``
-------------------
-
-``bell()`` rings the system alert sound — a quick way to flag an invalid action
-or a finished job. Every widget has it:
-
-.. code-block:: python
-
-   app.bell()
-
-It plays the platform's default alert; there is no volume or tone control. Use it
-sparingly — a beep on every keystroke gets old fast.
-
-Our dialogs and toasts can ring it for you: pass ``alert=True`` to
-``ToastNotification``, and ``Messagebox`` error dialogs already do.
-
 Mark a window busy
-------------------
+==================
 
 For a slow operation you want to both **show a wait cursor** and **stop the user
 clicking** meanwhile. ``busy()`` does both: it covers the widget with a
@@ -40,8 +18,11 @@ runs, so without it the user sees nothing before the blocking work starts —
 and Tk's own docs recommend a full ``update`` here, to guarantee the hold takes
 effect before any queued clicks are dispatched.
 
-Always release it — even on error — by pairing the calls with ``try``/
-``finally``:
+Always release it
+-----------------
+
+Pair the calls with ``try``/``finally`` so an exception can't strand the app
+looking busy forever:
 
 .. code-block:: python
 
@@ -62,10 +43,9 @@ keep a slow action from being started twice:
 
 .. warning::
 
-   **The busy overlay does nothing on macOS.** Tk's busy command has no effect
-   under Aqua. The calls succeed and ``busy_status()`` still reports ``True``,
-   but no overlay is drawn and no input is blocked — it fails silently rather
-   than raising.
+   **The busy overlay is not supported on macOS.** The calls succeed and
+   ``busy_status()`` still reports ``True``, but nothing is drawn and nothing is
+   blocked — so it fails quietly rather than raising.
 
    On macOS, get the same effect by disabling the controls that start the work
    and setting the cursor yourself:
@@ -123,6 +103,8 @@ busy state is up.
 
    - :doc:`Run background work <threads>` — the thread-and-``after`` pattern for
      work too long to block on.
+   - :doc:`Ring the system bell <bell>` — the other half of telling the user what
+     is going on.
    - :doc:`Windows guide </user-guide/feature-guides/windows>` — window-level
      behavior.
 

--- a/docs/user-guide/how-to/clipboard.rst
+++ b/docs/user-guide/how-to/clipboard.rst
@@ -38,7 +38,15 @@ Read what is on the clipboard with ``clipboard_get``:
       except TclError:
           text = ""
 
-A copy action, wired to a button or a shortcut, is just those two calls:
+.. note::
+
+   On Linux the clipboard belongs to the app that set it, so what you copy is
+   typically gone once your app exits — unless the user runs a clipboard manager
+   that holds onto it. Windows and macOS hand the text to the system, where it
+   outlives the process. Nothing to code around; just don't rely on a copy
+   surviving your own shutdown on Linux.
+
+A copy action, wired to a button, is just those two calls:
 
 .. code-block:: python
 
@@ -47,7 +55,22 @@ A copy action, wired to a button or a shortcut, is just those two calls:
        app.clipboard_append(result_var.get())
 
    ttk.Button(app, text="Copy", command=copy_result, bootstyle="secondary").pack()
-   app.bind_all("<Control-c>", lambda e: copy_result())
+
+To put it on a keyboard shortcut too, pick the key for the platform — macOS
+copies with **Command-c**, Windows and Linux with **Control-c**:
+
+.. code-block:: python
+
+   copy_key = "<Command-c>" if ttk.windowing_system(app) == "aqua" else "<Control-c>"
+   app.bind(copy_key, lambda e: copy_result())
+
+.. warning::
+
+   Bind the shortcut on a specific widget or frame, not with ``bind_all``. The
+   copy key is already the native copy gesture inside every Entry and Text —
+   ``bind_all`` fires on top of that handling, so a user who selects text in a
+   field and copies it gets your value on the clipboard instead of their
+   selection.
 
 The current selection
 ---------------------
@@ -70,14 +93,26 @@ through the same call instead:
 
 .. note::
 
-   The **PRIMARY** selection is an X11 (Linux) convention — highlighting text
-   makes it available to paste with the middle mouse button. On Windows and macOS
-   there is no persistent PRIMARY selection, so for portable copy/paste use the
-   **clipboard** methods above; keep PRIMARY for Linux-specific niceties.
+   Reading your own app's selection with ``selection_get`` works on every
+   platform. What differs is **sharing** it with other applications: on Linux
+   (X11), PRIMARY is a system-wide channel — highlighting text makes it pastable
+   with the middle mouse button. On Windows and macOS, Tk provides PRIMARY only
+   within your own application. For copy and paste that crosses application
+   boundaries, use the **clipboard** methods above everywhere.
 
 .. seealso::
 
    - :doc:`Events guide </user-guide/feature-guides/events>` — binding the
      copy/paste shortcuts.
-   - The ``<<Copy>>`` / ``<<Paste>>`` / ``<<Cut>>`` virtual events that Entry and
-     Text already handle for you.
+   - :doc:`Menus guide </user-guide/feature-guides/menus>` — putting Copy and
+     Paste on a menu with the right accelerator per platform.
+
+Reference
+---------
+
+- :doc:`Clipboard </reference/capabilities/clipboard>` — ``clipboard_clear``,
+  ``clipboard_append``, and ``clipboard_get``.
+- :doc:`Selection </reference/capabilities/selection>` — ``selection_get`` and
+  the ``selection=`` argument.
+- :doc:`Built-in virtual events </reference/events/virtual-events>` — the
+  ``<<Copy>>`` / ``<<Cut>>`` / ``<<Paste>>`` events Entry and Text already handle.

--- a/docs/user-guide/how-to/error-handling.rst
+++ b/docs/user-guide/how-to/error-handling.rst
@@ -35,11 +35,22 @@ value, and traceback. This is your **safety net**, not a substitute for handling
 expected failures where they happen; use it to make sure nothing fails
 *invisibly*.
 
+Set it on the root. Every window's callback errors route to the root's handler,
+so one covers the whole app — and a handler set on a ``Toplevel`` is never
+called at all.
+
 .. note::
 
-   This handler only sees exceptions raised **inside** the event loop — callbacks
-   and ``after`` jobs. An exception raised during setup, before ``mainloop()``,
-   propagates normally; wrap that code in your own ``try``/``except``.
+   This handler only sees exceptions raised inside a **callback** — a ``command=``
+   handler, a ``bind`` callback, an ``after`` job. Straight-line setup code is not
+   a callback, so an exception there propagates normally; wrap that code in your
+   own ``try``/``except``.
+
+.. warning::
+
+   If a repeating ``after`` job is what's failing, showing a modal dialog from
+   this handler queues one dialog per tick. Log instead, or stop the job before
+   you show anything.
 
 ``TclError``
 ------------
@@ -54,18 +65,28 @@ a call is expected to fail:
    from tkinter import TclError
 
    try:
-       widget.configure(bootstyle="not-a-real-style")
-   except TclError as err:
-       ...
+       text = app.clipboard_get()
+   except TclError:
+       text = ""          # the clipboard is empty, or holds something that isn't text
 
 A common source is a numeric variable holding in-progress text: ``IntVar.get()``
 raises ``TclError`` when the bound entry is empty or half-typed. Guard the read,
 or validate the field instead — see
 :doc:`Input validation </user-guide/feature-guides/validation>`.
 
+.. note::
+
+   An unrecognized ``bootstyle`` is **not** one of these cases. Rather than
+   raising, an unknown token warns and is ignored, and the widget falls back to
+   its plain style — so a misspelled ``bootstyle`` shows up as a widget that
+   looks wrong, not as an exception you can catch.
+
 .. seealso::
 
    - :doc:`Variables guide </user-guide/feature-guides/variables>` — the
      numeric-variable coercion gotcha.
+   - :doc:`Copy and paste text <clipboard>` — the clipboard call guarded above.
+   - :doc:`The bootstyle grammar </user-guide/foundations/bootstyle-grammar>` —
+     the token vocabulary, and what an unknown token does.
    - :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
      — the event loop that these callbacks run inside.

--- a/docs/user-guide/how-to/feedback.rst
+++ b/docs/user-guide/how-to/feedback.rst
@@ -62,17 +62,13 @@ keep a slow action from being started twice:
 
 .. warning::
 
-   Two limits to know before you rely on this:
+   **The busy overlay does nothing on macOS.** Tk's busy command has no effect
+   under Aqua. The calls succeed and ``busy_status()`` still reports ``True``,
+   but no overlay is drawn and no input is blocked — it fails silently rather
+   than raising.
 
-   - **It does nothing on macOS.** Tk's busy command has no effect under Aqua.
-     The calls succeed and ``busy_status()`` still reports ``True``, but no
-     overlay is drawn and no input is blocked — it fails silently rather than
-     raising.
-   - **It needs Python 3.13.** The busy methods were added to tkinter in 3.13,
-     so on 3.10–3.12 they don't exist at all.
-
-   Where either applies, get the same effect by disabling the controls that start
-   the work and setting the cursor yourself:
+   On macOS, get the same effect by disabling the controls that start the work
+   and setting the cursor yourself:
 
    .. code-block:: python
 
@@ -81,8 +77,23 @@ keep a slow action from being started twice:
           run.configure(state="disabled" if is_busy else "normal")
 
    A cursor set on the window covers everything inside it — a child with no
-   cursor of its own inherits its parent's. This works on every platform and
-   every supported Python.
+   cursor of its own inherits its parent's. This works on every platform.
+
+.. note::
+
+   The busy overlay itself is a Tk 8.6 feature, so it is there on every Python
+   we support — but tkinter only grew the ``busy()`` / ``tk_busy_*`` methods in
+   **3.13**. To use it on Python 3.10–3.12, call Tk directly; it is the same
+   command underneath:
+
+   .. code-block:: python
+
+      app.tk.call("tk", "busy", "hold", app, "-cursor", "watch")
+      app.update()
+      try:
+          do_slow_work()
+      finally:
+          app.tk.call("tk", "busy", "forget", app)
 
 .. note::
 

--- a/docs/user-guide/how-to/feedback.rst
+++ b/docs/user-guide/how-to/feedback.rst
@@ -17,66 +17,105 @@ or a finished job. Every widget has it:
 It plays the platform's default alert; there is no volume or tone control. Use it
 sparingly — a beep on every keystroke gets old fast.
 
+Our dialogs and toasts can ring it for you: pass ``alert=True`` to
+``ToastNotification``, and ``Messagebox`` error dialogs already do.
+
 Mark a window busy
 ------------------
 
 For a slow operation you want to both **show a wait cursor** and **stop the user
-clicking** meanwhile. ``tk_busy_hold`` does both: it covers the widget with a
-transparent overlay that swallows mouse and keyboard input and shows a busy
-cursor, until you release it with ``tk_busy_forget``:
+clicking** meanwhile. ``busy()`` does both: it covers the widget with a
+transparent overlay that swallows mouse-pointer events and shows a busy cursor,
+until you release it with ``busy_forget()``:
 
 .. code-block:: python
 
-   app.tk_busy_hold(cursor="watch")
-   app.update_idletasks()        # paint the overlay + cursor before blocking
+   app.busy(cursor="watch")
+   app.update()                  # paint the overlay + cursor before blocking
    do_slow_work()
-   app.tk_busy_forget()
+   app.busy_forget()
 
-The ``update_idletasks`` call matters: without it the overlay never gets a chance
-to draw before the blocking work starts, so the user sees nothing.
+The ``update`` call matters. The overlay is only mapped when the event loop next
+runs, so without it the user sees nothing before the blocking work starts —
+and Tk's own docs recommend a full ``update`` here, to guarantee the hold takes
+effect before any queued clicks are dispatched.
 
 Always release it — even on error — by pairing the calls with ``try``/
 ``finally``:
 
 .. code-block:: python
 
-   app.tk_busy_hold(cursor="watch")
-   app.update_idletasks()
+   app.busy(cursor="watch")
+   app.update()
    try:
        do_slow_work()
    finally:
-       app.tk_busy_forget()
+       app.busy_forget()
 
-``tk_busy_status()`` reports whether a widget is currently held busy:
+``busy_status()`` reports whether a widget is currently held busy — useful to
+keep a slow action from being started twice:
 
 .. code-block:: python
 
-   if app.tk_busy_status():
-       ...
+   if not app.busy_status():
+       start_work()
+
+.. warning::
+
+   Two limits to know before you rely on this:
+
+   - **It does nothing on macOS.** Tk's busy command has no effect under Aqua.
+     The calls succeed and ``busy_status()`` still reports ``True``, but no
+     overlay is drawn and no input is blocked — it fails silently rather than
+     raising.
+   - **It needs Python 3.13.** The busy methods were added to tkinter in 3.13,
+     so on 3.10–3.12 they don't exist at all.
+
+   Where either applies, get the same effect by disabling the controls that start
+   the work and setting the cursor yourself:
+
+   .. code-block:: python
+
+      def busy(is_busy):
+          app.configure(cursor="watch" if is_busy else "")
+          run.configure(state="disabled" if is_busy else "normal")
+
+   A cursor set on the window covers everything inside it — a child with no
+   cursor of its own inherits its parent's. This works on every platform and
+   every supported Python.
 
 .. note::
 
-   ``tk_busy_hold`` differs from simply setting ``cursor="watch"``: besides the
-   cursor, it **blocks input** to the widget and everything inside it. Set
-   ``cursor=`` alone (see :doc:`Cursors </reference/cursors>`) when you only want
-   to change the pointer without disabling the window.
+   ``busy()`` differs from simply setting ``cursor="watch"``: besides the cursor,
+   it blocks **pointer events** to the widget and everything inside it. It does
+   not block the keyboard — a widget that already had focus keeps receiving
+   keystrokes, so move focus off the busy area if that matters. Set ``cursor=``
+   alone (see :doc:`Cursors </reference/cursors>`) when you only want to change
+   the pointer.
 
 .. note::
 
-   The method is ``tk_busy_hold`` / ``tk_busy_forget`` / ``tk_busy_configure`` /
-   ``tk_busy_status`` on every supported Python. Python 3.13 adds shorter
-   ``busy_hold`` / ``busy_forget`` / … aliases for the same calls.
+   The methods are also spelled ``tk_busy_hold`` / ``tk_busy_forget`` /
+   ``tk_busy_status`` / ``tk_busy_configure``. Those are the same calls under
+   their longer names, added in the same version.
 
 Long work still needs a thread
 ------------------------------
 
-``tk_busy`` only helps for work short enough to block on briefly — while the main
-loop is blocked, the busy overlay is the *only* thing the window can do, and it
+The busy state only helps for work short enough to block on briefly — while the
+main loop is blocked, the overlay is the *only* thing the window can do, and it
 cannot repaint or animate. For genuinely long work, run it on a background thread
-and marshal results back with ``after``, so the UI stays responsive.
+and marshal results back with ``after``, so the UI stays responsive while the
+busy state is up.
 
 .. seealso::
 
-   - :doc:`Cursors </reference/cursors>` — the pointer names.
+   - :doc:`Run background work <threads>` — the thread-and-``after`` pattern for
+     work too long to block on.
    - :doc:`Windows guide </user-guide/feature-guides/windows>` — window-level
      behavior.
+
+Reference
+---------
+
+- :doc:`Cursors </reference/cursors>` — the pointer names you can set.

--- a/docs/user-guide/how-to/index.rst
+++ b/docs/user-guide/how-to/index.rst
@@ -1,23 +1,21 @@
 How-To
 ======
 
-.. note::
-
-   The How-To section is being written for 2.0. Each recipe below will become
-   its own page as it is authored; this page lists the planned set.
-
 Short, task-focused recipes for common jobs — the everyday tkinter tasks a
 newcomer arrives needing, written the ttkbootstrap way (ttkbootstrap widgets and
 idioms throughout, with links to the :doc:`Reference </reference/index>` for the
-full API). This band absorbs the recipes from the old cookbook.
+full API).
 
 Building interfaces
 -------------------
 
-- **Lay out widgets** — ``pack``, ``grid``, and ``place``, and when to reach for
-  each (uses the fluent geometry helpers).
-- **Wire events and variables** — ``bind``, ``command=``, and the tk variable
-  classes (``StringVar``/``IntVar``/…).
+- **Lay out widgets** — for ``pack``, ``grid``, and ``place``, and when to reach
+  for each, see :doc:`Arranging widgets
+  </user-guide/foundations/arranging-widgets>`.
+- **Wire events and variables** — for ``bind``, ``command=``, and the variable
+  classes, see :doc:`Events and callbacks
+  </user-guide/foundations/events-and-callbacks>` and the
+  :doc:`Variables guide </user-guide/feature-guides/variables>`.
 - **Menus** — for a menu bar, submenus, context menus, and the cross-platform
   macOS application menu, see the :doc:`Menus guide </user-guide/feature-guides/menus>`.
 - :doc:`Show images and icons <working-with-images>` — ``PhotoImage`` and Pillow,
@@ -30,7 +28,8 @@ Interaction and data
 
 - **Message boxes and dialogs** — for ``Messagebox``/``Querybox`` and the shipped
   pickers, see the :doc:`Dialogs guide </user-guide/feature-guides/dialogs>`.
-- **Validate a form** — attach validation rules and read the result.
+- **Validate a form** — for attaching validation rules and reading the result,
+  see the :doc:`Validation guide </user-guide/feature-guides/validation>`.
 - :doc:`Open a second window <multiple-windows>` — a second ``Toplevel``, a modal
   dialog that returns a value, and the close button.
 - :doc:`Run background work <threads>` — ``after`` and worker threads, updating
@@ -39,13 +38,14 @@ Interaction and data
   current selection.
 - :doc:`Handle callback errors <error-handling>` — take over
   ``report_callback_exception`` and deal with ``TclError``.
-- :doc:`Beep and show busy <feedback>` — a system beep and a busy overlay that
+- :doc:`Beep and show busy <feedback>` — a system beep and a busy state that
   blocks a window while it works.
 
 Presentation
 ------------
 
-- **Animate a GIF** *(salvaged from the cookbook)* — frame-by-frame animation
-  with ``PhotoImage``.
-- **Splash screen** — a borderless startup window with ``window_type``.
-- **Application icon** — set the window/taskbar icon.
+- :doc:`Animate a GIF <animate-gif>` — frame-by-frame animation with
+  ``PhotoImage`` and ``after``.
+- :doc:`Show a splash screen <splash-screen>` — a borderless startup window that
+  hands off to the main one.
+- :doc:`Set the app icon <application-icon>` — the titlebar and taskbar icon.

--- a/docs/user-guide/how-to/index.rst
+++ b/docs/user-guide/how-to/index.rst
@@ -38,8 +38,10 @@ Interaction and data
   current selection.
 - :doc:`Handle callback errors <error-handling>` — take over
   ``report_callback_exception`` and deal with ``TclError``.
-- :doc:`Beep and show busy <feedback>` — a system beep and a busy state that
-  blocks a window while it works.
+- :doc:`Ring the system bell <bell>` — a system beep to flag a rejected action
+  or a finished job.
+- :doc:`Mark a window busy <busy>` — a wait cursor and a block on clicks while
+  a slow job runs.
 
 Presentation
 ------------

--- a/docs/user-guide/how-to/multiple-windows.rst
+++ b/docs/user-guide/how-to/multiple-windows.rst
@@ -18,6 +18,10 @@ Open a second window
 
 .. code-block:: python
 
+   import ttkbootstrap as ttk
+
+   app = ttk.App(title="Main", size=(320, 200))
+
    win = ttk.Toplevel(master=app, title="Details")
    ttk.Label(win, text="A second window").pack(padx=20, pady=20)
 
@@ -35,7 +39,8 @@ the dialog left behind:
        dialog = ttk.Toplevel(master=parent, title="Your name", transient=parent)
 
        name = ttk.StringVar()
-       ttk.Entry(dialog, textvariable=name).pack(padx=10, pady=10, fill="x")
+       entry = ttk.Entry(dialog, textvariable=name)
+       entry.pack(padx=10, pady=10, fill="x")
 
        result = {}
        def submit():
@@ -44,6 +49,8 @@ the dialog left behind:
        ttk.Button(dialog, text="OK", command=submit,
                   bootstyle="primary").pack(pady=(0, 10))
 
+       dialog.place_window_center()
+       entry.focus_set()              # put the cursor in the field
        dialog.grab_set()
        parent.wait_window(dialog)     # blocks until the dialog is destroyed
        return result.get("name")      # None if closed without OK
@@ -53,8 +60,7 @@ the dialog left behind:
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder
 
-   The modal "Your name" dialog centered over its parent window, with the entry
-   and OK button.
+   The modal "Your name" dialog centered on screen, with the entry and OK button.
 
 .. tip::
 
@@ -66,29 +72,46 @@ Intercept the close button
 --------------------------
 
 Run your own code when the user clicks **✕** — confirm, save, then close (or
-don't):
+don't). Hand the callback to ``on_close``:
 
 .. code-block:: python
 
    from ttkbootstrap.dialogs import Messagebox
 
-   def on_close():
-       if Messagebox.yesno("Discard changes?", parent=win) == "Yes":
-           win.destroy()
+   def confirm_close():
+       if Messagebox.yesno("Discard changes?", parent=win) != "Yes":
+           return False               # cancel the close; the window stays
 
-   win.protocol("WM_DELETE_WINDOW", on_close)
+   win.on_close(confirm_close)
 
-The window closes only if your handler calls ``destroy()``.
+Return ``False`` to cancel the close. Return nothing and the window is destroyed
+for you. You can pass the same callable at construction instead —
+``ttk.Toplevel(on_close=confirm_close)``.
+
+.. note::
+
+   ``yesno`` returns the button's *displayed* text, which is translated when
+   localization is active — so a bare ``== "Yes"`` misses under a non-English
+   locale. See the :doc:`Dialogs guide </user-guide/feature-guides/dialogs>`.
 
 Reuse a window instead of rebuilding it
 ---------------------------------------
 
-Hide an expensive window and bring it back rather than recreating it:
+To keep an expensive window around and show it again later, hide it rather than
+destroying it — and intercept ✕ so the user's close hides it too:
 
 .. code-block:: python
 
-   win.withdraw()        # hide
-   win.deiconify()       # show again
+   def hide():
+       win.withdraw()
+       return False               # keep the window alive for next time
+
+   win.on_close(hide)             # ✕ now hides instead of destroying
+   win.deiconify()                # show it again later
+
+That ``on_close`` is what makes the recipe work. Without it, ✕ destroys the
+window for good and the next ``deiconify()`` raises ``TclError: bad window path
+name``.
 
 .. seealso::
 
@@ -96,3 +119,11 @@ Hide an expensive window and bring it back rather than recreating it:
      concepts.
    - :doc:`Structuring an app </user-guide/getting-started/app-structures>` — the
      single-root rule.
+   - :doc:`Show a splash screen <splash-screen>` — a borderless window shown
+     while the app starts up.
+
+Reference
+---------
+
+- :doc:`Toplevel </reference/windows/toplevel>` — every constructor option and
+  window method, including ``on_close`` and ``place_window_center``.

--- a/docs/user-guide/how-to/scrollable.rst
+++ b/docs/user-guide/how-to/scrollable.rst
@@ -4,9 +4,8 @@ Scroll long content
 When content outgrows its window — a long form, a wall of log text — you need a
 scrollable region. Plain tkinter makes you pair a ``Canvas`` (or ``Text``) with
 a ``Scrollbar`` and wire the two together by hand. ttkbootstrap ships two widgets
-that do that wiring for you: :class:`~ttkbootstrap.ScrolledFrame` for arbitrary
-widgets, and :class:`~ttkbootstrap.ScrolledText` for text. Both are re-exported
-at the top level.
+that do that wiring for you: :doc:`ScrolledFrame </widgets/scrolled>` for
+arbitrary widgets, and :doc:`ScrolledText </widgets/scrolled>` for text.
 
 A scrollable frame
 ------------------
@@ -33,8 +32,11 @@ they overflow:
 - ``auto_hide=True`` hides the scrollbar until the pointer enters the region, then
   shows it — tidy for dense UIs. Leave it off (the default) to keep the scrollbar
   always visible.
-- The frame scrolls vertically by default. Pass ``height=``/``width=`` to fix its
-  size; without a fixed size it requests the size of its content.
+- The frame scrolls vertically only.
+- The viewport is a fixed size — the content never stretches it, which is the
+  whole point: the overflow scrolls instead. It defaults to 300×200; pass
+  ``height=``/``width=`` to change that, or ``pack(fill="both", expand=True)``
+  as above to let it fill its parent.
 
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder
@@ -44,9 +46,12 @@ they overflow:
 
 .. note::
 
-   Add your widgets with the ``ScrolledFrame`` as their ``master`` — not a child
-   frame of your own. The widget manages an internal container and reparents
-   your content into the scrollable area automatically.
+   ``pack``/``grid``/``place`` on a ``ScrolledFrame`` lay out the whole assembly
+   — frame plus scrollbar — so most parents just work. A ``Notebook`` or
+   ``PanedWindow`` is different: it takes a child rather than laying one out, so
+   give it ``scroller.container``::
+
+      notebook.add(scroller.container, text="Settings")
 
 A scrollable text box
 ---------------------
@@ -72,16 +77,18 @@ for the standard Text API (``insert``, ``get``, ``delete``, tags):
 
 - ``.text`` is the real ``Text`` widget — anything the :doc:`Text reference
   </reference/api/text>` documents works on it.
-- Pass ``hbar=True`` for a horizontal scrollbar too (off by default); ``vbar`` is
-  on by default.
+- Pass ``hbar=True`` for a horizontal scrollbar too (off by default; ``vbar`` is
+  on). Turning it on also stops the text wrapping — long lines run off to the
+  right and scroll sideways instead, which is what the horizontal bar is for.
 - ``see("end")`` keeps the newest content in view — the usual move for a log.
 
 .. admonition:: Making a log read-only
    :class: note
 
    A ``Text`` is editable by default. To use one purely for output, set its
-   ``state`` to ``"disabled"`` and flip it back around each write, since a
-   disabled Text rejects ``insert`` too::
+   ``state`` to ``"disabled"`` and flip it back around each write — a disabled
+   Text silently discards ``insert``, with no error, so the line simply never
+   appears::
 
       log.text.configure(state="normal")
       log.text.insert("end", line)
@@ -89,6 +96,8 @@ for the standard Text API (``insert``, ``get``, ``delete``, tags):
 
 .. seealso::
 
+   - :doc:`Scrolled </widgets/scrolled>` — the widget catalog entry for both
+     widgets.
    - :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>` — packing
      and gridding content.
    - :doc:`Run background work <threads>` — streaming output into a

--- a/docs/user-guide/how-to/splash-screen.rst
+++ b/docs/user-guide/how-to/splash-screen.rst
@@ -1,0 +1,123 @@
+Show a splash screen
+====================
+
+A splash screen is a borderless window shown while an app gets ready, replaced
+by the real window once the work is done. This recipe builds one that reports
+its progress and then hands off to the main window.
+
+Hide the main window first
+--------------------------
+
+The application root exists from the moment you create ``App``, so the order is:
+create the root, hide it, show the splash, then bring the root back when the
+work is finished.
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(theme="bootstrap-light", size=(600, 400), title="Contact Book")
+   app.withdraw()
+
+``withdraw`` takes the window off the screen without destroying it —
+``deiconify`` puts it back later. Build the main window's widgets now, while it
+is hidden; that is usually the slow part you want the splash to cover.
+
+Build the splash
+----------------
+
+The splash is a ``Toplevel``. Two options strip the window chrome, and you want
+both — each covers different platforms:
+
+.. code-block:: python
+
+   splash = ttk.Toplevel(
+       window_type="splash",
+       override_redirect=True,
+       topmost=True,
+       size=(360, 200),
+   )
+
+   panel = ttk.Frame(splash, bootstyle="primary").pack(fill="both", expand=True)
+   ttk.Label(panel, text="Contact Book", bootstyle="inverse-primary",
+             font="-size 18 -weight bold").pack(pady=(50, 4))
+   status = ttk.Label(panel, text="Starting…", bootstyle="inverse-primary")
+   status.pack()
+
+   splash.place_window_center()
+
+``topmost`` keeps it above other windows, and ``place_window_center`` puts it in
+the middle of the screen. A splash has no titlebar to drag, so centering it is
+not a nicety — it's the only placement the user gets.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Option
+     - What it does
+   * - ``window_type="splash"``
+     - Removes the chrome on Linux and macOS. On macOS it also gets the window
+       a real system shadow and rounded corners. Ignored on Windows.
+   * - ``override_redirect=True``
+     - Removes the chrome on Windows and Linux. Ignored on macOS, where it
+       breaks click handling.
+
+Show it, then work
+------------------
+
+``mainloop`` is not running yet, so nothing you have built has been drawn.
+Call ``update`` to pump the event loop once and paint the splash:
+
+.. code-block:: python
+
+   app.update()
+
+   status.configure(text="Loading contacts…")
+   app.update()
+   load_contacts()
+
+   status.configure(text="Connecting…")
+   app.update()
+   connect()
+
+Every time you change the status text, ``update`` again — otherwise the label
+holds its old text until the next time the event loop runs, which is after all
+your work has finished.
+
+Hand off to the main window
+---------------------------
+
+Destroy the splash, show the real window, and start the event loop:
+
+.. code-block:: python
+
+   splash.destroy()
+   app.deiconify()
+   app.mainloop()
+
+.. note::
+
+   Sprinkling ``update`` through a slow startup keeps the splash painted, but the
+   app is still frozen between calls — the splash won't redraw if it's dragged
+   over, and a spinner won't spin. If your startup is long enough to care, run
+   the work on a thread and let the splash animate while it runs; see
+   :doc:`Run background work <threads>`.
+
+.. seealso::
+
+   - :doc:`Open a second window <multiple-windows>` — ``Toplevel`` windows,
+     modals, and the close button.
+   - :doc:`Windows guide </user-guide/feature-guides/windows>` — the window
+     geometry and state model in full.
+   - :doc:`Animate a GIF <animate-gif>` — a spinner for the splash to show while
+     it waits.
+
+Reference
+---------
+
+- :doc:`Toplevel </reference/windows/toplevel>` — ``window_type``,
+  ``override_redirect``, ``topmost``, and ``place_window_center``.
+- :doc:`App </reference/windows/app>` — ``withdraw`` and ``deiconify``.
+- :doc:`Lifecycle </reference/capabilities/lifecycle>` — ``update``, and what
+  pumping the event loop by hand actually does.

--- a/docs/user-guide/how-to/threads.rst
+++ b/docs/user-guide/how-to/threads.rst
@@ -9,9 +9,9 @@ can slice up, and a worker thread for work you can't.
 
 .. seealso::
 
-   :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
-   for the event loop this recipe builds on — why one slow callback stalls
-   everything.
+   - :doc:`How a tkinter app runs </user-guide/foundations/how-a-tkinter-app-runs>`
+     — the event loop this recipe builds on, and why one slow callback stalls
+     everything.
 
 Deferring and repeating with ``after``
 --------------------------------------
@@ -69,9 +69,13 @@ separate :class:`threading.Thread` so the UI thread stays free. The catch:
 .. admonition:: The one rule
    :class: warning
 
-   **Never touch a widget from a worker thread.** Tkinter is not thread-safe;
-   calling a widget method off the main thread causes intermittent crashes and
-   corruption. The worker computes; the **main thread** updates the UI.
+   **Never touch a widget from a worker thread.** A Tcl interpreter belongs to
+   the thread that created it. Tkinter will forward a call made from another
+   thread back to that thread — but only while the event loop is running.
+   Outside it, the call fails with ``RuntimeError: main thread is not in main
+   loop``; inside it, your worker blocks until the UI thread services the call,
+   serializing the work onto the very thread you were trying to keep free. The
+   worker computes; the **main thread** updates the UI.
 
 The safe pattern hands results back through a :class:`queue.Queue` that the main
 thread drains with a short ``after`` poll. The worker only ever ``put``\ s onto
@@ -105,17 +109,20 @@ the queue; only the poller — running on the UI thread — configures widgets:
                    bar.configure(value=payload)
                elif kind == "done":
                    status.configure(text=payload, bootstyle="success")
+                   run.configure(state="normal")
                    return                    # stop polling; work is done
        except queue.Empty:
            pass
        app.after(100, drain)                 # nothing yet — check again soon
 
    def start():
+       run.configure(state="disabled")       # no second worker on the same queue
        status.configure(text="Working…", bootstyle="warning")
        threading.Thread(target=work, daemon=True).start()
        app.after(100, drain)                 # begin polling for results
 
-   ttk.Button(app, text="Start", command=start, bootstyle="primary").pack(pady=10)
+   run = ttk.Button(app, text="Start", command=start, bootstyle="primary")
+   run.pack(pady=10)
 
    app.mainloop()
 
@@ -128,7 +135,9 @@ How it fits together:
   whatever the worker has queued, updates the widgets, and reschedules itself
   until it sees the ``"done"`` message. A ``Queue`` is thread-safe, so this
   hand-off needs no locks.
-- **``daemon=True``** lets the program exit even if the thread is still running.
+- **The Start button** disables itself for the duration. Without that, a second
+  click starts a second worker and a second poller racing on one queue.
+- ``daemon=True`` lets the program exit even if the thread is still running.
 
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder
@@ -144,6 +153,15 @@ How it fits together:
 
 .. seealso::
 
-   The `threading <https://docs.python.org/3/library/threading.html>`_ and
-   `queue <https://docs.python.org/3/library/queue.html>`_ modules for the
-   standard-library tools this pattern uses.
+   - :doc:`Scroll long content <scrollable>` — streaming worker output into a
+     ``ScrolledText``.
+   - `threading <https://docs.python.org/3/library/threading.html>`_ — the worker
+     thread this pattern runs the blocking work on.
+   - `queue <https://docs.python.org/3/library/queue.html>`_ — the thread-safe
+     hand-off between the worker and the poller.
+
+Reference
+---------
+
+- :doc:`After </reference/capabilities/after>` — ``after``, ``after_cancel``,
+  ``after_idle``, and job ids.

--- a/docs/user-guide/how-to/working-with-images.rst
+++ b/docs/user-guide/how-to/working-with-images.rst
@@ -8,18 +8,13 @@ gotcha to know before anything else.
 Which image class
 -----------------
 
-- ``ttk.PhotoImage`` — tkinter's built-in image, re-exported for convenience. It
-  reads **GIF, PNG, PGM, and PPM** files (and base64-encoded GIF/PNG data), and
-  needs no extra library.
+- ``ttk.PhotoImage`` — tkinter's built-in image. It reads **GIF, PNG, PGM, and
+  PPM** files (and base64-encoded GIF/PNG data), and needs no extra library.
 - Pillow's ``ImageTk.PhotoImage`` — reads **every common format** (JPEG, BMP,
   TIFF, WebP, …) and lets you resize, crop, and filter first. Pillow is already a
   dependency of ttkbootstrap, so it is always available.
 
-Reach for Pillow for anything beyond a simple GIF/PNG — which is most real work:
-
-.. code-block:: python
-
-   from PIL import Image, ImageTk
+Reach for Pillow for anything beyond a simple GIF/PNG — which is most real work.
 
 .. _images-keep-a-reference:
 
@@ -60,8 +55,10 @@ say where the image sits relative to the label:
 
    ttk.Button(app, text="Open", image=photo, compound="left")
 
-``compound`` takes ``"left"``, ``"right"``, ``"top"``, ``"bottom"``, ``"center"``
-(text over image), or ``"none"`` (image only).
+``compound`` takes ``"left"``, ``"right"``, ``"top"``, ``"bottom"`` (the image on
+that side of the text), ``"center"`` (text over image), ``"image"`` (image only),
+``"text"`` (text only), or ``"none"`` (the image if there is one, otherwise the
+text).
 
 Loading and resizing with Pillow
 --------------------------------
@@ -136,5 +133,14 @@ stays on screen:
 
 .. seealso::
 
-   For the raster-image formats and manipulation, see the `Pillow
-   <https://pillow.readthedocs.io/>`__ documentation.
+   - :doc:`Animate a GIF <animate-gif>` — swapping frames on a timer.
+   - :doc:`Set the app icon <application-icon>` — the titlebar and taskbar icon.
+   - :doc:`Icons guide </user-guide/feature-guides/icons>` — glyph names, sizing,
+     and per-state icons.
+   - The `Pillow <https://pillow.readthedocs.io/>`__ documentation — raster
+     formats and image manipulation.
+
+Reference
+---------
+
+- :doc:`Imaging </reference/imaging>` — the full ``PhotoImage`` API.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -240,7 +240,8 @@ Task-focused recipes — common tkinter jobs done the ttkbootstrap way. See the
    how-to/threads
    how-to/clipboard
    how-to/error-handling
-   how-to/feedback
+   how-to/bell
+   how-to/busy
    how-to/animate-gif
    how-to/splash-screen
    how-to/application-icon

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -236,8 +236,11 @@ Task-focused recipes — common tkinter jobs done the ttkbootstrap way. See the
    how-to/index
    how-to/working-with-images
    how-to/scrollable
-   how-to/feedback
-   how-to/clipboard
-   how-to/error-handling
    how-to/multiple-windows
    how-to/threads
+   how-to/clipboard
+   how-to/error-handling
+   how-to/feedback
+   how-to/animate-gif
+   how-to/splash-screen
+   how-to/application-icon


### PR DESCRIPTION
Completes the last content thread of Workstream H, per `development/2_0_docs_howto_handoff.md`. The screenshot slice remains the only open docs-H thread.

## Audit pass (7 authored pages)

One grounded read-only agent per page, using the PR #1222 method: read the full page, **probe every claim and run every snippet headlessly** against the real library, cross-check tkinter concepts against the Tcl/Tk 8.6 manuals, and flag standing-rule violations. I re-verified each finding myself before acting on it. The substantive ones:

| Page | Finding |
|---|---|
| `feedback` | **`tk busy` is a no-op on macOS** — Tk's manual says so, and I reproduced it: the `._Busy` overlay is never created, `busy_status()` still reports `True`, and the button still clicks. It fails *silently*. **And the busy methods were added in Python 3.13**, so they're absent on 3.10–3.12 of our `>=3.10` floor (`hasattr(tkinter.Misc, 'tk_busy_hold')` → `False` on 3.10). The page's note claimed the exact opposite — that `tk_busy_*` works "on every supported Python". Also "swallows mouse and keyboard input" → pointer events only. |
| `clipboard` | **`<Control-c>` is not the copy key on macOS** (`<<Copy>>` → `<Mod1-Key-c>`), so the page's shortcut never fired there; `bind_all` on the native copy key also clobbers the user's Entry/Text selection app-wide. The PRIMARY note was wrong on macOS — Tk provides PRIMARY everywhere; what differs is *cross-application* sharing. |
| `error-handling` | The `TclError` example used a bad `bootstyle`, which **warns and falls back rather than raising** — the `except` branch was unreachable in both strict and default modes. Also: the handler must live on the **root** (a `Toplevel`'s is never called), and the real boundary is callback-vs-setup, not before/after `mainloop()` (a pre-`mainloop` callback *does* route through it). |
| `multiple-windows` | Taught raw `protocol("WM_DELETE_WINDOW")` instead of 2.0's public `on_close`; "reuse a window" **broke after the user clicked ✕** (`deiconify()` → `TclError`) because it never intercepted the close. |
| `scrollable` | `ScrolledFrame` never sizes to its content (`propagate(False)`) and has **no** horizontal scrollbar (`hbar` hard-returns `None`); the note warned against a nested frame that works fine, while omitting the real `Notebook`/`PanedWindow` constraint (`add(scroller.container)`). |
| `threads` | The "one rule" gave the wrong mechanism — tkinter *marshals* cross-thread calls; you get a clean `RuntimeError: main thread is not in main loop`, not "crashes and corruption". Rule kept, reason repaired. Plus a literal-backtick leak that `-W` doesn't catch. |
| `working-with-images` | `compound="none"` documented backwards (it means "image if present, else text"), and `"image"`/`"text"` were missing. |

## New recipes (3)

- **Animate a GIF** — frame loading via `PhotoImage`'s `format="gif -index N"` (with the `TclError` past-the-end idiom as the loop terminator), the reference-keeping list, `after` cycling, start/stop, and per-frame delays via Pillow.
- **Show a splash screen** — `withdraw` → borderless `Toplevel` → `deiconify`. `window_type="splash"` and `override_redirect=True` cover *different* platforms, so the recipe passes both and a table says which does what where.
- **Set the app icon** — `iconphoto=` (path / `""` / `None`), per-window overrides, the Windows `.ico` case, and changing it at runtime.

## Index

The Foundations-overlapping entries (**Lay out widgets**, **Wire events and variables**, **Validate a form**) become **cross-references** rather than duplicate pages — matching how Menus and Dialogs already resolve. The *"being written for 2.0"* note is dropped; every entry now either links a page or points at its guide.

## Verification

- **Build gate green:** `sphinx -b html -W -q -E docs <out>` → exit 0.
- **Every snippet run headlessly** before it landed, including the full animate-GIF program, the splash hand-off, and the reworked worker example.
- **Rule sweeps clean:** no nested inline markup, no `\` continuations, no `themename=`/legacy theme names, no impl-detail jargon.
- Suite: **659 passed**. Three `tests/test_menu_api.py::*_off_mac` failures are **pre-existing on `2.0`** (confirmed by checking out the base) — they assert non-macOS behavior and fail on any Mac. Worth a follow-up gate; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)