### PR TITLE
fix(style): address durable-style-options review findings

### DIFF
--- a/src/ttkbootstrap/style/builders/notebook.py
+++ b/src/ttkbootstrap/style/builders/notebook.py
@@ -50,6 +50,7 @@ def build_notebook_style(builder: StyleBuilderTTK, colorname=DEFAULT):
         ttk_style_tab,
         focuscolor="",
         foreground=selected_fg,
+        bordercolor=border_color,
         padding=builder.scale_size((6, 5)),
     )
     builder.style.map(
@@ -62,14 +63,13 @@ def build_notebook_style(builder: StyleBuilderTTK, colorname=DEFAULT):
             ("selected", builder.colors.bg),
             ("!selected", unselected_bg),
         ],
-        bordercolor=[
-            ("selected", border_color),
-            ("!selected", border_color),
-        ],
-        padding=[
-            ("selected", builder.scale_size((6, 5))),
-            ("!selected", builder.scale_size((6, 5))),
-        ],
+        # NOTE: `padding` and `bordercolor` are deliberately NOT mapped. They
+        # used to be mapped to the same value for both `selected` and
+        # `!selected` -- a no-op that changed nothing visually but, because the
+        # two states cover every state, made `lookup` always resolve through the
+        # map and silently mask any user `configure(ttk_style_tab, padding=...)`.
+        # The values still come from `configure` above; leaving them unmapped is
+        # what makes a user override (durable or not) actually take effect.
         foreground=[("selected", selected_fg), ("!selected", unselected_fg)],
     )
 

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -771,14 +771,15 @@ class Style(ttk.Style):
         `lookup` alone: overrides are re-applied AFTER the recipe runs, so the
         lookup would still see the pre-override value.
         """
-        value = None
-        for name in self._style_ancestors(ttk_style):
+        for name in reversed(self._style_ancestors(ttk_style)):
             opts = self._user_options.get(name)
             if opts and option in opts:
-                value = opts[option]
-        if value is None:
-            value = self.lookup(ttk_style, option) or None
-        return default if value is None else value
+                return opts[option]
+        # `lookup` returns "" for an unset option; anything else is a real value
+        # -- including falsy ones like 0, which must not fall through to
+        # `default` (a `borderwidth` of 0 is a value, not an absence).
+        looked_up = self.lookup(ttk_style, option)
+        return default if looked_up == "" else looked_up
 
     def reset_style_options(self, style=None):
         """Drop durable style-option overrides recorded via ``configure()``.

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -446,11 +446,17 @@ def _build_icon_style(style, base, name, size, states, compound, icon_only=False
         config["compound"] = compound
     if padding is not None:
         config["padding"] = padding
-    # Internal path (not public Style.configure) so this derived style's padding
-    # is not captured as a durable user override; register it as the public path
-    # would have.
-    style._build_configure(derived, **config)
+    # Register FIRST, then configure. Registering replays durable user overrides
+    # onto this style (a `configure("TButton", padding=...)` fans out to
+    # `Icon<digest>.TButton`), so writing the icon's own values afterwards keeps
+    # them authoritative: `icon_only` padding is computed to make the control
+    # square, not a default a base-class override should stretch. Only the
+    # options actually in `config` are pinned, so a plain (text+icon) button
+    # still follows a global padding override.
+    # Internal path (not public Style.configure) so this padding is not captured
+    # as a durable user override; register as the public path would have.
     style._register_ttkstyle(derived)
+    style._build_configure(derived, **config)
     if image_map:
         style.map(derived, image=image_map)
     return derived

--- a/tests/test_durable_style_options.py
+++ b/tests/test_durable_style_options.py
@@ -31,6 +31,14 @@ def _padding(app, style):
     return int(val)
 
 
+def _padding_tuple(app, style):
+    """Full padding as a tuple of ints (ttk returns "6 5" or (6, 5))."""
+    val = _lookup(app, style, "padding")
+    if isinstance(val, str):
+        val = val.split()
+    return tuple(int(p) for p in val)
+
+
 @pytest.fixture(autouse=True)
 def _isolate_user_options(root):
     """Reset durable overrides and rebuild touched base styles after each test."""
@@ -42,11 +50,9 @@ def _isolate_user_options(root):
         ("default", "entry"),
         ("default", "panedwindow"),
         ("default", "button"),
+        ("default", "notebook"),
     ):
-        try:
-            builder.build_style(variant, family, "default")
-        except Exception:
-            pass
+        builder.build_style(variant, family, "default")
 
 
 # --- #1238: overrides survive variant builds and theme switches ------------
@@ -157,6 +163,66 @@ def test_reset_all_clears_registry(root):
     root.style.configure("Sash", sashthickness=9)
     root.style.reset_style_options()
     assert root.style._user_options == {}
