### PR TITLE
docs: add "What tkinter wraps" (the Tcl/Tk seam)

### DIFF
--- a/docs/user-guide/foundations/the-widget-model.rst
+++ b/docs/user-guide/foundations/the-widget-model.rst
@@ -165,6 +165,8 @@ spelling you use:
 
    btn.cget("nope")     # TclError: unknown option "-nope"
 
+.. _widget-model-what-comes-back:
+
 What comes back
 ~~~~~~~~~~~~~~~
 

--- a/docs/user-guide/foundations/what-tkinter-wraps.rst
+++ b/docs/user-guide/foundations/what-tkinter-wraps.rst
@@ -1,0 +1,166 @@
+What tkinter wraps
+==================
+
+tkinter is not a GUI toolkit. It is a thin Python layer over one: **Tcl/Tk**, a
+toolkit written in another language, with its own conventions. When you import
+tkinter, a Tcl interpreter starts up inside your process, and every widget you
+create becomes a command sent to it.
+
+You never have to write Tcl, and this page will not teach it. But the seam
+shows — in the names widgets carry, in the values you read back, and above all in
+the error messages, which arrive in Tk's words rather than Python's. Once you can
+see the seam, the parts of tkinter that look arbitrary stop being arbitrary.
+
+A widget is a command with a path name
+--------------------------------------
+
+Tk identifies each widget by a **path name**: a dotted string spelling out its
+position in the tree, exactly like a filesystem path. The root is ``.``, and each
+child appends its own name. That is what ``str(widget)`` gives you:
+
+.. code-block:: python
+
+   app = ttk.App()
+   toolbar = ttk.Frame(app)
+   save = ttk.Button(toolbar, text="Save")
+
+   str(save)          # '.!frame.!button'
+
+Those ``!``-prefixed names are just what tkinter auto-generates when you don't
+name a widget yourself. The path is not decoration — in Tcl the widget *is* a
+command with that name, and your Python method calls are relayed to it:
+
+.. code-block:: python
+
+   save.cget("text")                          # 'Save'  -- the Python way
+   app.tk.call(str(save), "cget", "-text")    # 'Save'  -- the same call, in Tcl
+
+This one fact explains a family of error messages. Destroying a widget deletes
+its command, so *using* the widget afterward isn't a Python error about a missing
+attribute — it's Tcl telling you there is no such command:
+
+.. code-block:: python
+
+   save.destroy()
+   save.cget("text")     # TclError: invalid command name ".!frame.!button"
+
+Options carry a leading dash
+----------------------------
+
+In Tcl, options are written ``-text``, ``-width``. tkinter lets you write them as
+Python keywords and adds the dash on the way through. It does not take it off
+again on the way back, which is why the dash appears in errors for options you
+wrote without one:
+
+.. code-block:: python
+
+   save.configure(text="Saved")       # you write this
+   save.cget("nope")                  # TclError: unknown option "-nope"
+
+Values are Tcl's, not Python's
+------------------------------
+
+Tcl's values are strings first, coerced as needed, and its idea of truth is
+broader than Python's: ``"yes"``, ``"true"``, ``"1"`` and ``"on"`` are all true.
+Values you read back come from Tk, so their types are Tk's — see
+:ref:`What comes back <widget-model-what-comes-back>` in the widget model. When
+you need to convert one, use the helpers that apply Tk's rules rather than
+Python's, because ``"0"`` and ``"false"`` are non-empty strings and therefore
+truthy to Python:
+
+.. code-block:: python
+
+   app.getboolean("no")     # False   -- bool("no") would be True
+
+A variable is a named Tcl variable
+----------------------------------
+
+``StringVar`` and friends don't hold your value in Python. Each one creates a
+variable *inside the interpreter* and holds its name:
+
+.. code-block:: python
+
+   name = ttk.StringVar(value="Ada")
+   str(name)                  # 'PY_VAR0'
+
+The widget and the variable are linked through that name, which is how a
+``textvariable`` keeps an entry and your value in step without any code of yours
+running. It also explains the classic footgun: let the Python object be garbage
+collected and the Tcl variable goes with it, while the widget keeps pointing at a
+name that no longer exists. See the
+:doc:`Variables guide </user-guide/feature-guides/variables>`.
+
+A callback is a registered command
+----------------------------------
+
+Tcl can't call a Python function directly. When you pass ``command=``, tkinter
+registers your function as a Tcl command and hands Tk *that name*. Ask for it
+back and the name is what you get:
+
+.. code-block:: python
+
+   save.configure(command=my_handler)
+   save.cget("command")       # '...my_handler'  -- a Tcl command name
+
+So ``cget`` is no way to recover a callback or a variable. Keep your own
+reference to anything you need later.
+
+Reading a TclError
+------------------
+
+``TclError`` is the interpreter reporting a problem in its own vocabulary. The
+wording is Tk's, so it names Tcl things — commands, paths, dashed options — and
+knowing the four seams above is usually enough to translate:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 46 54
+
+   * - Message
+     - What it means
+   * - ``unknown option "-nope"``
+     - The widget has no such option. You wrote ``nope``; the dash is Tcl's.
+   * - | ``invalid command name ".!button"``
+       | ``bad window path name ".!toplevel"``
+     - The widget was destroyed — its command no longer exists. Guard with
+       ``winfo_exists()`` if it might be gone.
+   * - ``expected integer but got "abc"``
+     - A value couldn't be coerced — often an ``IntVar`` read while the entry
+       bound to it holds half-typed text.
+   * - ``CLIPBOARD selection doesn't exist``
+     - Nothing to read: the clipboard is empty or holds non-text.
+
+:doc:`Handle callback errors </user-guide/how-to/error-handling>` covers catching
+these.
+
+One interpreter, one thread
+---------------------------
+
+The interpreter belongs to the thread that created it. That is the real reason
+for the rule in :doc:`Run background work </user-guide/how-to/threads>`: a worker
+thread must not touch widgets, because the interpreter they live in isn't
+running there.
+
+Reaching past tkinter
+---------------------
+
+``app.tk.call(...)`` sends a command straight to the interpreter, as the second
+example on this page did. You should almost never need it — if a Tk feature has a
+tkinter method, use the method. It's worth recognizing because you will meet it
+in older code and in answers online, usually reaching for something tkinter
+hadn't wrapped yet.
+
+.. seealso::
+
+   - :doc:`The widget model </user-guide/foundations/the-widget-model>` — the
+     tree, options, and what reading one gives back.
+   - :doc:`Variables guide </user-guide/feature-guides/variables>` — the named
+     variables this page describes, and the lifetime rule that follows.
+   - :doc:`Handle callback errors </user-guide/how-to/error-handling>` — catching
+     ``TclError`` where it's expected.
+
+Reference
+---------
+
+- :doc:`Interpreter </reference/capabilities/interpreter>` — the value-conversion
+  helpers, ``register``, and the Tk version.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -68,6 +68,13 @@ respond to input, and how ttkbootstrap styles them.
 
       The widget tree, options (``configure``/``cget``), and ttk states.
 
