### PR TITLE
Issue sweep: eager native-dialog styles (#1224) + DateEntry start_date docs (#1151)

### DIFF
--- a/docs/reference/api/dateentry.rst
+++ b/docs/reference/api/dateentry.rst
@@ -35,7 +35,10 @@ Options
        Default ``6``.
    * - ``start_date``
      - ``datetime | date``
-     - The date focused when the popup first opens. Default ``None`` (today).
+     - The date the widget starts on — fills the field at construction and is
+       the ``get_date()`` fallback when the field is empty. The displayed date
+       after construction is ``value`` / ``set_date()``. Default ``None``
+       (today).
    * - ``button_icon``
      - ``str``
      - The Bootstrap-Icons glyph shown on the button. Default

--- a/docs/widgets/dateentry.rst
+++ b/docs/widgets/dateentry.rst
@@ -59,12 +59,16 @@ Format and calendar
 -------------------
 
 ``date_format`` is a ``strftime`` pattern for how the date reads in the field;
-``start_date`` sets which date (and month) the calendar opens on; ``first_weekday``
-sets the leftmost column (``0`` = Monday … ``6`` = Sunday):
+``start_date`` is the date the widget starts on; ``first_weekday`` sets the
+leftmost column (``0`` = Monday … ``6`` = Sunday):
 
 .. code-block:: python
 
    DateEntry(app, date_format="%Y-%m-%d", start_date=datetime(2025, 1, 1), first_weekday=6)
+
+``start_date`` fills the field at construction and is the date ``get_date()``
+falls back to when the field is empty; the displayed date after construction is
+``value`` / ``set_date()``.
 
 ``show_outside_days=False`` hides the adjacent-month days the calendar uses to pad
 the first and last weeks.

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -292,11 +292,13 @@ class StyleBuilderTTK:
             focuscolor="",
         )
 
-        # Native dialog buttons need the base TButton even when an application
-        # only instantiates styled variants.
-        self.build_style(
-            DEFAULT_VARIANT, "button", DEFAULT, required=True
-        )
+        # Native dialogs (file/directory choosers, message boxes) are built
+        # from base ttk styles the app itself may never instantiate. Unbuilt,
+        # those styles inherit the theme foreground from `.` but keep clam's
+        # light field/fill -- near-white text on a white entry in dark mode
+        # (#1224). Build the dialog set eagerly.
+        for family in ("button", "entry", "combobox", "menubutton", "scrollbar"):
+            self.build_style(DEFAULT_VARIANT, family, DEFAULT, required=True)
 
         # General styles used by Tableview and Tooltip internals.
         self.build_style("link", "button", DEFAULT, required=True)

--- a/src/ttkbootstrap/widgets/dateentry.py
+++ b/src/ttkbootstrap/widgets/dateentry.py
@@ -87,8 +87,10 @@ class DateEntry(ConfigureDelegationMixin, Frame):
                 etc...
 
             start_date (datetime, optional):
-                The date that is in focus when the widget is displayed. Default is
-                current date.
+                The date the widget starts on — fills the field at construction
+                and is the `get_date()` fallback when the field is empty. The
+                displayed date after construction is `value` / `set_date()`.
+                Default is the current date.
 
             bootstyle (str, optional):
                 A style keyword used to set the focus color of the entry

--- a/tests/widget_styles/test_default_dialog_styles.py
+++ b/tests/widget_styles/test_default_dialog_styles.py
@@ -1,0 +1,50 @@
+"""Regression test for issue #1224 (companion to #1062 / test_default_button_style).
+
+Tk's native file/directory dialogs on X11 are built from base ttk styles
+(``TEntry``, ``TCombobox``, ``TMenubutton``, the scrollbars) the application
+may never instantiate. Unbuilt, those styles inherit the theme foreground from
+the root style but keep clam's light field/fill -- near-white text on a white
+entry field in dark mode. The dialog set must be themed at theme-load time,
+with no widget created, and follow runtime theme changes.
+
+Runnable headlessly with pytest.
+"""
+import ttkbootstrap as ttk
+
+DIALOG_STYLES = (
+    "TButton",
+    "TEntry",
+    "TCombobox",
+    "TMenubutton",
+    "Vertical.TScrollbar",
+    "Horizontal.TScrollbar",
+)
+
+
+def _lookup(app, style_name, option):
+    return str(app.tk.call("ttk::style", "lookup", style_name, f"-{option}"))
+
+
+def test_dialog_base_styles_built_at_theme_load(root):
+    """Every base style a native dialog uses is built with no widget created."""
+    style = root.style
+    style.theme_use("bootstrap-dark")
+    for name in DIALOG_STYLES:
+        assert style.style_exists_in_theme(name), \
+            f"{name} should be built at theme load"
+
+
+def test_entry_field_readable_in_dark_without_widgets(root):
+    """The dark-mode TEntry field is themed, not clam's white (#1224)."""
+    style = root.style
+    style.theme_use("bootstrap-dark")
+    fg = _lookup(root, "TEntry", "foreground")
+    field = _lookup(root, "TEntry", "fieldbackground")
+    # unbuilt, field is '' (clam falls back to a light default under the
+    # near-white dark-theme foreground)
+    assert field not in ("", "#ffffff", "white")
+    assert field != fg
+
+    # and it keeps tracking the active theme
+    style.theme_use("bootstrap-light")
+    assert _lookup(root, "TEntry", "fieldbackground") != field


### PR DESCRIPTION
## Summary

Two items from today's open-issue audit, per author rulings.

**Fixes #1224 — native-dialog white-on-white in dark themes.** Tk's file/directory choosers on X11 are built from base ttk styles the app may never instantiate. Unbuilt, `TEntry`/`TCombobox`/`TMenubutton` inherit the theme foreground from the root style but keep clam's light field/fill — near-white text on a white entry field in dark mode (probe-confirmed live on `2.0`). Extends the #1062 eager-`TButton` pattern in `create_default_style` to the dialog set (entry, combobox, menubutton, both scrollbar orientations). New regression tests (`tests/widget_styles/test_default_dialog_styles.py`) assert the set is built at theme load with **no widget created**, that the dark-mode `TEntry` field is themed, and that it tracks theme switches.

**Closes #1151 — DateEntry `start_date` clarified.** Author ruling: `start_date` is a configuration option, by name — it does not drive the display after construction and gets no configure-time refresh. All three doc surfaces (catalog page, API reference, docstring) now state what it *is*: the date the widget starts on — fills the field at construction and is the `get_date()` fallback when the field is empty; the displayed date after construction is `value` / `set_date()`. Behavior probed headlessly (construction seeds the display; later `configure(start_date=...)` changes only the fallback; the old reference text — "the date focused when the popup first opens" — was not accurate).

## Test plan

- Full headless suite: **691 passed** (689 + 2 new regression tests)
- Sphinx build `-W -q -E`: exit 0
- Probes: dark-theme `ttk::style lookup` on the dialog set with zero widgets, before/after `theme_use`; DateEntry construction/configure/empty-field fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)