### PR TITLE
docs: walk the widget tree + close the undocumented-method gap (41 -> 8)

### DIFF
--- a/docs/reference/capabilities/after.rst
+++ b/docs/reference/capabilities/after.rst
@@ -42,3 +42,15 @@ The canonical upstream reference is the Tcl
 
    :param id: the id returned by the scheduling call.
    :returns: ``None``.
+
+.. py:method:: after_info(id=None)
+   :noindex:
+
+   Report the callbacks scheduled with ``after``/``after_idle`` that have not yet
+   run — useful when tracking down a timer that outlives the widget it updates.
+
+   :param id: an optional scheduling id to ask about.
+   :returns: with no argument, the ids of all pending callbacks; with an ``id``,
+      that callback's ``(script, type)``, where type is ``"timer"`` or
+      ``"idle"``.
+   :rtype: tuple

--- a/docs/reference/capabilities/bind.rst
+++ b/docs/reference/capabilities/bind.rst
@@ -51,6 +51,25 @@ Binding callbacks
 
    :returns: ``None``.
 
+.. py:method:: unbind_all(sequence)
+   :noindex:
+
+   Remove an application-wide binding made with ``bind_all``.
+
+   :param str sequence: the event sequence to unbind.
+   :returns: ``None``.
+
+.. py:method:: unbind_class(className, sequence)
+   :noindex:
+
+   Remove a class binding made with ``bind_class``. This affects **every** widget
+   of that class, including the ones Tk installs by default — removing a built-in
+   class binding takes that behavior away from every widget of the class.
+
+   :param str className: the Tk class name, e.g. ``"TEntry"``.
+   :param str sequence: the event sequence to unbind.
+   :returns: ``None``.
+
 Bind tags
 ---------
 

--- a/docs/reference/capabilities/busy.rst
+++ b/docs/reference/capabilities/busy.rst
@@ -1,0 +1,94 @@
+Busy
+====
+
+Tk can cover a widget with a transparent window that swallows pointer events and
+shows a busy cursor, so a slow operation can't be clicked into. These methods
+hold and release that state. For the worked recipe — including the ``update``
+call that makes it visible, and the ``try``/``finally`` that always releases it —
+see :doc:`Mark a window busy </user-guide/how-to/busy>`.
+
+The canonical upstream reference is the Tcl
+`tk busy <https://www.tcl-lang.org/man/tcl8.6/TkCmd/busy.htm>`__ manual page
+(Tk 8.6).
+
+.. note::
+
+   **Not supported on macOS.** The calls succeed and ``busy_status()`` reports
+   ``True``, but nothing is drawn and nothing is blocked.
+
+   The busy command is Tk 8.6, so it is available on every Python ttkbootstrap
+   supports. tkinter itself only grew these methods in **3.13**; on 3.10–3.12
+   ttkbootstrap supplies them, issuing the same Tk command underneath.
+
+Each method also has a longer ``tk_busy_*`` spelling — ``busy_hold`` is
+``tk_busy_hold``, ``busy_forget`` is ``tk_busy_forget``, and so on. They are the
+same calls; the short names are used here.
+
+.. py:method:: busy(**kw)
+   :noindex:
+
+   Make this widget appear busy: block pointer events to it and everything inside
+   it, and show a busy cursor. Aliases: ``busy_hold``, ``tk_busy``,
+   ``tk_busy_hold``.
+
+   Call ``update`` immediately afterward — the overlay is only mapped once the
+   event loop runs, so without it nothing appears before your blocking work
+   starts.
+
+   Pointer events only: a widget that already had keyboard focus keeps receiving
+   keystrokes.
+
+   :param cursor: the cursor to show while busy (e.g. ``"watch"``). The only
+      supported option.
+   :returns: ``None``.
+
+.. py:method:: busy_forget()
+   :noindex:
+
+   Release the busy state; the widget receives user events again. Alias:
+   ``tk_busy_forget``.
+
+   :returns: ``None``.
+
+.. py:method:: busy_status()
+   :noindex:
+
+   Whether this widget is currently held busy. Alias: ``tk_busy_status``.
+
+   :returns: ``True`` while held, ``False`` otherwise.
+   :rtype: bool
+
+.. py:method:: busy_current(pattern=None)
+   :noindex:
+
+   The widgets currently held busy. Alias: ``tk_busy_current``.
+
+   :param pattern: an optional glob matched against widget path names.
+   :returns: the matching busy widget objects.
+   :rtype: list
+
+.. py:method:: busy_cget(option)
+   :noindex:
+
+   Read one busy configuration option. The widget must already be held busy.
+   Alias: ``tk_busy_cget``.
+
+   :param str option: the option name, e.g. ``"cursor"``.
+   :returns: the option's current value.
+
+.. py:method:: busy_configure(cnf=None, **kw)
+   :noindex:
+
+   Query or change the busy options while held. Aliases: ``busy_config``,
+   ``tk_busy_config``, ``tk_busy_configure``.
+
+   :param cnf: an optional dict of options (merged with ``kw``).
+   :param kw: option/value pairs to set.
+   :returns: with no arguments, a dict mapping each option to its spec
+      ``(name, dbName, dbClass, default, current)``; otherwise ``None``.
+
+.. seealso::
+
+   - :doc:`Mark a window busy </user-guide/how-to/busy>` — the recipe, and what
+     to do on macOS instead.
+   - :doc:`Cursors </reference/cursors>` — the names ``cursor`` accepts.