+   .. grid-item-card:: What tkinter wraps
+      :link: foundations/what-tkinter-wraps
+      :link-type: doc
+
+      The Tcl/Tk layer underneath — path names, dashed options, and how to read
+      a ``TclError``.
+
    .. grid-item-card:: Arranging widgets
       :link: foundations/arranging-widgets
       :link-type: doc
@@ -273,6 +280,7 @@ Task-focused recipes — common tkinter jobs done the ttkbootstrap way.
 
    foundations/how-a-tkinter-app-runs
    foundations/the-widget-model
+   foundations/what-tkinter-wraps
    foundations/arranging-widgets
    foundations/layout-with-grid
    foundations/layout-with-pack


### PR DESCRIPTION
Agreed, and the evidence for it is stronger than I expected: **the docs lean on the Tcl relationship everywhere and explain it nowhere.**

- `TclError` appears across **8 pages**
- `unknown option "-bootstyle"` shows a **dash the reader never wrote**
- *Open a second window* quotes `bad window path name`
- *Variables* says each one wraps a **"named Tcl variable"** — and hangs the GC footgun off that fact
- *Run background work* says **"a Tcl interpreter belongs to the thread that created it"**
- *Localization* wraps **msgcat**
- meanwhile **`how-a-tkinter-app-runs` never mentions Tcl at all**

And you're right that the *Walking the tree* section I added in #1232 assumes path names outright.

## The page

`foundations/what-tkinter-wraps.rst`, placed **after the widget model** — by then the reader has already met `.!frame.!button`, `-nope`, and `cget`'s Tk-shaped values, so it answers a question they now have instead of front-loading strangeness on page one.

Scope is exactly what you asked for: **the seam, not Tcl**. It says so in the intro and teaches no Tcl. Its spine is the one fact everything else falls out of — a widget *is* a Tcl command named by its path:

```python
save.cget("text")                        # 'Save'   -- the Python way
app.tk.call(str(save), "cget", "-text")  # 'Save'   -- the same call, in Tcl
```

From there: destroying a widget deletes its command (hence `invalid command name`), options carry Tcl's dash (hence `unknown option "-nope"`), values are Tk's not Python's, a `StringVar` is a *name* (`PY_VAR0`), and a callback is a registered command name (hence `cget("command")` can't give your function back).

It closes with the practical payoff — **a table translating the `TclError`s readers actually hit** — plus the one-interpreter-per-thread rule (the real reason behind the threads guide) and the `tk.call` escape hatch, framed as something to *recognize* in older code rather than reach for.

Also adds a `widget-model-what-comes-back` label so the page points at the type discussion rather than repeating it.

Every claim probed live and the error text quoted verbatim — `unknown option "-nope"`, `invalid command name ".!frame.!button"`, `getboolean("no")` → `False` where `bool("no")` is `True`. Build green (`-W`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)