### PR TITLE
docs: fix the 2026-07-16 author-review findings (fonts, geometry, styling API)

### DIFF
--- a/docs/reference/geometry/grid.rst
+++ b/docs/reference/geometry/grid.rst
@@ -12,17 +12,51 @@ The canonical upstream reference is the Tk
 `grid <https://www.tcl-lang.org/man/tcl8.6/TkCmd/grid.htm>`__ manual page
 (Tcl 8.6).
 
+Options
+-------
+
+Every option below is a keyword argument to ``grid()``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``row`` / ``column``
+     - ``int``
+     - The cell to occupy (0-based). ``column`` defaults to ``0``; ``row``
+       defaults to the first empty row.
+   * - ``rowspan`` / ``columnspan``
+     - ``int``
+     - How many rows / columns the widget covers. Default ``1``.
+   * - ``sticky``
+     - ``str``
+     - Which sides of the cell the widget sticks to — any combination of
+       ``"nsew"``. Opposite pairs stretch the widget; the default centers it
+       at its natural size.
+   * - ``padx`` / ``pady``
+     - ``int | tuple``
+     - External space around the widget, in pixels. A ``(left, right)`` /
+       ``(top, bottom)`` tuple pads the two sides differently.
+   * - ``ipadx`` / ``ipady``
+     - ``int``
+     - Internal padding added to the widget's own size, in pixels.
+   * - ``in_``
+     - ``Widget``
+     - Grid inside a container other than the parent (the container must be
+       the parent or one of its descendants). Rarely needed.
+
 Placing a widget
 ----------------
 
 .. py:method:: grid(**options)
    :noindex:
 
-   Place the widget in a cell (or span of cells). Alias: ``grid_configure``.
+   Place the widget in a cell (or span of cells), using the options above.
+   Alias: ``grid_configure``.
 
-   :param options: ``row``, ``column``, ``rowspan``, ``columnspan``,
-      ``sticky`` (any of ``"nsew"``), ``padx``/``pady`` (external),
-      ``ipadx``/``ipady`` (internal).
    :returns: the widget (ttkbootstrap), for chaining.
 
 .. py:method:: grid_forget()

--- a/docs/reference/geometry/pack.rst
+++ b/docs/reference/geometry/pack.rst
@@ -12,14 +12,60 @@ The canonical upstream reference is the Tk
 `pack <https://www.tcl-lang.org/man/tcl8.6/TkCmd/pack.htm>`__ manual page
 (Tcl 8.6).
 
+Options
+-------
+
+Every option below is a keyword argument to ``pack()``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``side``
+     - ``str``
+     - The side of the remaining space the widget stacks against: ``"top"``
+       (default), ``"bottom"``, ``"left"``, or ``"right"``.
+   * - ``fill``
+     - ``str``
+     - Stretch the widget to fill its slot: ``"x"``, ``"y"``, ``"both"``, or
+       ``"none"`` (default).
+   * - ``expand``
+     - ``bool``
+     - Claim a share of the parent's leftover space — the *slot* grows; pair
+       with ``fill`` so the widget grows with it.
+   * - ``anchor``
+     - ``str``
+     - Where the widget sits inside its slot when it does not fill it:
+       ``"center"``, a side (``"n"``/``"s"``/``"e"``/``"w"``), or a corner
+       (``"ne"``, ``"sw"``, …).
+   * - ``padx`` / ``pady``
+     - ``int | tuple``
+     - External space around the widget, in pixels. A ``(left, right)`` /
+       ``(top, bottom)`` tuple pads the two sides differently.
+   * - ``ipadx`` / ``ipady``
+     - ``int``
+     - Internal padding added to the widget's own size, in pixels.
+   * - ``before`` / ``after``
+     - ``Widget``
+     - Insert the widget into the packing order relative to a sibling that is
+       already packed.
+   * - ``in_``
+     - ``Widget``
+     - Pack inside a container other than the parent (the container must be
+       the parent or one of its descendants). Rarely needed.
+
+Methods
+-------
+
 .. py:method:: pack(**options)
    :noindex:
 
