### PR TITLE
docs: close out the author-review batch in the handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,15 @@ Feature guides · How-To — **there is NO "Concepts" band** (dissolved: styling
 essentials → Fundamentals; deep styling/theming → Feature guides). **Variables &
 events are FEATURES** (Foundations gives the on-ramp; robust `Variables`/`Events`
 feature guides own the depth). Author was firm: **teach layout/mechanics
-BY BUILDING, never option-tours.** The full IA (charters, §14 curriculum map,
+BY BUILDING, never option-tours.** **More standing rules (2026-07-15 batch):**
+**one job per How-To** (that split "Beep and show busy" in two); **no band index
+pages** (only How-To had one — the sidebar + the user-guide cards already do it);
+**don't `/`-join items in a table cell** — one per line via an rST line block
+(prose slashes are fine: *"returns "OK" / "Cancel""* reads well in a sentence);
+**state what a thing IS, not what it isn't** — don't write defensively at a bug you
+just found (the macOS busy limit is "not supported on macOS", full stop; the
+rationale for why it can't be emulated belongs in git, not the page — CLAUDE.md's
+comment convention applies to docs too). The full IA (charters, §14 curriculum map,
 tkinter-surface coverage audit + supersession map, screenshot-placeholder
 convention) lives in `development/2_0_docs_design.md`. **NEXT (content authoring,
 fresh branch off `2.0`):** the **Build-your-first-app** tutorial
@@ -364,7 +372,9 @@ grounding discipline, build cmd, done/remaining, PR-stack state, deferred ideas)
 in **`development/2_0_docs_api_reference.md` — read it first to continue this
 work.** Headlines: a **Capabilities** section (`docs/reference/capabilities/`, one
 spec page per Tcl/Tk-manual area — configuration/pack/grid/place/stacking/focus/
-grab/after/lifecycle/clipboard/selection, with events+winfo folded in) plus
+grab/after/lifecycle/clipboard/selection, with events+winfo folded in; `busy` and
+`interpreter` were added later by the #1232 audit, and pack/grid/place/stacking
+have since moved to the top-level Geometry section) plus
 **per-widget API pages** (`docs/reference/api/<w>.rst`, options tables +
 `py:method` specs). **Done:** the Capabilities section + the tk pages
 Text/Canvas/Listbox/Menu. **Remaining:** the trivial tk containers (Tk/TkFrame/
@@ -427,9 +437,47 @@ shimmed** (Tk's busy window is a *transparent* input shield; Tk has no transpare
 color, so any emulation is opaque and hides the UI) — docs state it as a plain
 platform fact plus the disable+cursor fallback. **Standing lesson (memory-saved):**
 `event_generate` **bypasses pointer hit-testing** and can never prove input is
-blocked — probe with `winfo_containing` + a positive control. **Pre-existing on
-`2.0`, unrelated:** `tests/test_menu_api.py::*_off_mac` ×3 fail on any Mac (they
-assert non-macOS behavior) — not in the known-flake list; worth gating. Suite 684.
+blocked — probe with `winfo_containing` + a positive control. **An author-review
+batch then merged (#1227–#1233)**, all driven by the author reading the shipped
+docs; in nearly every case the plausible answer was wrong and only a probe settled
+it: #1227 **dropped `how-to/index`** (the only band index; it duplicated the sidebar
+and invented 3 buckets) + **unslashed 32 list-table cells** onto rST line blocks;
+#1228 **nested the variant Styling-options sections** on Button/Checkbutton (two
+generated partials × the same 5 headings had rendered every heading twice at h3 —
+structural, not duplicated content; nested partials now render at `^`, guarded by
+two tests derived from the `.. include::` order); #1229 made the menu `*_off_mac`
+tests **force the windowing-system probe** rather than trust the host (**suite is
+now 689/0 on macOS** — forcing beats `skipif`, which would leave a Mac dev running
+neither branch); #1230 fixed **`command` fires on invoke, not on selection change**
+(probed: `var.set()` selects without firing; re-invoking the already-selected button
+fires without a change — wrong in *both* directions; Space invokes too, so the docs
+say "invoked"); #1231/#1232 reworked **the widget model** — explicit
+configure/cget/`[]` patterns (a widget is NOT a dict; `config` is an older alias),
+a new **What comes back** section (`cget("width")`→int even from `"8"`;
+`command`/`textvariable` → **Tk's name, not your object**), and **Walking the tree**
+(`master` is the object, `winfo_parent()` a *string*, `nametowidget()` converts,
+`children` is a **dict attribute**, `winfo_children()` does **not** recurse);
+#1232 also closed a **reference audit of `tkinter.Misc`: 41 → 8 undocumented** —
+new `capabilities/busy.rst` (a hole we made in #1226: 16 aliases shipped, 3
+documented, no reference page) and `capabilities/interpreter.rst` (the homeless
+methods shared a theme — they all cross the Python↔Tcl boundary), plus `after_info`,
+`unbind_all`/`unbind_class`, `selection_handle`, `quit`, `image_types`, and
+`event_add`/`event_delete`/`event_info` (bind.rst had *promised* the Events
+reference specced them; it didn't). The **option database** got a brief mention +
+Tk-manual link (not ours to teach, but the tk widgets make it reachable) — probing
+corrected the draft: it can't reach ttk widgets at all, and on tk widgets **our own
+theming overrides it** (only `autostyle=False` lets it through). Remaining 8 are
+deliberate (`getvar`/`setvar` → Variables guide; `propagate`/`slaves` aliases; 4
+legacy). #1233 added the Foundations page **What tkinter wraps** — the docs leaned
+on the Tcl seam everywhere (`TclError` across 8 pages, a dash the reader never
+wrote, `bad window path name`, "named Tcl variable") and explained it nowhere; its
+scope is the **seam, not Tcl**, spined on `app.tk.call(str(w), "cget", "-text")`
+== `w.cget("text")`, placed **after** the-widget-model. **Two corrections to earlier
+CLAUDE.md claims:** the menu `*_off_mac` failures are **fixed** (not "worth
+gating"), and suite is **689**. **PROCESS NOTE:** a `checkout -b … || checkout …`
+fallback once left commits on a second branch while `git push origin <name>` pushed
+a different ref — #1231 merged without the work reported in it (recovered as
+#1232). **Verify `git branch --show-current` before pushing.**
 **NEXT docs-H thread:** the deferred **screenshot slice** (46 placeholders across
 catalog + guides; the 5 new/split how-to pages have none — decide during the slice;
 capture tooling is Windows-canonical, so postponed on macOS), plus optional Track B

--- a/development/2_0_handoff.md
+++ b/development/2_0_handoff.md
@@ -10,10 +10,14 @@
 **Docs Workstream H is content-complete.** The Widgets catalog (all ~29 pages), the
 self-authored API-reference layer, the Geometry + Variables reference sections, the
 usage-guide enrichment pass, the reference/See-also cross-reference cleanup, and —
-as of 2026-07-15 — **the How-To band** (audit pass + 3 new recipes + the bell/busy
-split, #1225/#1226) are all **merged into `2.0`**. Full build is green
+as of 2026-07-15 — **the How-To band** (#1225/#1226) plus a **review-driven batch**
+(#1227–#1233: the bell/busy split + index removal, variant-styling nesting, the
+`busy()` shim, `command`-fires-on-invoke, the widget-model configuration + tree
+sections, the 41→8 Misc reference audit, and the new **What tkinter wraps**
+Foundations page) are all **merged into `2.0`**. Full build is green
 (`.venv/bin/python -m sphinx -b html -W -q -E docs <out>`, exit 0, 0 warnings); the
-catalog coverage test passes; suite 684 passed.
+catalog coverage test passes; **suite 689 passed, 0 failed — green on macOS for the
+first time** (#1229 made the menu `*_off_mac` tests platform-independent).
 
 **The one remaining docs-H thread is the SCREENSHOT SLICE** (design: `2_0_docs_design.md`
 §7). Everything is staged for it:
@@ -46,6 +50,76 @@ catalog coverage test passes; suite 684 passed.
 The dated running log below has the full history. Latest entry first.
 
 ---
+
+_Last updated: 2026-07-15b (**AUTHOR-REVIEW BATCH — #1227–#1233, all MERGED into
+`2.0`.** Everything here came from the author reading the merged How-To band and
+pulling threads; each item is listed with what the probe actually showed, because
+in almost every case the plausible answer was the wrong one. **#1227** dropped the
+`how-to/index` page (the only band index — getting-started/foundations/
+feature-guides have none; it duplicated the sidebar and invented 3 buckets for 11
+recipes), unslashed **32 list-table cells** onto rST line blocks, and closed out
+the how-to handoff; deleting the index exposed a dead link (`querybox.rst` pointed
+"tkinter.filedialog" at `/user-guide/how-to/index`). **#1228** fixed duplicated
+**Styling options** headings on Button/Checkbutton: those pages fold in *two*
+generated partials and every partial carries the same 5 headings, so all 5
+rendered twice at h3 separated only by a bold paragraph. Content was NOT duplicated
+(mapping/layout/states differ; checkbutton-vs-toggle even differ on options) — the
+defect was structural, fixed by rendering nested partials one level deeper (`^` vs
+`~`) under a real heading; `NESTED_PARTIALS` is guarded by two tests derived from
+the `.. include::` order, **both verified to fail** when the set is wrong.
+**#1229** made the menu `*_off_mac` tests force the windowing-system probe
+(`_force_off_aqua`, mirroring the existing `_force_aqua`) instead of trusting the
+host — they had failed on every Mac forever. Forcing beat `skipif`: under skipif a
+macOS dev runs *neither* branch. **Suite is now 689/0 on macOS.** **#1230**
+corrected `command` semantics on radiobutton+checkbutton (catalog *and* reference):
+it fires on **invoke**, not on selection change. Probed: `size.set("large")`
+selects without firing; invoking the *already-selected* button fires without a
+change — so the old wording was wrong in both directions. Matches the Tk manual
+("evaluate whenever the widget is invoked"). Space also invokes, so the docs say
+"invoked", not "clicked". **#1231/#1232** reworked **the widget model**: the
+configuration patterns are now explicit (configure/cget/`[]` as interchangeable
+spellings; a widget is NOT a dict; `config` is an older alias; keys()/no-arg
+configure() dict/`configure("opt")` spec) with a new **What comes back** section
+(`cget("width")`→int even when set from `"8"`, `padding`→tuple, and
+`command`/`textvariable` → **Tk's name, not your object**); plus **Walking the
+tree** (`master` is the object, `winfo_parent()` is a *string*, `nametowidget()`
+converts back, `children` is a **dict attribute** not a method, `winfo_children()`
+does **not** recurse). Probing corrected two bugs on `capabilities/configuration.rst`
+— `cget` was documented "always as a string from Tk; cast as needed" (false: int
+and tuple come back, and Tk normalizes width to int for you) and `configure`'s
+`:returns:` never mentioned the **no-arg dict**, its most-used form. **#1232 also
+closed the reference audit: 41 → 8** of `tkinter.Misc`'s 156 public methods. New
+`capabilities/busy.rst` (**a hole we made ourselves in #1226**: 16 aliases shipped,
+3 documented, in a how-to, no reference page) and new `capabilities/interpreter.rst`
+(the author's "base widget page" idea — the homeless methods shared a real theme:
+they all cross the Python↔Tcl boundary — `getboolean`/`getint`/`getdouble`,
+`register`/`deletecommand` (what `validatecommand` uses), `info_patchlevel` (a
+version *tuple*)). Asymmetric gaps filled: `after_info`, `unbind_all`/
+`unbind_class`, `selection_handle`, `quit` (verified `mainloop` returns, widgets
+survive, loop re-enters), `image_types`, and `event_add`/`event_delete`/`event_info`
+— bind.rst had *promised* "their options live in the Events reference" and the
+Events reference never specced them. The **option database** got a brief mention +
+Tk-manual link (author's call: not ours to teach, but the tk widgets make it
+reachable); probing corrected the draft — it can't reach ttk widgets at all, and on
+the tk widgets **our own theming overrides it** (`ttk.Text` reads `#ffffff` despite
+`option_add("*Text.background", …)`; only `autostyle=False` lets it through).
+Remaining 8 are deliberate: `getvar`/`setvar` (Variables guide), `propagate`/
+`slaves` (bare aliases), `send`/`tk_bisque`/`tk_setPalette`/`tk_strictMotif`
+(legacy). **#1233** added the Foundations page **What tkinter wraps** — the docs
+leaned on the Tcl relationship everywhere (`TclError` across 8 pages, a dash the
+reader never wrote, `bad window path name`, "named Tcl variable", "a Tcl
+interpreter belongs to the thread that created it", msgcat) and explained it
+nowhere (`how-a-tkinter-app-runs` never says "Tcl"). Scope is the **seam, not
+Tcl**; spine is that a widget *is* a Tcl command named by its path
+(`app.tk.call(str(save), "cget", "-text")` == `save.cget("text")`), from which
+`invalid command name`, `unknown option "-nope"`, `PY_VAR0` and the
+callback-is-a-name all follow; ends with a table translating the TclErrors readers
+hit. Placed **after** the-widget-model deliberately. **PROCESS NOTE:** #1231 was
+reported merged with work it did not contain — a `checkout -b … || checkout …`
+fallback silently left the commits on a second branch while `git push origin
+<name>` pushed a *different* ref. Recovered intact as #1232. Verify
+`git branch --show-current` before pushing; and note the Misc audit is what caught
+it (it would have read 41, not 8). Prior entry follows.**)_
 
 _Last updated: 2026-07-15 (**Docs HOW-TO BAND — COMPLETE, plus a busy() shim. Both
 MERGED into `2.0`** (#1225 `84b6f78f`, #1226 `c7d10f0d`). Ran the plan in the (now


### PR DESCRIPTION
The handoff log stopped at #1227. This records **#1227–#1233** in `2_0_handoff.md` and `CLAUDE.md`, so the next session starts from what's actually on `2.0`.

## What's recorded

The how-to index removal + 32 unslashed table cells, the variant-styling nesting, the platform-independent menu tests, the `command`-fires-on-invoke correction, the widget-model configuration + tree sections, the **41 → 8** Misc reference audit (`busy.rst` + `interpreter.rst`), and the **What tkinter wraps** Foundations page.

Each entry records **what the probe showed**, not just what changed — because in nearly every case this batch the plausible answer was the wrong one, and that's the reusable part:

- `tk busy` is inert on macOS; the tkinter methods are 3.13+ but the Tcl command is Tk 8.6 (two unrelated limits the page had conflated, and inverted)
- `<Control-c>` isn't the copy key on macOS
- a bad `bootstyle` warns and falls back rather than raising — the old `except TclError` was unreachable
- `cget("command")` returns Tk's name, not your function
- `option_add` can't reach ttk at all, and our own theming overrides it on tk widgets
- `command` fires on invoke — `var.set()` selects without firing, and re-invoking the selected button fires without a change

## Two corrections to claims CLAUDE.md still made

- the menu `*_off_mac` failures are **fixed** (#1229), not "worth gating"
- the suite is **689**, not 684 — and it's **green on macOS**

Also refreshes the Capabilities blurb, which predated `busy`/`interpreter` and the Geometry move.

## Standing rules this batch established

**One job per How-To** (that split "Beep and show busy"); **no band index pages** (only How-To had one); **don't `/`-join items in a table cell** — one per line via a line block, though prose slashes are fine; and **state what a thing IS, not what it isn't** — don't write defensively at a bug you just found. That last is CLAUDE.md's own comment convention, applied to docs.

## Process note

A `checkout -b … || checkout …` fallback left commits on a second branch while `git push origin <name>` pushed a different ref — so **#1231 merged without the work I reported in it** (recovered as #1232). Recorded, with the fix: verify `git branch --show-current` before pushing. Worth noting the Misc audit is what caught it — it would have read 41, not 8.

Build green (`-W`, exit 0); suite **689**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)