### PR TITLE
Resolve adapted legacy theme names to their curated theme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -689,6 +689,78 @@ __main__.py` is modified in the tree — that is the AUTHOR'S demo WIP, leave it
 untouched** (as with the author's other live WIP: dialog-button styling in
 `dialogs/colorchooser.py`, `dialogs/fontdialog.py`, `examples/widgets/dialogs.py`).
 
+**Session 2026-07-18b→19 — ghost variant across the button family + LabeledScale
+`value=` + demo rework + landing hero + Object lifetime docs (all MERGED into
+`2.0`; supersedes the 2026-07-18 UNCOMMITTED state above — now shipped).**
+**#1265 (`feat/2.0-ghost-and-widget-polish`, merge `c896b18d`)** completed the
+**`ghost`** look across the button family (plain Button already had it): a new
+**ghost toolbutton** (`style/builders/toolbutton.py`, `("ghost","toolbutton")`) —
+transparent at rest, and when toggled **ON reuses the ghost *button's* hover
+surface** (`neutral_fill(1)` neutral / a `0.16` accent tint colored), no
+hover/press preview (a toolbutton is a toggle), quieter than `outline toolbutton`;
+and a new **ghost menubutton** (`style/builders/menubutton.py`,
+`("ghost","menubutton")`) — momentary like a button (wash on hover/press), caret
+via `_build_menubutton_arrow`, **inherited free by `OptionMenu`** (winfo_class
+`TMenubutton`). Because menubutton **infers** its base, ghost menubutton reuses the
+existing `ghost`/`<color> ghost` strings (NO new `BootStyle` entries — only a
+reference-table row); ghost *toolbutton* DID add 10 entries (`<color> ghost
+toolbutton` + bare + `neutral ghost toolbutton`), regenerated via
+`tools/generate_bootstyle_reference.py`. Registry keys added to
+`test_builder_registry` EXPECTED_KEYS; catalog docs surface the three toolbutton
+fills (checkbutton/radiobutton), the three menubutton variants, and outline+ghost
+on optionmenu; logged in `2_0_breaking_changes.md`. The PR also folded in the held
+**bare-solid-neutral toolbutton** + **Tableview row-height 27→21** + **demo
+rework** (the 2026-07-18 WIP) and a **LabeledScale `value=`** fix
+(`widgets/labeledscale.py`): the advertised param was ignored (ctor always set
+`from_`); now forwarded, default `None`→`from_` (a **sentinel**, so a non-zero
+`from_` and the passed-`variable` contract survive — `test_explicit_variable_
+respected`), **clamped into `[from_,to]`** because LabeledScale's `_adjust` reverts
+out-of-range values and `_last_valid` must stay in range (a bare `ttk.Scale` stores
+raw). Suite **718 passed** excl. the `nl.msg` flake. **#1266 (`docs/2.0-landing-
+hero`, merge `5d10c788`)** added the **landing hero**: `docs/screenshots/home-
+hero.py` — a self-contained widget **sampler** (own `App`, **module-level so the
+harness writes clean `home-hero-{light,dark}.png`** — a SCENES dict would name them
+`<page>-<scene>-…`; reads the live theme name; `_capture_full_window`,
+`_capture_max_width=960`), captured **874×529** light/dark on THIS Windows box;
+wired into `docs/index.rst` after `.. container:: hero-ctas`, deleted the stale "in
+development" `.. note::`, added the `quickstart hello` **glimpse** shot after the
+code block. It shows the palette + the button family (default/primary/outline/
+ghost) + inputs + toolbuttons (all ON) + meter/progress + a **Tableview** + a
+**Notebook** — the choice controls (check/radio/toggle) live on the notebook's
+**VISIBLE first tab** because **only the active tab renders in a static screenshot**
+(anything on a hidden tab is invisible). The scene is **frozen/self-contained
+(adapt the demo, don't import it)** so the demo evolves independently. **#1267
+(`docs/2.0-object-lifetime`, merge `1624fafb`)** added a Foundations page
+**`object-lifetime.rst`** consolidating tkinter's GC footguns (previously scattered
+across ~9 files) onto the *Python owns / Tcl references by name* model from
+`what-tkinter-wraps`: a collected `StringVar`/`PhotoImage`/named `Font` takes its
+Tcl entity with it → the widget empties/blanks/reverts, while **widgets survive
+because the tree owns them**; teach-by-example fixes (instance attr / return it /
+`label.image=`) + the inverse (callbacks/`after` keeping objects alive; the
+pending-`after`-into-a-destroyed-widget case → `after_cancel` in `destroy()`).
+Wired into the foundations toctree + card after What-tkinter-wraps; repointed that
+page's variable-footgun link + seealso at it. Every claim probed live (var→empty,
+image→blank, `ttk.Font`→reverts, orphan widget survives) and every snippet verified
+headlessly; docs build clean under `-W`. **A follow-on theme backwards-compat fix**
+(`style/engine.py` `_resolve_theme_alias` + a guard in `theme_use`): an
+unregistered theme name is routed through an alias resolver so the five pre-2.0
+names that carried over as curated families (`minty`/`pulse`/`sandstone`/`united`/
+`vapor`) resolve to their **curated** variant at the *legacy theme's own*
+light/dark mode (`minty`→`minty-light`, `vapor`→`vapor-dark`) — no error, no
+deprecation warning, and **never the app's current mode** (a 1.x caller sees the
+light/dark they expect). An explicit `install_legacy_themes()` still wins (only
+names not already registered are aliased). Legacy-only names (`darkly`/`flatly`/…)
+keep the legacy-dict migration path + warning. Added `LEGACY_THEME_ALIASES` in
+`themes/standard.py` so the historical `cerculean` typo (1.x shipped Bootswatch's
+*cerulean* misspelled; the typo stays canonical for 1.x code) also accepts the
+correct `cerulean` spelling. **Author ruling: bare curated-*only* family names
+(`nord`/`bootstrap`/…) intentionally stay an error** — not a backwards-compat case.
+Logged in `2_0_breaking_changes.md` (extended the Slice-1 legacy-names entry) + the
+migrating/theming guides; `tests/widget_styles/test_theme_anchor.py` +2. Suite
+**719 passed** excl. the `nl.msg` flake; docs build clean under `-W`. **NEXT
+(optional, unchanged):** the deferred **macOS application-menu shot** (`menus.rst`),
+landing/hero polish, Track B odds/ends (Linux/x11, DPI matrix).
+
 ## Repository layout
 
 ```