-   Place the widget against a side of its parent. Alias: ``pack_configure``.
+   Place the widget against a side of its parent, using the options above.
+   Alias: ``pack_configure``.
 
-   :param options: ``side`` (``"top"``/``"bottom"``/``"left"``/``"right"``),
-      ``fill`` (``"x"``/``"y"``/``"both"``), ``expand`` (bool), ``anchor``,
-      ``padx``/``pady`` (external), ``ipadx``/``ipady`` (internal).
    :returns: the widget (ttkbootstrap), for chaining.
 
 .. py:method:: pack_forget()

--- a/docs/reference/geometry/place.rst
+++ b/docs/reference/geometry/place.rst
@@ -12,14 +12,55 @@ The canonical upstream reference is the Tk
 `place <https://www.tcl-lang.org/man/tcl8.6/TkCmd/place.htm>`__ manual page
 (Tcl 8.6).
 
+Options
+-------
+
+Every option below is a keyword argument to ``place()``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 16 62
+
+   * - Option
+     - Type
+     - Description
+   * - ``x`` / ``y``
+     - ``int``
+     - The anchor point's position, in pixels from the parent's top-left
+       corner.
+   * - ``relx`` / ``rely``
+     - ``float``
+     - The anchor point's position as a fraction of the parent's size,
+       ``0.0``–``1.0``. Combines with ``x`` / ``y``, which then act as a
+       pixel offset.
+   * - ``width`` / ``height``
+     - ``int``
+     - The widget's size, in pixels.
+   * - ``relwidth`` / ``relheight``
+     - ``float``
+     - The widget's size as a fraction of the parent's size, ``0.0``–``1.0``.
+       Combines with ``width`` / ``height`` as a pixel adjustment.
+   * - ``anchor``
+     - ``str``
+     - Which point of the *widget* is placed at the given position:
+       ``"nw"`` (default), ``"center"``, ``"se"``, ….
+   * - ``bordermode``
+     - ``str``
+     - Whether coordinates are measured ``"inside"`` (default) or
+       ``"outside"`` the parent's border.
+   * - ``in_``
+     - ``Widget``
+     - Place relative to a container other than the parent. Rarely needed.
+
+Methods
+-------
+
 .. py:method:: place(**options)
    :noindex:
 
-   Position the widget by coordinates. Alias: ``place_configure``.
+   Position the widget by coordinates, using the options above. Alias:
+   ``place_configure``.
 
-   :param options: ``x``/``y`` (absolute pixels) or ``relx``/``rely`` (0.0–1.0
-      of the parent), ``width``/``height`` or ``relwidth``/``relheight``, and
-      ``anchor``.
    :returns: the widget (ttkbootstrap), for chaining.
 
 .. py:method:: place_forget()

--- a/docs/reference/styling.rst
+++ b/docs/reference/styling.rst
@@ -57,11 +57,13 @@ worked example.
 
 .. autoclass:: ttkbootstrap.El
    :members:
+   :exclude-members: name, options, children
 
 .. autofunction:: ttkbootstrap.register_style
 
 .. autoclass:: ttkbootstrap.StyleName
    :members:
+   :exclude-members: colorname, element, ttk_style
 
 .. note::
 

--- a/docs/user-guide/feature-guides/typography.rst
+++ b/docs/user-guide/feature-guides/typography.rst
@@ -182,13 +182,15 @@ than erroring, so it is safe to call at startup:
 
 .. code-block:: python
 
-   ttk.Fonts.create_alias("Caption", family="Georgia", size=9, slant="italic")
+   ttk.Fonts.create_alias("HeadingSm", family="Helvetica", size=12, weight="bold")
 
