### PR TITLE
refactor(style): rename card frame variant -> bordered; frame border+surface compose

### DIFF
--- a/development/2_0_surface_scale_design.md
+++ b/development/2_0_surface_scale_design.md
@@ -50,12 +50,21 @@ Border and surface stay **orthogonal**: the `card`/`highlight` frame *variants*
 and remain internal. A bordered card on a surface would be `card @card` once the
 variant honors surface too — deferred; not needed here.
 
+## Follow-up: `card` frame variant renamed → `bordered`
+
+The Frame catalog page documents the border variant, so the `card`-variant vs
+`@card`-surface clash was in fact user-facing. Resolved by renaming the **variant**
+`card` → `bordered` (what it does — a hairline border; `highlight` keeps its name
+as the focus-ring sibling). Clean rename, no back-compat alias: the variants are
+new in unreleased 2.0 (#1126). Border and surface are now fully orthogonal and
+compose — `bordered @card` is a hairline-bordered frame filled with the card
+surface, and the border derives from `builder.border(surface)` so it stays visible
+on any surface. `Card.TFrame` → `Bordered.TFrame` (datepicker, ScrolledText,
+tests updated); `bordered`/`highlight` stay out of the cross-family public Literal
+(frame-only) but are documented on the Frame page.
+
 ## Not done (deliberately)
 
-- No rename of the internal `card`/`highlight` frame **variant**. The
-  variant-vs-surface name clash only surfaced when the `card` variant was exposed
-  in user docs; the docs now use the `@card` *surface* instead, so users never
-  see the clash. Renaming the internal token is optional cleanup for later.
 - `labelframe` not added as a surface consumer yet (no driver).
 
 ## Tests

--- a/docs/widgets/frame.rst
+++ b/docs/widgets/frame.rst
@@ -21,7 +21,12 @@ Usage
 
 A frame holds other widgets: pass the frame as their ``master``, then place the
 frame in its own parent. Frames are how you break a window into regions and nest
-layouts — a header, a sidebar, a form — each managed independently:
+layouts — a header, a sidebar, a form — each managed independently.
+
+A frame's ``bootstyle`` controls three independent things: a **border**
+(``bordered``), a **surface** to fill it (``@card`` / ``@chrome``), and a bold
+**color** fill (``primary`` …). They compose — ``"bordered @card"`` is a bordered
+panel on the card surface.
 
 .. code-block:: python
 
@@ -49,36 +54,60 @@ Adding a border
 ---------------
 
 By default a frame is invisible — it takes the window background. The most common
-reason to style one is to **set a region off with a border**. The ``card`` variant
-draws a hairline border around the frame's contents:
+reason to style one is to **set a region off with a border**. The ``bordered``
+variant draws a hairline border around the frame's contents:
 
 .. code-block:: python
 
-   ttk.Frame(app, padding=16, bootstyle="card")
+   ttk.Frame(app, padding=16, bootstyle="bordered")
+
+The border color is derived from the surface the frame is filled with, so it stays
+a visible hairline on the window, a card, or a chrome panel alike.
 
 The ``highlight`` variant is the same hairline, but drawn in the **accent color
 while the frame is in the** ``focus`` **state**. A frame does not track its
 children's focus on its own, so you set that state yourself — for example, to make
-a card glow while an entry inside it is focused:
+a panel glow while an entry inside it is focused:
 
 .. code-block:: python
 
-   card = ttk.Frame(app, padding=16, bootstyle="highlight")
-   card.pack()
-   entry = ttk.Entry(card)
+   panel = ttk.Frame(app, padding=16, bootstyle="highlight")
+   panel.pack()
+   entry = ttk.Entry(panel)
    entry.pack()
 
-   entry.bind("<FocusIn>",  lambda event: card.state(["focus"]))
-   entry.bind("<FocusOut>", lambda event: card.state(["!focus"]))
+   entry.bind("<FocusIn>",  lambda event: panel.state(["focus"]))
+   entry.bind("<FocusOut>", lambda event: panel.state(["!focus"]))
 
-Prefer ``card`` and ``highlight`` over a raw ``relief=``/``borderwidth=`` border:
-plain ttk relief is theme-dependent and needs a non-zero ``borderwidth`` to show
-at all, while the ``card`` hairline matches the rest of the theme.
+Prefer ``bordered`` and ``highlight`` over a raw ``relief=``/``borderwidth=``
+border: plain ttk relief is theme-dependent and needs a non-zero ``borderwidth``
+to show at all, while the ``bordered`` hairline matches the rest of the theme.
+
+Filling with a surface
+----------------------
+
+Give a frame an ``@`` **surface** token to fill it with a neutral panel color on
+the theme's elevation scale — ``@chrome`` (recessive framing: a toolbar or status
+bar) or ``@card`` (a raised panel: a sidebar or grouped region). Unlike a bold
+color, a surface reads as a subtle, theme-matched region and gives the widgets
+inside it a background to blend onto:
+
+.. code-block:: python
+
+   sidebar = ttk.Frame(app, bootstyle="@card", padding=12)   # the frame IS the card surface
+   sidebar.pack(side="left", fill="y")
+   ttk.Button(sidebar, text="Home", bootstyle="@card link").pack(fill="x")
+
+Put the same ``@card`` token on the controls inside so a ghost, outline, or link
+button blends onto the surface instead of painting a wrong-colored box. See
+:doc:`Styling with bootstyle </user-guide/foundations/bootstyle-grammar>` for the
+full surface grammar. A surface composes with ``bordered`` — ``"bordered @card"``
+is a card panel with a hairline edge.
 
 Colored background
 ------------------
 