--- a/development/2_0_breaking_changes.md
+++ b/development/2_0_breaking_changes.md
@@ -15,7 +15,7 @@
 |---|---|---|
 | Theme model, `Theme`, default theme, ramp addressing | API | `development/2_0_theme_migration.md` |
 | **User theme store removed; ttkcreator exports a `Theme(...).register()` snippet** | Removed | this doc, below |
-| **Legacy theme names auto-register on use (no hard-stop)** | Fix/Deprecated | this doc, below (Slice 1) |
+| **Legacy theme names auto-register on use; adapted names resolve to their curated theme** | Fix/Deprecated | this doc, below (Slice 1) |
 | **`App` (canonical) / `Window` alias; `theme` / `themename` alias** | New | this doc, below (Slice 2) |
 | **`on_close` window close handler (`App`/`Toplevel` method + kwarg)** | New | this doc, below |
 | **`utils/` package; `utility`/`colorutils` → warn-and-forward shims** | Deprecated | this doc, below (Slice 0) |
@@ -316,6 +316,22 @@ mapping (`darkly` ≠ `bootstrap-dark`, different palettes), so forcing migratio
 would change every app's colors *and* its code. This intentionally reverses
 Workstream E's "opt-in only" decision — that decision is what created the wall —
 while keeping its deprecation nudge (a per-name `DeprecationWarning`).
+
+**Adapted names use the curated theme (not the legacy dict).** Five pre-2.0 names
+carried over into the curated catalog as families — `minty`, `pulse`, `sandstone`,
+`united`, `vapor`. For these, `theme_use("minty")` now resolves to the **curated**
+variant at the legacy theme's own light/dark mode (`minty` → `minty-light`,
+`vapor` → `vapor-dark`) instead of adapting the legacy 16-key dict — so 1.x code
+gets the polished 2.0 version of that theme, with **no** deprecation warning (it's
+a first-class 2.0 theme now). The *legacy* mode is used, never the app's current
+mode, so a 1.x caller sees the light/dark they expect. An explicit
+`install_legacy_themes()` still wins (it registers the legacy `minty` by name,
+which then takes precedence). Legacy names with no curated counterpart (`darkly`,
+`flatly`, …) are unchanged — legacy dict + warning, as above.
+
+**`cerulean` spelling accepted.** 1.x shipped Bootswatch's *cerulean* misspelled as
+`cerculean`; the typo stays the canonical name (1.x code uses it), and the correct
+spelling `cerulean` is now accepted as an alias.
 
 **Not changed.** The default theme: `ttk.Window()` with no name still renders
 `bootstrap-light` — a documented *visual* change, not a crash.

--- a/docs/user-guide/feature-guides/theming.rst
+++ b/docs/user-guide/feature-guides/theming.rst
@@ -104,6 +104,10 @@ Browse every one — a sample card per family, in light and dark — in the
    registered by default. Call :func:`~ttkbootstrap.install_legacy_themes` to
    register them all (it warns, and they are removed in 3.0), or just name one —
    ``App(themename="darkly")`` lazily registers that single theme with a warning.