-   ttk.Label(app, text="figure 1 — quarterly revenue", font="Caption").pack()
+   ttk.Label(app, text="Quarterly revenue", font="HeadingSm").pack()
 
-Define your fonts once and the rest of the code just names the role; restyle a
-role later — a bigger caption, a different heading family — in that one place and
-the whole app follows.
+Pick a name that is not already taken — Tk predefines ``TkCaptionFont``,
+``TkHeadingFont``, and the other built-in roles above, so an alias like
+``Caption`` would shadow territory Tk already names. Define your fonts once and
+the rest of the code just names the role; restyle a role later — a bigger
+heading, a different family — in that one place and the whole app follows.
 
 .. admonition:: 📷 Screenshot (placeholder)
    :class: screenshot-placeholder

--- a/docs/user-guide/foundations/layout-with-grid.rst
+++ b/docs/user-guide/foundations/layout-with-grid.rst
@@ -95,6 +95,12 @@ they stretch to fill it. This pairing is the whole secret to a responsive grid:
    means "stay at content size"; larger weights split the spare space in
    proportion.
 
+Sizing also flows the other way: a container with gridded children shrinks or
+grows to fit them, so a ``width``/``height`` you set on the container yields to
+the content. Call ``grid_propagate(False)`` on the container to keep the fixed
+size instead (the grid counterpart of ``pack_propagate`` from
+:doc:`Layout with pack </user-guide/foundations/layout-with-pack>`).
+
 Step 5 — span several cells
 ---------------------------
 

--- a/src/ttkbootstrap/dialogs/colordropper.py
+++ b/src/ttkbootstrap/dialogs/colordropper.py
@@ -29,7 +29,7 @@ class ColorDropperDialog:
 
     This widget is implemented for **Windows** and **Linux** only.
 
-    !!! warning "high resolution displays"
+    Warning:
         This widget may not function properly on high resolution
         displays if you are not using the application in high
         resolution mode. This is enabled automatically on Windows.

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -299,11 +299,12 @@ def icon_element(style, name, *, size, default, states=None, **options):
 
     Per-state spec grammar (`default` and each `states` value):
 
