### PR TITLE
fix(tableview): return configure query results + pagesize cget/configure parity

### DIFF
--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -644,7 +644,7 @@ class Tableview(ttk.Frame):
 
     def configure(self, cnf=None, **kwargs) -> Union[Any, None]:
         """Configure the internal `Treeview` widget. If cnf is provided,
-        value of the option is return. Otherwise the widget is
+        the option's configure spec is returned. Otherwise the widget is
         configured via kwargs.
 
         Parameters:
@@ -654,21 +654,76 @@ class Tableview(ttk.Frame):
 
             **kwargs (Dict):
                 Optional keyword arguments used to configure the internal
-                Treeview widget.
+                Treeview widget. Options the Treeview does not accept are
+                applied to the container frame.
 
         Returns:
 
             Union[Any, None]:
-                The value of cnf or None.
+                The configure spec of cnf, the full option dict for a
+                no-argument call, or None after a set.
         """
+        if isinstance(cnf, dict):
+            kwargs = {**cnf, **kwargs}
+            cnf = None
+        if "pagesize" in kwargs:
+            pagesize: int = kwargs.pop("pagesize")
+            self._pagesize.set(value=pagesize)
+            if cnf is None and not kwargs:
+                return None
+        if cnf == "pagesize":
+            return ("pagesize", "pagesize", "Pagesize", None, self._pagesize.get())
+        if cnf in ("style", "class"):
+            # the wrapper frame's own identity (the theme walk reads style)
+            return super().configure(cnf)
         try:
-            if "pagesize" in kwargs:
-                pagesize: int = kwargs.pop("pagesize")
-                self._pagesize.set(value=pagesize)
+            result = self.view.configure(cnf, **kwargs)
+        except tk.TclError:
+            result = super().configure(cnf, **kwargs)
+        if cnf is None and not kwargs and result is not None:
+            # no-arg query: merge the custom option into the full dict
+            result["pagesize"] = (
+                "pagesize", "pagesize", "Pagesize", None, self._pagesize.get()
+            )
+        return result
 
-            self.view.configure(cnf, **kwargs)
-        except:
-            super().configure(cnf, **kwargs)
+    def cget(self, cnf) -> Any:
+        """Return the current value of an option, matching `configure`'s
+        routing: the custom `pagesize`, then the internal `Treeview`,
+        falling back to the container frame.
+
+        Parameters:
+
+            cnf (str):
+                The option to query.
+
+        Returns:
+
+            Any:
+                The value of the option.
+        """
+        if cnf == "pagesize":
+            return self._pagesize.get()
+        if cnf in ("style", "class"):
+            # the wrapper frame's own identity (the theme walk reads style)
+            return super().cget(cnf)
+        try:
+            return self.view.cget(cnf)
+        except tk.TclError:
+            return super().cget(cnf)
+
+    # tkinter binds `__getitem__ = cget` at function level, so the inherited
+    # subscript forms bypass the overrides above; route them explicitly.
+    def __getitem__(self, key: str) -> Any:
+        if key in ("bootstyle", "style"):
+            return super().__getitem__(key)
+        return self.cget(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        if key in ("bootstyle", "style"):
+            super().__setitem__(key, value)
+            return
+        self.configure(**{key: value})
 
     # DATA HANDLING
 

--- a/tests/test_tableview_api.py
+++ b/tests/test_tableview_api.py
@@ -237,3 +237,48 @@ def test_menu_labels_have_no_decorative_glyphs(root):
     # (the first header entry, "Reset table", is covered by the glyph check above;
     # no literal-text assertion here -- the label is localized, so it varies by
     # the active MessageCatalog locale.)
+
+
+# --------------------------------------------------------------------------
+# configure/cget query parity
+# --------------------------------------------------------------------------
+
+def test_configure_query_returns_spec(root):
+    # Regression: configure() computed the query result and dropped it
+    # (no ``return``), so every query answered None.
+    tv = _make_table(root)
+    spec = tv.configure("height")
+    assert spec is not None and spec[0] == "height"
+
+
+def test_configure_no_args_returns_option_dict(root):
+    tv = _make_table(root)
+    options = tv.configure()
+    assert isinstance(options, dict)
+    assert "height" in options
+    assert "pagesize" in options
+
+
+def test_pagesize_configure_and_cget_parity(root):
+    # ``pagesize`` was settable via configure(pagesize=...) but raised
+    # "unknown option" on every query form.
+    tv = _make_table(root)
+    tv.configure(pagesize=5)
+    assert tv.cget("pagesize") == 5
+    assert tv.configure("pagesize")[-1] == 5
+    assert tv["pagesize"] == 5
+
+
+def test_cget_routes_to_view_with_frame_fallback(root):
+    tv = _make_table(root)
+    tv.configure(height=4)             # a Treeview option (rows)
+    assert tv.cget("height") == 4      # read back from the view, not the frame
+    tv.configure(relief="solid")       # a frame-only option
+    assert str(tv.cget("relief")) == "solid"
+
+
+def test_style_stays_on_the_wrapper_frame(root):
+    # The theme walk reads cget("style") off the wrapper; it must keep
+    # reporting the frame's style, not the inner Treeview's.
+    tv = _make_table(root)
+    assert str(tv.cget("style")) != str(tv.view.cget("style"))


### PR DESCRIPTION
## Summary

Found by the API-reference introspection audit: `Tableview` missed the #1109 `ConfigureDelegationMixin` normalization pass and kept a `configure()` that **never returns anything** — `configure("height")`, `configure("cursor")`, and no-arg `configure()` all computed their answer and dropped it (always `None`), and the custom `pagesize` option was settable via `configure(pagesize=...)` but raised `unknown option "-pagesize"` on every query form. `cget` was also unrouted (inherited straight from Frame), so `cget("height")` and `configure(height=...)` disagreed about which widget they addressed.

## Changes

- `configure(opt)` returns the option spec; no-arg `configure()` returns the full option dict with `pagesize` merged in; dict-form `cnf` is accepted (tkinter's `__setitem__` passes one)
- `configure("pagesize")` / `cget("pagesize")` / `tv["pagesize"]` all answer; the bare `except:` is narrowed to `TclError`
- new `cget` matches `configure`'s routing: inner Treeview first, container-frame fallback
- `style`/`class` stay on the wrapper frame in both directions, so the theme walk's `cget("style")` behavior (#1122) is unchanged
- explicit `__getitem__`/`__setitem__`: tkinter aliases `__getitem__ = cget` at *function* level, which bypasses subclass overrides; `bootstyle`/`style` still defer to `BootMixin`

A full `ConfigureDelegationMixin` migration was considered and deliberately not done: the mixin's set path routes all non-delegated options to a single target with no fallback, but Tableview needs view-first-then-frame in both directions (`height` is a view option, `relief` a frame option).

## Verification

- `tests/test_tableview_api.py` +5 (query spec, full dict, pagesize parity incl. subscript, view/frame routing, wrapper-style invariance)
- full suite: **697 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)