### PR TITLE
test: use sys-level output capture to fix a flaky Tcl file read on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,13 @@ where = ["src"]
 # Only the headless suite under tests/ is collected. Interactive mainloop()
 # demos live in examples/ and are not tests.
 testpaths = ["tests"]
+# Capture output at the Python (sys.stdout/stderr) level, NOT the default
+# fd level. The default fd capture replaces OS file descriptors 0/1/2, and on
+# Windows that intermittently breaks the Tcl interpreter's file-channel reads --
+# surfacing as a flaky `couldn't read file ".../msgs/nl.msg": No error` when
+# msgcat lazily sources a Tk-shipped catalog. sys-level capture leaves the OS
+# fds the Tcl channels depend on untouched.
+addopts = "--capture=sys"
 markers = [
     "gui: requires a Tk display (deselect with -m 'not gui')",
 ]


### PR DESCRIPTION
pytest's default fd-level capture (`--capture=fd`) replaces OS fds 0/1/2; on Windows that intermittently breaks the Tcl interpreter's file-channel read when msgcat lazily sources a Tk-shipped `.msg` catalog — flaky `couldn't read file .../nl.msg: No error` (~60% under load, never in isolation). Diagnosed by varying only capture mode: fd ~12/20 fail, sys 0/25, -s 0/20. Fix: `addopts = "--capture=sys"` in pyproject.toml. Verification: test_msgcat 0/30 after; full suite 835 passed / 3 skipped, green 5/5 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)