### PR TITLE
feat: shim tkinter's busy methods onto Python 3.10-3.12

### DIFF
--- a/docs/user-guide/how-to/busy.rst
+++ b/docs/user-guide/how-to/busy.rst
@@ -61,19 +61,11 @@ keep a slow action from being started twice:
 
 .. note::
 
-   The busy overlay itself is a Tk 8.6 feature, so it is there on every Python
-   we support — but tkinter only grew the ``busy()`` / ``tk_busy_*`` methods in
-   **3.13**. To use it on Python 3.10–3.12, call Tk directly; it is the same
-   command underneath:
-
-   .. code-block:: python
-
-      app.tk.call("tk", "busy", "hold", app, "-cursor", "watch")
-      app.update()
-      try:
-          do_slow_work()
-      finally:
-          app.tk.call("tk", "busy", "forget", app)
+   ``busy()`` works on every Python ttkbootstrap supports. tkinter only grew
+   these methods in 3.13; on 3.10–3.12 ttkbootstrap supplies them, issuing the
+   same Tk command underneath. They are also spelled ``tk_busy_hold`` /
+   ``tk_busy_forget`` / ``tk_busy_status`` / ``tk_busy_configure`` — the same
+   calls under their longer names.
 
 .. note::
 
@@ -83,12 +75,6 @@ keep a slow action from being started twice:
    keystrokes, so move focus off the busy area if that matters. Set ``cursor=``
    alone (see :doc:`Cursors </reference/cursors>`) when you only want to change
    the pointer.
-
-.. note::
-
-   The methods are also spelled ``tk_busy_hold`` / ``tk_busy_forget`` /
-   ``tk_busy_status`` / ``tk_busy_configure``. Those are the same calls under
-   their longer names, added in the same version.
 
 Long work still needs a thread
 ------------------------------

--- a/src/ttkbootstrap/internal/busy.py
+++ b/src/ttkbootstrap/internal/busy.py
@@ -10,13 +10,8 @@ exist at all, leaving `tk.call` reach-ins as the only way to use it.
 exist, and issues the identical `tk.call` where they don't, so the same code
 runs on every supported Python.
 
