### PR TITLE
fix(icons): keep registered => configured for derived icon styles (#1284)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -832,9 +832,29 @@ DONE.** Optional post-release polish only from here.
 > doing for anything touching scaling, assets, geometry, or event bindings.
 >
 > **The durable style-options cluster is COMPLETE** — #1253, #1238, #1161, #1160
-> all closed (PRs #1277–#1283). Suite **770 passed**. Remaining 2.1 work: the two
-> big design-gated items **#1236** (value tokens) and **#1242** (file dialog), plus
-> the small review follow-ups **#1284** / **#1286** (and **#1285**, unmilestoned).
+> all closed (PRs #1277–#1283). Suite **770 passed**. **Remaining 2.1 work (5
+> open issues) and the LOCKED sequence (2026-07-24):**
+>
+> **Phase 1 — finish the durable-options review cluster** (do this first, while
+> that seam's context is warm and BEFORE #1236 re-opens the builder color/config
+> seam): **#1284** (register-before-configure invariant bug — code-ready, smallest,
+> fix + regression test) → **#1286** (backfill the guarantees the cluster relies on
+> — cheap, overlaps #1284's test file, sets the assertion baseline) → **#1285**
+> (warn on inert durable option — design-gated; its empirical-mismatch runtime check
+> is the cousin of what #1286 pins, so do it last in the cluster; issue leans
+> option 3 empirical-detection gated behind option 4 strict-mode). #1285 was
+> **milestoned onto 2.1** this session.
+> **Phase 2 — #1236** (bootstyle value tokens; flagship, design-session-gated per
+> `2_1_bootstyle_value_tokens_design.md` §10). Sequenced AFTER Phase 1 because both
+> rewrite the builder color/config seam — never two concurrent rewrites of it.
+> **Phase 3 — #1242** (in-house themed file dialog). Deliberately last: biggest
+> single build, most standalone (doesn't touch the seam), lowest urgency (dialog
+> works, just unthemed on X11), and the named DROP CANDIDATE if 2.1 must close
+> sooner — parks cleanly to 2.2 without stranding seam work.
+> Two design sessions gate real work: #1285 (small) and #1236 (large).
+> **Housekeeping this session:** closed **#1224** (filedialog white-on-white —
+> subsumed by #1242; the dark-mode base-style half was already fixed in #1239) and
+> **#1252** (v1 empty/clearable DateEntry — superseded by shipped #1253 + 3.0 #1276).
 >
 > **User-visible 2.1 changes are logged in `development/2_1_changes.md`** (the
 > running log, same role `2_0_breaking_changes.md` played for 2.0; it is the source

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -729,8 +729,8 @@ class Style(ttk.Style):
             return
         self._user_options.setdefault(style, {}).update(recorded)
         for built in list(self._theme_styles.get(self.theme.name, ())):
-            if built in self._derived_styles:
-                continue  # framework-derived; excluded from fan-out (#1284)
+            # Derived styles are skipped inside _reapply_user_options (#1284), so
+            # the retroactive path needs no separate guard here.
             if built != style and style in self._style_ancestors(built):
                 self._reapply_user_options(built)
 

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -109,6 +109,13 @@ class Style(ttk.Style):
         # keyed by style name, replayed after each build so they survive variant
         # builds and theme switches. Only DURABLE_STYLE_OPTIONS are recorded.
         self._user_options = {}
+        # Styles the framework *derives* (e.g. the per-widget `Icon<hash>.<base>`
+        # icon styles). They are excluded from the durable-options fan-out: they
+        # already inherit a base-class `configure` through ttk's native dotted-name
+        # resolution, and fanning a user override onto them would overwrite the
+        # icon's own computed values (e.g. stretch a square `icon_only` control).
+        # See #1284.
+        self._derived_styles = set()
         self._theme_names = set()
         # Optional designated light/dark theme pair for the theme_mode setter /
         # toggle_theme(); None means "derive from the -light/-dark naming".
@@ -722,6 +729,8 @@ class Style(ttk.Style):
             return
         self._user_options.setdefault(style, {}).update(recorded)
         for built in list(self._theme_styles.get(self.theme.name, ())):
+            if built in self._derived_styles:
+                continue  # framework-derived; excluded from fan-out (#1284)
             if built != style and style in self._style_ancestors(built):
                 self._reapply_user_options(built)
 
@@ -747,6 +756,12 @@ class Style(ttk.Style):
         internal path), so they are not re-recorded.
         """
         if not self._user_options:
+            return
+        # A framework-derived style (icon styles) is excluded from fan-out: it
+        # inherits a base-class `configure` natively and owns its computed values
+        # (#1284). It never carries its own recorded overrides, so there is
+        # nothing else to replay onto it either.
+        if built_style in self._derived_styles:
             return
         handled = set()
         if built_style:

--- a/src/ttkbootstrap/style/icons.py
+++ b/src/ttkbootstrap/style/icons.py
@@ -446,19 +446,21 @@ def _build_icon_style(style, base, name, size, states, compound, icon_only=False
         config["compound"] = compound
     if padding is not None:
         config["padding"] = padding
-    # Register FIRST, then configure. Registering replays durable user overrides
-    # onto this style (a `configure("TButton", padding=...)` fans out to
-    # `Icon<digest>.TButton`), so writing the icon's own values afterwards keeps
-    # them authoritative: `icon_only` padding is computed to make the control
-    # square, not a default a base-class override should stretch. Only the
-    # options actually in `config` are pinned, so a plain (text+icon) button
-    # still follows a global padding override.
-    # Internal path (not public Style.configure) so this padding is not captured
-    # as a durable user override; register as the public path would have.
-    style._register_ttkstyle(derived)
+    # Mark this as a framework-derived style, then configure BEFORE registering.
+    # `_derived_styles` excludes it from the durable-options fan-out, so a
+    # `configure("TButton", padding=...)` is NOT stamped onto it -- yet a plain
+    # (text+icon) button still follows that override, because `Icon<digest>.TButton`
+    # inherits the base `configure` through ttk's native dotted-name resolution
+    # while an `icon_only` control keeps its own computed square padding (which it
+    # sets in `config`). Configuring first keeps `registered => configured` true:
+    # if a write raises, the style is never marked built and is retried (#1284).
+    # `_build_configure` is the internal path (not public `Style.configure`), so
+    # this padding is never captured as a durable user override.
+    style._derived_styles.add(derived)
     style._build_configure(derived, **config)
     if image_map:
         style.map(derived, image=image_map)
+    style._register_ttkstyle(derived)
     return derived
 
 

--- a/tests/test_durable_style_options.py
+++ b/tests/test_durable_style_options.py
@@ -186,6 +186,48 @@ def test_text_icon_button_still_follows_base_override(root):
     assert _padding_tuple(root, btn.cget("style")) == (40, 2)
 
 
+# --- #1284: derived icon styles keep `registered => configured` ------------
+# The icon style is registered AFTER it is configured and is excluded from the
+# durable-options fan-out, so registering it can never leave it built-but-blank
+# and a base-class override can never overwrite its computed values.
+
+def test_registered_icon_style_is_configured(root):
+    """Every registered derived icon style has its glyph image set (#1284)."""
+    ttk.Button(root, icon="calendar-week", icon_only=True).pack()
+    root.update_idletasks()
+    icon_styles = [s for s in root.style._style_registry if s.startswith("Icon")]
+    assert icon_styles  # at least one derived style was built
+    for name in icon_styles:
+        assert name in root.style._derived_styles
+        assert _lookup(root, name, "image") != ""
+
+
+def test_icon_style_config_failure_is_not_left_registered(root, monkeypatch):
+    """A raise mid-configure must not mark the icon style built (#1284).
+
+    A registered-but-unconfigured style is never rebuilt (the build gate skips
+    it), so it would show a permanently blank icon with inherited base padding.
+    Configuring before registering keeps the style out of the registry on failure
+    so the next attempt retries it.
+    """
+    style = root.style
+    before = {s for s in style._style_registry if s.startswith("Icon")}
+    real = style._build_configure
+
+    def failing(ttkstyle, **kw):
+        # fail only the fresh icon style this test forces (a unique icon_size)
+        if ttkstyle.startswith("Icon") and ttkstyle not in before:
+            raise RuntimeError("boom")
+        return real(ttkstyle, **kw)
+
+    monkeypatch.setattr(style, "_build_configure", failing)
+    with pytest.raises(RuntimeError):
+        ttk.Button(root, icon="calendar-week", icon_only=True, icon_size=97)
+
+    after = {s for s in style._style_registry if s.startswith("Icon")}
+    assert after == before  # nothing new was left registered
+
+
 # --- an all-states map must not mask a user configure ----------------------
 
 def test_notebook_tab_padding_override_takes_effect(root):

--- a/tests/test_durable_style_options.py
+++ b/tests/test_durable_style_options.py
@@ -202,6 +202,22 @@ def test_registered_icon_style_is_configured(root):
         assert _lookup(root, name, "image") != ""
 
 
+def test_icon_only_button_stays_square_when_override_comes_later(root):
+    """The retroactive fan-out must skip an already-built icon style (#1284).
+
+    The sibling square test records the override *before* the button exists (the
+    build-time skip). This creates the button first, so a later base-class
+    override goes through the retroactive path in `_record_user_options`, which
+    must leave the icon's own computed padding alone.
+    """
+    btn = ttk.Button(root, icon="calendar-week", icon_only=True)
+    btn.pack()
+    root.update_idletasks()
+    root.style.configure("TButton", padding=(40, 2))  # after the widget exists
+    root.update_idletasks()
+    assert btn.winfo_reqwidth() == btn.winfo_reqheight()
+
+
 def test_icon_style_config_failure_is_not_left_registered(root, monkeypatch):
     """A raise mid-configure must not mark the icon style built (#1284).
 


### PR DESCRIPTION
Closes #1284. First PR of the Phase-1 durable-options review cluster.

## Problem

`_build_icon_style` registered each `Icon<hash>.<base>` style **before** configuring it (the #1282 ordering trick, so the icon's computed values would win over a fanned-in base-class override). That made the invariant **`registered ⇒ configured`** false: registering marks a style built, so a raise in `_build_configure` left it permanently *registered-but-unconfigured* — a blank icon with inherited base padding that the build gate never rebuilds. Low severity (it self-heals on theme change), but a latent trap resting on a fragile precondition.

## Fix (issue option b — the structural one)

Exclude framework-derived styles from the durable-options fan-out via a new `Style._derived_styles` set, consulted in **both** fan-out paths — build-time (`_register_ttkstyle` → `_reapply_user_options`) and retroactive (`_record_user_options`).

A `configure("TButton", padding=…)` no longer touches the icon style at all, yet the two behaviors #1282 protected still hold:

- **text+icon follows a global override** — `Icon<hash>.TButton` inherits the base `configure` through ttk's *native* dotted-name resolution (probed: a dotted child that sets no padding resolves the parent's; one that sets its own keeps it), so fan-out onto it was always redundant.
- **`icon_only` stays square** — it sets its own computed padding in `config`, which native inheritance leaves alone.

With fan-out gone, `_build_icon_style` reorders to **configure-first / register-last**, so a failed write is never marked built and is retried.

## Tests

- `test_registered_icon_style_is_configured` — every registered icon style is in `_derived_styles` and has its glyph image set.
- `test_icon_style_config_failure_is_not_left_registered` — a raise mid-configure leaves nothing new in the registry.
- Existing `icon_only`-square and text+icon-follows-override tests unchanged.

Full suite: **784 passed, 3 skipped**.

No `2_1_changes.md` entry: purely internal hardening, no user-visible behavior change (the square-icon behavior shipped in #1282, all within the unreleased 2.1 cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)