+   The five names that carried over into the curated catalog above — ``minty``,
+   ``pulse``, ``sandstone``, ``united``, ``vapor`` — instead resolve to their
+   curated variant at the 1.x theme's own light/dark mode (``vapor`` →
+   ``vapor-dark``), with no warning.
 
 Reading theme colors
 --------------------

--- a/docs/user-guide/getting-started/migrating.rst
+++ b/docs/user-guide/getting-started/migrating.rst
@@ -236,9 +236,15 @@ The built-in catalog is now 15 curated **families**, each generating a matched
    registers it on demand with a warning. To register the whole pre-2.0 set at once
    (say, to list them in a theme picker), call
    :func:`~ttkbootstrap.install_legacy_themes`. Legacy themes keep their authored
-   colors; only their inconsistent plumbing is regenerated. There is no one-to-one
-   legacy-to-curated mapping (``darkly`` is not ``bootstrap-dark``), so pick a
-   curated theme deliberately rather than expecting an automatic swap.
+   colors; only their inconsistent plumbing is regenerated. For most names there is
+   no one-to-one legacy-to-curated mapping (``darkly`` is not ``bootstrap-dark``), so
+   pick a curated theme deliberately rather than expecting an automatic swap.
+
+   Five names *did* carry over into the curated catalog — ``minty``, ``pulse``,
+   ``sandstone``, ``united``, and ``vapor``. Naming one of these gives you the
+   **curated** theme at the 1.x theme's own light/dark mode (``minty`` →
+   ``minty-light``, ``vapor`` → ``vapor-dark``), with no warning. And ``cerulean``
+   works whether or not you spell it the way 1.x did (``cerculean``).
 
 See :doc:`Theming & Colors </user-guide/feature-guides/theming>` for the theme model
 and how to author your own.

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 
 from ttkbootstrap.internal import utility as util
 from ttkbootstrap.constants import *
-from ttkbootstrap.themes.standard import STANDARD_THEMES
+from ttkbootstrap.themes.standard import LEGACY_THEME_ALIASES, STANDARD_THEMES
 
 from ttkbootstrap.style.theme import ThemeDefinition
 from ttkbootstrap.style.scaling import Scaling
@@ -206,6 +206,30 @@ class Style(ttk.Style):
         self._theme_definitions[theme] = definition
         self._theme_styles[theme] = set()
 