-Note: `tk busy` has no effect on macOS (aqua) -- a Tk limitation, documented in
-the PORTABILITY section of the `tk busy` manual and still present in Tk 9. The
-calls succeed and `busy_status` reports True, but nothing is drawn or blocked.
-This mixin does not paper over that: emulating the transparent input shield
-would mean covering the widget with an opaque frame (Tk has no transparent
-color), which would hide the UI it is meant to shield. On macOS, disable the
-controls that start the work and set `cursor=` instead.
+`tk busy` is not supported on macOS (aqua): the calls succeed and `busy_status`
+reports True, but nothing is drawn or blocked.
 """
 from tkinter import _cnfmerge
 

--- a/src/ttkbootstrap/internal/busy.py
+++ b/src/ttkbootstrap/internal/busy.py
@@ -1,0 +1,132 @@
+"""Backport of tkinter's busy methods for Python < 3.13.
+
+Tk's ``tk busy`` command covers a widget with a transparent window that blocks
+pointer events and shows a busy cursor. The command is Tk 8.6, so it is
+available on every Python ttkbootstrap supports -- but tkinter only grew the
+``busy``/``tk_busy_*`` method wrappers in **3.13**. On 3.10-3.12 they don't
+exist at all, leaving `tk.call` reach-ins as the only way to use it.
+
+`BusyMixin` closes that gap: it delegates to tkinter's own methods where they
+exist, and issues the identical `tk.call` where they don't, so the same code
+runs on every supported Python.
+
+Note: `tk busy` has no effect on macOS (aqua) -- a Tk limitation, documented in
+the PORTABILITY section of the `tk busy` manual and still present in Tk 9. The
+calls succeed and `busy_status` reports True, but nothing is drawn or blocked.
+This mixin does not paper over that: emulating the transparent input shield
+would mean covering the widget with an opaque frame (Tk has no transparent
+color), which would hide the UI it is meant to shield. On macOS, disable the
+controls that start the work and set `cursor=` instead.
+"""
+from tkinter import _cnfmerge
+
+
+class BusyMixin:
+    """Give a widget the tkinter busy methods on every supported Python.
+
+    Mixed into the ttkbootstrap widget classes and into `App`/`Toplevel`, so
+    `app.busy(cursor="watch")` works on Python 3.10 as it does on 3.13+.
+
+    Each method prefers tkinter's native implementation when it is available
+    (3.13+), falling back to the same underlying Tcl call otherwise. The
+    signatures, aliases, and return types mirror tkinter's exactly.
+    """
+
+    def _busy_native(self, name):
+        """Return tkinter's own busy method, or None on Python < 3.13.
+
+        Looked up along the MRO *past* this mixin, so it finds `tkinter.Misc`'s
+        implementation rather than recursing into ours.
+        """
+        return getattr(super(), name, None)
+
+    def tk_busy_hold(self, **kw):
+        """Make this widget appear busy.
+
+        The specified widget and its descendants will be blocked from user
+        interactions. Normally `update` should be called immediately afterward
+        to insure that the hold operation is in effect before the application
+        starts its processing.
+
+        The only supported configuration option is:
+
+            cursor: the cursor to be displayed when the widget is made busy.
+        """
+        native = self._busy_native('tk_busy_hold')
+        if native is not None:
+            return native(**kw)
+        self.tk.call('tk', 'busy', 'hold', self._w, *self._options(kw))
+
+    busy = busy_hold = tk_busy = tk_busy_hold
+
+    def tk_busy_forget(self):
+        """Make this widget no longer busy.
+
+        User events will again be received by the widget.
+        """
+        native = self._busy_native('tk_busy_forget')
+        if native is not None:
+            return native()
+        self.tk.call('tk', 'busy', 'forget', self._w)
+
+    busy_forget = tk_busy_forget
+
+    def tk_busy_status(self):
+        """Return True if the widget is busy, False otherwise."""
+        native = self._busy_native('tk_busy_status')
+        if native is not None:
+            return native()
+        return self.tk.getboolean(self.tk.call(
+            'tk', 'busy', 'status', self._w))
+
+    busy_status = tk_busy_status
+
+    def tk_busy_current(self, pattern=None):
+        """Return a list of widgets that are currently busy.
+
+        If a pattern is given, only busy widgets whose path names match a
+        pattern are returned.
+        """
+        native = self._busy_native('tk_busy_current')
+        if native is not None:
+            return native(pattern)
+        return [self._nametowidget(x) for x in
+                self.tk.splitlist(self.tk.call(
+                    'tk', 'busy', 'current', pattern))]
+
+    busy_current = tk_busy_current
+
+    def tk_busy_cget(self, option):
+        """Return the value of a busy configuration option.
+
+        The widget must have been previously made busy by `tk_busy_hold`.
+        Option may have any of the values accepted by `tk_busy_hold`.
+        """
+        native = self._busy_native('tk_busy_cget')
+        if native is not None:
+            return native(option)
+        return self.tk.call('tk', 'busy', 'cget', self._w, '-' + option)
+
+    busy_cget = tk_busy_cget
+
+    def tk_busy_configure(self, cnf=None, **kw):
+        """Query or modify the busy configuration options.
+
+        The widget must have been previously made busy by `tk_busy_hold`.
+        Options may have any of the values accepted by `tk_busy_hold`.
+        """
+        native = self._busy_native('tk_busy_configure')
+        if native is not None:
+            return native(cnf, **kw)
+        if kw:
+            cnf = _cnfmerge((cnf, kw))
+        elif cnf:
+            cnf = _cnfmerge(cnf)
+        if cnf is None:
+            return self._getconfigure('tk', 'busy', 'configure', self._w)
+        if isinstance(cnf, str):
+            return self._getconfigure1(
+                'tk', 'busy', 'configure', self._w, '-' + cnf)
+        self.tk.call('tk', 'busy', 'configure', self._w, *self._options(cnf))
+
+    busy_config = busy_configure = tk_busy_config = tk_busy_configure

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -23,6 +23,7 @@ from ttkbootstrap.constants import (
     BootStyle,
     surface_segment,
 )
+from ttkbootstrap.internal.busy import BusyMixin
 from ttkbootstrap.style import _compat
 from ttkbootstrap.style.engine import Style
 from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
@@ -973,7 +974,7 @@ class FluentGeometryMixin:
     place = place_configure
 
 
-class BootMixin(FluentGeometryMixin):
+class BootMixin(FluentGeometryMixin, BusyMixin):
     """Mixin that adds the ``bootstyle`` API to a ttk widget class.
 
     Concrete subclasses such as ``class Button(BootMixin, ttk.Button)`` are
@@ -1141,7 +1142,7 @@ class BootMixin(FluentGeometryMixin):
         return super().__getitem__(key)
 
 
-class AutoStyleMixin(FluentGeometryMixin):
+class AutoStyleMixin(FluentGeometryMixin, BusyMixin):
     """Mixin that auto-applies the theme to a legacy ``tk`` widget class.
 
     The tk counterpart to `BootMixin`. Legacy tk widgets have no ttk style;

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Optional, Tuple, Union
 from ttkbootstrap import utils
 from ttkbootstrap.constants import *
 from ttkbootstrap.internal import positioning
+from ttkbootstrap.internal.busy import BusyMixin
 from ttkbootstrap.style import Style, Bootstyle
 from ttkbootstrap.style._compat import normalize_window_kwargs
 
@@ -185,7 +186,7 @@ def on_select_all(event: tkinter.Event) -> None:
         widget.icursor(END)
 
 
-class _BaseWindow:
+class _BaseWindow(BusyMixin):
     """Window logic shared by `App` (root) and `Toplevel` (secondary).
 
     Used as a mixin alongside `tkinter.Tk`/`tkinter.Toplevel`, so both classes

