### PR TITLE
feat(style): surface elevation scale (chrome) + frames consume @surface

### DIFF
--- a/development/2_0_surface_scale_design.md
+++ b/development/2_0_surface_scale_design.md
@@ -1,0 +1,65 @@
+# 2.0 — Surface elevation scale + frames as surface consumers
+
+Small follow-on to the 2.0 surface-color work (the `@surface` grammar). Two
+changes, settled in a live design discussion:
+
+## 1. A named elevation scale: `background` < `chrome` < `card`
+
+The surface tokens now form a mode-aware elevation scale — each a step off the
+window background (`shade` in a light theme, `tint` in a dark one), so a surface
+reads as progressively more separated from the base content:
+
+| token        | elevation | role                                             |
+|--------------|-----------|--------------------------------------------------|
+| `background` | 0         | the app canvas / main content (the default)      |
+| `@chrome`    | 0.03      | recessive app framing: toolbars, status bars     |
+| `@card`      | 0.06      | a distinct raised panel (the ceiling)            |
+
+`card` stays the ceiling — past ~0.06 a flat theme reads muddy. `chrome` is
+deliberately subtler than `card`: the deciding rule is **nesting** — a card can
+sit *on* chrome (a panel inside a sidebar) and must still read as raised, while
+chrome never sits on a card. So `card` out-contrasts `chrome`.
+
+Concrete (light): `#ffffff → #f7f7f7 → #f0f0f0`; (dark): `#212529 → #282c2f →
+#2e3236`. Implemented as `_CHROME_ELEVATION`/`_CARD_ELEVATION` +
+`_elevated_surface(elevation)` in `style/builders_ttk.py`; `chrome_surface()`
+joins `card_surface()`; `resolve_surface` handles `"chrome"`. Vocab: `chrome`
+added to `BOOTSTYLE_SURFACES` in `constants.py`.
+
+## 2. Frames consume a surface (a container that *is* a surface)
+
+Previously frames were excluded from `_SURFACE_FAMILIES` — "surface producers,
+not consumers." But there was then **no way to make a container render as a
+given surface**: `bootstyle="card"` is the border-only `Card.TFrame` (background
+= window bg), and `@card` was silently dropped on a frame. So a sidebar/panel
+could not take the elevation surface, and the grammar docs' own example put a
+`@card` button (blend `#f0f0f0`) on a `card`-variant frame (bg `#ffffff`) — a
+mismatch.
+
+`frame` is now in `_SURFACE_FAMILIES`, and the default frame recipe
+(`style/builders/frame.py`) resolves `self._surface` for its background and
+`surface_prefix`es its style name, mirroring the label recipe. So:
+
+- `ttk.Frame(app, bootstyle="@card")` → `@card.TFrame`, filled with the card
+  surface — a sidebar/panel on the scale.
+- `ttk.Frame(app, bootstyle="@chrome")` → the recessive framing surface.
+- `@surface` composes with a color (`@chrome primary` → `@chrome.primary.TFrame`).
+
+Border and surface stay **orthogonal**: the `card`/`highlight` frame *variants*
+(the hairline border, used internally by ScrolledText/datepicker) are untouched
+and remain internal. A bordered card on a surface would be `card @card` once the
+variant honors surface too — deferred; not needed here.
+
+## Not done (deliberately)
+
+- No rename of the internal `card`/`highlight` frame **variant**. The
+  variant-vs-surface name clash only surfaced when the `card` variant was exposed
+  in user docs; the docs now use the `@card` *surface* instead, so users never
+  see the clash. Renaming the internal token is optional cleanup for later.
+- `labelframe` not added as a surface consumer yet (no driver).
+
+## Tests
+
+`test_surface_color.py` (chrome rung), `test_surface_families.py` (frame in the
+gate), `test_surface_grammar.py` (frame consumes surface + composes with color).
+Reference regenerated via `tools/generate_bootstyle_reference.py`. Suite green.

--- a/docs/_generated/bootstyle_reference.rst
+++ b/docs/_generated/bootstyle_reference.rst
@@ -12,7 +12,7 @@ Surfaces
 
 The optional ``@<surface>`` slot names the surface a control sits on so it can blend on a card or an accent bar. It accepts:
 
-``@card``, ``@primary``, ``@secondary``, ``@success``, ``@info``, ``@warning``, ``@danger``, ``@light``, ``@dark``.
+``@chrome``, ``@card``, ``@primary``, ``@secondary``, ``@success``, ``@info``, ``@warning``, ``@danger``, ``@light``, ``@dark``.
 
 Widget families and variants
 ----------------------------

