### PR TITLE
Release prep: MANIFEST, RTD config, 404 page + redirect map

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,13 +2,16 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: false
+  # The docs are maintained warning-clean (built locally with -W); enforce that
+  # on Read the Docs too, so a broken cross-reference fails the build (including
+  # PR previews) instead of shipping silently.
+  fail_on_warning: true
 
 python:
   install:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,5 @@
 include LICENSE
 include README.md
-include README_ja.md
-include README_zh.md
 
 graft src/ttkbootstrap
 graft src/ttkcreator

--- a/development/2_0_rtd_redirects.md
+++ b/development/2_0_rtd_redirects.md
@@ -1,0 +1,95 @@
+# Read the Docs redirects for the 2.0 docs rebuild
+
+The 2.0 release moved the documentation from **mkdocs** to **Sphinx** and
+reorganized the information architecture. Two things changed for every page:
+
+1. **URL shape.** mkdocs used directory URLs (`/en/latest/foo/`); Sphinx serves
+   `/en/latest/foo.html`.
+2. **Location.** Pages were regrouped into a new IA (Getting started / User guide
+   / Widgets / Reference / Themes).
+
+So every old inbound link — bookmarks, Google results, Stack Overflow answers,
+old README/PyPI links — now 404s. These redirects map the old paths to their new
+homes.
+
+## How to apply
+
+Read the Docs does **not** read redirects from `.readthedocs.yaml`. Add them in
+the project dashboard: **Admin → Redirects**, or via the
+[RTD redirects API](https://docs.readthedocs.io/en/stable/api/v3.html#redirects).
+The `From URL` is the path under the version root (RTD applies it across
+versions). Wildcards use a trailing `*`, captured as `:splat` in the `To URL`.
+
+`docs/404.rst` (the `sphinx-notfound-page` extension) is the safety net for
+anything not listed here.
+
+## Keep the last 1.x version active
+
+Old **versioned** builds keep their original mkdocs URLs, so `/en/v1.x/...` links
+still resolve as long as that version is not deactivated. Only `latest`/`stable`
+serve the new structure and need these redirects — confirm `stable` is not
+silently pointing 1.x readers at 2.0's pages.
+
+## Exact redirects (highest-traffic pages, land precisely)
+
+| Type | From URL | To URL |
+|---|---|---|
+| Exact | `/en/latest/gettingstarted/tutorial/` | `/en/latest/user-guide/getting-started/quickstart.html` |
+| Exact | `/en/latest/gettingstarted/installation/` | `/en/latest/user-guide/getting-started/installation.html` |
+| Exact | `/en/latest/gettingstarted/legacy/` | `/en/latest/user-guide/getting-started/migrating.html` |
+| Exact | `/en/latest/themes/themecreator/` | `/en/latest/user-guide/feature-guides/theming.html` |
+
+## Per-widget redirects (`styleguide/<w>/` → `widgets/<w>.html`, 1:1)
+
+These old style-guide slugs map one-to-one to the new widget pages. Add as Exact
+redirects (or a single `styleguide/*` wildcard — see below — if you prefer fewer
+rules and don't mind landing on the catalog index for the odd ones out).
+
+| From URL | To URL |
+|---|---|
+| `/en/latest/styleguide/button/` | `/en/latest/widgets/button.html` |
+| `/en/latest/styleguide/checkbutton/` | `/en/latest/widgets/checkbutton.html` |
+| `/en/latest/styleguide/combobox/` | `/en/latest/widgets/combobox.html` |
+| `/en/latest/styleguide/dateentry/` | `/en/latest/widgets/dateentry.html` |
+| `/en/latest/styleguide/entry/` | `/en/latest/widgets/entry.html` |
+| `/en/latest/styleguide/floodgauge/` | `/en/latest/widgets/floodgauge.html` |
+| `/en/latest/styleguide/frame/` | `/en/latest/widgets/frame.html` |
+| `/en/latest/styleguide/label/` | `/en/latest/widgets/label.html` |
+| `/en/latest/styleguide/labelframe/` | `/en/latest/widgets/labelframe.html` |
+| `/en/latest/styleguide/menubutton/` | `/en/latest/widgets/menubutton.html` |
+| `/en/latest/styleguide/meter/` | `/en/latest/widgets/meter.html` |
+| `/en/latest/styleguide/notebook/` | `/en/latest/widgets/notebook.html` |
+| `/en/latest/styleguide/panedwindow/` | `/en/latest/widgets/panedwindow.html` |
+| `/en/latest/styleguide/progressbar/` | `/en/latest/widgets/progressbar.html` |
+| `/en/latest/styleguide/radiobutton/` | `/en/latest/widgets/radiobutton.html` |
+| `/en/latest/styleguide/scale/` | `/en/latest/widgets/scale.html` |
+| `/en/latest/styleguide/scrollbar/` | `/en/latest/widgets/scrollbar.html` |
+| `/en/latest/styleguide/separator/` | `/en/latest/widgets/separator.html` |
+| `/en/latest/styleguide/sizegrip/` | `/en/latest/widgets/sizegrip.html` |
+| `/en/latest/styleguide/spinbox/` | `/en/latest/widgets/spinbox.html` |
+| `/en/latest/styleguide/treeview/` | `/en/latest/widgets/treeview.html` |
+| `/en/latest/styleguide/datepickerpopup/` | `/en/latest/widgets/dateentry.html` |
+| `/en/latest/styleguide/legacywidgets/` | `/en/latest/widgets/index.html` |
+
+## Section wildcards (catch-all for the rest)
+
+Add these so *any* remaining old path in a retired tree lands on the nearest new
+home instead of 404ing. Put wildcards **after** the exact rules above (exacts win).
+
+| Type | From URL | To URL |
+|---|---|---|
+| Wildcard | `/en/latest/styleguide/*` | `/en/latest/widgets/index.html` |
+| Wildcard | `/en/latest/api/*` | `/en/latest/reference/index.html` |
+| Wildcard | `/en/latest/themes/*` | `/en/latest/themes.html` |
+| Wildcard | `/en/latest/gettingstarted/*` | `/en/latest/user-guide/getting-started/quickstart.html` |
+| Wildcard | `/en/latest/gallery/*` | `/en/latest/index.html` |
+| Wildcard | `/en/latest/cookbook/*` | `/en/latest/user-guide/index.html` |
+
+Notes:
+- The old **API** tree (`api/...`) had a completely different structure; a
+  catch-all to the reference landing is safer than mapping each page.
+- **Gallery** and **Cookbook** were retired in 2.0 (their content wasn't carried
+  over); send them to the home / user-guide landing.
+- `about/` and `license/` still exist under `about/` — add exacts if those old
+  paths saw traffic (`/en/latest/about/` → `/en/latest/about/index.html`,
+  `/en/latest/license/` → `/en/latest/about/license.html`).

--- a/docs/404.rst
+++ b/docs/404.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+Page not found
+==============
+
+The page you're looking for may have moved. The 2.0 release rebuilt this
+documentation from the ground up, which reorganized the site and changed page
+URLs — an old bookmark or search result can land here.
+
+Use the search box or the navigation, or jump to one of these:
+
+.. Absolute links (not ``:doc:``): this page is served in place at whatever URL
+.. 404'd, so relative links would resolve against that path. Absolute paths
+.. resolve from the domain root regardless of depth.
+
+- `Documentation home </en/latest/index.html>`_
+- `Quickstart </en/latest/user-guide/getting-started/quickstart.html>`_
+- `Widgets </en/latest/widgets/index.html>`_
+- `API reference </en/latest/reference/index.html>`_
+- `Migrating to 2.0 </en/latest/user-guide/getting-started/migrating.html>`_ — if
+  you followed a link into the 1.x docs.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,12 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "myst_parser",
+    # Themed, navigable 404 page (docs/404.rst). The mkdocs->Sphinx move changed
+    # every URL; RTD redirects (development/2_0_rtd_redirects.md) catch the known
+    # paths, and this handles anything they miss. The extension rewrites the 404
+    # page's links to absolute so they resolve at any served path depth; on Read
+    # the Docs the URL prefix is detected automatically.
+    "notfound.extension",
 ]
 
 # ---------------------------------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,6 @@ pydata-sphinx-theme
 sphinx-design
 sphinx-copybutton
 sphinx-autobuild
+sphinx-notfound-page
 myst-parser
 Pillow>=10,<13


### PR DESCRIPTION
Release-prep packaging + Read the Docs items.

- **MANIFEST.in** — drop the `include README_ja.md` / `README_zh.md` lines (those files were removed; the sdist build warned on the missing files). `graft src/ttkcreator` kept — it's a real shipped package.
- **`.readthedocs.yaml`** — `fail_on_warning: true` (the docs are maintained `-W`-clean; enforce it on RTD + PR previews so a broken cross-reference fails the build instead of shipping silently) and bump the build image to `ubuntu-24.04`.
- **404 page** — add `sphinx-notfound-page` + `docs/404.rst`, a themed, navigable 404 as a safety net for old inbound links the redirects miss. Body links are absolute (`/en/latest/...`) so they resolve regardless of the depth the 404 is served at (the extension only rewrites chrome/resource URLs, not `:doc:` body links).
- **`development/2_0_rtd_redirects.md`** — the copy-paste old→new redirect map to add in the RTD dashboard (mkdocs directory-URLs → Sphinx `.html`, recovered from the deleted `mkdocs.yml` nav): 4 exacts + 22 per-widget `styleguide/*`→`widgets/*` + section wildcards for `api`/`themes`/`gallery`/`cookbook`.

Docs build clean under `-W`; `404.html` generates with absolute links.

Note: RTD redirects can't live in `.readthedocs.yaml` — they're dashboard/API only, hence the map as a committed reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)