### PR TITLE
fix(style): don't crash on a bootstyle for a widget class with no family

### DIFF
--- a/docs/reference/styling.rst
+++ b/docs/reference/styling.rst
@@ -27,6 +27,16 @@ The widgets ttkbootstrap ships already accept ``bootstyle``. These helpers exten
 that keyword to widgets it does not ship — a third-party ttk widget, or a plain
 ``tkinter.ttk`` widget you created yourself.
 
+How much of the ``bootstyle`` vocabulary applies depends on the widget's ttk
+class. A widget that keeps a standard ttk class (a subclass of ``ttk.Button``,
+``ttk.Entry``, …) gets the full vocabulary and behaves exactly like the
+corresponding ttkbootstrap widget. A widget with its own ttk class has no
+ttkbootstrap style recipe: a bare color (``bootstyle="info"``) warns and leaves
+the widget's style unchanged, and naming a base type explicitly
+(``bootstyle="info-frame"``) borrows that standard recipe where the widget's
+elements support it. A composite widget's internal sub-widgets style themselves
+and are not reached either way.
+
 .. autofunction:: ttkbootstrap.bootify
 
 .. autofunction:: ttkbootstrap.apply_bootstyle

--- a/docs/reference/styling.rst
+++ b/docs/reference/styling.rst
@@ -34,8 +34,14 @@ corresponding ttkbootstrap widget. A widget with its own ttk class has no
 ttkbootstrap style recipe: a bare color (``bootstyle="info"``) warns and leaves
 the widget's style unchanged, and naming a base type explicitly
 (``bootstyle="info-frame"``) borrows that standard recipe where the widget's
-elements support it. A composite widget's internal sub-widgets style themselves
-and are not reached either way.
+elements support it.
+
+A composite widget's internals follow the active theme on their own —
+standard-class children resolve against the per-theme base styles, so they
+match every theme switch without any wrapping. The accent, however, is not
+fanned out to them: which child should carry it is the widget's design, not
+something a wrapper can infer. To accent a specific internal, call
+``apply_bootstyle`` on that child.
 
 .. autofunction:: ttkbootstrap.bootify
 

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -1227,9 +1227,13 @@ def bootify(cls):
     - A widget with its **own ttk class** has no ttkbootstrap style recipe: a
       bare color (``bootstyle="info"``) warns and leaves the widget's style
       unchanged. Name a base type explicitly (``bootstyle="info-frame"``) to
-      borrow a standard recipe where the widget's elements support it. The
-      widget's internal sub-widgets style themselves and are not reached
-      either way.
+      borrow a standard recipe where the widget's elements support it.
+
+    A composite widget's internals follow the active theme on their own
+    (standard-class children resolve against the per-theme base styles), but
+    the accent is not fanned out to them — which child should carry it is the
+    widget's design, not something a wrapper can infer. To accent a specific
+    internal, use `apply_bootstyle` on that child.
     """
     return type(cls.__name__, (BootMixin, cls), {})
 

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -730,8 +730,32 @@ class Bootstyle:
                     ):
                         return style_string
                 else:
-                    # A third-party widget whose class maps to no ttkbootstrap
-                    # builder: pass its style through untouched.
+                    if is_bootstyle:
+                        # A bootstyle on a widget whose class maps to no
+                        # ttkbootstrap family (e.g. a bootified third-party
+                        # widget with its own widget class): there is no
+                        # recipe to build, and the raw fragment ("info") is
+                        # not a ttk style name -- assigning it would crash
+                        # with "Layout ... not found". Fail loudly (except
+                        # for the implicit default resolve) and keep the
+                        # widget's current style.
+                        if style_string != "default":
+                            widget_class = ""
+                            try:
+                                widget_class = widget.winfo_class()
+                            except (AttributeError, TclError):
+                                pass
+                            _compat.report_invalid(
+                                "family", widget_class or "<unknown>",
+                                style_string,
+                            )
+                        try:
+                            return str(widget.cget("style"))
+                        except (AttributeError, TclError):
+                            return ""
+                    # An already-built style name from a third-party widget
+                    # whose class maps to no ttkbootstrap builder: pass it
+                    # through untouched.
                     return style_string
 
         # Graceful degrade (2.0 surface-color): if a surface was requested but the
@@ -1184,16 +1208,28 @@ def bootify(cls):
     """Return a ``bootstyle``-enabled subclass of any ttk widget class.
 
     Use this to wrap a third-party ttk-derived widget that ttkbootstrap does
-    not ship a blessed subclass for:
+    not ship a subclass for:
 
     ```python
-    ThemedCalendar = bootify(tkcalendar.Calendar)
-    cal = ThemedCalendar(root, bootstyle="info")
+    ThemedGadget = bootify(Gadget)
+    gadget = ThemedGadget(root, bootstyle="info")
     ```
 
-    The result is ``type(cls.__name__, (BootMixin, cls), {})`` — i.e. the same
-    construction used for the built-in blessed widgets, so it gains the full
+    The result is ``type(cls.__name__, (BootMixin, cls), {})`` — the same
+    construction used for the widgets ttkbootstrap ships, so it gains the full
     ``bootstyle`` API without mutating the original class.