--- a/docs/user-guide/foundations/bootstyle-grammar.rst
+++ b/docs/user-guide/foundations/bootstyle-grammar.rst
@@ -26,9 +26,12 @@ slot order::
 
    [@surface] [color] [variant] <base-type> [orient]
 
-- **@surface** — the surface the control sits on: ``@card`` (a neutral raised
-  panel) or an accent (``@primary`` …), so a ghost, outline, or link control
-  blends on a card or an accent bar instead of only the window background.
+- **@surface** — the surface the control sits on, a mode-aware elevation scale
+  ``@chrome`` (recessive app framing) → ``@card`` (a raised panel), or an accent
+  (``@primary`` …), so a ghost, outline, or link control blends on a card or an
+  accent bar instead of only the window background. A container **frame** can take
+  the same token to *become* that surface — ``ttk.Frame(app, bootstyle="@card")``
+  is a sidebar or panel on the scale.
   Optional and position-free.
 - **color** — the semantic intent: ``primary``, ``secondary``, ``success``,
   ``info``, ``warning``, ``danger``, ``light``, ``dark``, ``neutral``.
@@ -89,7 +92,7 @@ sits on:
 
 .. code-block:: python
 
-   card = ttk.Frame(app, bootstyle="card", padding=12)
+   card = ttk.Frame(app, bootstyle="@card", padding=12)   # the frame IS the card surface
    ttk.Button(card, text="More", bootstyle="@card primary ghost")
 
 The token exists because tkinter has no transparency. Where a control seems to
@@ -97,8 +100,10 @@ let the surface show through — the fill of a ghost, outline, or link button, t
 label background of a checkbutton or radiobutton — the widget is really painted
 a solid color, and by default that color is the window background. Sitting on a
 card or an accent bar, that shows up as a wrong-colored box around the control.
-``@card`` (a neutral raised panel) or an accent (``@primary`` …) names the
-surface instead, and the theme paints the control to match it.
+``@chrome`` or ``@card`` (the neutral elevation scale) or an accent
+(``@primary`` …) names the surface instead, and the theme paints the control to
+match it. A container frame can take the same token to *render as* that surface,
+so a control and the panel beneath it agree.
 
 Chameleon base-types
 --------------------

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -118,14 +118,16 @@ BOOTSTYLE_ORIENTS: Final = ("horizontal", "vertical")
 
 # Named neutral surfaces a widget can be placed on (2.0 surface-color). The
 # *surface* is the background a widget renders against; the style engine resolves
-# it to a concrete color (style/builders_ttk.py `resolve_surface`). `background`
-# is the application default -- the only surface that produces no style-name
-# segment; `card` is a mode-aware raised panel. Accent colors (BOOTSTYLE_COLORS)
-# are ALSO valid surfaces (resolved separately), so a ghost/outline/link control
-# can blend into an accent container. A non-default surface prefixes the style
-# name with an `@<surface>.` segment. Raw-hex surfaces are deferred.
+# it to a concrete color (style/builders_ttk.py `resolve_surface`). They form a
+# mode-aware elevation scale `background` < `chrome` < `card`: `background` is
+# the application default -- the only surface that produces no style-name segment;
+# `chrome` is the recessive app-framing step (toolbars, status bars); `card` is
+# the raised-panel ceiling. Accent colors (BOOTSTYLE_COLORS) are ALSO valid
+# surfaces (resolved separately), so a ghost/outline/link control can blend into
+# an accent container. A non-default surface prefixes the style name with an
+# `@<surface>.` segment. Raw-hex surfaces are deferred.
 DEFAULT_SURFACE: Final = "background"
-BOOTSTYLE_SURFACES: Final = ("background", "card")
+BOOTSTYLE_SURFACES: Final = ("background", "chrome", "card")
 # The full accepted surface vocabulary: named neutral surfaces + every accent
 # color (an accent doubles as a surface). Single source of truth, shared by the
 # bootstyle-string validator and the builder's resolver so they cannot diverge.

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -98,13 +98,15 @@ _TOKEN_SPLIT = re.compile(r"[-\s]+")
 # (e.g. "@primary success ghost") and, when non-default, prefixes the style name
 # with an `@<surface>.` segment. `_SURFACE_FAMILIES` gates which families a recipe
 # consumes surface for yet -- it grows one PR at a time as families are migrated;
-# a surface for any other family is silently ignored (frames are intentionally
-# never in it -- they are surface producers, not consumers). The token vocab lives
-# once in constants (`BOOTSTYLE_SURFACE_TOKENS`).
+# a surface for any other family is silently ignored. `frame` consumes a surface
+# to fill itself with it (`@card`/`@chrome` -- a container that *is* a surface, so
+# a sidebar or panel renders on the elevation scale); leaf widgets consume it to
+# blend onto the surface they sit on. The token vocab lives once in constants
+# (`BOOTSTYLE_SURFACE_TOKENS`).
 _SURFACE_TOKENS = frozenset(BOOTSTYLE_SURFACE_TOKENS)
 _SURFACE_FAMILIES = frozenset(
     {"button", "checkbutton", "radiobutton", "toggle", "label",
-     "scale", "progressbar", "scrollbar"}
+     "scale", "progressbar", "scrollbar", "frame"}
 )
 
 