--- a/docs/reference/capabilities/configuration.rst
+++ b/docs/reference/capabilities/configuration.rst
@@ -39,3 +39,37 @@ options that widget accepts; the methods here are how you read and write them.
 
    :returns: the option names.
    :rtype: list[str]
+
+A value read back is Tk's, so its type is Tk's too. To convert one — especially a
+Tk boolean, where ``"no"`` and ``"0"`` are truthy strings to Python — use
+``getboolean``/``getint``/``getdouble`` from
+:doc:`Interpreter </reference/capabilities/interpreter>`.
+
+The option database
+-------------------
+
+Tk has a second, older way to set option values: an **option database** of
+patterns matched against widget names and classes, which supplies a default for
+any option a widget wasn't given explicitly. The methods are ``option_add``,
+``option_get``, ``option_clear`` and ``option_readfile``.
+
+It is standard Tk, not ttk, so it does not reach a ttk widget at all — a ttk
+Button has no ``background`` option to default; appearance there comes from the
+theme and ``bootstyle``. It applies only to the classic tk widgets
+(:doc:`Text </reference/api/text>`, :doc:`Canvas </reference/api/canvas>`,
+:doc:`Listbox </reference/api/listbox>`, :doc:`Menu </reference/api/menu>`) — and
+even there ttkbootstrap paints them with the active theme when they are created,
+which overrides the database. To let it through, opt that widget out of theming:
+
+.. code-block:: python
+
+   app.option_add("*Text.background", "#fdf6e3")
+
+   ttk.Text(app)                    # '#ffffff'  -- the theme wins
+   ttk.Text(app, autostyle=False)   # '#fdf6e3'  -- the database wins
+
+So it is rarely the right tool here: setting the option on the widget is clearer,
+and theming already covers the job it was invented for. It is documented because
+the tk widgets make it reachable, and you will meet it in older tkinter code. The
+`Tk option manual <https://www.tcl-lang.org/man/tcl8.6/TkCmd/option.htm>`__ has
+the pattern syntax and precedence rules.

--- a/docs/reference/capabilities/index.rst
+++ b/docs/reference/capabilities/index.rst
@@ -59,6 +59,19 @@ widget (pack, grid, place, stacking order) have their own
 
       Read, clear, and own the current selection.
 
