### PR TITLE
docs(geometry): unslash the paired option cells onto rST line blocks

### DIFF
--- a/docs/reference/geometry/grid.rst
+++ b/docs/reference/geometry/grid.rst
@@ -24,11 +24,13 @@ Every option below is a keyword argument to ``grid()``.
    * - Option
      - Type
      - Description
-   * - ``row`` / ``column``
+   * - | ``row``
+       | ``column``
      - ``int``
      - The cell to occupy (0-based). ``column`` defaults to ``0``; ``row``
        defaults to the first empty row.
-   * - ``rowspan`` / ``columnspan``
+   * - | ``rowspan``
+       | ``columnspan``
      - ``int``
      - How many rows / columns the widget covers. Default ``1``.
    * - ``sticky``
@@ -36,11 +38,13 @@ Every option below is a keyword argument to ``grid()``.
      - Which sides of the cell the widget sticks to — any combination of
        ``"nsew"``. Opposite pairs stretch the widget; the default centers it
        at its natural size.
-   * - ``padx`` / ``pady``
+   * - | ``padx``
+       | ``pady``
      - ``int | tuple``
      - External space around the widget, in pixels. A ``(left, right)`` /
        ``(top, bottom)`` tuple pads the two sides differently.
-   * - ``ipadx`` / ``ipady``
+   * - | ``ipadx``
+       | ``ipady``
      - ``int``
      - Internal padding added to the widget's own size, in pixels.
    * - ``in_``

--- a/docs/reference/geometry/pack.rst
+++ b/docs/reference/geometry/pack.rst
@@ -41,14 +41,17 @@ Every option below is a keyword argument to ``pack()``.
      - Where the widget sits inside its slot when it does not fill it:
        ``"center"``, a side (``"n"``/``"s"``/``"e"``/``"w"``), or a corner
        (``"ne"``, ``"sw"``, …).
-   * - ``padx`` / ``pady``
+   * - | ``padx``
+       | ``pady``
      - ``int | tuple``
      - External space around the widget, in pixels. A ``(left, right)`` /
        ``(top, bottom)`` tuple pads the two sides differently.
-   * - ``ipadx`` / ``ipady``
+   * - | ``ipadx``
+       | ``ipady``
      - ``int``
      - Internal padding added to the widget's own size, in pixels.
-   * - ``before`` / ``after``
+   * - | ``before``
+       | ``after``
      - ``Widget``
      - Insert the widget into the packing order relative to a sibling that is
        already packed.

--- a/docs/reference/geometry/place.rst
+++ b/docs/reference/geometry/place.rst
@@ -24,19 +24,23 @@ Every option below is a keyword argument to ``place()``.
    * - Option
      - Type
      - Description
-   * - ``x`` / ``y``
+   * - | ``x``
+       | ``y``
      - ``int``
      - The anchor point's position, in pixels from the parent's top-left
        corner.
-   * - ``relx`` / ``rely``
+   * - | ``relx``
+       | ``rely``
      - ``float``
      - The anchor point's position as a fraction of the parent's size,
        ``0.0``–``1.0``. Combines with ``x`` / ``y``, which then act as a
        pixel offset.
-   * - ``width`` / ``height``
+   * - | ``width``
+       | ``height``
      - ``int``
      - The widget's size, in pixels.
-   * - ``relwidth`` / ``relheight``
+   * - | ``relwidth``
+       | ``relheight``
      - ``float``
      - The widget's size as a fraction of the parent's size, ``0.0``–``1.0``.
        Combines with ``width`` / ``height`` as a pixel adjustment.


### PR DESCRIPTION
## Summary

The pack/grid/place Options tables added in #1246 joined paired options with `/` in the Option column (`padx` / `pady`, `row` / `column`, …), against the standing one-item-per-line line-block convention established in #1227. All 11 paired cells across the three pages now stack via rST line blocks:

```rst
* - | ``padx``
    | ``pady``
```

Descriptions untouched (prose slashes in sentences are fine per the convention).

## Verification

`sphinx -b html -W -q -E docs` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)