+
+
+# --- computed layout is not stretched by a base-class override -------------
+# `icon_only` padding is derived to make the control square, so it must win over
+# a fanned-out `TButton` padding -- while a plain text+icon button still follows
+# that override (the fix must not be over-broad).
+
+def test_icon_only_button_stays_square_under_base_override(root):
+    root.style.configure("TButton", padding=(40, 2))
+    btn = ttk.Button(root, icon="calendar-week", icon_only=True)
+    btn.pack()
+    root.update_idletasks()
+    assert btn.winfo_reqwidth() == btn.winfo_reqheight()
+
+
+def test_text_icon_button_still_follows_base_override(root):
+    root.style.configure("TButton", padding=(40, 2))
+    btn = ttk.Button(root, text="Save", icon="calendar-week")
+    btn.pack()
+    root.update_idletasks()
+    assert _padding_tuple(root, btn.cget("style")) == (40, 2)
+
+
+# --- an all-states map must not mask a user configure ----------------------
+
+def test_notebook_tab_padding_override_takes_effect(root):
+    """The recipe used to map padding for every state, masking `configure`."""
+    ttk.Notebook(root)
+    root.style.configure("TNotebook.Tab", padding=(30, 20))
+    assert _padding_tuple(root, "TNotebook.Tab") == (30, 20)
+
+
+def test_notebook_tab_defaults_unchanged(root):
+    """Dropping the redundant map must not change the default look."""
+    ttk.Notebook(root)
+    assert _padding_tuple(root, "TNotebook.Tab") == (6, 5)
+    # bordercolor moved from the map into configure; it must still be set
+    assert _lookup(root, "TNotebook.Tab", "bordercolor") != ""
+
+
+# --- _effective_style_option and falsy values ------------------------------
+
+def test_effective_option_preserves_falsy_value(root):
+    """A real 0 is a value, not an absence -- it must not fall through."""
+    root.style._build_configure("Probe.TFrame", borderwidth=0)
+    assert root.style._effective_style_option(
+        "Probe.TFrame", "borderwidth", "FALLBACK"
+    ) == 0
+
+
+def test_effective_option_returns_default_when_unset(root):
+    assert root.style._effective_style_option(
+        "Probe.TFrame", "nosuchoption", "FALLBACK"
+    ) == "FALLBACK"
+
+
+def test_effective_option_prefers_override_over_lookup(root):
+    root.style._build_configure("Probe2.TFrame", borderwidth=3)
+    root.style.configure("Probe2.TFrame", borderwidth=9)
+    assert root.style._effective_style_option("Probe2.TFrame", "borderwidth") == 9
 
 
 # --- the allowlist covers every geometry option recipes write --------------


### PR DESCRIPTION
Follow-up to #1279, from a code review of the merged durable style-options layer. Three defects, all verified by probe rather than inspection.

## 1. 🔴 A base-class override stretched `icon_only` buttons

#1279 wired the derived icon style into `_register_ttkstyle`, which put it in the fan-out path. A global `configure("TButton", padding=(40,2))` therefore merged into `Icon<digest>.TButton` **after** the icon's own padding, breaking its square geometry:

```
icon_only, no override : 29x29   ← square, as designed
+ global TButton padding : 103x27  ← stretched
```

That triggers on precisely the workflow #1238 exists to enable ("set consistent button padding app-wide"). `icon_only` padding is a *computed layout requirement*, not a default an inherited override should stretch.

**Fix:** the icon style now registers **before** it configures, so its computed values land last. Only options actually present in `config` are pinned — so a plain text+icon button still follows a global padding override (covered by a test, to keep the fix from being over-broad).

## 2. 🟡 Notebook tab padding was silently un-overridable

The recipe mapped `padding` to the **same** value for both `selected` and `!selected`. Since those two states cover every state, `lookup` always resolved through the map and masked any user `configure` — the override was recorded as durable and replayed forever with **zero effect**. Vanilla ttk honors the same call, so this was ours, not Tk's.

```
ttkbootstrap  -> 6 5     (user value masked)
vanilla ttk   -> 30 20   (works)
after clearing the map -> 30 20   ← the value was there all along
```

**Fix:** drop both redundant map entries. `bordercolor` had no `configure` value (it existed *only* in the map), so it moves into `configure` — the default look is unchanged, verified by a test.

## 3. 🟡 `_effective_style_option` swallowed falsy values

`self.lookup(...) or None` turned a real `borderwidth=0` into the caller's default. Now only the `""` ttk returns for an unset option falls through. Harmless for `font` (the only current caller) but a trap for numeric options — and it disagreed with the registry path, which handled `0` correctly.

## Also

Narrowed the test fixture's bare `except Exception` cleanup, which could mask a genuine teardown failure.

## Tests

`tests/test_durable_style_options.py` (+7): icon-only stays square under a base override; text+icon still follows it; tab padding override takes effect; tab defaults unchanged; falsy / unset / override-precedence for the option helper. Full suite **770 passed**.

Refs #1238, #1279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)