+   .. grid-item-card:: Busy
+      :link: busy
+      :link-type: doc
+
+      Block input to a widget while it works — ``busy``, ``busy_forget``.
+
+   .. grid-item-card:: Interpreter
+      :link: interpreter
+      :link-type: doc
+
+      Crossing the Tcl boundary — converting Tk values, ``register``, the Tk
+      version.
+
    .. grid-item-card:: Widget & screen info
       :link: /reference/winfo
       :link-type: doc
@@ -76,4 +89,6 @@ widget (pack, grid, place, stacking order) have their own
    lifecycle
    clipboard
    selection
+   busy
+   interpreter
    /reference/winfo

--- a/docs/reference/capabilities/interpreter.rst
+++ b/docs/reference/capabilities/interpreter.rst
@@ -1,0 +1,98 @@
+Interpreter
+===========
+
+Tkinter is a thin layer over a Tcl interpreter, and every widget carries a handle
+to it. Most of the time that boundary is invisible. These methods are the places
+you cross it deliberately: turning Tcl's values into Python ones, exposing a
+Python function so Tcl can call it, and asking which Tk you are running on.
+
+Converting Tk values
+--------------------
+
+Tk hands some values back as strings, and its idea of a boolean is broader than
+Python's — ``"yes"``, ``"true"``, ``"1"`` and ``"on"`` are all true. These
+helpers apply Tk's rules, so use them instead of ``int()`` or truth-testing a
+string: in Python every non-empty string is truthy, **including** ``"0"`` and
+``"false"``.
+
+.. py:method:: getboolean(s)
+   :noindex:
+
+   Convert a Tk boolean to a Python ``bool``.
+
+   :param s: a Tk boolean — ``"yes"``/``"no"``, ``"true"``/``"false"``,
+      ``"on"``/``"off"``, ``1``/``0``.
+   :returns: the value.
+   :rtype: bool
+   :raises ValueError: if ``s`` isn't a recognized boolean.
+
+.. py:method:: getint(s)
+   :noindex:
+
+   Convert a Tk value to a Python ``int``.
+
+   :param s: the value to convert.
+   :rtype: int
+
+.. py:method:: getdouble(s)
+   :noindex:
+
+   Convert a Tk value to a Python ``float``.
+
+   :param s: the value to convert.
+   :rtype: float
+
+Exposing a callback to Tcl
+--------------------------
+
+A few Tk options take a *Tcl command name* rather than a Python callable — most
+notably ``validatecommand``, which also needs substitution codes like ``%P``.
+``register`` wraps a Python function as a Tcl command and gives you back its
+name.
+
+.. code-block:: python
+
+   check = app.register(lambda proposed: proposed.isdigit())
+   ttk.Entry(app, validate="key", validatecommand=(check, "%P"))
+
+:doc:`Validation </user-guide/feature-guides/validation>` does this for you —
+reach for ``register`` only when you are wiring a Tcl-level option by hand.
+
+.. py:method:: register(func, subst=None, needcleanup=1)
+   :noindex:
+
+   Register a Python callable as a Tcl command.
+
+   :param func: the callable to expose.
+   :param subst: an optional callable applied to the arguments first.
+   :param needcleanup: whether to delete the command when the widget is destroyed.
+   :returns: the Tcl command name to hand to the option.
+   :rtype: str
+
+.. py:method:: deletecommand(name)
+   :noindex:
+
+   Delete a Tcl command created by ``register``, releasing the Python callable.
+   Calling the name afterward raises ``TclError``.
+
+   :param str name: the command name ``register`` returned.
+   :returns: ``None``.
+
+Which Tk is this
+----------------
+
+.. py:method:: info_patchlevel()
+   :noindex:
+
+   The exact Tk version behind this interpreter — useful when a feature is gated
+   on it.
+
+   :returns: a version tuple ``(major, minor, micro, releaselevel, serial)``;
+      ``str()`` of it gives ``"8.6.17"``.
+
+.. seealso::
+
+   - :doc:`Configuration </reference/capabilities/configuration>` — reading option
+     values, which is where Tk's types usually surface.
+   - :doc:`Validation </user-guide/feature-guides/validation>` — the wrapper
+     around ``register`` you normally want.

