### PR TITLE
docs: record the 2.0.1 release and rebase the 2.1 log onto it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -811,6 +811,26 @@ DONE.** Optional post-release polish only from here.
 > conveys the target release; tag issues/PRs topically (`enhancement`/`bug`) and
 > set the **milestone**.
 >
+> **2.0.1 SHIPPED (2026-07-23)** — a patch release carrying two Tcl/Tk 9 fixes and
+> nothing else: the scroll-event contract (#1290, PR #1291 — trackpads fire
+> `<TouchpadScroll>` and were completely dead; wheel deltas normalized to ±120 so
+> one notch jumped to the end; X11 no longer delivers Button-4/5) and the aqua
+> scaling baseline (PR #1292 — Tk 9 moved aqua from 72 to 96 dpi, so every asset
+> and padding rendered 33% larger than designed while the text stayed put).
+> **Cut from the `v2.0.0` tag, NOT `master`**, which is the 2.1 mainline and
+> carries features + a visual change that don't belong in a patch. The
+> `release/2.0` branch used to build it was **deleted after publishing** — per the
+> author's convention, `release/*` holds maintenance branches for *superseded*
+> majors (`release/v0.5`, `release/v1`) and the latest always lives on `master`;
+> the `v2.0.1` tag preserves the release point, so branch again from the tag if a
+> 2.0.2 is ever needed. Both fixes are also on `master`. Tag `v2.0.1` + GitHub
+> release live; on PyPI at https://pypi.org/project/ttkbootstrap/2.0.1/.
+> **Tk 9 is now testable on the Mac** — Homebrew `/opt/homebrew/bin/python3.14` is
+> Tk 9.0.4 while the default `python`/`.venv` is 8.6.17; run the suite against it
+> with a `--system-site-packages` venv + `PYTHONPATH=src`. **There is still no CI**
+> (`.github/workflows/` does not exist), so a Tk 9 run is a manual step — worth
+> doing for anything touching scaling, assets, geometry, or event bindings.
+>
 > **The durable style-options cluster is COMPLETE** — #1253, #1238, #1161, #1160
 > all closed (PRs #1277–#1283). Suite **770 passed**. Remaining 2.1 work: the two
 > big design-gated items **#1236** (value tokens) and **#1242** (file dialog), plus

--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -5,9 +5,12 @@
 > (`2_0_breaking_changes.md`) played: kept in `development/` so it survives, and
 > it is the source for the 2.1 release notes.
 >
-> Scope is **relative to released 2.0.0**. Regressions introduced *and* fixed
-> within the 2.1 cycle never reached a user and are deliberately not logged here
-> (they live in the dev log in `CLAUDE.md`).
+> Scope is **relative to the latest released 2.0.x** (currently 2.0.1).
+> Regressions introduced *and* fixed within the 2.1 cycle never reached a user
+> and are deliberately not logged here (they live in the dev log in
+> `CLAUDE.md`) -- and neither does anything already shipped in a 2.0.x patch,
+> since the 2.1 notes must not re-announce it. The two Tcl/Tk 9 fixes shipped
+> in **2.0.1** for exactly that reason.
 >
 > Legend: **API** = source-level break · **Visual** = appearance-only (no code
 > change needed) · **New** = additive · **Fix** = something that did not work
@@ -21,8 +24,6 @@
 | **Durable style options — `style.configure()` survives variants & theme switches** | New | this doc, below |
 | **Notebook tab `padding` / `bordercolor` are now overridable** | Fix | this doc, below |
 | **`DateEntry(value=…)` — a nullable, clearable date field** | New | this doc, below |
-| **Scrolling works on Tcl/Tk 9** | Fix | this doc, below |
-| **macOS renders at its designed size on Tcl/Tk 9** | Fix | this doc, below |
 
 There are **no API breaks in 2.1**: nothing was removed, and no call that worked
 in 2.0.0 fails. One change is visually noticeable without any code change (the
@@ -138,74 +139,3 @@ where an empty field reads as `None` instead of falling back to `start_date`.
 **Why.** An optional date is a normal form requirement (discussion #476) and had
 no supported spelling. The additive half of #1253 (PR #1277); making
 `value=None` the *default* is a breaking change deferred to 3.0 (#1276).
-
----
-
-## Scrolling works on Tcl/Tk 9  *(Fix)*
-
-**What.** `ScrolledFrame` (and the color dropper's zoom) scrolls correctly on a
-Tk 9 interpreter. In 2.0.0, on Tk 9:
-
-- a **trackpad, Magic Mouse or Magic Trackpad did nothing at all** — those
-  devices fire `<TouchpadScroll>`, which nothing was listening for;
-- **one wheel notch jumped to the end of the content** on macOS;
-- **wheel scrolling was dead on Linux**, where `<Button-4>`/`<Button-5>` are no
-  longer delivered to scripts.
-
-**Who notices.** Anyone on an interpreter linked against Tk 9 — a Homebrew,
-conda or pyenv build. The python.org installers still ship Tk 8.6, where nothing
-changes. Check with:
-
-```
-python -c "import tkinter; print(tkinter.Tcl().eval('info patchlevel'))"
-```
-
-**Why.** Tk 9 changed the scroll-event contract: precise-delta devices report
-through `<TouchpadScroll>` instead of `<MouseWheel>`, wheel deltas are normalized
-to multiples of 120 on every platform (macOS previously reported 1 per notch),
-and X11 wheel buttons are translated to `<MouseWheel>` internally (TIP 474). The
-widgets were written against Tk 8.6 and read every one of those the old way.
-
-One notch now moves one unit on every platform and Tk version, and a trackpad
-gesture scrolls smoothly — pixel deltas are accumulated and spent as whole canvas
-units, following Tk's own convention for units-based widgets.
-
-Widgets that rely on Tk's class bindings (`Treeview`, `Listbox`, `Text`, and so
-`ScrolledText`) were never affected: Tk 9 binds `<TouchpadScroll>` on those
-classes itself. Fixes #1290.
-
----
-
-## macOS renders at its designed size on Tcl/Tk 9  *(Fix)*
-
-**What.** On a Tk 9 interpreter, every asset and every pixel-valued piece of
-geometry rendered **33% larger than designed** on macOS — while the text inside
-it stayed the same size. Padding, borders, indicators and icons inflated around
-unchanged type:
-
-| widget | Tk 8.6 | Tk 9 in 2.0.0 | Tk 9 in 2.1 |
-|---|---|---|---|
-| `Button` | 56 x 30 | 62 x 32 | 56 x 30 |
-| `Entry` | 194 x 30 | 198 x 34 | 194 x 30 |
-| `Checkbutton` | 44 x 18 | 52 x 24 | 44 x 18 |
-| `Label` (text only, no scaled padding) | 34 x 20 | 34 x 20 | 34 x 20 |
-
-That last row is the tell: a plain label was identical throughout, because it is
-pure text. Only the parts ttkbootstrap scales moved.
-
-**Who notices.** macOS users on an interpreter linked against Tk 9 — Homebrew,
-conda or pyenv. Windows and Linux were never affected, and the python.org
-installers still ship Tk 8.6.
-
-**Why.** ttkbootstrap converts logical UI units to pixels against a baseline for
-what "100% scaling" reports. Aqua assumed **72 dpi** (`tk scaling` 1.0), while
-every other platform assumed 96 (4/3). Tk 9 aligned aqua with the rest at 96, so
-the same unchanged screen now reports 1.333 — and reading it against the old
-baseline yielded a 4/3 factor where the answer should be 1.0. The baseline is now
-gated on the Tk version as well as the platform.
-
-**Fonts were never the problem, which is what makes it subtle.** Tk 9 restates
-`TkDefaultFont` as size 10 where Tk 8.6 called it 13, but both render at a 16px
-linespace — the nominal number changed with the dpi assumption, the rendered text
-did not. Had the text actually grown, scaling the assets to match would have been
-correct.


### PR DESCRIPTION
Bookkeeping after publishing **2.0.1** (https://pypi.org/project/ttkbootstrap/2.0.1/).

- **`development/2_1_changes.md`** — drops the two Tcl/Tk 9 entries. That log's only job is to be the source for the 2.1 release notes, and those fixes already reached users in 2.0.1; leaving them in would re-announce them. The scope line moves from "relative to released 2.0.0" to the latest released 2.0.x, and now states the patch-release rule outright so the next 2.0.x fix is handled the same way.
- **`CLAUDE.md`** — records what shipped, why it was cut from the `v2.0.0` tag rather than `master` (which carries 2.1 features and a visual change), why `release/2.0` was deleted after publishing (`release/*` is for superseded majors; latest lives on `master`, and the tag preserves the release point), and the Tk 9 interpreter now available for testing on the Mac.

Docs only — no code, no test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)