### PR TITLE
fix(scaling): correct the aqua baseline on Tcl/Tk 9

### DIFF
--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -22,6 +22,7 @@
 | **Notebook tab `padding` / `bordercolor` are now overridable** | Fix | this doc, below |
 | **`DateEntry(value=…)` — a nullable, clearable date field** | New | this doc, below |
 | **Scrolling works on Tcl/Tk 9** | Fix | this doc, below |
+| **macOS renders at its designed size on Tcl/Tk 9** | Fix | this doc, below |
 
 There are **no API breaks in 2.1**: nothing was removed, and no call that worked
 in 2.0.0 fails. One change is visually noticeable without any code change (the
@@ -172,3 +173,39 @@ units, following Tk's own convention for units-based widgets.
 Widgets that rely on Tk's class bindings (`Treeview`, `Listbox`, `Text`, and so
 `ScrolledText`) were never affected: Tk 9 binds `<TouchpadScroll>` on those
 classes itself. Fixes #1290.
+
+---
+
+## macOS renders at its designed size on Tcl/Tk 9  *(Fix)*
+
+**What.** On a Tk 9 interpreter, every asset and every pixel-valued piece of
+geometry rendered **33% larger than designed** on macOS — while the text inside
+it stayed the same size. Padding, borders, indicators and icons inflated around
+unchanged type:
+
+| widget | Tk 8.6 | Tk 9 in 2.0.0 | Tk 9 in 2.1 |
+|---|---|---|---|
+| `Button` | 56 x 30 | 62 x 32 | 56 x 30 |
+| `Entry` | 194 x 30 | 198 x 34 | 194 x 30 |
+| `Checkbutton` | 44 x 18 | 52 x 24 | 44 x 18 |
+| `Label` (text only, no scaled padding) | 34 x 20 | 34 x 20 | 34 x 20 |
+
+That last row is the tell: a plain label was identical throughout, because it is
+pure text. Only the parts ttkbootstrap scales moved.
+
+**Who notices.** macOS users on an interpreter linked against Tk 9 — Homebrew,
+conda or pyenv. Windows and Linux were never affected, and the python.org
+installers still ship Tk 8.6.
+
+**Why.** ttkbootstrap converts logical UI units to pixels against a baseline for
+what "100% scaling" reports. Aqua assumed **72 dpi** (`tk scaling` 1.0), while
+every other platform assumed 96 (4/3). Tk 9 aligned aqua with the rest at 96, so
+the same unchanged screen now reports 1.333 — and reading it against the old
+baseline yielded a 4/3 factor where the answer should be 1.0. The baseline is now
+gated on the Tk version as well as the platform.
+
+**Fonts were never the problem, which is what makes it subtle.** Tk 9 restates
+`TkDefaultFont` as size 10 where Tk 8.6 called it 13, but both render at a 16px
+linespace — the nominal number changed with the dpi assumption, the rendered text
+did not. Had the text actually grown, scaling the assets to match would have been
+correct.