--- a/docs/reference/capabilities/lifecycle.rst
+++ b/docs/reference/capabilities/lifecycle.rst
@@ -13,6 +13,20 @@ happen, or destroy a widget.
 
    :returns: ``None``.
 
+.. py:method:: quit()
+   :noindex:
+
+   Stop the ``mainloop`` that is running, without destroying anything. Execution
+   resumes after the ``mainloop()`` call; the widgets still exist, so the loop can
+   be entered again.
+
+   To close an application you almost always want ``destroy`` on the root, which
+   tears the widgets down and ends the loop with them. Reach for ``quit`` only
+   when you deliberately want to leave the loop and keep the widget tree — for
+   instance to hand control back to an embedding program.
+
+   :returns: ``None``.
+
 .. py:method:: update_idletasks()
    :noindex:
 

--- a/docs/reference/capabilities/selection.rst
+++ b/docs/reference/capabilities/selection.rst
@@ -46,3 +46,17 @@ page (Tcl 8.6).
    :returns: the owning widget.
    :rtype: Misc
    :raises tkinter.TclError: if no widget in this application owns it.
+
+.. py:method:: selection_handle(command, **kw)
+   :noindex:
+
+   Supply the selection's contents on demand: register ``command`` to be called
+   when another application asks this widget for the selection it owns. Tk calls
+   it with an offset and a maximum byte count, and it returns that slice of the
+   value. Use it when the selection is large or generated — for a plain string,
+   owning the selection is enough.
+
+   :param command: called as ``command(offset, length)``; returns the requested
+      slice as a string.
+   :param kw: ``selection=`` names which selection, ``type=`` the target form.
+   :returns: ``None``.

--- a/docs/reference/events/virtual-events.rst
+++ b/docs/reference/events/virtual-events.rst
@@ -4,8 +4,48 @@ Built-in virtual events
 A **virtual event** is a named notification in double brackets — ``<<Copy>>``,
 ``<<ThemeChanged>>`` — decoupled from any one physical event. Bind them exactly
 like physical events. This page catalogs the ones Tk, ttk, and ttkbootstrap
-define; to define or fire your *own*, see
+define, and documents the methods that define your own. For how to use them, see
 :doc:`Events & callbacks </user-guide/foundations/events-and-callbacks>`.
+
+Defining your own
+-----------------
+
+A virtual event is bound to one or more physical sequences; firing any of them
+fires the virtual event. This is how you name an action once (``<<Save>>``) and
+let each platform reach it by its own key.
+
+.. py:method:: event_add(virtual, *sequences)
+   :noindex:
+
+   Map one or more physical sequences onto a virtual event, creating it if
+   needed. Adds to any sequences already mapped.
+
+   :param str virtual: the virtual event name, e.g. ``"<<Save>>"``.
+   :param sequences: physical sequences, e.g. ``"<Control-s>"``, ``"<F2>"``.
+   :returns: ``None``.
+
+.. py:method:: event_delete(virtual, *sequences)
+   :noindex:
+
+   Remove sequences from a virtual event. With no ``sequences``, removes every
+   sequence mapped to it.
+
+   :param str virtual: the virtual event name.
+   :param sequences: the sequences to unmap; omit for all.
+   :returns: ``None``.
+
+.. py:method:: event_info(virtual=None)
+   :noindex:
+
+   Report the physical sequences mapped to a virtual event. Useful for asking
+   what a built-in event is bound to on *this* platform — ``event_info("<<Copy>>")``
+   answers ``('<Control-Key-c>', ...)`` on Windows and Linux but
+   ``('<Mod1-Key-c>', ...)`` on macOS, where the copy key is Command.
+
+   :param virtual: a virtual event name; omit to list every defined virtual event.
+   :returns: the sequences mapped to ``virtual``, or the names of all virtual
+      events when called with no argument.
+   :rtype: tuple
 
 Editing & clipboard
 -------------------