--- a/src/ttkbootstrap/style/builders/frame.py
+++ b/src/ttkbootstrap/style/builders/frame.py
@@ -17,12 +17,15 @@ def build_frame_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             The color label used to style the widget.
     """
     ttk_class = "TFrame"
+    # The surface the frame sits on (2.0 surface-color); default == theme bg, so
+    # a plain `@card`/`@chrome` frame gets the elevation surface as its fill.
+    surface = builder.resolve_surface(builder._surface)
 
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
-        background = builder.colors.bg
+        ttk_style = builder.surface_prefix(ttk_class)
+        background = surface
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
         background = builder.colors.get(colorname)
 
     builder.configure(ttk_style, background=background)

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -29,7 +29,13 @@ from ttkbootstrap.style.theme import (
 _TROUGH_SHADE = 0.2    # recessed dark-theme track/trough behind a filled bar
 _STRIPE_TINT = 0.2     # lighter diagonal highlight over a progress bar
 _MUTE_AMOUNT = 0.4     # unchecked-indicator muting
-_CARD_ELEVATION = 0.06  # mode-aware raise of the background for the `card` surface
+# Surface elevation scale (2.0 surface-color): a mode-aware step off the
+# background -- darker in a light theme, lighter in a dark one -- so each named
+# surface reads as progressively more separated from the base content. `chrome`
+# is the recessive framing step (toolbars, status bars); `card` is the ceiling,
+# a distinct grouped panel that can even sit on chrome.
+_CHROME_ELEVATION = 0.03  # `chrome` surface: recessive app framing
+_CARD_ELEVATION = 0.06    # `card` surface: a distinct raised panel (the ceiling)
 
 
 class StyleBuilderTTK:
@@ -152,17 +158,35 @@ class StyleBuilderTTK:
         """
         return _accent_on_color(color)
 
-    def card_surface(self) -> str:
-        """Return the `card` surface: a mode-aware raise of the background.
+    def _elevated_surface(self, elevation: float) -> str:
+        """Raise `colors.bg` by `elevation` in a mode-aware direction.
 
         Darkens the background in a light theme, lightens it in a dark theme, so
-        a card reads as a subtly raised panel in either mode. Derived from
-        `colors.bg` at build time, so it follows theme switches.
+        the surface reads as separated from the base content in either mode.
+        Derived from `colors.bg` at build time, so it follows theme switches.
         """
         bg = self.colors.bg
         if self.is_light_theme:
-            return self.shade(bg, _CARD_ELEVATION)
-        return self.tint(bg, _CARD_ELEVATION)
+            return self.shade(bg, elevation)
+        return self.tint(bg, elevation)
+
+    def chrome_surface(self) -> str:
+        """Return the `chrome` surface: the recessive app-framing step.
+
+        A whisper of separation from the background for structural framing --
+        toolbars, sidebars' quieter cousins, status bars -- deliberately subtler
+        than `card` so a card placed on chrome still reads as raised.
+        """
+        return self._elevated_surface(_CHROME_ELEVATION)
+
+    def card_surface(self) -> str:
+        """Return the `card` surface: a mode-aware raise of the background.
+
+        The top of the elevation scale -- a distinct grouped panel that reads as
+        raised over both the background and `chrome`. Derived from `colors.bg` at
+        build time, so it follows theme switches.
+        """
+        return self._elevated_surface(_CARD_ELEVATION)
 
     def resolve_surface(self, surface: str | None = None) -> str:
         """Resolve a surface token to a concrete background color.
@@ -172,7 +196,9 @@ class StyleBuilderTTK:
           - `None` / `""` / `"background"` -- the application background
             (`colors.bg`); the default, and the only surface that produces no
             style-name segment.
-          - `"card"` -- a mode-aware raised surface (`card_surface`).
+          - `"chrome"` -- the recessive app-framing surface (`chrome_surface`).
+          - `"card"` -- a mode-aware raised surface (`card_surface`), the top of
+            the elevation scale (`background` < `chrome` < `card`).
           - an accent color name (`primary`, `success`, ..., `neutral`) -- that
             color, so a ghost/outline/link control can blend into an accent
             container (e.g. an accent toolbar).