-Less often, give a frame a ``bootstyle`` color to make it a filled band — a
+Less often, give a frame a ``bootstyle`` color to make it a bold filled band — a
 colored header or footer. Put ``inverse-<color>`` labels inside so their text
 reads against the fill (as the header in `Usage`_ does):
 

--- a/docs/widgets/frame.rst
+++ b/docs/widgets/frame.rst
@@ -37,7 +37,7 @@ panel on the card surface.
 
    header = ttk.Frame(app, padding=10, bootstyle="primary")
    header.pack(fill=X)
-   ttk.Label(header, text="Dashboard", bootstyle="inverse-primary").pack()
+   ttk.Label(header, text="Dashboard", bootstyle="@primary").pack()
 
    content = ttk.Frame(app, padding=20)
    content.pack(fill=BOTH, expand=YES)
@@ -108,8 +108,8 @@ Colored background
 ------------------
 
 Less often, give a frame a ``bootstyle`` color to make it a bold filled band — a
-colored header or footer. Put ``inverse-<color>`` labels inside so their text
-reads against the fill (as the header in `Usage`_ does):
+colored header or footer. Put ``@<color>`` labels inside so their text reads
+against the fill (as the header in `Usage`_ does):
 
 .. code-block:: python
 

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -96,12 +96,15 @@ NEUTRAL_FAMILIES: Final = ("button", "menubutton", "toolbutton")
 BOOTSTYLE_MODIFIERS: Final = (
     "outline", "link", "ghost", "inverse", "round", "square", "striped", "thin",
 )
-# Internal-only composite modifiers used by Meter/DateEntry/Tableview/Scrolled to
-# build their sub-styles. Valid grammar tokens, but undocumented and not in any
-# public Literal -- end users never type these. `card`/`highlight` are the bordered
-# and focus-accent frame variants ScrolledText uses to own its border.
+# Composite modifiers kept out of the cross-family public Literal (a frame-only
+# variant like `bordered` must not generate `bordered-button`). `meter`/
+# `metersubtxt`/`table` are truly internal sub-style tokens (Meter/DateEntry/
+# Tableview/Scrolled). `bordered`/`highlight` are the two user-facing frame
+# variants -- a hairline border, and the same border state-mapped to the accent
+# on focus -- documented on the Frame page; ScrolledText uses `highlight` to own
+# its border. (Distinct from the `@card` surface, which fills a frame.)
 BOOTSTYLE_INTERNAL_MODIFIERS: Final = (
-    "meter", "metersubtxt", "table", "card", "highlight",
+    "meter", "metersubtxt", "table", "bordered", "highlight",
 )
 # User-nameable base-types -- matches BootBase.
 BOOTSTYLE_BASES: Final = ("toggle", "toolbutton")

--- a/src/ttkbootstrap/dialogs/datepicker.py
+++ b/src/ttkbootstrap/dialogs/datepicker.py
@@ -323,7 +323,7 @@ class DatePickerDialog:
     def _setup_calendar(self) -> None:
         """Setup the calendar widget"""
         # create the widget containers
-        frm_style = "Card.TFrame" if windowing_system(self.root) != 'aqua' else "TFrame"
+        frm_style = "Bordered.TFrame" if windowing_system(self.root) != 'aqua' else "TFrame"
         self.frm_calendar = ttk.Frame(master=self.root, padding=2, style=frm_style).pack(fill=BOTH, expand=YES)
         self.frm_title = ttk.Frame(self.frm_calendar, padding=(3, 3)).pack(fill=X)
         self.frm_header = ttk.Frame(self.frm_calendar).pack(fill=X)