--- a/src/ttkbootstrap/style/scaling.py
+++ b/src/ttkbootstrap/style/scaling.py
@@ -3,6 +3,7 @@
 Theme recipes use logical UI units. This service converts them exactly once to
 the physical pixels consumed by Tk and Pillow.
 """
+import tkinter
 from math import ceil, floor
 
 
@@ -42,8 +43,16 @@ class Scaling:
 
     @property
     def baseline(self) -> float:
-        """Tk scaling value that corresponds to a 1.0 (unscaled) UI factor."""
-        return 1.0 if self.windowing_system == "aqua" else 4 / 3
+        """Tk scaling value that corresponds to a 1.0 (unscaled) UI factor.
+
+        A standard-density display reports 4/3 (96 dpi) everywhere -- except on
+        aqua before Tk 9, which assumed 72 dpi and reported 1.0. Reading the
+        wrong baseline scales every asset and every pixel-valued geometry by the
+        ratio between them, so the version gate matters as much as the platform.
+        """
+        if self.windowing_system == "aqua" and tkinter.TkVersion < 8.7:
+            return 1.0
+        return 4 / 3
 
     @property
     def tk_scaling(self) -> float:

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,5 +1,6 @@
 """Root-bound scaling and asset-geometry regression tests."""
 import ast
+import tkinter
 from math import floor
 from pathlib import Path
 
@@ -53,13 +54,42 @@ def test_logical_matrix_uses_round_half_up(factor, expected):
 
 
 @pytest.mark.parametrize(
-    ("windowing_system", "baseline"),
-    [("win32", 4 / 3), ("x11", 4 / 3), ("aqua", 1.0)],
+    ("windowing_system", "tk_version", "baseline"),
+    [
+        ("win32", 8.6, 4 / 3),
+        ("x11", 8.6, 4 / 3),
+        ("win32", 9.0, 4 / 3),
+        ("x11", 9.0, 4 / 3),
+        # aqua is the only platform whose baseline moved: it assumed 72 dpi
+        # until Tk 9 aligned it with everyone else at 96.
+        ("aqua", 8.6, 1.0),
+        ("aqua", 9.0, 4 / 3),
+    ],
 )
-def test_platform_baseline_and_nominal_noise(windowing_system, baseline):
+def test_platform_baseline_and_nominal_noise(
+    monkeypatch, windowing_system, tk_version, baseline
+):
+    # force the version rather than skip, so both eras run on either host
+    monkeypatch.setattr(tkinter, "TkVersion", tk_version)
     scaling = Scaling(_FakeRoot(windowing_system, baseline * 1.00049))
     assert scaling.baseline == baseline
     assert scaling.factor == 1.0
+
+
+def test_a_standard_display_scales_nothing_on_either_tk(monkeypatch):
+    """A 100% display renders identical geometry on Tk 8.6 and Tk 9.
+
+    The regression this pins: aqua reports `tk scaling` 1.0 on Tk 8.6 and
+    1.333 on Tk 9 for the very same screen. Reading the 8.6 baseline on Tk 9
+    inflated every asset and padding by 4/3 while the text, whose rendered
+    size did not change, stayed put.
+    """
+    for tk_version, reported in ((8.6, 1.0), (9.0, 4 / 3)):
+        monkeypatch.setattr(tkinter, "TkVersion", tk_version)
+        scaling = Scaling(_FakeRoot("aqua", reported))
+        assert scaling.factor == 1.0
+        assert scaling.logical(15) == 15
+        assert scaling.logical((6, 5)) == [6, 5]
 
 
 def test_source_conversion_rounds_only_at_final_boundary():


### PR DESCRIPTION
Follow-on to #1291. Fixes the 7 asset/geometry tests that fail on Tk 9 — but they were a symptom, not the bug.

## The bug

On a Tk 9 interpreter, **every asset and every pixel-valued geometry rendered 33% larger than designed on macOS, while the text inside stayed the same size.** Padding, borders, indicators and icons inflated around unchanged type.

| widget | Tk 8.6 | Tk 9 on `master` | Tk 9 with this PR |
|---|---|---|---|
| `Button` | 56 × 30 | 62 × 32 | 56 × 30 |
| `Entry` | 194 × 30 | 198 × 34 | 194 × 30 |
| `Checkbutton` | 44 × 18 | 52 × 24 | 44 × 18 |
| `Combobox` | 208 × 30 | 216 × 33 | 208 × 30 |
| `Label` (text only, no scaled padding) | 34 × 20 | 34 × 20 | 34 × 20 |

That last row is the control: a plain label is identical throughout because it is pure text. Only the parts ttkbootstrap scales moved.

## Root cause

`Scaling.baseline` hardcoded what "100% scaling" reports per platform: **1.0 on aqua** (72 dpi), 4/3 everywhere else (96 dpi). Tk 9 aligned aqua with every other platform at 96, so the same unchanged display now reports `tk scaling` **1.333** — and dividing that by the old baseline gives a 4/3 factor where the answer is 1.0.

The baseline is now gated on **Tk version as well as windowing system**. Tk 8.6 behavior is untouched on every platform.

## Why this was easy to get backwards

Tk 9 restates `TkDefaultFont` as **size 10** where Tk 8.6 called it **13** — which looks like the UI got smaller and invites "scale it up." But both render at a **16px linespace**: the nominal number tracks the dpi assumption, the rendered text does not change. Had the text actually grown, scaling the assets to match would have been *correct* and this PR would be wrong. The `Label` control above is what settles it.

## Tests

`test_platform_baseline_and_nominal_noise` now covers both Tk eras by **forcing `tkinter.TkVersion`** rather than skipping — a `skipif` would leave a developer on Tk 8.6 exercising neither branch (same reasoning as #1229). Plus `test_a_standard_display_scales_nothing_on_either_tk` pinning the regression directly. Both fail against unmodified source *on the Tk 8.6 host*.

Suite **782 passed** on Tcl/Tk 8.6.17, **785 passed** on Tcl/Tk 9.0.4 — the Tk 9 run was 7 failing before this change and is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)