+
+    How much of the vocabulary applies depends on the widget's ttk class:
+
+    - A widget that keeps a **standard ttk class** (a subclass of
+      ``ttk.Button``, ``ttk.Entry``, …) gets the full vocabulary — it behaves
+      exactly like the corresponding ttkbootstrap widget.
+    - A widget with its **own ttk class** has no ttkbootstrap style recipe: a
+      bare color (``bootstyle="info"``) warns and leaves the widget's style
+      unchanged. Name a base type explicitly (``bootstyle="info-frame"``) to
+      borrow a standard recipe where the widget's elements support it. The
+      widget's internal sub-widgets style themselves and are not reached
+      either way.
     """
     return type(cls.__name__, (BootMixin, cls), {})
 
@@ -1210,6 +1246,11 @@ def apply_bootstyle(widget, bootstyle: BootStyle | str) -> str:
     b = ttk.Button(root, text="Save")
     apply_bootstyle(b, "success")
     ```
+
+    The same widget-class rules as `bootify` apply: a widget with its own ttk
+    class has no style recipe, so a bare color warns and leaves the style
+    unchanged — name a base type explicitly (``"info-frame"``) to borrow a
+    standard recipe.
 
     Returns the resolved ttk style name.
     """

--- a/tests/test_mixin_api.py
+++ b/tests/test_mixin_api.py
@@ -180,6 +180,44 @@ def test_apply_bootstyle_styles_existing_instance(root):
     assert b.cget("style") == "danger.TButton"
 
 
+class _CustomClassFrame(tkttk.Frame):
+    """A stand-in for a third-party widget with its own ttk widget class."""
+
+    def __init__(self, master=None, **kw):
+        kw.setdefault("class_", "ThirdPartyGadget")
+        super().__init__(master, **kw)
+
+
+def test_bootify_unknown_family_bare_construction(root):
+    # Regression: constructing a bootified custom-class widget crashed with
+    # TclError "Layout default not found" -- the implicit default resolve
+    # returned the raw bootstyle fragment as if it were a ttk style name.
+    w = ttk.bootify(_CustomClassFrame)(root)
+    assert str(w.cget("style")) == ""
+
+
+def test_bootify_unknown_family_color_warns_and_keeps_style(root):
+    # A bare color has no recipe for an unknown widget class: fail loudly,
+    # leave the style unchanged (was: TclError "Layout info not found").
+    Wrapped = ttk.bootify(_CustomClassFrame)
+    with pytest.warns(UserWarning, match="ThirdPartyGadget"):
+        w = Wrapped(root, bootstyle="info")
+    assert str(w.cget("style")) == ""
+
+
+def test_bootify_unknown_family_explicit_base_type_works(root):
+    # Naming a base type explicitly borrows the standard recipe.
+    w = ttk.bootify(_CustomClassFrame)(root, bootstyle="info-frame")
+    assert str(w.cget("style")) == "info.TFrame"
+
+
+def test_apply_bootstyle_unknown_family_warns_not_crashes(root):
+    w = _CustomClassFrame(root)
+    with pytest.warns(UserWarning, match="ThirdPartyGadget"):
+        returned = ttk.apply_bootstyle(w, "info")
+    assert returned == str(w.cget("style"))
+
+
 def test_enable_global_api_is_idempotent_and_styles_stock_widgets(root):
     """Runs last: enabling the global API is an irreversible process-wide switch."""
     ttk.enable_global_api()


### PR DESCRIPTION
## Summary

The author's docs review asked *"How effective is bootify at enabling styles? What are the limitations? It is not clear."* — probing the answer found that `bootify` was **broken for exactly the case its docstring advertised**: a third-party ttk widget with its own widget class.

With no inferable family, `update_ttk_widget_style` returned the raw bootstyle fragment (`"info"`, or the implicit `"default"`) as if it were a ttk style name, and assigning it crashed with `TclError: Layout ... not found`:

```python
class Gadget(ttk.Frame):                    # class_="Gadget"
    ...
bootify(Gadget)(root)                       # crashed (default)
bootify(Gadget)(root, bootstyle="info")     # crashed (info)
apply_bootstyle(gadget, "info")             # crashed (info)
```

## Changes

- When the input is a **bootstyle** (not an already-built style name) and the widget's class maps to no ttkbootstrap family: `report_invalid` fires (warn, or raise under strict mode) naming the widget class — except for the implicit `"default"` resolve, which stays silent — and the widget's current style is returned unchanged. The already-built-style-name pass-through for third-party widgets is untouched.
- Naming a base type explicitly still borrows the standard recipe (`bootstyle="info-frame"` → `"info.TFrame"`).
- The docs now answer the review question: the `bootify`/`apply_bootstyle` docstrings and the *Applying styles to any widget* reference section spell out how much of the vocabulary applies per widget class (full for standard ttk classes; warn-and-keep for custom classes unless a base type is named; composite internals are never reached).

## Verification

- `tests/test_mixin_api.py` +4 (bare construction, color warn-and-keep, explicit base type, `apply_bootstyle` parity)
- suite 696 passed; `sphinx -W -E` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)