@@ -186,6 +212,8 @@ class StyleBuilderTTK:
         """
         if not surface or surface == DEFAULT_SURFACE:
             return self.colors.bg
+        if surface == "chrome":
+            return self.chrome_surface()
         if surface == "card":
             return self.card_surface()
         if surface in BOOTSTYLE_COLORS:

--- a/tests/test_surface_color.py
+++ b/tests/test_surface_color.py
@@ -31,6 +31,16 @@ def test_card_surface_differs_from_background(root):
     assert card == b.card_surface()
 
 
+def test_chrome_surface_sits_between_background_and_card(root):
+    """The elevation scale is background < chrome < card: chrome is a distinct,
+    subtler step than card (both mode-aware raises of the background)."""
+    b = _builder()
+    chrome = b.resolve_surface("chrome")
+    assert chrome == b.chrome_surface()
+    assert chrome != b.colors.bg          # distinct from the base
+    assert chrome != b.resolve_surface("card")   # a different rung than card
+
+
 def test_accent_surface_resolves_to_color(root):
     b = _builder()
     assert b.resolve_surface("primary") == b.colors.primary

--- a/tests/test_surface_families.py
+++ b/tests/test_surface_families.py
@@ -156,6 +156,7 @@ def test_every_gated_family_honors_surface(root):
         "scale": ttk.Scale(root, bootstyle="@card"),
         "progressbar": ttk.Progressbar(root, bootstyle="@card"),
         "scrollbar": ttk.Scrollbar(root, bootstyle="@card"),
+        "frame": ttk.Frame(root, bootstyle="@card"),
     }
     # the test must cover exactly the gate (update both together)
     assert set(cases) == set(bs._SURFACE_FAMILIES)

--- a/tests/test_surface_grammar.py
+++ b/tests/test_surface_grammar.py
@@ -131,10 +131,20 @@ def test_surface_token_is_case_normalized(root):
     )
 
 
-def test_frame_ignores_surface_family_gate(root):
-    """Frames are surface producers -- an @surface token is gated out."""
-    frm = ttk.Frame(root, bootstyle="@card primary")
-    assert "@" not in frm.cget("style")
+def test_frame_consumes_surface(root):
+    """A frame renders AS the surface it names -- a container that *is* a
+    surface (2.0 surface-color), so `@card`/`@chrome` fill it with the elevation
+    surface for sidebars and panels."""
+    frm = ttk.Frame(root, bootstyle="@card")
+    assert frm.cget("style") == "@card.TFrame"
+    bg = root.tk.call("ttk::style", "lookup", "@card.TFrame", "-background")
+    assert bg and bg != str(root.cget("background"))  # not the plain window bg
+
+
+def test_frame_surface_composes_with_color(root):
+    """A surface prefix composes with an accent-colored frame fill."""
+    frm = ttk.Frame(root, bootstyle="@chrome primary")
+    assert frm.cget("style") == "@chrome.primary.TFrame"
 
 
 def test_unknown_surface_warns(root):


### PR DESCRIPTION
Small follow-on to the 2.0 surface-color grammar, shaped in a design discussion
while wiring up the docs app-shell screenshots (the sidebar wanted a "card
surface" and there was no way to give it one). Design note:
`development/2_0_surface_scale_design.md`.

## 1. Elevation scale: `background` < `chrome` < `card`

Surface tokens now form a mode-aware scale (a step off the window background —
darker in light, lighter in dark):

| token | elevation | role |
|---|---|---|
| `background` | 0 | app canvas / content (default) |
| `@chrome` | 0.03 | recessive framing: toolbars, status bars |
| `@card` | 0.06 | a distinct raised panel (ceiling) |

`card` stays the ceiling; `chrome` is subtler because a card can sit **on**
chrome and must still read as raised (chrome never sits on a card).

## 2. Frames consume a surface

`ttk.Frame(bootstyle="@card")` now renders **as** the card surface — a container
that *is* a surface, for sidebars/panels on the scale — and composes with a color
(`@chrome primary`). Before, frames were surface *producers* only, so there was
no way to fill a container with an elevation surface (`@card` was silently
dropped on a frame). `frame` joins `_SURFACE_FAMILIES`; the default frame recipe
resolves/prefixes the surface exactly like the label recipe.

Border and surface stay **orthogonal** — the internal `card`/`highlight` frame
*variants* (ScrolledText/datepicker's hairline border) are untouched and stay
internal. This also corrects the grammar-doc example, where a `@card` button sat
on a `card`-variant frame whose background was the window color (a mismatch).

## Tests / build

`test_surface_color.py` (chrome rung), `test_surface_families.py` (frame in the
gate), `test_surface_grammar.py` (frame consumes + composes). Bootstyle reference
regenerated. Suite green (703); docs build `-W` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