--- a/tests/test_busy_api.py
+++ b/tests/test_busy_api.py
@@ -5,8 +5,8 @@ Tcl ``tk busy`` command is Tk 8.6 and works on every Python we support. These
 tests pin that the shim presents the same surface either way -- delegating to
 tkinter's methods when they exist and issuing the same Tcl call when they don't.
 
-Note: ``tk busy`` is a documented no-op on macOS (aqua), so these tests assert
-Tk's *bookkeeping* (status/cget/current), which is consistent across platforms,
+``tk busy`` is not supported on macOS (aqua), so these tests assert Tk's
+*bookkeeping* (status/cget/current), which is consistent across platforms,
 rather than whether input is actually blocked.
 """
 import tkinter

--- a/tests/test_busy_api.py
+++ b/tests/test_busy_api.py
@@ -1,0 +1,144 @@
+"""The busy-method shim (`ttkbootstrap.internal.busy.BusyMixin`).
+
+tkinter grew the ``busy``/``tk_busy_*`` methods in Python 3.13; the underlying
+Tcl ``tk busy`` command is Tk 8.6 and works on every Python we support. These
+tests pin that the shim presents the same surface either way -- delegating to
+tkinter's methods when they exist and issuing the same Tcl call when they don't.
+
+Note: ``tk busy`` is a documented no-op on macOS (aqua), so these tests assert
+Tk's *bookkeeping* (status/cget/current), which is consistent across platforms,
+rather than whether input is actually blocked.
+"""
+import tkinter
+
+import pytest
+
+import ttkbootstrap as ttk
+
+
+NATIVE = hasattr(tkinter.Misc, "tk_busy_hold")
+
+ALIASES = [
+    "busy", "busy_hold", "tk_busy", "tk_busy_hold",
+    "busy_forget", "tk_busy_forget",
+    "busy_status", "tk_busy_status",
+    "busy_cget", "tk_busy_cget",
+    "busy_configure", "busy_config", "tk_busy_config", "tk_busy_configure",
+    "busy_current", "tk_busy_current",
+]
+
+
+@pytest.fixture
+def widgets(root):
+    """A window, a ttk widget, and a tk widget -- the three mixin paths."""
+    frame = ttk.Frame(root)
+    frame.pack()
+    canvas = ttk.Canvas(root)
+    canvas.pack()
+    root.update_idletasks()
+    return root, frame, canvas
+
+
+@pytest.mark.parametrize("name", ALIASES)
+def test_every_alias_is_present_on_a_window(root, name):
+    assert callable(getattr(root, name))
+
+
+def test_aliases_present_on_ttk_and_tk_widgets(widgets):
+    _, frame, canvas = widgets
+    for name in ALIASES:
+        assert callable(getattr(frame, name)), f"ttk widget missing {name}"
+        assert callable(getattr(canvas, name)), f"tk widget missing {name}"
+
+
+def test_hold_status_forget_round_trip(widgets):
+    _, frame, _ = widgets
+    assert frame.busy_status() is False
+    frame.busy(cursor="watch")
+    assert frame.busy_status() is True
+    frame.busy_forget()
+    assert frame.busy_status() is False
+
+
+def test_cursor_option_reaches_tk(widgets):
+    _, frame, _ = widgets
+    frame.busy(cursor="watch")
+    try:
+        assert frame.busy_cget("cursor") == "watch"
+    finally:
+        frame.busy_forget()
+
+
+def test_busy_configure_updates_the_cursor(widgets):
+    _, frame, _ = widgets
+    frame.busy(cursor="watch")
+    try:
+        frame.busy_configure(cursor="clock")
+        assert frame.busy_cget("cursor") == "clock"
+    finally:
+        frame.busy_forget()
+
+
+def test_busy_current_lists_held_widgets(widgets):
+    root, frame, _ = widgets
+    assert frame not in root.busy_current()
+    frame.busy(cursor="watch")
+    try:
+        assert frame in root.busy_current()
+    finally:
+        frame.busy_forget()
+    assert frame not in root.busy_current()
+
+
+def test_busy_status_returns_a_real_bool(widgets):
+    """Not the Tcl "0"/"1" string -- callers write `if w.busy_status():`."""
+    _, frame, _ = widgets
+    assert isinstance(frame.busy_status(), bool)
+    frame.busy()
+    try:
+        assert isinstance(frame.busy_status(), bool)
+    finally:
+        frame.busy_forget()
+
+
+def test_tk_busy_hold_and_busy_are_the_same_call(widgets):
+    _, frame, _ = widgets
+    frame.tk_busy_hold(cursor="watch")
+    try:
+        assert frame.busy_status() is True
+    finally:
+        frame.tk_busy_forget()
+    assert frame.busy_status() is False
+
+
+@pytest.mark.skipif(not NATIVE, reason="tkinter has no native busy methods")
+def test_delegates_to_tkinter_when_native(widgets, monkeypatch):
+    """On 3.13+ the shim must hand off rather than reimplement."""
+    _, frame, _ = widgets
+    called = []
+    monkeypatch.setattr(
+        tkinter.Misc, "tk_busy_hold",
+        lambda self, **kw: called.append(kw), raising=True,
+    )
+    frame.busy(cursor="watch")
+    assert called == [{"cursor": "watch"}]
+
+
+def test_fallback_path_works_without_native_methods(widgets, monkeypatch):
+    """Force the < 3.13 branch and prove the tk.call fallback is equivalent.
+
+    This is the path 3.10-3.12 users actually take, so it is exercised here
+    even on a newer interpreter.
+    """
+    _, frame, _ = widgets
+    for name in ("tk_busy_hold", "tk_busy_forget", "tk_busy_status",
+                 "tk_busy_cget"):
+        monkeypatch.delattr(tkinter.Misc, name, raising=False)
+
+    frame.busy(cursor="watch")
+    try:
+        assert frame.busy_status() is True
+        assert frame.busy_cget("cursor") == "watch"
+    finally:
+        frame.busy_forget()
+    assert frame.busy_status() is False


### PR DESCRIPTION
Stacked on #1225 (the How-To band). **Retarget to `2.0` once #1225 merges.**

Came out of reviewing the `feedback` how-to: the page taught `busy()`, and pinning down its real constraints surfaced a genuine portability gap worth closing in the library rather than documenting around.

## The gap

Tk's `tk busy` command is **Tk 8.6** — the capability ships with every Python we support. But tkinter only grew the `busy`/`tk_busy_*` **method wrappers** in **3.13**. On 3.10–3.12 they don't exist at all:

```
$ grep -rci busy <3.10>/tkinter/__init__.py   ->  0     # not under any name
$ grep -rci busy <3.14>/tkinter/__init__.py   ->  37    # defined at :934-1011
```

So a 3.10–3.12 user had to reach past tkinter into Tcl (`app.tk.call("tk", "busy", "hold", ...)`) to use a feature their Tk has had for years.

## The shim

New `internal/busy.py`. `BusyMixin` delegates to tkinter's own methods where they exist and issues the identical `tk.call` where they don't — mirroring tkinter's implementation, signatures, return types, and all 16 aliases. Mixed into `BootMixin`/`AutoStyleMixin` (every ttkbootstrap widget) and `_BaseWindow` (`App`/`Toplevel`).

**Verified against a real 3.10.11 interpreter**, not just the fallback branch in isolation — the same script, byte-identical output on both:

| | Python 3.10.11 (native: **False**) | Python 3.14.0 (native: **True**) |
|---|---|---|
| `app.busy(cursor="watch")` → `busy_status()` | `True` | `True` |
| `busy_cget("cursor")` | `watch` | `watch` |
| `busy_current()` | `[<App object .>]` | `[<App object .>]` |
| `busy_forget()` → `busy_status()` | `False` | `False` |

## What this deliberately does *not* fix

**The macOS no-op stays.** `tk busy` has no effect under Aqua — documented in the PORTABILITY section of the [`tk busy` manual](https://www.tcl-lang.org/man/tcl8.6/TkCmd/busy.htm), **still present in [Tk 9.0](https://www.tcl-lang.org/man/tcl9.0/TkCmd/busy.html)**, and reproduced here: no `_Busy` window is created and hit-testing is unchanged before vs. after the call, though `busy_status()` still reports `True`.

Emulating it was considered and rejected. Tk's busy window is a *transparent* input shield; Tk has no transparent color (`background="transparent"` → `TclError`), so an emulation would cover the widget with an **opaque frame** — hiding the very UI it exists to shield. That's a visual regression a headless suite would never catch. The docs keep the macOS warning and the disable-and-set-cursor fallback, which has no visual cost and works everywhere.

## Tests

`tests/test_busy_api.py` (+25): the alias surface across window/ttk/tk widgets, the hold→status→forget round trip, `cget`/`configure`/`current`, the real-`bool` return, native delegation, and — by deleting the methods off `tkinter.Misc` — **the <3.13 fallback path itself**, so the 3.10 branch is exercised on every interpreter CI runs.

Suite **684 passed**. The 3 `test_menu_api.py::*_off_mac` failures are **pre-existing on `2.0`** (they assert non-macOS behavior and fail on any Mac). Docs build green (`-W`, exit 0); import stays warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)