+    def _resolve_theme_alias(self, themename):
+        """Map a pre-2.0 name that was adapted into the curated catalog to that
+        theme's variant matching its ORIGINAL light/dark mode.
+
+        Backwards compatibility: five legacy names carry over as curated
+        families (``minty``/``pulse``/``sandstone``/``united``/``vapor``). A 1.x
+        caller writing ``theme_use("minty")`` expects a *light* minty and
+        ``theme_use("vapor")`` a *dark* vapor -- the legacy theme's own mode, not
+        the app's current mode. Resolve to ``<name>-<legacy-mode>`` when that
+        curated variant is registered; otherwise return the name unchanged, so a
+        legacy name with no curated counterpart still falls through to the
+        legacy-dict migration path in ``theme_use``.
+
+        A spelling alias (``cerulean`` -> the misspelled-but-canonical
+        ``cerculean``) is normalized first, so both spellings resolve.
+        """
+        themename = LEGACY_THEME_ALIASES.get(themename, themename)
+        spec = STANDARD_THEMES.get(themename)
+        if spec is not None:
+            variant = f"{themename}-{spec.get('type', 'light')}"
+            if variant in self._theme_names:
+                return variant
+        return themename
+
     def theme_use(self, themename=None):
         """Changes the theme used in rendering the application widgets.
 
@@ -234,6 +258,13 @@ class Style(ttk.Style):
 
         # change to an existing theme
         existing_themes = super().theme_names()
+        # Backwards compat: a pre-2.0 name adapted into the curated catalog (and
+        # not otherwise registered -- so an explicit install_legacy_themes()
+        # still wins) resolves to its curated variant at the legacy mode, e.g.
+        # theme_use("minty") -> "minty-light". Legacy names with no curated
+        # counterpart pass through unchanged to the legacy-dict path below.
+        if themename not in existing_themes and themename not in self._theme_names:
+            themename = self._resolve_theme_alias(themename)
         if themename in existing_themes:
             self.theme = self._theme_definitions.get(themename)
             super().theme_use(themename)

--- a/src/ttkbootstrap/themes/standard.py
+++ b/src/ttkbootstrap/themes/standard.py
@@ -386,3 +386,11 @@ STANDARD_THEMES = {
         },
     },
 }
+
+# Spelling aliases for legacy names -> their canonical `STANDARD_THEMES` key.
+# ttkbootstrap 1.x shipped Bootswatch's "cerulean" theme misspelled as
+# "cerculean"; 1.x code uses the typo, so it stays the canonical key, and the
+# correct spelling is accepted as an alias.
+LEGACY_THEME_ALIASES = {
+    "cerulean": "cerculean",
+}

--- a/tests/widget_styles/test_theme_anchor.py
+++ b/tests/widget_styles/test_theme_anchor.py
@@ -268,6 +268,57 @@ def test_legacy_theme_use_lazy_registers_then_bulk_opt_in(root):
         style.theme_use("bootstrap-light")
 
 
+def test_adapted_legacy_name_resolves_to_curated_variant(root):
+    """Backwards compat: a pre-2.0 name that carried over as a curated family
+    resolves to that family's variant at the LEGACY theme's own mode -- never an
+    error, never a deprecation warning, and never the app's current mode. So a
+    1.x caller's `theme_use("minty")` (light in 1.x) yields `minty-light` and
+    `theme_use("vapor")` (dark in 1.x) yields `vapor-dark`."""
+    style = root.style
+    try:
+        for legacy, expected in (("minty", "minty-light"),
+                                 ("pulse", "pulse-light"),
+                                 ("united", "united-light"),
+                                 ("vapor", "vapor-dark")):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                style.theme_use(legacy)
+            assert style.theme.name == expected
+            assert not [x for x in w if issubclass(x.category, DeprecationWarning)
+                        and "legacy" in str(x.message)], \
+                f"adapted name {legacy!r} should not warn -- it maps to a curated theme"
+            # the bare legacy name itself is never registered; it resolved to
+            # the curated variant, not the legacy dict
+            assert legacy not in style._theme_names
+        # a legacy name with NO curated counterpart is left unchanged, so it
+        # still takes the legacy-dict migration path (and its warning)
+        assert style._resolve_theme_alias("darkly") == "darkly"
+        assert style._resolve_theme_alias("minty") == "minty-light"
+        assert style._resolve_theme_alias("vapor") == "vapor-dark"
+    finally:
+        style.theme_use("bootstrap-light")
+
+
+def test_cerulean_spelling_alias_resolves(root):
+    """1.x shipped Bootswatch's "cerulean" misspelled as "cerculean"; both
+    spellings now work (the typo stays canonical for 1.x code)."""
+    style = root.style
+    before = set(style._theme_names)
+    try:
+        assert style._resolve_theme_alias("cerulean") == "cerculean"
+        with pytest.warns(DeprecationWarning, match="legacy"):
+            style.theme_use("cerulean")
+        assert style.theme.name == "cerculean"
+    finally:
+        for name in list(style._theme_names):
+            if name not in before:
+                style._theme_names.discard(name)
+                style._theme_definitions.pop(name, None)
+                style._theme_styles.pop(name, None)
+                style._theme_objects.pop(name, None)
+        style.theme_use("bootstrap-light")
+
+
 # --------------------------------------------------------------------------- #
 # Light/dark theme mode (theme_mode get/set / toggle_theme / set_theme_modes)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Backwards-compat fix for theme-name resolution. `theme_use` routes an *unregistered* name through a new `_resolve_theme_alias` before erroring:

- **Adapted families** — the five pre-2.0 names that carried over into the curated catalog (`minty`, `pulse`, `sandstone`, `united`, `vapor`) resolve to their **curated** variant at the **legacy theme's own light/dark mode** (`minty` → `minty-light`, `vapor` → `vapor-dark`). So a 1.x caller's `theme_use("minty")` / `App(theme="minty")` / `Window(themename="minty")` gets the mode they expect — never the app's current mode — with **no** error and **no** deprecation warning (it's a first-class 2.0 theme now).
- **`cerulean` spelling** — 1.x shipped Bootswatch's *cerulean* misspelled as `cerculean`; the typo stays canonical (1.x code uses it) and the correct spelling is now accepted via `LEGACY_THEME_ALIASES` in `themes/standard.py`.
- **Unchanged** — legacy-only names (`darkly`, `flatly`, …) keep the legacy-dict migration path + warning; an explicit `install_legacy_themes()` still wins (only names not already registered are aliased).

**Deliberately out of scope:** bare curated-*only* family names (`nord`, `bootstrap`, …) still error — those are new in 2.0, not a backwards-compat case.

Logged in `2_0_breaking_changes.md` (extended the Slice-1 legacy-names entry) and the migrating / theming guides. `tests/widget_styles/test_theme_anchor.py` +2. Suite **719 passed** (excl. the known `nl.msg` env flake); docs build clean under `-W`. Also carries the pending CLAUDE.md session-log update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)