### PR TITLE
Make the ToolTip popup topmost by default (fixes #1086)

### DIFF
--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -38,6 +38,7 @@
 | **`LabelFrame` is now the ttk alias (was the classic tk widget)** | API | this doc, below — **not in the migration guide** (author call) |
 | **Bare `outline` renders neutral (was primary)** | Visual | this doc, below |
 | **`@surface` fixed on Checkbutton / Radiobutton (background now paints)** | Fix | this doc, below |
+| **ToolTip popup topmost by default (`topmost=False` opts out)** | New | this doc, below |
 | **`neutral` color** | New | this doc, below |
 | **`ghost` button variant** | New | this doc, below |
 | **`thin` scrollbar variant** | New | this doc, below |
@@ -1842,3 +1843,22 @@ toolbutton/menubutton/entry silently drops the token and falls back to the
 plain style (their builders don't participate in surface naming). Extend per
 demand; the grammar page names only supported cases (button family variants,
 check/radio labels).
+
+## ToolTip popup is topmost by default  *(New / behavior)*
+
+**What.** The tooltip popup `Toplevel` now defaults `topmost=True` (a
+`setdefault` next to the existing `alpha=0.95`), so tips draw above every
+window. `ToolTip(..., topmost=False)` opts out via the existing
+Toplevel-kwargs passthrough (now documented, catalog + reference).
+
+**Why (#1086).** A `-topmost` main window hid its own tooltips on Windows —
+the popup sat below it. Native tooltips are always-on-top (Win32 tooltips are
+`WS_EX_TOPMOST`; aqua help tags float), so topmost *is* the platform-native
+default. Probed: on aqua the tooltip's `help` window class (#1125) already
+floats natively — `-topmost` reads 1 with or without the attribute — so the
+change is a no-op there; Windows/X11 are where the new default lands.
+
+**Accepted edge.** Alt-Tabbing away while a tip is showing (pointer unmoved →
+no `<Leave>`) leaves it briefly floating over the new foreground app until the
+mouse moves. Native tooltips share the property (they mask it with auto-hide
+timeouts, which ours doesn't have).

--- a/docs/reference/dialogs/tooltip.rst
+++ b/docs/reference/dialogs/tooltip.rst
@@ -52,6 +52,12 @@ Options are passed to the constructor and can be changed later with
      - Placement relative to the widget — a space-separated combination of
        ``"left"``, ``"right"``, ``"top"``, ``"bottom"``, ``"center"`` (e.g.
        ``"top left"``). Default ``None`` (offset from the pointer).
+   * - ``**kwargs``
+     - ``any``
+     - Passed to the popup :class:`~ttkbootstrap.Toplevel` — e.g. ``alpha``
+       (default ``0.95``) and ``topmost``. ``topmost`` defaults to ``True`` so
+       the tip draws above every window, matching native tooltips; pass
+       ``topmost=False`` to keep it above its own application only.
 
 Methods
 -------

--- a/docs/widgets/tooltip.rst
+++ b/docs/widgets/tooltip.rst
@@ -57,6 +57,15 @@ or a pair like ``"top left"``:
 A ``ToolTip`` isn't fire-and-forget — ``configure()`` changes its ``text``,
 ``bootstyle``, and other options later, and a visible tip updates in place.
 
+Extra keyword arguments go to the popup window itself. The tip draws above
+every window — like native tooltips — so it stays readable even over a
+``topmost`` main window; pass ``topmost=False`` to keep it above its own
+application only:
+
+.. code-block:: python
+
+   ToolTip(save, text="Save the file", topmost=False)
+
 Color
 -----
 

--- a/src/ttkbootstrap/widgets/tooltip.py
+++ b/src/ttkbootstrap/widgets/tooltip.py
@@ -106,6 +106,9 @@ class ToolTip:
 
             **kwargs (Dict):
                 Other keyword arguments passed to the `Toplevel` window.
+                `topmost` defaults to True so the tooltip draws above every
+                window, matching native tooltips (pass `topmost=False` to
+                keep it above its own application only).
         """
         self.widget = widget
         self.text = text
@@ -128,6 +131,11 @@ class ToolTip:
         kwargs["window_type"] = "tooltip"
         if "alpha" not in kwargs:
             kwargs["alpha"] = 0.95
+        # Native tooltips draw above every window (Win32 tooltips are TOPMOST;
+        # aqua help tags float); without this, a `-topmost` main window hides
+        # its own tooltips (#1086).
+        if "topmost" not in kwargs:
+            kwargs["topmost"] = True
         self.toplevel_kwargs = kwargs
 
         # the live popup label, held so a visible tooltip can be reconfigured

--- a/tests/test_labeledscale_tooltip_api.py
+++ b/tests/test_labeledscale_tooltip_api.py
@@ -199,3 +199,21 @@ def test_configure_reconfigures_live_popup(root):
     assert tip._label.cget("text") == "updated"
     tip.hide_tip()
     assert tip.toplevel is None
+
+def test_tooltip_topmost_default_and_optout(root):
+    """The popup is topmost by default, matching native tooltips (#1086);
+    `topmost=False` opts out. On aqua the tooltip window *class* floats
+    natively, so the opt-out is asserted at the kwargs seam, not the
+    attribute."""
+    btn = ttk.Button(root, text="x")
+    btn.pack()
+
+    tip = ToolTip(btn, text="tip")
+    assert tip.toplevel_kwargs["topmost"] is True
+    tip.show_tip()
+    root.update_idletasks()
+    assert int(tip.toplevel.attributes("-topmost")) == 1
+    tip.hide_tip()
+
+    plain = ToolTip(btn, text="tip", topmost=False)
+    assert plain.toplevel_kwargs["topmost"] is False


### PR DESCRIPTION
## Summary

Fixes #1086: a `-topmost` main window hid its own tooltips on Windows. Native tooltips are always-on-top (Win32 tooltips are `WS_EX_TOPMOST`; aqua help tags float), so topmost is the platform-native default — the popup `Toplevel` now defaults `topmost=True` (one `setdefault` next to the existing `alpha=0.95`), with `ToolTip(..., topmost=False)` as the opt-out via the existing Toplevel-kwargs passthrough.

- **Docs**: the passthrough and `topmost` are now documented on both tooltip pages (catalog + reference) — previously neither was mentioned anywhere.
- **Probed on aqua**: the tooltip's `help` window class (#1125) already floats natively — `-topmost` reads 1 with or without the attribute — so the new default is a no-op on macOS; Windows/X11 are where it lands. The regression test therefore asserts the default at the kwargs seam plus the shown-popup attribute, keeping it green cross-platform.
- **Accepted edge** (dev-log): Alt-Tabbing away while a tip shows leaves it briefly floating over the new foreground app until the mouse moves — native tooltips share the property.

## Test plan

- Full headless suite: **692 passed** (+1: `test_tooltip_topmost_default_and_optout`)
- Sphinx build `-W -q -E`: exit 0
- Probes: default and opt-out kwargs; shown popup `-topmost`; aqua `MacWindowStyle help` coexistence; the new docs snippet run headlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)