### PR TITLE
fix(scroll): support the Tk 9 scroll-event contract

### DIFF
--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -21,6 +21,7 @@
 | **Durable style options — `style.configure()` survives variants & theme switches** | New | this doc, below |
 | **Notebook tab `padding` / `bordercolor` are now overridable** | Fix | this doc, below |
 | **`DateEntry(value=…)` — a nullable, clearable date field** | New | this doc, below |
+| **Scrolling works on Tcl/Tk 9** | Fix | this doc, below |
 
 There are **no API breaks in 2.1**: nothing was removed, and no call that worked
 in 2.0.0 fails. One change is visually noticeable without any code change (the
@@ -136,3 +137,38 @@ where an empty field reads as `None` instead of falling back to `start_date`.
 **Why.** An optional date is a normal form requirement (discussion #476) and had
 no supported spelling. The additive half of #1253 (PR #1277); making
 `value=None` the *default* is a breaking change deferred to 3.0 (#1276).
+
+---
+
+## Scrolling works on Tcl/Tk 9  *(Fix)*
+
+**What.** `ScrolledFrame` (and the color dropper's zoom) scrolls correctly on a
+Tk 9 interpreter. In 2.0.0, on Tk 9:
+
+- a **trackpad, Magic Mouse or Magic Trackpad did nothing at all** — those
+  devices fire `<TouchpadScroll>`, which nothing was listening for;
+- **one wheel notch jumped to the end of the content** on macOS;
+- **wheel scrolling was dead on Linux**, where `<Button-4>`/`<Button-5>` are no
+  longer delivered to scripts.
+
+**Who notices.** Anyone on an interpreter linked against Tk 9 — a Homebrew,
+conda or pyenv build. The python.org installers still ship Tk 8.6, where nothing
+changes. Check with:
+
+```
+python -c "import tkinter; print(tkinter.Tcl().eval('info patchlevel'))"
+```
+
+**Why.** Tk 9 changed the scroll-event contract: precise-delta devices report
+through `<TouchpadScroll>` instead of `<MouseWheel>`, wheel deltas are normalized
+to multiples of 120 on every platform (macOS previously reported 1 per notch),
+and X11 wheel buttons are translated to `<MouseWheel>` internally (TIP 474). The
+widgets were written against Tk 8.6 and read every one of those the old way.
+
+One notch now moves one unit on every platform and Tk version, and a trackpad
+gesture scrolls smoothly — pixel deltas are accumulated and spent as whole canvas
+units, following Tk's own convention for units-based widgets.
+
+Widgets that rely on Tk's class bindings (`Treeview`, `Listbox`, `Text`, and so
+`ScrolledText`) were never affected: Tk 9 binds `<TouchpadScroll>` on those
+classes itself. Fixes #1290.

--- a/src/ttkbootstrap/dialogs/colordropper.py
+++ b/src/ttkbootstrap/dialogs/colordropper.py
@@ -13,8 +13,12 @@ from PIL.Image import Resampling
 import ttkbootstrap as ttk
 from ttkbootstrap import utils
 from ttkbootstrap.constants import *
+from ttkbootstrap.internal import wheel
 
 ColorChoice = namedtuple('ColorChoice', 'rgb hsl hex')
+
+# trackpad pixels per zoom step -- one notch's worth of gesture
+_ZOOM_STEP_PIXELS = 40
 
 
 class ColorDropperDialog:
@@ -39,6 +43,7 @@ class ColorDropperDialog:
         """Initialize the dropper with no active toplevel and an empty result."""
         self.toplevel: Optional[ttk.Toplevel] = None
         self.result: ttk.Variable = ttk.Variable()
+        self._touchpad = wheel.PixelAccumulator()
 
     def build_screenshot_canvas(self) -> None:
         """Build the screenshot canvas"""
@@ -73,20 +78,26 @@ class ColorDropperDialog:
         self.zoom_canvas.pack(fill=BOTH, expand=YES)
         self.zoom_toplevel = toplevel
 
+    def _apply_zoom(self, steps: int) -> None:
+        """Zoom by whole steps, keeping the magnification at 1x or more."""
+        level = max(1, self.zoom_level - steps)
+        if level != self.zoom_level:
+            self.zoom_level = level
+            self.on_mouse_motion()
+
     def on_mouse_wheel(self, event: tk.Event) -> None:
-        """Zoom in and out on the image underneath the mouse
-        TODO Cross platform testing needed
+        """Zoom in and out on the image underneath the mouse"""
+        self._apply_zoom(round(wheel.wheel_notches(self.toplevel, event)))
+
+    def on_touchpad_scroll(self, event: tk.Event) -> None:
+        """Zoom in and out in response to a precise-delta gesture.
+
+        A trackpad reports pixels roughly sixty times a second, so they are
+        accumulated into whole zoom steps rather than spent as they arrive.
         """
-        if self.toplevel and self.toplevel.winsys.lower() == 'win32':
-            delta = -int(event.delta / 120)
-        elif self.toplevel and self.toplevel.winsys.lower() == 'aqua':
-            delta = -event.delta
-        elif event.num == 4:
-            delta = -1
-        elif event.num == 5:
-            delta = 1
-        self.zoom_level += delta
-        self.on_mouse_motion()
+        _, dy = wheel.precise_deltas(event)
+        if dy:
+            self._apply_zoom(self._touchpad.add(0, dy, 1, _ZOOM_STEP_PIXELS)[1])
 
     def on_left_click(self, _: tk.Event) -> Optional[ColorChoice]:
         """Capture the color underneath the mouse cursor and destroy
@@ -153,11 +164,11 @@ class ColorDropperDialog:
         self.toplevel.bind("<Button-1>", self.on_left_click, "+")
         self.toplevel.bind("<Button-3>", self.on_right_click, "+")
 
-        if self.toplevel.winsys.lower() == 'x11':
-            self.toplevel.bind("<Button-4>", self.on_mouse_wheel, "+")
-            self.toplevel.bind("<Button-5>", self.on_mouse_wheel, "+")
-        else:
-            self.toplevel.bind("<MouseWheel>", self.on_mouse_wheel, "+")
+        for seq in wheel.wheel_sequences(self.toplevel):
+            self.toplevel.bind(seq, self.on_mouse_wheel, "+")
+        if wheel.has_touchpad_scroll():
+            self.toplevel.bind(
+                wheel.TOUCHPAD_SCROLL, self.on_touchpad_scroll, "+")
 
         # initial snip setup
         self.zoom_level: int = 2

--- a/src/ttkbootstrap/internal/wheel.py
+++ b/src/ttkbootstrap/internal/wheel.py
@@ -1,0 +1,154 @@
+"""Scroll-gesture normalization across Tk 8.6 and Tk 9.
+
+Tk 9 changed the scroll-event contract in two ways that break code written
+against Tk 8.6:
+
+* A precise-delta device -- every Apple trackpad, Magic Mouse and Magic
+  Trackpad -- now fires `<TouchpadScroll>` and **never** `<MouseWheel>`.
+  Binding only the wheel leaves those devices completely dead.
+* Wheel deltas are normalized to multiples of 120 on every windowing system.
+  On aqua a notch used to report 1; it now reports 120.
+
+On X11, `<Button-4>`/`<Button-5>` are no longer delivered to scripts at all
+-- Tk translates them to `<MouseWheel>` internally (TIP 474).
+
+This module hides all of that behind one vocabulary: callers ask for the
+sequences to bind, then convert an incoming event to either wheel *notches*
+or precise *pixels*.
+
+Sign convention (matching Tk's own bindings): a positive value means the
+wheel rolled away from the user, i.e. the view should move toward the
+*start* of the content. Callers negate to get a scroll amount.
+"""
+
+import tkinter
+
+from ttkbootstrap.utils import windowing_system
+
+TOUCHPAD_SCROLL = "<TouchpadScroll>"
+"""Sequence for precise-delta scroll gestures. Tk 8.7+ only."""
+
+_WHEEL_UNITS = 120.0
+"""Delta reported for one wheel notch on a normalized (Tk 8.7+) build."""
+
+_TOUCHPAD_TK = 8.7
+"""First Tk release generating `<TouchpadScroll>` and normalized deltas."""
+
+
+def has_touchpad_scroll() -> bool:
+    """Return whether the running Tk generates `<TouchpadScroll>` events."""
+    return tkinter.TkVersion >= _TOUCHPAD_TK
+
+
+def uses_x11_buttons(widget) -> bool:
+    """Return whether wheel input arrives as `<Button-4>`/`<Button-5>` here.
+
+    True only on legacy X11 builds: Tk 8.7+ translates those buttons to
+    `<MouseWheel>` and stops delivering them to scripts.
+    """
+    return not has_touchpad_scroll() and windowing_system(widget) == "x11"
+
+
+def wheel_sequences(widget, shift: bool = False):
+    """Return the event sequences carrying wheel notches for `widget`.
+
+    Parameters:
+
+        widget (Misc):
+            Any widget; used to resolve the windowing system.
+
+        shift (bool):
+            Request the horizontal (Shift-modified) sequences.
+
+    Returns:
+
+        Tuple[str, ...]:
+            The sequences to bind.
+    """
+    if uses_x11_buttons(widget):
+        if shift:
+            return ("<Shift-Button-4>", "<Shift-Button-5>")
+        return ("<Button-4>", "<Button-5>")
+    return ("<Shift-MouseWheel>",) if shift else ("<MouseWheel>",)
+
+
+def wheel_notches(widget, event) -> float:
+    """Return the signed notch count for a wheel event.
+
+    One physical notch is 1.0 on every platform and Tk version. The value is
+    positive when the wheel rolled away from the user.
+    """
+    num = getattr(event, "num", None)
+    if num in (4, 6):
+        return 1.0
+    if num in (5, 7):
+        return -1.0
+
+    try:
+        delta = float(event.delta)
+    except (AttributeError, TypeError, ValueError):
+        return 0.0
+    if not delta:
+        return 0.0
+
+    # Tk 8.6 on aqua reported one notch as 1; everything else uses 120.
+    if not has_touchpad_scroll() and windowing_system(widget) == "aqua":
+        return delta
+    return delta / _WHEEL_UNITS
+
+
+def precise_deltas(event):
+    """Unpack a `<TouchpadScroll>` event into `(dx, dy)` pixels.
+
+    Tk packs both axes into the delta field as two signed 16-bit values;
+    this mirrors Tcl's `::tk::PreciseScrollDeltas`.
+    """
+    try:
+        packed = int(event.delta)
+    except (AttributeError, TypeError, ValueError):
+        return (0, 0)
+    dx = packed >> 16
+    low = packed & 0xFFFF
+    dy = low if low < 0x8000 else low - 0x10000
+    return (dx, dy)
+
+
+def scale_num(widget, value) -> int:
+    """Scale a pixel amount for display density, like `::tk::ScaleNum`."""
+    try:
+        scaling = float(widget.tk.call("tk", "scaling"))
+    except (tkinter.TclError, TypeError, ValueError):
+        scaling = 1.0
+    return round(value * scaling * 0.75)
+
+
+class PixelAccumulator:
+    """Converts precise pixel deltas into whole discrete scroll steps.
+
+    A touchpad reports small deltas roughly sixty times a second. Widgets
+    that scroll by rows or canvas units cannot act on each one, so the
+    fractional remainder is carried forward until it adds up to a step.
+    """
+
+    __slots__ = ("_x", "_y")
+
+    def __init__(self) -> None:
+        self._x = 0.0
+        self._y = 0.0
+
+    def add(self, dx, dy, step_x, step_y):
+        """Add a delta and return the whole `(x, y)` steps it completes."""
+        step_x = step_x if step_x and step_x > 0 else 1.0
+        step_y = step_y if step_y and step_y > 0 else 1.0
+        self._x += dx
+        self._y += dy
+        out_x = int(self._x / step_x)
+        out_y = int(self._y / step_y)
+        self._x -= out_x * step_x
+        self._y -= out_y * step_y
+        return (out_x, out_y)
+
+    def reset(self) -> None:
+        """Drop any carried remainder."""
+        self._x = 0.0
+        self._y = 0.0

--- a/src/ttkbootstrap/widgets/scrolled.py
+++ b/src/ttkbootstrap/widgets/scrolled.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Optional, Tuple
 
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
+from ttkbootstrap.internal import wheel
 from ttkbootstrap.internal.configure_delegation import ConfigureDelegationMixin
 from ttkbootstrap.style._compat import normalize_scrolled_kwargs, warn_deprecated
 from ttkbootstrap.utils import windowing_system
@@ -433,11 +434,13 @@ class ScrolledFrame(ttk.Frame):
         # in each widget's bindtags -- no O(subtree) rebinding, no clobbering
         # the app's own wheel handlers).
         self._wheel_tag = f"ScrolledFrame_{id(self)}"
-        if self.winsys.lower() == "x11":
-            self.bind_class(self._wheel_tag, "<Button-4>", self._on_mousewheel, "+")
-            self.bind_class(self._wheel_tag, "<Button-5>", self._on_mousewheel, "+")
-        else:
-            self.bind_class(self._wheel_tag, "<MouseWheel>", self._on_mousewheel, "+")
+        self._touchpad = wheel.PixelAccumulator()
+        for seq in wheel.wheel_sequences(self):
+            self.bind_class(self._wheel_tag, seq, self._on_mousewheel, "+")
+        if wheel.has_touchpad_scroll():
+            self.bind_class(
+                self._wheel_tag, wheel.TOUCHPAD_SCROLL, self._on_touchpad_scroll, "+"
+            )
 
         # show/enable on enter, hide/disable on leave
         self.container.bind("<Enter>", self._on_enter, "+")
@@ -534,27 +537,38 @@ class ScrolledFrame(ttk.Frame):
         self._scroll_enabled = False
         self._del_scroll_binding()
 
-    def _on_mousewheel(self, event: tkinter.Event) -> None:
-        """Scroll the canvas vertically in response to the mouse wheel."""
-        # do nothing when the content already fits (avoids capturing the wheel)
+    def _content_fits(self) -> bool:
+        """Whether the content already fits (so the gesture isn't captured)."""
         try:
             first, last = self._canvas.yview()
-            if first <= 0.0 and last >= 1.0:
-                return
         except tkinter.TclError:
-            pass
-        if self.winsys.lower() == "win32":
-            delta = -int(event.delta / 120)
-        elif self.winsys.lower() == "aqua":
-            delta = -event.delta
-        elif event.num == 4:
-            delta = -1
-        elif event.num == 5:
-            delta = 1
-        else:
-            delta = 0
+            return False
+        return first <= 0.0 and last >= 1.0
+
+    def _on_mousewheel(self, event: tkinter.Event) -> None:
+        """Scroll the canvas vertically in response to the mouse wheel."""
+        if self._content_fits():
+            return
+        delta = -round(wheel.wheel_notches(self, event))
         if delta:
             self._canvas.yview_scroll(delta, UNITS)
+
+    def _on_touchpad_scroll(self, event: tkinter.Event) -> None:
+        """Scroll the canvas in response to a precise-delta gesture.
+
+        Tk reports these roughly sixty times a second in pixels, while the
+        canvas scrolls in units of a tenth of the viewport, so the pixels are
+        accumulated and spent as whole units to keep the gesture smooth.
+        """
+        if self._content_fits():
+            return
+        _, dy = wheel.precise_deltas(event)
+        if not dy:
+            return
+        step = self._canvas.winfo_height() / 10 or 1
+        _, units = self._touchpad.add(0, dy, 1, step)
+        if units:
+            self._canvas.yview_scroll(-units, UNITS)
 
     # -- scrollbar visibility ------------------------------------------------ #
     @property
@@ -635,11 +649,10 @@ class ScrolledFrame(ttk.Frame):
             return super().destroy()
         self._destroying = True
         try:
-            if self.winsys.lower() == "x11":
-                self.unbind_class(self._wheel_tag, "<Button-4>")
-                self.unbind_class(self._wheel_tag, "<Button-5>")
-            else:
-                self.unbind_class(self._wheel_tag, "<MouseWheel>")
+            for seq in wheel.wheel_sequences(self):
+                self.unbind_class(self._wheel_tag, seq)
+            if wheel.has_touchpad_scroll():
+                self.unbind_class(self._wheel_tag, wheel.TOUCHPAD_SCROLL)
         except tkinter.TclError:
             pass
 

--- a/tests/test_scroll_events.py
+++ b/tests/test_scroll_events.py
@@ -1,0 +1,158 @@
+"""Headless tests for the Tk 8.6 / Tk 9 scroll-event contract (issue #1290).
+
+Tk 9 normalizes wheel deltas to multiples of 120 on every platform, stops
+delivering `<Button-4>`/`<Button-5>` to scripts on X11, and routes every
+precise-delta device (any Apple trackpad or Magic Mouse) through
+`<TouchpadScroll>` instead of `<MouseWheel>`. These pin the normalization
+helpers and the ScrolledFrame bindings that consume them.
+
+The touchpad cases only run on a Tk that generates the event; the rest are
+version-independent. Uses the shared `root` fixture from conftest.
+"""
+import tkinter
+
+import pytest
+
+from ttkbootstrap.internal import wheel
+from ttkbootstrap.widgets.scrolled import ScrolledFrame
+
+requires_touchpad = pytest.mark.skipif(
+    not wheel.has_touchpad_scroll(),
+    reason="Tk 8.6 generates no <TouchpadScroll> events",
+)
+
+
+def _notch_event(widget, down=True):
+    """A wheel event carrying exactly one notch on the running Tk.
+
+    Tk 8.6 on aqua reported a notch as 1; every other build uses 120, so the
+    raw delta a real device sends is not the same number everywhere.
+    """
+    event = tkinter.Event()
+    event.num = "??"
+    unit = 1 if wheel.wheel_notches(widget, _delta_event(1)) == 1.0 else 120
+    event.delta = -unit if down else unit
+    return event
+
+
+def _delta_event(delta):
+    event = tkinter.Event()
+    event.num = "??"
+    event.delta = delta
+    return event
+
+
+def _tall_frame(root, rows=80):
+    """A realized ScrolledFrame whose content overflows the viewport."""
+    sf = ScrolledFrame(root, auto_hide=False, height=200, width=300)
+    sf.pack(fill="both", expand=True)
+    for i in range(rows):
+        tkinter.Label(sf, text=f"row {i}").pack(anchor="w")
+    for _ in range(3):
+        root.update_idletasks()
+        root.update()
+    return sf
+
+
+# --------------------------------------------------------------------------- #
+# normalization helpers
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(
+    not wheel.has_touchpad_scroll(), reason="Tk 8.6 aqua reports a notch as 1"
+)
+def test_one_notch_is_one_unit(root):
+    """A normalized (Tk 8.7+) 120-delta event is one notch, not 120."""
+    assert wheel.wheel_notches(root, _delta_event(-120)) == pytest.approx(-1.0)
+    assert wheel.wheel_notches(root, _delta_event(240)) == pytest.approx(2.0)
+
+
+def test_x11_buttons_report_a_notch_each_way(root):
+    up, down = tkinter.Event(), tkinter.Event()
+    up.num, down.num = 4, 5
+    assert wheel.wheel_notches(root, up) == 1.0
+    assert wheel.wheel_notches(root, down) == -1.0
+
+
+def test_precise_deltas_unpack_both_signed_axes():
+    """`%D` packs dx in the high word and a signed dy in the low word."""
+    event = tkinter.Event()
+    event.delta = (3 << 16) | (0x10000 - 7)  # dx=3, dy=-7
+    assert wheel.precise_deltas(event) == (3, -7)
+
+    event.delta = (-2 << 16) | 5
+    assert wheel.precise_deltas(event) == (-2, 5)
+
+
+def test_pixel_accumulator_carries_the_remainder():
+    acc = wheel.PixelAccumulator()
+    assert acc.add(0, 9, 1, 10)[1] == 0       # not a whole step yet
+    assert acc.add(0, 9, 1, 10)[1] == 1       # 18px -> one step, 8px carried
+    acc.reset()
+    assert acc.add(0, 9, 1, 10)[1] == 0       # remainder dropped
+
+
+def test_x11_buttons_only_on_legacy_tk(root):
+    """Tk 8.7+ translates Button-4/5 internally, so they must not be bound."""
+    if wheel.has_touchpad_scroll():
+        assert not wheel.uses_x11_buttons(root)
+        assert wheel.wheel_sequences(root) == ("<MouseWheel>",)
+
+
+# --------------------------------------------------------------------------- #
+# ScrolledFrame
+# --------------------------------------------------------------------------- #
+def test_wheel_is_bound_on_every_platform(root):
+    """The wheel tag always carries a sequence Tk actually delivers here."""
+    sf = _tall_frame(root)
+    bound = set(root.tk.call("bind", sf._wheel_tag))
+    assert set(wheel.wheel_sequences(sf)) <= bound
+    sf.destroy()
+
+
+@requires_touchpad
+def test_touchpad_scroll_is_bound(root):
+    sf = _tall_frame(root)
+    assert wheel.TOUCHPAD_SCROLL in root.tk.call("bind", sf._wheel_tag)
+    sf.destroy()
+
+
+def test_one_notch_scrolls_one_unit_not_to_the_end(root):
+    """The Tk 9 regression: one notch jumped the view to the bottom."""
+    sf = _tall_frame(root)
+    canvas = sf._canvas
+    sf._on_mousewheel(_notch_event(sf))
+    root.update_idletasks()
+    first, _ = canvas.yview()
+    assert 0.0 < first < 0.5, f"one notch moved to {first}"
+    sf.destroy()
+
+
+def test_wheel_does_not_scroll_content_that_fits(root):
+    sf = _tall_frame(root, rows=1)
+    sf._on_mousewheel(_notch_event(sf))
+    root.update_idletasks()
+    assert sf._canvas.yview()[0] == 0.0
+    sf.destroy()
+
+
+@requires_touchpad
+def test_touchpad_gesture_scrolls_the_canvas(root):
+    """A run of precise deltas moves the view instead of doing nothing."""
+    sf = _tall_frame(root)
+    canvas = sf._canvas
+    event = tkinter.Event()
+    event.delta = 0x10000 - 12  # dy = -12 px, one gesture tick
+    for _ in range(20):
+        sf._on_touchpad_scroll(event)
+    root.update_idletasks()
+    first, _ = canvas.yview()
+    assert first > 0.0, "trackpad gesture did not scroll"
+    sf.destroy()
+
+
+def test_destroy_unbinds_the_wheel_tag(root):
+    sf = _tall_frame(root)
+    tag = sf._wheel_tag
+    sf.destroy()
+    root.update_idletasks()
+    assert root.tk.call("bind", tag) == ""


### PR DESCRIPTION
Fixes #1290.

Tk 9 changed the scroll-event contract in three ways, and `ScrolledFrame` read every one of them the Tk 8.6 way:

- **Trackpads are dead, not degraded.** A precise-delta device — every Apple trackpad, Magic Mouse and Magic Trackpad — fires `<TouchpadScroll>` and never `<MouseWheel>`.
- **One notch jumped to the end.** Deltas are normalized to multiples of 120 on every platform; aqua used to report 1 per notch, so `-event.delta` scrolled 120 canvas units.
- **Wheel scrolling is dead on Linux.** X11 no longer delivers `<Button-4>`/`<Button-5>` to scripts (TIP 474) — they were the only sequence bound there.

## What changed

Normalization moves into `internal/wheel.py` — `wheel_sequences()`, `wheel_notches()`, `precise_deltas()`, `scale_num()` and a `PixelAccumulator`. Bindings are unconditional; the X11 buttons remain as a Tk ≤ 8.6 fallback gated on **Tk version** rather than the windowing system. A trackpad gesture accumulates pixels and spends them as whole canvas units, following Tk's own convention for units-based widgets.

`colordropper` used the same delta branch and gets the same treatment, plus a clamp keeping the magnification at 1x or more (a trackpad drove the zoom level negative in a fraction of a second).

`ScrolledText` needs no change — it relies on the `Text` class bindings, which Tk 9 extends with `<TouchpadScroll>` itself.

## Verification

Measured on a live window, same script as the issue:

| | before | after |
|---|---|---|
| Tk 9.0.4, one notch | `0.813` (at the end) | `0.019` |
| Tk 9.0.4, 20-event trackpad gesture | `0.0` (dead) | `0.017 → 0.168` |
| Tk 8.6.17, one real aqua notch | `0.019` | `0.019` (unchanged) |

`tests/test_scroll_events.py` (+11) pins the normalization helpers and the bindings; the three touchpad/notch regression tests fail against the unmodified source on Tk 9 and skip on Tk 8.6. Suite **778 passed** on Tk 8.6.17.

Unrelated, but worth its own issue: **7 tests fail on Tk 9** (icon/asset sizing, notebook tab defaults). They fail identically without this change — pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)