### PR TITLE
Rewrite README for 2.0 + Release notes nav link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,82 +10,79 @@
 # ttkbootstrap
 English | [日本語](README_ja.md) | [中文](README_zh.md)
 
-ttkbootstrap is a Python library that enhances tkinter by providing modern, flat-style themes inspired by Bootstrap. Easily create stylish GUI applications with built-in themes, pre-defined widget styles, and more.
+ttkbootstrap is a theming extension for tkinter. It generates modern, flat,
+Bootstrap-inspired light and dark themes on demand and adds a single
+`bootstyle` keyword to every ttk widget — so you describe *intent*
+(`"primary"`, `"success"`, `"outline"`) instead of hand-picking colors or
+wrangling long ttk style names.
 
 ## Documentation
-👀 Check out the [documentation](https://ttkbootstrap.readthedocs.io/en/latest/).
+👀 Read the [documentation](https://ttkbootstrap.readthedocs.io/en/latest/).
 
-
-![](https://raw.githubusercontent.com/israel-dryer/ttkbootstrap/master/docs/assets/themes/themes.gif)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/israel-dryer/ttkbootstrap/master/docs/_static/examples/home-hero-dark.png">
+  <img alt="A ttkbootstrap window: color swatches above themed buttons, inputs, a meter, a table, and a notebook" src="https://raw.githubusercontent.com/israel-dryer/ttkbootstrap/master/docs/_static/examples/home-hero-light.png">
+</picture>
 
 ## Features
 
-✔️ [**Built-in Themes**](https://ttkbootstrap.readthedocs.io/en/latest/themes/)   
-Over a dozen curated dark and light themes.
+✔️ [**30 curated themes**](https://ttkbootstrap.readthedocs.io/en/latest/themes.html)  
+Fifteen families, each with a coordinated light and dark variant, that re-theme at runtime.
 
-✔️ [**Pre-defined Styles:**](https://ttkbootstrap.readthedocs.io/en/latest/styleguide/)  
-Loads of beautiful pre-defined widget styles such as **outline** and **round toggle** buttons.
+✔️ [**One-keyword styling**](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/foundations/bootstyle-grammar.html)  
+Style any ttk widget with the `bootstyle` keyword — `bootstyle="success"`, `bootstyle="info outline"`, `bootstyle="round toggle"` — instead of the legacy `primary.Striped.Horizontal.TProgressbar` style names. If you've used Bootstrap on the web, the idea will feel familiar.
 
-✔️ [**Simple keyword API:**](https://ttkbootstrap.readthedocs.io/en/latest/gettingstarted/tutorial/#use-themed-widgets)  
-Apply colors and types using simple keywords such as **primary** and **striped** instead of the legacy approach of **primary.Striped.Horizontal.TProgressbar**. If you've used Bootstrap for web development, you are already familiar with this approach using css classes.
+✔️ [**Batteries-included widgets**](https://ttkbootstrap.readthedocs.io/en/latest/widgets/index.html)  
+Beyond the styled ttk widgets, ttkbootstrap ships a few extras — **Meter**, **DateEntry**, **Floodgauge**, and **Tableview** — plus fully themed **dialogs**.
 
-✔️ [**Lots of new Widgets:**](https://ttkbootstrap.readthedocs.io/en/latest/api/widgets/dateentry/)  
-ttkbootstrap comes with several new beautifully designed widgets such as **Meter**, **DateEntry**, and **Floodgauge**. Additionally, **dialogs** are now themed and fully customizable.
-
-✔️ [**Built-in Theme Creator:**](https://ttkbootstrap.readthedocs.io/en/latest/themes/themecreator/)  
-Want to create your own theme? Easy! ttkboostrap includes a built-in **theme creator** that enables you to easily build, load, expore, and apply your own custom themes.
+✔️ [**Custom themes & styles**](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/feature-guides/theming.html)  
+Define your own theme with the declarative `Theme(...)` API, or build reusable custom widget styles — the same machinery the built-in themes use.
 
 ## Installation
-Install ttkbootstrap using pip in the terminal/command prompt!
 
-```python
+Requires Python 3.10+. Install with pip:
+
+```bash
 python -m pip install ttkbootstrap
 ```
 
-## Simple Usage
-Instead of using long, complicated ttk style classes, you can use simple keywords with the "bootstyle" parameter.
+## Simple usage
 
-To get started, add the import statement at the top of your file in your preferred IDE:
+Instead of long ttk style names, style widgets with the `bootstyle` keyword:
+
 ```python
 import ttkbootstrap as ttk
+
+app = ttk.App(title="ttkbootstrap", theme="bootstrap-dark")
+
+ttk.Button(app, text="Submit", bootstyle="success").pack(side="left", padx=5, pady=10)
+ttk.Button(app, text="Submit", bootstyle="info outline").pack(side="left", padx=5, pady=10)
+
+app.mainloop()
 ```
 
-Then create a window using the ttk.Window(...) and .mainloop() commands.
-And add a couple buttons (b1 and b2) to create your first window!
-```python
-root = ttk.Window(themename="superhero")
+The `bootstyle` value is a small grammar — a color plus optional modifiers and a type:
 
-b1 = ttk.Button(root, text="Submit", bootstyle="success")
-b1.pack(side=LEFT, padx=5, pady=10)
+- `bootstyle="info"` — a colored widget
+- `bootstyle="info outline"` — color + variant
+- `bootstyle="success round toggle"` — color + modifier + type
 
-b2 = ttk.Button(root, text="Submit", bootstyle="info-outline")
-b2.pack(side=LEFT, padx=5, pady=10)
+Dashes work too (`"info-outline"`). See the [bootstyle grammar](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/foundations/bootstyle-grammar.html) for the full reference, and [Build your first app](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/getting-started/build-your-first-app.html) for a step-by-step walkthrough.
 
-root.mainloop()
-```
-Here is the desired result:
+## Upgrading from 1.x
 
-
-![Here is the result of the code used above:](beginningresult.png)
-
-For more detailed usage, please refer to the [**Getting Started page**](https://ttkbootstrap.readthedocs.io/en/latest/gettingstarted/tutorial/)
-This page includes creating buttons, adding widgets, different styles and more. 
-
-The new keyword API is very flexible. The following examples all produce the same result:
-- `bootstyle="info-outline"`
-- `bootstyle="info outline"`
-- `bootstyle=("info", "outline")`
-- `bootstyle=(INFO, OUTLINE)`
+2.0 is a cleanup-and-consolidation release with breaking changes (a canonical `bootstyle` grammar, a new theme catalog, `App` alongside `Window`, and more). Your existing code mostly keeps working — legacy theme names and older spellings are accepted with a deprecation warning. See the [Migrating to 2.0](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/getting-started/migrating.html) guide.
 
 ## Icons
 
-Add icons to your app buttons and labels using the [ttkbootstrap-icons](https://github.com/israel-dryer/ttkbootstrap-icons) library.
+Add icons to your app's buttons and labels with the [ttkbootstrap-icons](https://github.com/israel-dryer/ttkbootstrap-icons) library.
 
 ## Contributing
 We welcome contributions! If you'd like to contribute to ttkbootstrap, please check out our contributing guidelines.
 
 ## Links
-- **Documentation:** https://ttkbootstrap.readthedocs.io/en/latest/  
+- **Documentation:** https://ttkbootstrap.readthedocs.io/en/latest/
+- **Release notes:** https://github.com/israel-dryer/ttkbootstrap/releases
 - **GitHub:** https://github.com/israel-dryer/ttkbootstrap
 
 ## Support

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -142,4 +142,5 @@ ttkbootstrap requires Python 3.10 or newer. Install it with pip:
    widgets/index
    reference/index
    themes
+   Release notes <https://github.com/israel-dryer/ttkbootstrap/releases>
    about/index

--- a/docs/user-guide/feature-guides/menus.rst
+++ b/docs/user-guide/feature-guides/menus.rst
@@ -300,12 +300,6 @@ are simply skipped — put your Exit and Preferences where those platforms expec
 them (under *File* and *Edit*, say). ``add_help_menu`` returns an ordinary Help
 cascade off macOS, so a Help menu is present everywhere.
 
-.. admonition:: 📷 Screenshot (placeholder)
-   :class: screenshot-placeholder
-
-   The macOS screen-top menu bar with the bold **Editor** application menu open,
-   showing About Editor, Preferences… (⌘,), and Quit.
-
 .. seealso::
 
    - :doc:`Windows </user-guide/feature-guides/windows>` — the cross-platform


### PR DESCRIPTION
Release-facing docs prep.

**README rewrite** — it still described 1.x: deprecated tuple `bootstyle`, `Window(themename="superhero")` (a legacy theme), a hero image that no longer exists (`themes.gif`), and doc links to the retired mkdocs URLs. Now:
- Reframed as a *theming extension for tkinter*, leading with the `bootstyle` keyword.
- Usage snippet uses `ttk.App(theme="bootstrap-dark")` + space-separated `bootstyle` values — **verified it runs** (the old snippet referenced an undefined `LEFT`).
- Dead `themes.gif` replaced with the new light/dark landing-hero screenshots (`<picture>`).
- Every doc link repointed to the Sphinx IA; added a **Release notes** link and an **Upgrading from 1.x** section → the migration guide.
- Notes Python 3.10+.

**Release notes nav link** — a top-level external toctree entry to GitHub Releases, so the per-version changelog is discoverable from the docs nav with no in-docs page to maintain. Builds clean under `-W` and renders in the navbar.

Note: `README_ja.md` / `README_zh.md` now lag the English README (translations not updated here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)