### PR TITLE
docs: track the in-house file dialog (#1242) in the Post-2.0 backlog

### DIFF
--- a/development/2_0_plan.md
+++ b/development/2_0_plan.md
@@ -312,6 +312,11 @@ Tracked enhancements deliberately held out of the feature-frozen 2.0:
   silently drop the surface token today (known gap, logged in
   `2_0_breaking_changes.md` under the check/radio surface fix). Extend per
   demand.
+- **In-house themed file dialog** — Tk's X11 dialog hardcodes its file-list
+  canvas white in `iconlist.tcl`, unreachable by styling (#1224's residual
+  gap). X11 default / native elsewhere / routed through the `Querybox.get_*`
+  wrappers; prior art in `development/filedialogs/`. Tracked as **#1242** on
+  the **2.1 milestone**; design pass before implementation.
 
 ---
 


### PR DESCRIPTION
## Summary

One bullet in `2_0_plan.md`'s Post-2.0 (2.1) backlog for the in-house themed file dialog — #1224's residual gap (Tk hardcodes the X11 dialog's file-list canvas white in `iconlist.tcl`, unreachable by styling), now tracked as #1242 on the 2.1 milestone alongside the value tokens and @surface-participation entries.

## Test plan

- Dev-tracking doc only; nothing to build or run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)