--- a/docs/reference/imaging.rst
+++ b/docs/reference/imaging.rst
@@ -101,6 +101,17 @@ Photo images
 
    Return the value of one image option.
 
+One related method lives on the **widget**, not on ``PhotoImage``:
+
+.. py:method:: image_types()
+   :noindex:
+
+   The image types this Tk build can create — ``('photo', 'bitmap')``. Call it on
+   any widget.
+
+   :returns: the available image type names.
+   :rtype: tuple
+
 Icons
 -----
 

--- a/docs/reference/winfo.rst
+++ b/docs/reference/winfo.rst
@@ -45,7 +45,8 @@ Where a widget sits in the tree, what it is, and whether it is still alive.
        object.
    * - ``winfo_children()``
      - list
-     - The child widget *objects*, in stacking order.
+     - The child widget *objects*, in stacking order. One level only — it does
+       not recurse.
    * - ``winfo_toplevel()``
      - widget
      - The ``Tk``/``Toplevel`` window that contains this widget.
@@ -72,6 +73,29 @@ Where a widget sits in the tree, what it is, and whether it is still alive.
      - int
      - ``1`` only if the widget **and every ancestor** are mapped — i.e. it is
        actually on screen.
+
+Two more tree accessors are not ``winfo_*`` methods, but belong beside them:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 14 60
+
+   * - Name
+     - Returns
+     - Meaning
+   * - ``master``
+     - widget
+     - The parent widget *object* — the counterpart to ``winfo_parent()``, which
+       returns the parent's path name instead. An attribute, not a method.
+   * - ``children``
+     - dict
+     - The child widget objects keyed by their own names
+       (``{'!button': <Button ...>}``) — the same widgets ``winfo_children()``
+       returns as a list. An attribute, not a method.
+   * - ``nametowidget(path)``
+     - widget
+     - The widget object for a path name — turns ``winfo_parent()``'s string back
+       into a usable widget.
 
 Position & size
 ---------------

--- a/docs/user-guide/foundations/the-widget-model.rst
+++ b/docs/user-guide/foundations/the-widget-model.rst
@@ -26,10 +26,80 @@ and labels sit inside those. That parent-child chain is the widget tree:
 The tree decides three things: where a widget can be *placed* (only inside its
 parent — see :doc:`Arranging widgets </user-guide/foundations/arranging-widgets>`),
 what it *inherits* (the theme, and options like a cursor), and its *lifetime* —
-destroying a widget destroys everything under it. You can walk the tree with
-``widget.master`` (the parent) and ``widget.winfo_children()`` (the children);
-``winfo_class()`` reports the widget's Tk class (``"TButton"``). See
-:doc:`Widget & screen info </reference/winfo>` for the full introspection set.
+destroying a widget destroys everything under it.
+
+Walking the tree
+~~~~~~~~~~~~~~~~
+
+You never have to keep your own map of what contains what: every widget can tell
+you. Going **up**, ``master`` is the parent widget:
+
+.. code-block:: python
+
+   save.master           # the toolbar Frame -- the widget object itself
+
+Going **down**, ``winfo_children()`` returns a widget's children as a list, in
+stacking order:
+
+.. code-block:: python
+
+   toolbar.winfo_children()      # [<Button ...!button>, <Button ...!button2>]
+
+   for child in toolbar.winfo_children():
+       child.state(["disabled"])
+
+There is also a ``children`` **dict**, keyed by each child's own name — note it's
+an attribute, not a method, and the names are Tk's unless you chose them:
+
+.. code-block:: python
+
+   toolbar.children      # {'!button': <Button ...>, '!button2': <Button ...>}
+
+.. note::
+
+   Every widget also has a **path name** — ``".!frame.!button"`` — that spells out
+   its position in the tree, and that's what ``str(widget)`` gives you. This
+   matters because ``winfo_parent()`` returns the parent's *path*, a string,
+   while ``master`` returns the *widget*:
+
+   .. code-block:: python
+
+      save.master           # <Frame object .!frame>   -- the widget
+      save.winfo_parent()   # '.!frame'                -- a string
+
+   Reach for ``master`` when you want the parent. If you only have a path, turn it
+   back into a widget with ``nametowidget``:
+
+   .. code-block:: python
+
+      save.nametowidget(save.winfo_parent())   # the toolbar Frame
+
+``winfo_children()`` goes **one level down only** — the root's children are its
+frames, not the buttons inside them. To reach the whole tree, recurse:
+
+.. code-block:: python
+
+   def walk(widget, depth=0):
+       print("   " * depth + widget.winfo_class())
+       for child in widget.winfo_children():
+           walk(child, depth + 1)
+
+   walk(app)
+
+.. code-block:: text
+
+   Tk
+      TFrame
+         TButton
+         TButton
+      TFrame
+         TEntry
+
+``winfo_class()`` reports the widget's Tk class (``"TButton"``), which is what
+that walk prints. Finally, ``winfo_toplevel()`` jumps straight to the window a
+widget lives in, however deep it sits — useful when a callback needs the window
+but only has the widget. See :doc:`Widget & screen info </reference/winfo>` for
+the full introspection set.
 
 Options configure a widget
 --------------------------


