### PR TITLE
docs: command fires on invoke, not on selection change

### DIFF
--- a/docs/reference/api/checkbutton.rst
+++ b/docs/reference/api/checkbutton.rst
@@ -51,7 +51,8 @@ Each option can be set in the constructor and changed later with ``configure()``
      - The value written to ``variable`` when unchecked.
    * - ``command``
      - ``callable``
-     - The function called when the check state is toggled.
+     - The function called when the checkbutton is *invoked* — clicked, or
+       activated with :kbd:`Space`.
    * - ``image``
      - ``PhotoImage``
      - An image to display in place of, or beside, the text.

--- a/docs/reference/api/radiobutton.rst
+++ b/docs/reference/api/radiobutton.rst
@@ -48,7 +48,8 @@ Each option can be set in the constructor and changed later with ``configure()``
      - The value written to ``variable`` when this button is selected.
    * - ``command``
      - ``callable``
-     - The function called when this button is selected.
+     - The function called when this button is *invoked* — clicked, or activated
+       with :kbd:`Space`.
    * - ``image``
      - ``PhotoImage``
      - An image to display in place of, or beside, the text.

--- a/docs/widgets/checkbutton.rst
+++ b/docs/widgets/checkbutton.rst
@@ -31,8 +31,9 @@ Bind the checkbutton to a ``BooleanVar`` with ``variable=``. The variable is
 
    app.mainloop()
 
-To run code the moment it is toggled, pass ``command=`` — it fires on each change,
-after the variable has updated:
+To run code when the user toggles it, pass ``command=`` — it fires when the
+checkbutton is **invoked** (clicked, or activated with :kbd:`Space` while
+focused), after the variable has updated, so it can read the new value:
 
 .. code-block:: python
 
@@ -40,6 +41,12 @@ after the variable has updated:
        print("now", agree.get())
 
    ttk.Checkbutton(app, text="Notifications", variable=agree, command=on_toggle)
+
+To react to the value however it changes, trace the variable instead:
+
+.. code-block:: python
+
+   agree.trace_add("write", lambda *_: print("now", agree.get()))
 
 Switch and toolbutton looks
 ---------------------------

--- a/docs/widgets/radiobutton.rst
+++ b/docs/widgets/radiobutton.rst
@@ -40,8 +40,8 @@ button.
 Reacting to a choice
 --------------------
 
-To run code the moment the selection changes, pass ``command=`` — it fires on the
-button that becomes selected:
+To run code when the user picks an option, pass ``command=`` — it fires when that
+button is **invoked**: clicked, or activated with :kbd:`Space` while focused.
 
 .. code-block:: python
 
@@ -49,6 +49,12 @@ button that becomes selected:
        print("chose", size.get())
 
    ttk.Radiobutton(app, text="Small", variable=size, value="small", command=on_choice)
+
+To react to the choice however it changes, trace the variable instead:
+
+.. code-block:: python
+
+   size.trace_add("write", lambda *_: print("size is now", size.get()))
 
 The toolbutton look
 -------------------


### PR DESCRIPTION
You were right to doubt it. `command` is tied to the **invoke**, not to the selection — and the page was wrong in *both* directions.

## Probed on the live widget

| action | variable | command fired? |
|---|---|---|
| `invoke()` (what a click does) | → small | **yes** |
| `size.set("large")` — becomes selected, no click | → large | **no** |
| `invoke()` on the **already-selected** button | large (unchanged) | **yes** |

So a button can *become selected* without firing, and can fire *without the selection changing*. The page claimed `command` "fires on the button that becomes selected" and runs "the moment the selection changes" — each sentence contradicted by one of those rows.

Grounded in the Tk manual, which is unambiguous:

> **-command**: "A Tcl script to evaluate whenever the widget is **invoked**."
> **invoke**: "Sets the -variable to the -value, selects the widget, and evaluates the associated -command."

Your "runs when clicked only" was essentially right — with one addition: :kbd:`Space` on a focused widget also invokes it, which I verified. So the pages say **invoked** (clicked or Space) rather than "clicked".

## Checkbutton had it too

Not just radiobutton — `docs/widgets/checkbutton.rst` claimed `command` "fires on each change". Verified false: `agree.set(False)` then `agree.set(True)` change the value twice and fire nothing. Its *"after the variable has updated"* clause **is** correct (the callback reads the new value), so that's kept.

And both **API reference** pages carried the same error more quietly — *"called when this button is selected"* / *"called when the check state is toggled"* — which is precisely what `set()` does without calling.

## Scope

Four pages: the radiobutton and checkbutton catalog pages and their reference option tables. Each catalog page now points at `trace_add` for reacting to the value itself; both trace snippets verified headlessly.

**Button is unaffected** — it has no `variable`, so there's no desync trap; "on each click" stands.

Build green (`-W`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)