--- a/src/ttkbootstrap/style/builders/frame.py
+++ b/src/ttkbootstrap/style/builders/frame.py
@@ -34,26 +34,31 @@ def build_frame_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     builder.register_ttkstyle(ttk_style)
 
 
-@register_builder("card", "frame")
-def build_card_frame(builder: StyleBuilderTTK, colorname=DEFAULT):
-    """A simple inert bordered surface (a "card").
+@register_builder("bordered", "frame")
+def build_bordered_frame(builder: StyleBuilderTTK, colorname=DEFAULT):
+    """A container with a single flat hairline border (the `bordered` variant).
 
-    A container that owns a single flat 1px border so its contents sit inside
-    one frame. `relief=RAISED` with `lightcolor`/`darkcolor` blended into the
-    background suppresses the bevel, leaving just the `bordercolor` hairline --
-    the same border weight the inputs draw. Give the frame a little widget
-    `padding` so its children don't paint over the border (ttk frames inset from
-    the widget's padding, not the style's).
+    Owns one flat 1px border so its contents sit inside one frame. `relief=RAISED`
+    with `lightcolor`/`darkcolor` blended into the background suppresses the bevel,
+    leaving just the `bordercolor` hairline -- the same border weight the inputs
+    draw. Give the frame a little widget `padding` so its children don't paint over
+    the border (ttk frames inset from the widget's padding, not the style's).
+
+    This is a border only, orthogonal to the `@card`/`@chrome` surface (which
+    fills a frame); combine them for a bordered frame on a surface.
     """
-    ttk_class = "Card.TFrame"
+    ttk_class = "Bordered.TFrame"
+    # The border sits on a surface (2.0 surface-color); default == theme bg, so
+    # `bordered @card` is a hairline border on the card surface (orthogonal).
+    surface = builder.resolve_surface(builder._surface)
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
-        background = builder.colors.bg
+        ttk_style = builder.surface_prefix(ttk_class)
+        background = surface
         border = builder.border(background)
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
-        surface = builder.colors.get(colorname)
-        background = builder.mute(builder.colors.fg, surface, 0.16)
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
+        colored = builder.colors.get(colorname)
+        background = builder.mute(builder.colors.fg, colored, 0.16)
         border = builder.border(background)
 
     builder.configure(
@@ -72,22 +77,23 @@ def build_card_frame(builder: StyleBuilderTTK, colorname=DEFAULT):
 
 @register_builder("highlight", "frame")
 def build_highlight_frame(builder: StyleBuilderTTK, colorname=DEFAULT):
-    """A `card` whose border tracks widget state -- a focus ring.
+    """A `bordered` frame whose border tracks widget state -- a focus ring.
 
-    Identical to `card` at rest, but the border is state-mapped so it brightens
-    to the accent while the frame is in the `focus` state. Apply it once and
-    toggle the frame's state (`frame.state(["focus"])`) to drive the ring; no
+    Identical to `bordered` at rest, but the border is state-mapped so it
+    brightens to the accent while the frame is in the `focus` state. Apply it once
+    and toggle the frame's state (`frame.state(["focus"])`) to drive the ring; no
     style swap needed.
     """
     ttk_class = "Highlight.TFrame"
+    surface = builder.resolve_surface(builder._surface)
     if any([colorname == DEFAULT, colorname == ""]):
-        ttk_style = ttk_class
-        background = builder.colors.bg
+        ttk_style = builder.surface_prefix(ttk_class)
+        background = surface
         accent = builder.colors.primary
     else:
-        ttk_style = f"{colorname}.{ttk_class}"
-        surface = builder.colors.get(colorname)
-        background = builder.mute(builder.colors.fg, surface, 0.16)
+        ttk_style = builder.surface_prefix(f"{colorname}.{ttk_class}")
+        colored = builder.colors.get(colorname)
+        background = builder.mute(builder.colors.fg, colored, 0.16)
         accent = builder.colors.get(colorname)
 
     resting = builder.border(background)

--- a/src/ttkbootstrap/widgets/scrolled.py
+++ b/src/ttkbootstrap/widgets/scrolled.py
@@ -96,7 +96,7 @@ class ScrolledText(ConfigureDelegationMixin, ttk.Frame):
 
         super().__init__(master, padding=padding)
 
-        # The border is owned by an inner "card" frame, so the text and the
+        # The border is owned by an inner `highlight` frame, so the text and the
         # scrollbar sit inside a single bordered box (the inner Text is kept
         # borderless -- see StyleBuilderTK.update_text_style) rather than the
         # scrollbar hanging outside the text's own edge. A grid inside it keeps

--- a/tests/test_scrolled_api.py
+++ b/tests/test_scrolled_api.py
@@ -235,22 +235,22 @@ def test_scrolledtext_focus_drives_the_border_state(root):
 
 
 def test_highlight_frame_border_maps_to_accent_on_focus(root):
