### PR TITLE
docs(custom-styles): persistent style options + options widgets ignore

### DIFF
--- a/docs/user-guide/feature-guides/custom-styles.rst
+++ b/docs/user-guide/feature-guides/custom-styles.rst
@@ -23,6 +23,77 @@ its base class (``my.TButton`` → ``TButton``), so you only set what changes:
 
    app.mainloop()
 
+Change an option everywhere
+---------------------------
+
+To change a look for every widget of one kind, configure its **base style**. The
+change reaches the colored variants too, and it survives a theme switch:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   app = ttk.App(theme="bootstrap-light")
+
+   app.style.configure("TEntry", padding=8)
+
+   ttk.Entry(app).pack(padx=10, pady=4)
+   ttk.Entry(app, bootstyle="danger").pack(padx=10, pady=4)
+
+   app.mainloop()
+
+Both entries are padded — the plain one and the ``danger`` one. Set the option
+once on the base class and every variant built from it picks it up.
+
+To change one variant only, configure that name instead. The more specific name
+wins, so this pads every entry by ``8`` except the ``danger`` ones:
+
+.. code-block:: python
+
+   app.style.configure("TEntry", padding=8)
+   app.style.configure("danger.TEntry", padding=20)
+
+It also works the other way round: you can set the option after the widgets
+already exist, and they update.
+
+**Colors are the exception.** A color you set this way applies immediately but is
+not carried across a theme switch — colors keep following the theme, so a
+``bootstrap-light`` entry does not stay light after switching to
+``bootstrap-dark``. To change the colors a theme uses, see
+:doc:`Theming & Colors <theming>`.
+
+To go back to the shipped look, drop the option and let the next rebuild restore
+it:
+
+.. code-block:: python
+
+   app.style.reset_style_options("TEntry")   # one style
+   app.style.reset_style_options()           # everything you have set
+
+Options a widget doesn't read
+-----------------------------
+
+A style option only does something if the widget actually reads it. A few don't,
+and the setting is quietly ignored — the option is stored, it just never reaches
+the screen. These are the ones worth knowing:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Setting
+     - What to do instead
+   * - ``font`` on an entry, combobox, or spinbox
+     - These take their font from the widget, not the style.
+
+       | Pass it to the widget: ``ttk.Entry(app, font="-size 14")``
+       | Or change the named font they use, ``TkTextFont``
+   * - ``sashthickness`` on a panedwindow style
+     - The sash is drawn from a single global style, so it cannot be set per
+       widget — every panedwindow shares one thickness.
+
+       | Configure that style: ``app.style.configure("Sash", sashthickness=6)``
+
 Build a style from scratch
 --------------------------
 


### PR DESCRIPTION
The docs slice (PR 3) of the durable style-options cluster, documenting what shipped in #1279 / #1281 / #1282.

Two new sections in the Custom styles guide, both written task-first rather than as an option tour.

## Change an option everywhere

Configure a **base style** and the change reaches the colored variants too, and survives a theme switch. Covers:

- base → variant fan-out (`TEntry` reaches `danger.TEntry`)
- a more specific name wins
- it also applies to widgets that already exist
- **colors are the exception** — they keep following the theme
- `reset_style_options()` to restore the shipped look

## Options a widget doesn't read

A style option only does something if the widget actually reads it; otherwise the setting is quietly ignored. This came out of the review — there turned out to be several distinct cases, enough that it needed a section rather than a footnote:

| setting | what to do instead |
|---|---|
| `font` on entry/combobox/spinbox | set it on the widget, or change `TkTextFont` |
| `sashthickness` | one global `"Sash"` style; not settable per widget |

(The third case found in review — notebook tab padding — was a bug in our own recipe and is *fixed* in #1282, so it is deliberately not documented as a limitation.)

## Verification

Every snippet and claim was run against the library, including the negative one — a color set this way genuinely does not survive a theme switch (`#ff0000` → `#262b30`).

Also fixes a rST trap in the new table: line blocks need a blank line before them, without which the literal `|` leaks into the rendered text. `-W` does not flag this, so I checked the built HTML — and a scan of every `.rst` confirms no other page has the same issue (the #1227 conversions are all correct).

Docs build clean under `-W`.

Refs #1238, #1161, #1160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)