### PR TITLE
fix(treeview): size row height from the configured font (#1160)

### DIFF
--- a/src/ttkbootstrap/style/builders/treeview.py
+++ b/src/ttkbootstrap/style/builders/treeview.py
@@ -9,6 +9,52 @@ from ttkbootstrap.style.layout import El, layout
 from ttkbootstrap.style.builders.registry import register_builder
 
 
+def _style_font_metrics(builder: StyleBuilderTTK, ttk_style: str):
+    """Return ``(linespace, ascent)`` of the font `ttk_style` actually uses.
+
+    Row height must follow the configured font, not a fixed default: a font set
+    on `.` or `Treeview` (the documented technique) otherwise leaves taller text
+    clipped (#1160). `_effective_style_option` resolves the font a durable user
+    override will land on as well as the inherited Tcl value, so the row is sized
+    from the font the style ends up with rather than the one it had mid-build.
+
+    Measured with Tk's ``font metrics``, which accepts any font *description* --
+    a named font, a ``("family", size)`` tuple, or a ``-size N`` spec -- so no
+    Font object is allocated per build.
+    """
+    spec = builder.style._effective_style_option(ttk_style, "font", "TkDefaultFont")
+    try:
+        measure = builder.style.tk.call
+        return (
+            int(measure("font", "metrics", spec, "-linespace")),
+            int(measure("font", "metrics", spec, "-ascent")),
+        )
+    except tk.TclError:
+        metrics = font.nametofont("TkDefaultFont").metrics()
+        return metrics["linespace"], metrics["ascent"]
+
+
+# Row heights are computed in these helpers rather than inline so the geometry
+# passed to `configure(rowheight=...)` carries no numeric literal: font metrics
+# are already DPI-physical, and a ratio of one is physical too (it must NOT go
+# through the scaling service). Keeping the ratio here states that once.
+
+def _grid_row_height(builder: StyleBuilderTTK, ttk_style: str) -> int:
+    """Data-grid row: the text line plus ~half an ascent of breathing room.
+
+    Bare `linespace` (1.x) left the text flush to the row edges;
+    `linespace + ascent` overshot to nearly 2x the line height.
+    """
+    linespace, ascent = _style_font_metrics(builder, ttk_style)
+    return linespace + ascent // 2
+
+
+def _tree_row_height(builder: StyleBuilderTTK, ttk_style: str) -> int:
+    """Plain tree row: flush to the text line."""
+    linespace, _ = _style_font_metrics(builder, ttk_style)
+    return linespace
+
+
 @register_builder("table", "treeview")
 def build_table_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """Create a style for the Tableview widget.
@@ -22,12 +68,6 @@ def build_table_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Table.Treeview"
 
-    f = font.nametofont("TkDefaultFont")
-    metrics = f.metrics()
-    # A comfortable data-grid row: the text line plus ~half an ascent of
-    # breathing room. Bare `linespace` (1.x) left the text flush to the row
-    # edges; `linespace + ascent` overshot to nearly 2x the line height.
-    row_height = metrics['linespace'] + metrics['ascent'] // 2
     on_disabled = builder.disabled("text", builder.colors.inputbg)
 
     if any([colorname == DEFAULT, colorname == ""]):
@@ -45,6 +85,10 @@ def build_table_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         on_background = builder.on_color(background)
         tb_ttk_style = f"{colorname}.{ttk_class}"
         th_ttk_style = f"{colorname}.{ttk_class}.Heading"
+    # Sized from the style's own font, so a configured font sizes the row
+    # instead of clipping it (#1160).
+    row_height = _grid_row_height(builder, tb_ttk_style)
+
     hover = builder.active(background)
     header_border = builder.border(background)
     body_border = builder.border(builder.colors.inputbg)
@@ -112,9 +156,6 @@ def build_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
     """
     ttk_class = "Treeview"
 
-    f = font.nametofont("TkDefaultFont")
-    row_height = f.metrics()["linespace"]
-
     border = builder.border(builder.colors.bg)
     on_disabled = builder.disabled("text", builder.colors.inputbg)
 
@@ -133,6 +174,10 @@ def build_treeview_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         on_background = builder.on_color(background)
         tb_ttk_style = f"{colorname}.{ttk_class}"
         th_ttk_style = f"{colorname}.{ttk_class}.Heading"
+
+    # Sized from the style's own font, so a configured font sizes the row
+    # instead of clipping it (#1160).
+    row_height = _tree_row_height(builder, tb_ttk_style)
 
     # treeview header
     builder.configure(

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -762,6 +762,24 @@ class Style(ttk.Style):
             if name not in handled and opts:
                 self._build_configure(name, **opts)
 
+    def _effective_style_option(self, ttk_style, option, default=None):
+        """The value `ttk_style` will end up with for `option`.
+
+        Prefers a durable user override (most-specific ancestor wins) over the
+        current Tcl lookup. A recipe that *derives* geometry from an option (e.g.
+        treeview `rowheight` from `font`) must consult the registry rather than
+        `lookup` alone: overrides are re-applied AFTER the recipe runs, so the
+        lookup would still see the pre-override value.
+        """
+        value = None
+        for name in self._style_ancestors(ttk_style):
+            opts = self._user_options.get(name)
+            if opts and option in opts:
+                value = opts[option]
+        if value is None:
+            value = self.lookup(ttk_style, option) or None
+        return default if value is None else value
+
     def reset_style_options(self, style=None):
         """Drop durable style-option overrides recorded via ``configure()``.
 

--- a/tests/test_treeview_rowheight.py
+++ b/tests/test_treeview_rowheight.py
@@ -1,0 +1,120 @@
+"""Headless tests for font-aware Treeview/Tableview row height (#1160).
+
+`rowheight` was computed from `TkDefaultFont` at build time, so a font the user
+actually configured was ignored and taller text was clipped. It now derives from
+the font the style will really use.
+
+Assertions are relative (grew vs. the default) rather than absolute pixel counts,
+since font metrics vary by platform and DPI.
+
+The styles touched here are shared, so an autouse fixture restores their font and
+rebuilds them; `font` is a durable option (#1238) and would otherwise leak.
+"""
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.widgets.tableview import Tableview
+
+BIG = "-size 30"
+
+
+def _rowheight(app, style_name):
+    return int(app.tk.call("ttk::style", "lookup", style_name, "-rowheight"))
+
+
+def _rebuild(app, variant):
+    app.style._get_builder().build_style(variant, "treeview", "default")
+
+
+@pytest.fixture(autouse=True)
+def _isolate(root):
+    yield
+    style = root.style
+    style.reset_style_options()
+    for name in ("Treeview", "Table.Treeview"):
+        style._build_configure(name, font="TkDefaultFont")
+    for variant in ("default", "table"):
+        try:
+            _rebuild(root, variant)
+        except Exception:
+            pass
+
+
+# --- the row follows the configured font -----------------------------------
+
+def test_treeview_rowheight_follows_configured_font(root):
+    _rebuild(root, "default")
+    before = _rowheight(root, "Treeview")
+    root.style.configure("Treeview", font=BIG)
+    _rebuild(root, "default")
+    assert _rowheight(root, "Treeview") > before
+
+
+def test_table_treeview_rowheight_follows_configured_font(root):
+    _rebuild(root, "table")
+    before = _rowheight(root, "Table.Treeview")
+    root.style.configure("Table.Treeview", font=BIG)
+    _rebuild(root, "table")
+    assert _rowheight(root, "Table.Treeview") > before
+
+
+def test_rowheight_accepts_tuple_font(root):
+    """The #322 technique passes a ("family", size) tuple, not a named font."""
+    _rebuild(root, "table")
+    before = _rowheight(root, "Table.Treeview")
+    root.style.configure("Table.Treeview", font=("Courier", 30))
+    _rebuild(root, "table")
+    assert _rowheight(root, "Table.Treeview") > before
+
+
+def test_variant_inherits_ancestor_font(root):
+    """A font on the base class sizes a variant built afterwards."""
+    _rebuild(root, "default")
+    before = _rowheight(root, "Treeview")
+    root.style.configure("Treeview", font=BIG)
+    ttk.Treeview(root, bootstyle="danger")  # builds danger.Treeview fresh
+    assert _rowheight(root, "danger.Treeview") > before
+
+
+def test_tableview_widget_rows_follow_font(root):
+    """End-to-end through the real widget, not just the recipe.
+
+    Uses a color variant so the widget genuinely builds a new style, matching
+    the real flow (configure the font, then create the first such widget). A
+    style that already exists is not rebuilt, so a font set afterwards does not
+    resize it -- the deferred live-recompute case.
+    """
+    _rebuild(root, "table")
+    before = _rowheight(root, "Table.Treeview")
+    root.style.configure("Table.Treeview", font=BIG)
+    Tableview(
+        root,
+        coldata=["Name", "Value"],
+        rowdata=[("alpha", "one")],
+        bootstyle="info",
+    )
+    assert _rowheight(root, "info.Table.Treeview") > before
+
+
+# --- defaults still sane ----------------------------------------------------
+
+def test_default_rowheight_is_positive(root):
+    _rebuild(root, "default")
+    _rebuild(root, "table")
+    assert _rowheight(root, "Treeview") > 0
+    assert _rowheight(root, "Table.Treeview") > 0
+
+
+def test_grid_row_is_taller_than_plain_row(root):
+    """Table.Treeview adds ~half an ascent of breathing room; Treeview does not."""
+    _rebuild(root, "default")
+    _rebuild(root, "table")
+    assert _rowheight(root, "Table.Treeview") > _rowheight(root, "Treeview")
+
+
+def test_unset_font_falls_back_to_default_metrics(root):
+    """With no configured font the row is still sized (TkDefaultFont fallback)."""
+    root.style.reset_style_options()
+    root.style._build_configure("Treeview", font="TkDefaultFont")
+    _rebuild(root, "default")
+    assert _rowheight(root, "Treeview") > 0


### PR DESCRIPTION
## Summary

Treeview/Tableview `rowheight` was computed from **`TkDefaultFont`** at build time, so a font the user actually configured was ignored and taller text was clipped. This is the row-height counterpart to #399 (whose column-width half landed in #1158).

Row height now derives from the font the style will really use.

## The interesting part: the two mechanisms had to compose

The obvious fix (`style.lookup(style, "font")`) is only half right. Durable user overrides (#1238) are re-applied **after** a recipe runs, so a recipe that *derives* geometry from an option would still compute from the pre-override value.

Concretely, before this: `configure(".", font=...)` worked, but `configure("Treeview", font=...)` silently did **not** (rowheight stayed 15 instead of 36) — because configuring that style built it first, then applied the font, with no recompute.

So the font is resolved through a new `Style._effective_style_option`, which prefers a durable override (most-specific ancestor wins) over the current Tcl lookup. Both paths now work.

Metrics are read via Tk's `font metrics`, which accepts any font *description* — a named font, a `("family", size)` tuple (the #322 technique), or a `-size N` spec — so no `Font` object is allocated per build.

## Keeping the scaling guard honest

The two row formulas moved into `_grid_row_height` / `_tree_row_height` so the geometry passed to `configure(rowheight=...)` carries no numeric literal. That keeps `test_scaling`'s AST guard intact rather than widening its font-metric exemption — font metrics are already DPI-physical, and a ratio of one is too, so it must *not* go through the scaling service.

## Scope

Build-time only, per the locked design: a style that already exists is not rebuilt, so a font set *after the fact* does not resize it. Live font-change recompute remains explicitly out of scope.

## Verification

| case | before | after |
|---|---|---|
| plain `Treeview` default | 15 | 15 |
| `configure(".", font 24)` | 15 | **36** |
| `configure("Treeview", font 24)` | 15 | **36** |
| `Table.Treeview` default | 21 | 21 |
| `configure(".", font 24)` | 21 | **50** |
| tuple `("Cascadia Code", 24)` | 21 | **60** |

`tests/test_treeview_rowheight.py` (+8), assertions relative rather than absolute since metrics vary by platform/DPI. Full suite **763 passed**.

Closes #1160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)