-    # card = inert border; highlight = same resting border with a focus map to
-    # the accent (the focus ring).
+    # bordered = inert border; highlight = same resting border with a focus map
+    # to the accent (the focus ring).
     st = ScrolledText(root, height=5)
     st.pack()
-    # a plain card frame forces the (lazily built) Card.TFrame style to exist
-    card = ttk.Frame(root, bootstyle="card")
-    card.pack()
+    # a plain bordered frame forces the (lazily built) Bordered.TFrame style to exist
+    bordered = ttk.Frame(root, bootstyle="bordered")
+    bordered.pack()
     root.update_idletasks()
     style = ttk.Style.get_instance()
     resting = str(style.lookup("Highlight.TFrame", "bordercolor"))
     focus_map = str(style.map("Highlight.TFrame", "bordercolor"))
     assert "focus" in focus_map
     assert str(style.colors.primary) in focus_map
-    # the card variant is inert: the same resting border, no focus map
-    assert not style.map("Card.TFrame", "bordercolor")
-    assert str(style.lookup("Card.TFrame", "bordercolor")) == resting
+    # the bordered variant is inert: the same resting border, no focus map
+    assert not style.map("Bordered.TFrame", "bordercolor")
+    assert str(style.lookup("Bordered.TFrame", "bordercolor")) == resting
 
 
 def test_scrolledframe_vscroll_is_deprecated_alias_of_vbar(root):

--- a/tests/test_surface_grammar.py
+++ b/tests/test_surface_grammar.py
@@ -147,6 +147,25 @@ def test_frame_surface_composes_with_color(root):
     assert frm.cget("style") == "@chrome.primary.TFrame"
 
 
+def test_bordered_variant_fills_and_borders_from_surface(root):
+    """`bordered` (border, orthogonal to surface) composes with `@card`: the
+    frame fills with the card surface and its hairline border is derived from
+    that surface, so the border stays visible on any surface."""
+    style = ttk.Style.get_instance()
+    plain = ttk.Frame(root, bootstyle="bordered")
+    assert plain.cget("style") == "Bordered.TFrame"
+
+    carded = ttk.Frame(root, bootstyle="bordered @card")
+    carded.pack()
+    root.update_idletasks()
+    st = carded.cget("style")
+    assert st == "@card.Bordered.TFrame"
+    fill = str(style.lookup(st, "background"))
+    border = str(style.lookup(st, "bordercolor"))
+    assert fill == str(style.colors.bg) or fill != str(root.cget("background"))
+    assert border and border != fill      # a visible hairline off the surface
+
+
 def test_unknown_surface_warns(root):
     with pytest.warns(UserWarning):
         btn = ttk.Button(root, bootstyle="@bogus ghost")

--- a/tests/widget_styles/test_builder_registry.py
+++ b/tests/widget_styles/test_builder_registry.py
@@ -26,7 +26,7 @@ EXPECTED_KEYS = {
     ("default", "entry"),
     ("default", "floodgauge"),
     ("default", "frame"),
-    ("card", "frame"),
+    ("bordered", "frame"),
     ("highlight", "frame"),
     ("default", "label"),
     ("default", "labelframe"),


### PR DESCRIPTION
Finishes the surface-scale work (#1257) by resolving the `card` naming clash the
Frame catalog page exposed: it documented `bootstyle="card"` (a border **variant**)
right where a reader now meets `@card` (a **surface**). Two different things, same
word.

## Rename the variant: `card` → `bordered`

The hairline-border frame variant is now `bordered` — named for what it does.
`highlight` keeps its name (the focus-ring sibling). Clean rename, **no
back-compat alias**: these variants are new in unreleased 2.0 (#1126), so nothing
shipped with `card`. `Card.TFrame` → `Bordered.TFrame` (datepicker, ScrolledText,
tests updated).

## Border and surface now compose (orthogonal)

The `bordered`/`highlight` recipes resolve and prefix the `@surface` like the
default frame recipe, so:

- `bordered` — hairline border on the window
- `@card` / `@chrome` — a frame filled with the elevation surface (no border)
- `bordered @card` — a hairline-bordered frame **filled with the card surface**

The border derives from `builder.border(surface)`, so it's computed one step off
whatever surface fills the frame and **stays visible on any surface** — even a
`bordered @card` panel sitting on a `@card` region (same fill, border still
delineates it; verified visually in light and dark).

## Docs

`docs/widgets/frame.rst` now teaches three orthogonal things — `bordered`
(border), `@card`/`@chrome` (surface fill), and a bold color — and the old
card-variant example is corrected. `bordered`/`highlight` stay out of the
cross-family public Literal (frame-only variants).

Suite 704; docs build `-W` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