### PR DESCRIPTION
**This is the work I mistakenly reported as merged in #1231.** It never reached that PR — my branch handling was wrong, so #1231 merged only the configuration commit (2 files). Everything below sat on an unpushed local branch. It is intact, rebased on current `2.0`, and re-verified. Apologies for the bad status report.

## 1. Walking the tree (your children question)

The tree section built the tree, then packed navigation into one clause: *"You can walk the tree with `widget.master` and `widget.winfo_children()`"*. The section is called **The widget tree** — walking it deserves more than a mention.

New **Walking the tree** subsection: going up (`master`), going down (`winfo_children()`, and the `children` **dict** — an attribute, not a method; that's the `children` you were recalling, there is no `children()`), and the asymmetry that actually catches people:

```python
save.master           # <Frame object .!frame>   the widget
save.winfo_parent()   # '.!frame'                a string
```

with `nametowidget()` to convert back. Also: `winfo_children()` **does not recurse** (the root's children are its frames, not the buttons inside them), so it shows a recursive walk — whose printed output the page quotes verbatim from a verified run — plus `winfo_toplevel()`.

## 2. The audit: 41 → 8

Diffed all 156 public `tkinter.Misc` methods against `docs/reference`.

- **New `capabilities/busy.rst`** — the biggest gap, and one we made ourselves in #1226: 16 aliases shipped, 3 documented, in a how-to, no reference page.
- **New `capabilities/interpreter.rst`** — your base-widget-page suggestion. The homeless methods shared a real theme rather than being a junk drawer: they all cross the Python↔Tcl boundary — `getboolean`/`getint`/`getdouble`, `register`/`deletecommand` (what `validatecommand` uses), `info_patchlevel`.
- **Asymmetric gaps filled**: `after_info`, `unbind_all`/`unbind_class`, `selection_handle`, `quit` (verified: `mainloop` returns, widgets survive, the loop re-enters), `image_types`, and `event_add`/`event_delete`/`event_info` — bind.rst promised *"their options live in the Events reference"* and the Events reference never specced them.
- **The option database** — brief, with a link to the Tk manual, per your call. Probing corrected my draft: it can't reach ttk widgets at all, and on the tk widgets **our own theming overrides it** — `ttk.Text` reads `#ffffff` despite `option_add("*Text.background", ...)`; only `autostyle=False` lets it through. The example shows that instead of implying it works.

**Remaining 8 are deliberate**: `getvar`/`setvar` (Variables guide), `propagate`/`slaves` (bare aliases; `pack_*`/`grid_*` documented), `send`/`tk_bisque`/`tk_setPalette`/`tk_strictMotif` (legacy).

Every spec probed live. Build green (`-W`, exit 0); suite **689**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)