-      - **bare string** -> the icon *name*; its color **follows the foreground**
-        configured for that state.
-      - **dict `{name?, color?}`** -> `name` omitted = the `default` icon;
-        `color` omitted = follows the foreground. `color` is a bootstyle keyword
-        or a hex, resolved once against the active theme.
+    - A **bare string** is the icon *name*; its color follows the foreground
+      configured for that state.
+    - A **dict** with optional `name` and `color` keys: `name` omitted uses
+      the `default` icon; `color` omitted follows the foreground. `color` is
+      a bootstyle keyword or a hex value, resolved once against the active
+      theme.
 
     ```python
     state_map(style, "Favorite.TCheckbutton", foreground={"disabled": "#888"})

--- a/src/ttkbootstrap/style/layout.py
+++ b/src/ttkbootstrap/style/layout.py
@@ -45,10 +45,43 @@ def statespec(spec):
 class El:
     """A ttk layout element: a name, layout options, and child elements.
 
-    `layout()` lowers an `El` tree to ttk's nested `(name, {opts, "children":
-    [...]})` form. Mirrors bootstack's `Element.spec()`, but takes children as a
-    constructor `children=[...]` kwarg (unambiguous; reads as the tree it builds)
-    rather than fluent positional parenting.
+    Build an `El` tree and pass it to `layout()`, which lowers it to ttk's
+    nested ``(name, {options, "children": [...]})`` form and registers the
+    style.
+
+    Parameters:
+
+        name (str):
+            The element name (e.g. ``"Button.border"``).
+
+        side (str):
+            Which side of the remaining space the element occupies:
+            ``"left"``, ``"right"``, ``"top"``, or ``"bottom"``.
+
+        sticky (str):
+            How the element stretches within its allocation — any
+            combination of ``"nsew"``.
+
+        expand (bool):
+            Whether the element claims any leftover space.
+
+        border (int):
+            The border width reserved inside the element.
+
+        children (list[El]):
+            Elements nested inside this one.
+
+    Attributes:
+
+        name (str):
+            The element name.
+
+        options (dict):
+            The layout options that were set (``side``/``sticky``/
+            ``expand``/``border``).
+
+        children (list[El]):
+            The nested child elements.
     """
 
     __slots__ = ("name", "options", "children")
@@ -143,19 +176,43 @@ def state_map(style, ttk_style, **options):
 
 
 class StyleName:
-    """Absorbs the colorname / orientation / `.TS->.S` name surgery builders repeat.
+    """Derive the related names a custom style is built from.
 
-    From a ttk class token ("TScale", "TRadiobutton"), the requested colorname,
-    and an optional orientation it derives the three names every builder opens
-    with:
+    From a ttk class token (``"TScale"``, ``"TRadiobutton"``), a color name,
+    and an optional orientation, computes the style name and the matching
+    element-name prefix, so the three always agree.
 
-      .colorname  PRIMARY when the input is DEFAULT/"" (the per-widget default),
-                  else the input unchanged.
-      .ttk_style   the full ttk style name ("Horizontal.TScale",
-                  "info.Horizontal.TScale", "TRadiobutton", ...).
-      .element    the element-name prefix with the class token's leading "T"
-                  dropped ("info.Horizontal.TScale" -> "info.Horizontal.Scale"),
-                  matching the old `h_ttkstyle.replace(".TS", ".S")` dance.
+    Parameters:
+
+        ttk_class (str):
+            The ttk widget class token (e.g. ``"TButton"``,
+            ``"Treeview"``).
+
+        colorname (str):
+            The accent color name; ``DEFAULT`` or ``""`` resolves to
+            ``"primary"``.
+
+        orient (str):
+            An optional orientation segment (``"Horizontal"`` /
+            ``"Vertical"``).
+
+        surface (str):
+            An optional surface-color token carried as a name prefix.
+
+    Attributes:
+
+        colorname (str):
+            The resolved color name — ``"primary"`` when the input was the
+            default, otherwise the input unchanged.
+
+        ttk_style (str):
+            The full ttk style name (``"Horizontal.TScale"``,
+            ``"info.Horizontal.TScale"``, ``"TRadiobutton"``, …).
+
+        element (str):
+            The element-name prefix: ``ttk_style`` with the class token's
+            leading ``"T"`` dropped (``"info.Horizontal.TScale"`` →
+            ``"info.Horizontal.Scale"``).
     """
 
     __slots__ = ("colorname", "ttk_style", "element")

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -831,15 +831,28 @@ class Theme:
             to skip it.
     """
 
+    #: Family name; generated variants are ``<name>-light`` / ``<name>-dark``.
     name: str
+    #: Accent ``[500]`` anchor color (hex).
     primary: str = None
+    #: Accent ``[500]`` anchor color (hex).
     success: str = None
+    #: Accent ``[500]`` anchor color (hex).
     info: str = None
+    #: Accent ``[500]`` anchor color (hex).
     warning: str = None
+    #: Accent ``[500]`` anchor color (hex).
     danger: str = None
+    #: Optional colored secondary accent (hex); derives from the neutral
+    #: ramp when omitted.
     secondary: str = None
+    #: Gray base for the neutral ramp (secondary, the light/dark accents).
     neutral: str = _DEFAULT_NEUTRAL
+    #: ``{'background': ..., 'foreground': ...}`` for the light variant, or
+    #: ``None`` to skip it.
     light: dict = None
+    #: ``{'background': ..., 'foreground': ...}`` for the dark variant, or
+    #: ``None`` to skip it.
     dark: dict = None
 
     def _definition(self, mode):

--- a/src/ttkbootstrap/utils/scaling.py
+++ b/src/ttkbootstrap/utils/scaling.py
@@ -13,7 +13,7 @@ def enable_high_dpi_awareness(root=None, scaling=None):
     AFTER creating the `Tk` object. A number between 1.6 and 2.0 is
     usually suffient to scale for high-dpi screen.
 
-    !!! warning
+    Warning:
         If the `root` argument is provided, then `scaling` must also
         be provided. Otherwise, there is no effect.
 

--- a/src/ttkbootstrap/widgets/tableview.py
+++ b/src/ttkbootstrap/widgets/tableview.py
@@ -680,10 +680,10 @@ class Tableview(ttk.Frame):
         method. You may use a mixture of string and dictionary in
         the list of coldata.
 
-        !!!warning "Existing table data will be erased.
-            This method will completely rebuild the underlying table
-            with the new column and row data. Any existing data will
-            be lost.
+        Warning:
+            Existing table data will be erased: this method completely
+            rebuilds the underlying table with the new column and row
+            data, and any existing data is lost.
 
         Parameters:
 
@@ -847,15 +847,12 @@ class Tableview(ttk.Frame):
         of the columns in the table from left to right starting with
         index 0.
 
-        !!!Warning "Use this method with caution!
-            This method may or may not suffer performance issues.
-            Internally, this method calls the `delete_column` method
-            on each column specified in the list. The `delete_column`
-            method deletes the related column from each record in
-            the table data. So, if there are a lot of records this
-            could be problematic. It may be more beneficial to use
-            the `build_table_data` if you plan on changing the
-            structure of the table dramatically.
+        Warning:
+            This method calls `delete_column` for each column in the
+            list, and `delete_column` removes the value from every
+            record — with many records this can be slow. To change the
+            table's structure dramatically, `build_table_data` is
+            usually the better tool.
 
         Parameters:
 


### PR DESCRIPTION
## Summary

Fixes eight of the nine review findings from the author's docs read-through (the ninth — the `bootify` clarity question — turned out to be a crash-class code bug, fixed in its own PR):

- **typography** — the `create_alias` example used `"Caption"`, shadowing Tk's own `TkCaptionFont` role; now `"HeadingSm"`, plus a line teaching readers to pick names Tk hasn't taken. Snippet verified headlessly.
- **layout-with-grid** — `grid_propagate` was taught nowhere on the grid page (the pack page teaches `pack_propagate` and the geometry reference specs both); Step 4 now covers the child→parent sizing direction with a cross-ref. *(Answering the review question: propagate **was** already taught for pack — foundations pack page, frame catalog page, and both geometry reference specs — the grid foundations page was the one gap.)*
- **geometry pack/grid/place** — the placement options were crammed into a single run-on `:param:` line; each page now opens with a proper Options list-table (`side`/`fill`/`expand`/`anchor`/`padx`/`ipadx`/`before`/`after`/`in_` etc.), with the method spec pointing at it.
- **El** — constructor parameters and the `name`/`options`/`children` attributes documented (napoleon Parameters/Attributes; the `__slots__` descriptors excluded from `:members:` to avoid duplicate index entries).
- **StyleName** — the misrendered indented block is now a proper Attributes section; internal-history prose dropped; constructor parameters documented.
- **Theme** — the dataclass fields now carry `#:` doc comments, so autodoc renders documented attributes instead of bare names.
- **icon_element** — the per-state grammar list was an indented blockquote with illegal nested inline markup; now a flush-left rST list.
- **high-DPI warning** (+3 siblings) — four leftover mkdocs `!!!` admonitions in docstrings (`scaling.py`'s high-DPI warning, `colordropper.py`, `tableview.py` ×2) rendered as plain unstyled text under Sphinx; converted to napoleon `Warning:` sections, verified to render as styled warning admonitions in the built HTML.

## Verification

- `sphinx -b html -W -q -E docs` exit 0; rendered HTML spot-checked (warning admonition present, Theme/El attribute docs present, no `!!!` anywhere)
- suite 692 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)