### PR TITLE
feat(style): durable user style options (#1238, #1161)

### DIFF
--- a/development/2_1_durable_style_options_design.md
+++ b/development/2_1_durable_style_options_design.md
@@ -113,6 +113,12 @@ recorded for `TEntry` (the class) *and* for `danger.TEntry`. Setting the propert
 once on the base class fans out to every variant — exactly what "set general
 properties on the base style class" asks for.
 
+**Retroactive fan-out (added in implementation).** Fan-out at build time alone is
+order-dependent: a variant built *before* the user sets the base override would
+never receive it. So recording a base-class override also pushes it onto every
+*already-built* descendant immediately (via the same most-specific-wins merge),
+making the result independent of whether the override or the widget came first.
+
 ## 3. Capture immediacy & theme independence
 
 - `configure` keeps its current behavior (apply now) **and** records — so an

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -330,13 +330,17 @@ class StyleBuilderTTK:
 
         # General styles used by Tableview and Tooltip internals.
         self.build_style("link", "button", DEFAULT, required=True)
-        self.style.configure("symbol.Link.TButton", font="-size 16")
+        # Framework writes go through the internal path (self.configure ->
+        # _build_configure), NOT the public Style.configure, so their font/
+        # borderwidth/relief are not captured as durable "user" overrides.
+        self.configure("symbol.Link.TButton", font="-size 16")
+        self.register_ttkstyle("symbol.Link.TButton")
 
         self.build_style(
             DEFAULT_VARIANT, "label", DEFAULT, required=True
         )
-        self.style.configure(
-            style="tooltip.TLabel",
+        self.configure(
+            "tooltip.TLabel",
             background="#fffddd",
             foreground="#333",
             bordercolor="#888",
@@ -345,6 +349,7 @@ class StyleBuilderTTK:
             lightcolor="#fffddd",
             relief=RAISED,
         )
+        self.register_ttkstyle("tooltip.TLabel")
 
     def update_combobox_popdown_style(self, widget):
         """Delegate Tcl-level Combobox popdown styling to its family module."""

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -18,6 +18,34 @@ from ttkbootstrap.style.scaling import Scaling
 from ttkbootstrap.style.builders_ttk import StyleBuilderTTK
 
 
+# Geometry/layout options a user's `style.configure(...)` may set that should
+# SURVIVE variant builds and theme switches (the durable style-options layer,
+# #1238/#1161). Colors are deliberately excluded: they stay theme-reactive, so a
+# `configure(background=...)` applies once but is not replayed on rebuild. The
+# set must cover every non-color option any recipe writes, or that option stays
+# clobbered; `tests/test_durable_style_options.py` guards that by AST-scanning
+# the recipes.
+DURABLE_STYLE_OPTIONS = frozenset({
+    "padding",
+    "borderwidth",
+    "focusthickness",
+    "thickness",
+    "rowheight",
+    "sashthickness",
+    "gripcount",
+    "tabmargins",
+    "arrowsize",
+    "anchor",
+    "font",
+    "relief",
+    "pbarrelief",
+    "justify",
+    "insertwidth",
+    "indicatormargin",
+    "indicatorsize",
+})
+
+
 class Style(ttk.Style):
     """A singleton class for creating and managing the application
     theme and widget styles.
@@ -77,6 +105,10 @@ class Style(ttk.Style):
         self._theme_definitions = {}
         self._style_registry = set()  # all styles used
         self._theme_styles = {}  # styles used in theme
+        # Durable style-options layer (#1238/#1161): user `configure()` overrides
+        # keyed by style name, replayed after each build so they survive variant
+        # builds and theme switches. Only DURABLE_STYLE_OPTIONS are recorded.
+        self._user_options = {}
         self._theme_names = set()
         # Optional designated light/dark theme pair for the theme_mode setter /
         # toggle_theme(); None means "derive from the -light/-dark naming".
@@ -162,6 +194,13 @@ class Style(ttk.Style):
         """
         if query_opt:
             return super().configure(style, query_opt=query_opt, **kw)
+
+        # Capture durable geometry overrides so they survive later variant
+        # builds / theme switches (see _reapply_user_options). Builders write via
+        # _build_configure, NOT this public path, so recipe writes are not
+        # recorded -- only genuine user calls are.
+        if kw:
+            self._record_user_options(style, kw)
 
         # local import breaks the engine<-bootstyle cycle (bootstyle imports engine)
         from ttkbootstrap.style.bootstyle import Bootstyle
@@ -664,6 +703,81 @@ class Style(ttk.Style):
         self._style_registry.add(ttkstyle)
         theme = self.theme.name
         self._theme_styles[theme].add(ttkstyle)
+        # A recipe just (re)built this style, overwriting any user override with
+        # its hardcoded defaults. Replay the durable overrides so the user wins.
+        self._reapply_user_options(ttkstyle)
+
+    # -- durable style options (#1238/#1161) -------------------------------- #
+
+    def _record_user_options(self, style, kw):
+        """Record the durable (geometry) subset of a user `configure()` call.
+
+        Colors are intentionally skipped so they stay theme-reactive. Already-
+        built descendant variants are updated now (retroactive fan-out), so the
+        override reaches existing styles too and the result is independent of
+        whether the override or the widget came first.
+        """
+        recorded = {k: v for k, v in kw.items() if k in DURABLE_STYLE_OPTIONS}
+        if not recorded:
+            return
+        self._user_options.setdefault(style, {}).update(recorded)
+        for built in list(self._theme_styles.get(self.theme.name, ())):
+            if built != style and style in self._style_ancestors(built):
+                self._reapply_user_options(built)
+
+    @staticmethod
+    def _style_ancestors(style):
+        """ttk's dotted-name resolution chain, least- to most-specific.
+
+        ``"danger.Outline.TButton"`` -> ``["TButton", "Outline.TButton",
+        "danger.Outline.TButton"]``. Mirrors ttk stripping leading tokens, so an
+        override set on the base class fans out to its variants (#1238).
+        """
+        parts = style.split(".")
+        return [".".join(parts[i:]) for i in range(len(parts) - 1, -1, -1)]
+
+    def _reapply_user_options(self, built_style=None):
+        """Replay durable user overrides after a style (re)build.
+
+        For ``built_style``, overrides recorded on it AND on its base-class
+        ancestors are merged most-specific-wins and applied in one write (the
+        base-class fan-out). Every other recorded override is restored onto its
+        own name, which also covers un-namespaced globals like ``"Sash"`` that
+        any build clobbers (#1161). Writes go through ``_build_configure`` (the
+        internal path), so they are not re-recorded.
+        """
+        if not self._user_options:
+            return
+        handled = set()
+        if built_style:
+            merged = {}
+            for name in self._style_ancestors(built_style):
+                opts = self._user_options.get(name)
+                if opts:
+                    merged.update(opts)
+                    handled.add(name)
+            if merged:
+                self._build_configure(built_style, **merged)
+        for name, opts in self._user_options.items():
+            if name not in handled and opts:
+                self._build_configure(name, **opts)
+
+    def reset_style_options(self, style=None):
+        """Drop durable style-option overrides recorded via ``configure()``.
+
+        With no argument, clears every recorded override; with a style name,
+        clears only that one. The recipe's default value returns the next time
+        the affected style is rebuilt (a theme switch or a new variant build).
+
+        Parameters:
+
+            style (str, optional):
+                The style name to reset; ``None`` (default) resets all.
+        """
+        if style is None:
+            self._user_options.clear()
+        else:
+            self._user_options.pop(style, None)
 
     def _theme_walk(self):
         """Repaint the live widget tree for the current theme.

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -446,7 +446,11 @@ def _build_icon_style(style, base, name, size, states, compound, icon_only=False
         config["compound"] = compound
     if padding is not None:
         config["padding"] = padding
-    style.configure(derived, **config)
+    # Internal path (not public Style.configure) so this derived style's padding
+    # is not captured as a durable user override; register it as the public path
+    # would have.
+    style._build_configure(derived, **config)
+    style._register_ttkstyle(derived)
     if image_map:
         style.map(derived, image=image_map)
     return derived

--- a/tests/test_durable_style_options.py
+++ b/tests/test_durable_style_options.py
@@ -1,0 +1,206 @@
+"""Headless tests for the durable style-options layer (#1238 / #1161).
+
+A user's ``style.configure("TEntry", padding=3)`` must survive both a bootstyle
+variant build and a theme switch, and a base-class override must fan out to its
+variants. Colors are deliberately NOT recorded (they stay theme-reactive), and
+builder writes must never be captured as user overrides.
+
+The registry (``Style._user_options``) lives on the process-wide singleton, so an
+autouse fixture resets it and rebuilds the base styles these tests touch, keeping
+the leak out of the rest of the suite.
+"""
+import ast
+import warnings
+from pathlib import Path
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.style.engine import DURABLE_STYLE_OPTIONS
+
+
+def _lookup(app, style, option):
+    return app.tk.call("ttk::style", "lookup", style, "-" + option)
+
+
+def _padding(app, style):
+    """First padding component as an int (ttk returns a scalar or a 1-tuple)."""
+    val = _lookup(app, style, "padding")
+    if isinstance(val, (tuple, list)):
+        val = val[0]
+    return int(val)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_options(root):
+    """Reset durable overrides and rebuild touched base styles after each test."""
+    yield
+    style = root.style
+    style.reset_style_options()
+    builder = style._get_builder()
+    for variant, family in (
+        ("default", "entry"),
+        ("default", "panedwindow"),
+        ("default", "button"),
+    ):
+        try:
+            builder.build_style(variant, family, "default")
+        except Exception:
+            pass
+
+
+# --- #1238: overrides survive variant builds and theme switches ------------
+
+def test_padding_survives_variant_build(root):
+    root.style.configure("TEntry", padding=3)
+    ttk.Entry(root, bootstyle="danger")  # builds danger.TEntry from scratch
+    assert _padding(root, "danger.TEntry") == 3
+
+
+def test_padding_survives_theme_switch(root):
+    root.style.configure("TEntry", padding=3)
+    root.style.theme_use("bootstrap-dark")
+    assert _padding(root, "TEntry") == 3
+
+
+def test_override_fans_out_to_new_variant_after_switch(root):
+    root.style.configure("TEntry", padding=3)
+    root.style.theme_use("bootstrap-dark")
+    ttk.Entry(root, bootstyle="info")
+    assert _padding(root, "info.TEntry") == 3
+
+
+def test_base_class_override_reaches_variant(root):
+    # never touch the base style itself; the variant must still inherit it
+    root.style.configure("TButton", focusthickness=7)
+    ttk.Button(root, bootstyle="success")
+    assert int(_lookup(root, "success.TButton", "focusthickness")) == 7
+
+
+def test_override_after_variant_exists_is_retroactive(root):
+    ttk.Entry(root, bootstyle="warning")        # build the variant first
+    root.style.configure("TEntry", padding=3)   # override afterwards
+    assert _padding(root, "warning.TEntry") == 3
+
+
+def test_most_specific_wins(root):
+    root.style.configure("TEntry", padding=3)
+    root.style.configure("danger.TEntry", padding=9)
+    ttk.Entry(root, bootstyle="danger")
+    assert _padding(root, "danger.TEntry") == 9
+
+
+# --- #1161: the global Sash element ----------------------------------------
+
+def test_sash_configure_emits_no_warning(root):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        root.style.configure("Sash", sashthickness=9)
+    assert [str(w.message) for w in caught] == []
+
+
+def test_sash_survives_panedwindow_build(root):
+    root.style.configure("Sash", sashthickness=9)
+    ttk.Panedwindow(root, bootstyle="success")  # recipe clobbers global Sash
+    assert int(_lookup(root, "Sash", "sashthickness")) == 9
+
+
+def test_sash_survives_theme_switch(root):
+    root.style.configure("Sash", sashthickness=9)
+    root.style.theme_use("bootstrap-dark")
+    ttk.Panedwindow(root, bootstyle="info")
+    assert int(_lookup(root, "Sash", "sashthickness")) == 9
+
+
+# --- colors stay theme-reactive (not recorded) -----------------------------
+
+def test_color_not_recorded(root):
+    root.style.configure("TEntry", background="#123456")
+    assert "TEntry" not in root.style._user_options
+
+
+def test_mixed_configure_records_only_geometry(root):
+    root.style.configure("TEntry", padding=3, background="#123456")
+    assert root.style._user_options.get("TEntry") == {"padding": 3}
+
+
+# --- builder writes are never captured -------------------------------------
+
+def test_builder_writes_not_captured(root):
+    # Build a fresh crop of styles with no user configure at all.
+    ttk.Button(root, bootstyle="warning")
+    ttk.Entry(root, bootstyle="warning")
+    ttk.Panedwindow(root, bootstyle="warning")
+    assert root.style._user_options == {}
+
+
+def test_internal_default_styles_not_captured(root):
+    # symbol.Link.TButton / tooltip.TLabel are framework writes in
+    # create_default_style; they must not appear as user overrides.
+    root.style.theme_use("bootstrap-dark")  # rebuilds create_default_style
+    assert "symbol.Link.TButton" not in root.style._user_options
+    assert "tooltip.TLabel" not in root.style._user_options
+
+
+# --- reset -----------------------------------------------------------------
+
+def test_reset_one_style_returns_recipe_default(root):
+    root.style.configure("TEntry", padding=3)
+    root.style.reset_style_options("TEntry")
+    # a freshly built variant no longer inherits the override
+    ttk.Entry(root, bootstyle="secondary")
+    assert _padding(root, "secondary.TEntry") != 3
+
+
+def test_reset_all_clears_registry(root):
+    root.style.configure("TEntry", padding=3)
+    root.style.configure("Sash", sashthickness=9)
+    root.style.reset_style_options()
+    assert root.style._user_options == {}
+
+
+# --- the allowlist covers every geometry option recipes write --------------
+
+# Options recipes write that are theme-derived (colors) or asset-driven, and so
+# are deliberately NOT durable. Any recipe option outside this set OR the
+# allowlist trips the guard below, forcing a deliberate classification.
+_NON_DURABLE_RECIPE_OPTIONS = frozenset({
+    # colors
+    "background", "foreground", "bordercolor", "darkcolor", "lightcolor",
+    "troughcolor", "focuscolor", "insertcolor", "fieldbackground",
+    "selectbackground", "selectforeground", "arrowcolor", "indicatorcolor",
+    "bg", "fg", "selectbg", "selectfg", "fieldbg", "space",
+    "upperbordercolor", "lowerbordercolor",
+    # asset / non-geometry
+    "image", "compound",
+})
+
+
+def _recipe_configure_options():
+    """Every option name passed to a `.configure(...)` call in the builders pkg."""
+    pkg = Path(ttk.__file__).parent / "style" / "builders"
+    found = set()
+    for path in pkg.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                continue
+            if func.attr not in ("configure", "_build_configure"):
+                continue
+            for kw in node.keywords:
+                if kw.arg and kw.arg not in ("style", "query_opt"):
+                    found.add(kw.arg)
+    return found
+
+
+def test_allowlist_covers_all_recipe_geometry_options():
+    written = _recipe_configure_options()
+    unclassified = written - DURABLE_STYLE_OPTIONS - _NON_DURABLE_RECIPE_OPTIONS
+    assert not unclassified, (
+        "recipe configure() options neither durable nor classified non-durable "
+        f"(add to DURABLE_STYLE_OPTIONS or _NON_DURABLE_RECIPE_OPTIONS): "
+        f"{sorted(unclassified)}"
+    )


### PR DESCRIPTION
## Summary

First implementation PR of the durable style-options cluster (design in `development/2_1_durable_style_options_design.md`). Makes a user's `style.configure(...)` **survive bootstyle-variant builds and theme switches**, fixing the two clobber issues:

- **#1238** — `style.configure("TEntry", padding=3)` reverted the moment `bootstyle="danger"` was applied (the original discussion #536 complaint). Now it persists and fans out to variants.
- **#1161** — `style.configure("Sash", sashthickness=N)` was clobbered by building any panedwindow. Now it survives.

## Mechanism

- **Capture** geometry/layout overrides on the *public* `Style.configure` into a theme-independent registry. Builders write via the *internal* `_build_configure`, so recipe writes are never captured — only genuine user calls. Colors are excluded (the `DURABLE_STYLE_OPTIONS` allowlist), so they stay theme-reactive.
- **Re-apply** the registry after every build (`_register_ttkstyle` tail) so user values land as the last write and beat the recipe. Re-applying at build completion is what catches lazy per-variant rebuilds and the global un-namespaced `Sash`.
- **Base→variant fan-out** (most-specific-wins): setting a property once on `TEntry` reaches `danger.TEntry` etc. — the "set it on the base class" ask. Fan-out is **retroactive** to already-built variants, so the result is order-independent.
- **`Style.reset_style_options(style=None)`** drops overrides.

## Also fixed (seam hygiene)

Two framework sites were calling the *public* `Style.configure` internally, which would miscapture their `font`/`padding`/`relief` as fake user overrides: `create_default_style`'s `symbol.Link.TButton` / `tooltip.TLabel`, and the `apply_icon` derived style. Both routed through `_build_configure` + explicit register.

## Tests

`tests/test_durable_style_options.py` (+16): padding survives variant build + theme switch; base→variant fan-out; retroactive fan-out; most-specific-wins; `Sash` survives build/switch with no warning; colors not recorded; builder & internal-default writes not captured; reset. Plus an **AST guard** asserting every non-color option any recipe writes is in the allowlist (it already caught `pbarrelief`). Full suite green.

## Note (docs follow-up, PR 3)

`style.configure` persistence can't make a widget honor an option it never reads: ttk `Entry`/`Combobox`/`Spinbox` take `font` from the widget/named font, not the style. `padding` (the #1238 case) is honored and renders correctly. Worth a one-line caveat in the docs slice.

Refs #1238, #1161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
