### PR TITLE
feat(bootstyle): value tokens — raw hex + ramp accents & surfaces (#1236)

### DIFF
--- a/development/2_1_bootstyle_value_tokens_design.md
+++ b/development/2_1_bootstyle_value_tokens_design.md
@@ -4,9 +4,9 @@
 > raw hex colors and ramp-addressed roles — in the color and surface slots.
 > Author-initiated (2026-07-16), assessed feasible against the 2.0 engine.
 >
-> **Status: PROPOSED — tracked 2.1 enhancement (issue #1236, milestone 2.1).** 2.0 is feature-frozen; this
-> is additive and backward-compatible, so it loses nothing by waiting. Per the
-> project hard rule, a design session confirming §10 precedes implementation.
+> **Status: CONFIRMED — design session held 2026-07-24; §10 settled (see below).**
+> Tracked 2.1 enhancement (issue #1236, milestone 2.1). Additive and
+> backward-compatible. Implementation proceeds per the §9 PR shape.
 > Pair with `2_0_bootstyle_grammar_design.md` (the tokenizer this extends),
 > `2_0_surface_color_design.md` (the `@surface` mechanism), and
 > `2_0_theme_anchor_design.md` (the ramp model these tokens address).
@@ -172,20 +172,27 @@ styles rebuild like any other:
 
 Moderate total effort; the builder audit is the long tail.
 
-## 10. Open questions (settle in the design session)
+## 10. Open questions — SETTLED (design session, 2026-07-24)
 
-1. Extend `Colors.get` to accept value tokens vs a separate resolver
-   (lean: extend `Colors.get`).
-2. Accept 3-digit hex `#rgb` and normalize to 6 (lean: yes)?
-3. The exact rampable-role label set (lean: anything `colors.get` resolves,
-   enumerated in the docs table).
-4. Registry-growth mitigation: docs-only vs docs + one-time warning at N
-   distinct value-token styles (lean: warn at 256).
-5. Naming: keep `[stop]` brackets (matches Python-side `colors.primary[300]`)
-   vs an alternative spelling — brackets are the lean unless the Tcl audit
-   surfaces a problem.
-6. Should hex accents participate in `light`/`dark`-style contrast special
-   cases at all, or always take the generic path (lean: generic path)?
+All six confirmed; leans taken except Q4, which the #1285 ruling flipped.
+
+1. **Extend `Colors.get`** to accept value tokens (not a separate resolver) —
+   it is the single funnel and unknown labels already return `None` there.
+2. **Accept 3-digit hex `#rgb`** and normalize to 6 (`#f00` → `#ff0000`).
+3. **Rampable-role set = anything `colors.get` resolves** (the nine semantic
+   colors + the surface roles), enumerated in the docs table at implementation.
+4. **Docs-only — NO runtime warning** on registry growth. *(Overrides the
+   brief's original "warn at 256" lean.)* Rationale: the #1285 ruling —
+   ttkbootstrap wraps ttk→Tk, so a warning about lower-layer behavior it can't
+   reliably track is worse than none. The unbounded-hex leak is documented
+   prominently (§8.1) but never warned at runtime. Cross-ref
+   `2_1_durable_style_warn_design.md`.
+5. **Keep `[stop]` brackets** — matches Python-side `colors.primary[300]`
+   addressing; the Tcl-safety audit (§5) must confirm brackets are safe on
+   every engine path before this is final.
+6. **Hex accents always take the generic accent path** — a hex never matches
+   the `LIGHT`/`DARK`/`NEUTRAL` identity checks; no participation in the
+   contrast special-cases. Preserves the frozen-snapshot contract (§2).
 
 ## 11. Out of scope
 

--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -24,6 +24,7 @@
 | **Durable style options — `style.configure()` survives variants & theme switches** | New | this doc, below |
 | **Notebook tab `padding` / `bordercolor` are now overridable** | Fix | this doc, below |
 | **`DateEntry(value=…)` — a nullable, clearable date field** | New | this doc, below |
+| **Bootstyle value tokens — raw hex + ramp accents & surfaces** | New | this doc, below |
 
 There are **no API breaks in 2.1**: nothing was removed, and no call that worked
 in 2.0.0 fails. One change is visually noticeable without any code change (the
@@ -139,3 +140,43 @@ where an empty field reads as `None` instead of falling back to `start_date`.
 **Why.** An optional date is a normal form requirement (discussion #476) and had
 no supported spelling. The additive half of #1253 (PR #1277); making
 `value=None` the *default* is a breaking change deferred to 3.0 (#1276).
+
+---
+
+## Bootstyle value tokens — raw hex + ramp accents & surfaces  *(New)*
+
+**What.** The `bootstyle` grammar's two color-bearing slots — the color slot and
+the `@surface` slot — now accept **value tokens** alongside the closed
+vocabulary:
+
+- a **raw hex** color: `bootstyle="#2f2f2f"`, `bootstyle="@#ff0000 #ffffff"`
+  (3-digit `#f00` is accepted and normalized to `#ff0000`);
+- a **ramp-addressed role**: `bootstyle="primary[300]"`,
+  `bootstyle="@background[200] danger"` — `role[stop]`, where `stop` is a
+  50–950 ramp step and `role` one of the accent roles or `background`/
+  `foreground`, matching Python-side `colors.primary[300]` addressing.
+
+Everything already in the grammar is unchanged; these are two additional
+eagerly-validated patterns, so a malformed value token (`#ff00zz`,
+`primary[123]`) fails loudly like any unknown token — warn by default, raise
+under `set_bootstyle_strict(True)` / `TTKBOOTSTRAP_STRICT=1`. Value tokens are
+legal only in the color and surface slots; variants, base-types, and orients
+stay a closed vocabulary.
+
+**Reactivity.** A ramp token is semantic and **re-resolves on a theme switch**
+(`primary[300]` is "a tint of the current theme's primary" in every theme). A
+raw hex is a deliberate **frozen snapshot** — the same trade as a direct color on
+a `Label`: it survives theme switches without adapting, and contrast is the
+caller's responsibility. A hex accent's *derived* states (hover/pressed/disabled/
+on-color) still recompute per theme, so a hex button stays usable in both modes.
+
+**Why.** A one-off color previously required the full custom-style path
+(`register_style` / `Style.configure` + `style=`) — the right home for a bespoke
+*look*, but heavy ceremony for a single *color*. Value tokens give it a one-line
+spelling, the same move Tailwind's arbitrary-value syntax (`bg-[#ff0000]`) makes
+on the same kind of closed utility vocabulary.
+
+**Note.** Each distinct hex mints a ttk style that lives for the process (styles
+are never unregistered). The closed vocabulary and the ramp tokens are finite, so
+their styles plateau; the space of raw hex values is not, so an app that feeds
+many distinct hex values through `bootstyle` accumulates styles over its lifetime.

--- a/examples/value_token_preview.py
+++ b/examples/value_token_preview.py
@@ -1,0 +1,158 @@
+"""Bootstyle value-token preview.
+
+A visual spot-check for the value tokens the bootstyle grammar now accepts in its
+two color-bearing slots:
+
+  - a raw hex color            bootstyle="#2f2f2f"
+  - a ramp-addressed role      bootstyle="primary[300]"
+  - a hex surface + accent     bootstyle="@#2b2d42 light"
+  - a ramp surface + accent    bootstyle="@primary[100] primary[700]"
+
+Toggle light/dark (top-right) to see the contract: a **ramp** token is semantic
+and re-resolves against the new theme's anchor, while a **raw hex** is a frozen
+snapshot that stays put. The derived states of a hex accent (hover/pressed/text)
+still recompute, so a hex button stays usable in both modes.
+
+Run:  python examples/value_token_preview.py
+"""
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+
+
+HEXES = ("#2f2f2f", "#e63946", "#2a9d8f", "#e9c46a", "#6d597a")
+RAMP_STOPS = (100, 300, 500, 700, 900)
+RAMP_ROLES = ("primary", "success", "danger")
+
+
+def section(parent, title):
+    """A titled block that packs vertically; returns its body frame."""
+    ttk.Label(parent, text=title, font="-size 11 -weight bold").pack(
+        anchor=W, pady=(12, 4)
+    )
+    body = ttk.Frame(parent)
+    body.pack(fill=X)
+    return body
+
+
+def build_hex_accents(parent):
+    """Raw-hex accents: each button IS that color, text auto-contrasted."""
+    body = section(parent, "Raw hex accents  —  bootstyle=\"#rrggbb\"")
+    for hexcode in HEXES:
+        ttk.Button(body, text=hexcode, bootstyle=hexcode, width=10).pack(
+            side=LEFT, padx=(0, 6)
+        )
+    # 3-digit shorthand is accepted and normalized to 6
+    ttk.Button(body, text="#f0a (short)", bootstyle="#f0a", width=12).pack(
+        side=LEFT, padx=(0, 6)
+    )
+
+
+def build_ramp_accents(parent):
+    """Ramp accents: one role stepped 100->900 (tint through shade)."""
+    body = section(parent, "Ramp accents  —  bootstyle=\"role[stop]\"")
+    for role in RAMP_ROLES:
+        rowf = ttk.Frame(body)
+        rowf.pack(fill=X, pady=2)
+        ttk.Label(rowf, text=role, width=9).pack(side=LEFT)
+        for stop in RAMP_STOPS:
+            token = f"{role}[{stop}]"
+            ttk.Button(rowf, text=str(stop), bootstyle=token, width=6).pack(
+                side=LEFT, padx=(0, 4)
+            )
+
+
+def build_value_surfaces(parent):
+    """Value tokens in the @surface slot: hex and ramp panels."""
+    body = section(parent, "Value surfaces  —  @#hex  and  @role[stop]")
+
+    # a hex surface panel with a legible light accent control on it
+    hex_panel = ttk.Frame(body, bootstyle="#2b2d42", padding=14)
+    hex_panel.pack(side=LEFT, fill=BOTH, expand=YES, padx=(0, 6))
+    ttk.Label(hex_panel, text="@#2b2d42", bootstyle="@#2b2d42 light").pack(anchor=W)
+    ttk.Checkbutton(hex_panel, text="Checkbutton",
+                    bootstyle="@#2b2d42 light").pack(anchor=W, pady=(6, 2))
+    ttk.Button(hex_panel, text="Ghost", bootstyle="@#2b2d42 light ghost").pack(
+        anchor=W, pady=2
+    )
+
+    # a ramp surface panel (a pale primary tint) with a deep primary control
+    ramp_panel = ttk.Frame(body, bootstyle="primary[100]", padding=14)
+    ramp_panel.pack(side=LEFT, fill=BOTH, expand=YES, padx=6)
+    ttk.Label(ramp_panel, text="@primary[100]",
+              bootstyle="@primary[100] primary[800]").pack(anchor=W)
+    ttk.Checkbutton(ramp_panel, text="Checkbutton",
+                    bootstyle="@primary[100] primary[700]").pack(anchor=W, pady=(6, 2))
+    ttk.Button(ramp_panel, text="Ghost",
+               bootstyle="@primary[100] primary[700] ghost").pack(anchor=W, pady=2)
+
+
+def build_reactivity(parent):
+    """Side-by-side hex vs ramp swatch so the theme toggle shows the contract."""
+    body = section(parent, "Theme-reactivity  —  toggle light/dark to compare")
+    ttk.Button(body, text="frozen hex  #3b79d5", bootstyle="#3b79d5",
+               width=22).pack(side=LEFT, padx=(0, 8))
+    ttk.Button(body, text="reactive  primary[500]", bootstyle="primary[500]",
+               width=22).pack(side=LEFT)
+    ttk.Label(
+        parent,
+        text=("The hex button keeps #3b79d5 in both themes; the ramp button "
+              "follows each theme's primary anchor."),
+        bootstyle="secondary",
+    ).pack(anchor=W, pady=(6, 0))
+
+
+def build_interactive(parent):
+    """Type a hex and apply it live to a preview button."""
+    body = section(parent, "Try your own hex")
+    var = ttk.StringVar(value="#ff6b6b")
+    preview = ttk.Button(body, text="preview", bootstyle=var.get(), width=12)
+
+    def apply(*_):
+        value = var.get().strip()
+        if value:
+            try:
+                preview.configure(bootstyle=value)
+                preview.configure(text=value)
+            except Exception:
+                pass  # invalid hex already warns via the resolver
+
+    entry = ttk.Entry(body, textvariable=var, width=12)
+    entry.pack(side=LEFT, padx=(0, 6))
+    entry.bind("<Return>", apply)
+    ttk.Button(body, text="Apply", bootstyle="secondary-outline",
+               command=apply).pack(side=LEFT, padx=(0, 12))
+    preview.pack(side=LEFT)
+
+
+def main():
+    app = ttk.Window(title="Bootstyle value tokens", theme="bootstrap-light",
+                     size=(760, 620))
+
+    top = ttk.Frame(app, padding=(14, 12))
+    top.pack(fill=X)
+    ttk.Label(top, text="Bootstyle value tokens", font="-size 14 -weight bold"
+              ).pack(side=LEFT)
+
+    def toggle_theme():
+        name = app.style.theme.name
+        app.style.theme_use(
+            "bootstrap-dark" if name == "bootstrap-light" else "bootstrap-light"
+        )
+
+    ttk.Button(top, text="Toggle light/dark", bootstyle="secondary-outline",
+               command=toggle_theme).pack(side=RIGHT)
+
+    body = ttk.Frame(app, padding=(14, 0, 14, 12))
+    body.pack(fill=BOTH, expand=YES)
+
+    build_hex_accents(body)
+    build_ramp_accents(body)
+    build_value_surfaces(body)
+    build_reactivity(body)
+    build_interactive(body)
+
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ttkbootstrap/constants.py
+++ b/src/ttkbootstrap/constants.py
@@ -8,6 +8,7 @@ color/keyword constants. All names are exported via `__all__` for
 """
 from __future__ import annotations
 
+import re
 from typing import Final, Literal
 
 # ---------------------------
@@ -154,6 +155,78 @@ def surface_segment(surface: str) -> str:
     if surface and surface != DEFAULT_SURFACE:
         return f"@{surface}."
     return ""
+
+
+# ---------------------------------------------------------------------------
+# Bootstyle value tokens -- additive grammar. A *value token* is a raw hex color
+# (``#rgb``/``#rrggbb``) or a ramp-addressed role (``<role>[<stop>]``), legal only
+# in the two color-bearing slots: the color slot (``#2f2f2f``, ``primary[300]``)
+# and the surface slot (``@#ff0000``, ``@light[200]``). Everything in the closed
+# vocabulary above is unchanged; these two anchored, eagerly-validated patterns
+# sit alongside it, so a malformed value token fails loudly like any unknown
+# token. A ramp token re-resolves on theme switch (semantic); a hex token is a
+# frozen snapshot.
+# ---------------------------------------------------------------------------
+# Valid ramp stops: multiples of 50 in 50-950. Also the source for theme.py's
+# `_RAMP_STOPS` (one definition of the stop set).
+BOOTSTYLE_RAMP_STOPS: Final = tuple(range(50, 1000, 50))
+# Roles addressable by a ramp token. The eight iterable accent roles plus the two
+# surface aliases the surface slot needs (``background`` -> bg, ``foreground`` ->
+# fg). ``neutral`` is a render policy, not a ramp anchor, so it is excluded.
+BOOTSTYLE_RAMP_ROLES: Final = (
+    "primary", "secondary", "success", "info", "warning", "danger",
+    "light", "dark", "background", "foreground",
+)
+
+_HEX_TOKEN_RE = re.compile(r"#(?:[0-9a-f]{3}|[0-9a-f]{6})\Z")
+_RAMP_TOKEN_RE = re.compile(r"([a-z]+)\[([0-9]+)\]\Z")
+_RAMP_STOPS_SET = frozenset(BOOTSTYLE_RAMP_STOPS)
+_RAMP_ROLES_SET = frozenset(BOOTSTYLE_RAMP_ROLES)
+
+
+def normalize_hex_token(token: str) -> str:
+    """Return a ``#rgb``/``#rrggbb`` token as canonical lowercase 6-digit hex."""
+    token = token.lower()
+    if len(token) == 4:  # #rgb -> #rrggbb
+        return "#" + "".join(ch * 2 for ch in token[1:])
+    return token
+
+
+def is_hex_token(token: str) -> bool:
+    """Whether ``token`` is a valid ``#rgb``/``#rrggbb`` hex value token."""
+    return bool(_HEX_TOKEN_RE.match(token.lower()))
+
+
+def parse_ramp_token(token: str):
+    """Return ``(role, stop)`` for a valid ``role[stop]`` token, else ``None``."""
+    match = _RAMP_TOKEN_RE.match(token.lower())
+    if not match:
+        return None
+    role, stop = match.group(1), int(match.group(2))
+    if role in _RAMP_ROLES_SET and stop in _RAMP_STOPS_SET:
+        return role, stop
+    return None
+
+
+def is_value_token(token: str) -> bool:
+    """Whether ``token`` is a valid hex or ramp value token."""
+    return is_hex_token(token) or parse_ramp_token(token) is not None
+
+
+def looks_like_value_token(token: str) -> bool:
+    """Whether ``token`` is a value-token *attempt* (valid or malformed).
+
+    Routes a ``#...`` or bracketed fragment to value-token validation (loud-fail
+    on malformed) rather than the generic unknown-token path.
+    """
+    return token.startswith("#") or "[" in token or "]" in token
+
+
+def canonical_value_token(token: str) -> str:
+    """Canonicalize a valid value token (normalize hex; ramp lowercased)."""
+    if is_hex_token(token):
+        return normalize_hex_token(token)
+    return token.lower()
 
 # ---------------------------------------------------------------------------
 # Canonical bootstyle strings (generated). The closed set of bootstyle values
@@ -499,6 +572,10 @@ __all__ = [
     "BOOTSTYLE_BASES", "BOOTSTYLE_FAMILIES", "BOOTSTYLE_ORIENTS", "NEUTRAL_FAMILIES",
     "BOOTSTYLE_SURFACES", "DEFAULT_SURFACE", "BOOTSTYLE_SURFACE_TOKENS",
     "surface_segment",
+    # value tokens (2.1): hex + ramp accents & surfaces
+    "BOOTSTYLE_RAMP_STOPS", "BOOTSTYLE_RAMP_ROLES",
+    "is_hex_token", "normalize_hex_token", "parse_ramp_token",
+    "is_value_token", "looks_like_value_token", "canonical_value_token",
     # constants
     "NO", "FALSE", "OFF", "YES", "TRUE", "ON",
     "N", "S", "W", "E", "NW", "SW", "NE", "SE", "NS", "EW", "NSEW", "CENTER",

--- a/src/ttkbootstrap/style/bootstyle.py
+++ b/src/ttkbootstrap/style/bootstyle.py
@@ -23,6 +23,11 @@ from ttkbootstrap.constants import (
     NEUTRAL_FAMILIES,
     BootStyle,
     surface_segment,
+    is_value_token,
+    canonical_value_token,
+    parse_ramp_token,
+    is_hex_token,
+    normalize_hex_token,
 )
 from ttkbootstrap.internal.busy import BusyMixin
 from ttkbootstrap.style import _compat
@@ -138,6 +143,17 @@ def _normalize_surface(surface, family, source, warn):
     surface = str(surface).strip().lower()
     if not surface or surface == DEFAULT_SURFACE:
         return ""
+    # value-token surfaces (2.1): @#hex and @role[stop]. Validated eagerly like a
+    # named surface -- a malformed one loud-fails (loud dialect only); a valid one
+    # is family-gated the same way, then canonicalized (hex #rgb -> #rrggbb).
+    if surface.startswith("#") or "[" in surface or "]" in surface:
+        if is_value_token(surface):
+            if family not in _SURFACE_FAMILIES:
+                return ""
+            return canonical_value_token(surface)
+        if warn:
+            _compat.report_invalid("surface", surface, source)
+        return ""
     if surface not in _SURFACE_TOKENS:
         if warn:
             suggestions = difflib.get_close_matches(
@@ -178,6 +194,17 @@ def _classify_tokens(style_string, *, source=None, warn=False):
             if warn and color and token != color:
                 _compat.report_invalid("color", token, source)
             color = color or token
+        elif token.startswith("#") or "[" in token or "]" in token:
+            # value token in the color slot: #hex or role[stop]. Validated
+            # eagerly -- a malformed one loud-fails (a mistyped color), a valid
+            # one is canonicalized (hex #rgb -> #rrggbb) and stored like a color.
+            if is_value_token(token):
+                canonical = canonical_value_token(token)
+                if warn and color and canonical != color:
+                    _compat.report_invalid("color", token, source)
+                color = color or canonical
+            elif warn:
+                _compat.report_invalid("color", token, source)
         elif token in _MODIFIERS:
             if warn and token in _DEPRECATED_MODIFIERS:
                 _compat.warn_deprecated(
@@ -217,7 +244,12 @@ def _looks_like_style_name(style_string):
     """
     if "." in style_string:
         return True
-    if style_string.startswith("@"):
+    if style_string.startswith("@") or style_string.startswith("#"):
+        return False
+    # A dotless value-token bootstyle (``primary[300]``, ``@light[200]``) carries
+    # no Title-cased class segment; keep it on the loud bootstyle path so a typo'd
+    # token is reported rather than silently ignored as a custom style name.
+    if "[" in style_string or "]" in style_string:
         return False
     return (
         "-" not in style_string
@@ -249,6 +281,10 @@ def _classify_style_name(name):
         if seg.startswith("@"):
             surface = surface or seg[1:]
         elif seg in _COLORS:
+            color = color or seg
+        elif seg.startswith("#") and is_hex_token(seg):
+            color = color or normalize_hex_token(seg)
+        elif ("[" in seg) and parse_ramp_token(seg):
             color = color or seg
         elif seg in _MODIFIERS:
             modifier = modifier or seg

--- a/src/ttkbootstrap/style/builders_ttk.py
+++ b/src/ttkbootstrap/style/builders_ttk.py
@@ -202,13 +202,15 @@ class StyleBuilderTTK:
           - an accent color name (`primary`, `success`, ..., `neutral`) -- that
             color, so a ghost/outline/link control can blend into an accent
             container (e.g. an accent toolbar).
+          - a value token: a raw hex (`#ff0000`, a frozen snapshot) or a
+            ramp-addressed role (`light[200]`, theme-reactive), resolved through
+            `Colors.get`.
 
-        Named and accent surfaces are theme-reactive: they re-resolve on a theme
-        switch. An unknown token routes through the shared strictness gate --
-        warn-and-fall-back-to-background by default, raise under strict mode
-        (`set_bootstyle_strict` / `TTKBOOTSTRAP_STRICT`), matching how the
-        resolver treats an unknown bootstyle token. Raw-hex surfaces are not yet
-        accepted (deferred).
+        Named, accent, and ramp surfaces are theme-reactive: they re-resolve on a
+        theme switch; a hex surface stays frozen. An unknown token routes through
+        the shared strictness gate -- warn-and-fall-back-to-background by default,
+        raise under strict mode (`set_bootstyle_strict` / `TTKBOOTSTRAP_STRICT`),
+        matching how the resolver treats an unknown bootstyle token.
         """
         if not surface or surface == DEFAULT_SURFACE:
             return self.colors.bg
@@ -216,7 +218,13 @@ class StyleBuilderTTK:
             return self.chrome_surface()
         if surface == "card":
             return self.card_surface()
-        if surface in BOOTSTYLE_COLORS:
+        # value-token surfaces (#hex / role[stop]) resolve through Colors, which
+        # returns the frozen hex or the role's current-anchor ramp step.
+        if surface.startswith("#") or "[" in surface:
+            resolved = self.colors.get(surface)
+            if resolved is not None:
+                return resolved
+        elif surface in BOOTSTYLE_COLORS:
             if surface == NEUTRAL:
                 # local import breaks the builders<-utils cycle
                 from ttkbootstrap.style.builders.utils import neutral_fill
@@ -283,9 +291,18 @@ class StyleBuilderTTK:
         (`background`/`card`/`neutral`) keep the theme's soft `fg`, so a control
         on a card does not harden its text vs the same control on the app
         background. No surface -> the theme `fg`.
+
+        A hex surface is a genuine accent (an arbitrary color) and always flips.
+        A ramp surface follows its base role: an accent role flips, a
+        background/foreground role keeps the soft `fg`.
         """
         surface = self._surface
-        if surface and surface in BOOTSTYLE_COLORS and surface != NEUTRAL:
+        if not surface:
+            return self.colors.fg
+        if surface.startswith("#"):
+            return self.on_color(self.resolve_surface(surface))
+        role = surface.split("[", 1)[0] if "[" in surface else surface
+        if role in BOOTSTYLE_COLORS and role != NEUTRAL:
             return self.on_color(self.resolve_surface(surface))
         return self.colors.fg
 

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -96,7 +96,14 @@ def _color_ramp(color: str) -> Mapping[int, str]:
 # no hex/named color string is that long, so an int index of this magnitude is
 # unambiguously a ramp request and never collides with ordinary str indexing
 # (char indices 0-6, slices) -- which `RampColor` delegates to `str` untouched.
-_RAMP_STOPS = frozenset(range(50, 1000, 50))
+# The stop set lives once in constants (shared with the bootstyle value-token
+# validator).
+_RAMP_STOPS = frozenset(BOOTSTYLE_RAMP_STOPS)
+
+# Ramp-token role aliases: a value token names a surface role, but the stored
+# `Colors` field uses the short name. `background`/`foreground` map to bg/fg; the
+# accent roles are stored under their own name.
+_RAMP_ROLE_FIELDS = {"background": "bg", "foreground": "fg"}
 
 
 class RampColor(str):
@@ -475,6 +482,18 @@ class Colors:
             str:
                 A hexadecimal color value.
         """
+        # Value tokens resolve to a concrete color even though they are not
+        # stored fields: a hex (#rgb/#rrggbb) returns verbatim (canonical); a
+        # ramp token (role[stop]) addresses the role's current-anchor ramp, so
+        # it re-resolves on a theme switch.
+        if isinstance(color_label, str):
+            if color_label.startswith("#") and is_hex_token(color_label):
+                return _as_ramp_color(normalize_hex_token(color_label))
+            ramp = parse_ramp_token(color_label)
+            if ramp is not None:
+                role, stop = ramp
+                anchor = self.__dict__.get(_RAMP_ROLE_FIELDS.get(role, role))
+                return _as_ramp_color(anchor[stop]) if anchor is not None else None
         return self.__dict__.get(color_label)
 
     def ramp(self, color_label: str) -> Mapping[int, str]:

--- a/tests/test_bootstyle_value_tokens.py
+++ b/tests/test_bootstyle_value_tokens.py
@@ -1,0 +1,288 @@
+"""Value-token grammar + delivery tests.
+
+A *value token* extends the two color-bearing slots of a bootstyle with raw hex
+(`#rgb`/`#rrggbb`) and ramp-addressed roles (`role[stop]`). It is legal in the
+color slot (`#2f2f2f`, `primary[300]`) and the surface slot (`@#ff0000`,
+`@light[200]`); everything else in the grammar stays a closed vocabulary. Covers
+the pure validators, tokenizer classification (both dialects), the loud-fail
+contract on malformed tokens, resolution through `Colors.get`, the frozen-hex vs
+theme-reactive-ramp behavior on a theme switch, and Tcl-safety of a style name
+carrying brackets and hashes (build/map/layout/lookup/switch).
+"""
+import warnings
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import (
+    canonical_value_token,
+    is_hex_token,
+    is_value_token,
+    looks_like_value_token,
+    normalize_hex_token,
+    parse_ramp_token,
+)
+from ttkbootstrap.style._compat import set_bootstyle_strict
+from ttkbootstrap.style.bootstyle import (
+    _build_ttkstyle_name,
+    _classify_style_name,
+    _classify_tokens,
+    _looks_like_style_name,
+)
+
+
+def _lookup(app, style_name, option):
+    return app.tk.call("ttk::style", "lookup", style_name, f"-{option}")
+
+
+def _other_theme(app):
+    """A registered theme other than the default light/dark pair.
+
+    Theme switching is session-global state, so these tests deliberately avoid
+    the default `bootstrap-light`/`bootstrap-dark` pair other suites rely on and
+    switch to an unrelated family whose primary anchor differs from the current
+    one (enough to prove a ramp token re-resolves).
+    """
+    style = app.style
+    current = style.colors.primary[400]
+    for name in sorted(style.theme_names()):
+        if name.startswith("bootstrap"):
+            continue
+        definition = style._theme_definitions.get(name)
+        if definition and definition.colors.primary[400] != current:
+            return name
+    raise AssertionError("no alternate theme with a distinct primary found")
+
+
+# --- pure validators ------------------------------------------------------- #
+
+@pytest.mark.parametrize("token", ["#2f2f2f", "#FFF", "#f00", "#ABCDEF"])
+def test_valid_hex_tokens(token):
+    assert is_hex_token(token)
+    assert is_value_token(token)
+
+
+@pytest.mark.parametrize("token", ["#ff00zz", "#ff", "#fffff", "2f2f2f", "#12345g"])
+def test_invalid_hex_tokens(token):
+    assert not is_hex_token(token)
+
+
+def test_hex_normalization_expands_and_lowercases():
+    assert normalize_hex_token("#F00") == "#ff0000"
+    assert normalize_hex_token("#AbCdEf") == "#abcdef"
+    assert canonical_value_token("#F00") == "#ff0000"
+
+
+@pytest.mark.parametrize(
+    "token,expected",
+    [
+        ("primary[300]", ("primary", 300)),
+        ("light[200]", ("light", 200)),
+        ("background[200]", ("background", 200)),
+        ("DANGER[950]", ("danger", 950)),
+    ],
+)
+def test_valid_ramp_tokens(token, expected):
+    assert parse_ramp_token(token) == expected
+    assert is_value_token(token)
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "primary[123]",   # not a 50-step stop
+        "primary[0]",     # below the ramp
+        "primary[1000]",  # above the ramp
+        "primaryy[300]",  # unknown role
+        "neutral[300]",   # neutral is a policy, not a ramp anchor
+        "primary[300",    # malformed
+        "[300]",          # no role
+        "primary[]",      # no stop
+    ],
+)
+def test_invalid_ramp_tokens(token):
+    assert parse_ramp_token(token) is None
+    assert not is_value_token(token)
+
+
+def test_looks_like_value_token_flags_attempts():
+    # both valid and malformed attempts route to value-token validation
+    assert looks_like_value_token("#ff00zz")
+    assert looks_like_value_token("primary[123]")
+    assert looks_like_value_token("primary[300")
+    assert not looks_like_value_token("primary")
+    assert not looks_like_value_token("outline")
+
+
+# --- tokenizer classification --------------------------------------------- #
+
+def test_classify_tokens_hex_accent():
+    color, modifier, base, orient, surface = _classify_tokens("#2f2f2f")
+    assert color == "#2f2f2f"
+
+
+def test_classify_tokens_normalizes_short_hex():
+    color, *_ = _classify_tokens("#f00")
+    assert color == "#ff0000"
+
+
+def test_classify_tokens_ramp_accent():
+    color, *_ = _classify_tokens("primary[300]")
+    assert color == "primary[300]"
+
+
+def test_classify_tokens_value_surface_and_accent():
+    color, modifier, base, orient, surface = _classify_tokens(
+        "@#ff0000 #ffffff"
+    )
+    assert (color, surface) == ("#ffffff", "#ff0000")
+
+
+def test_classify_tokens_ramp_surface_and_semantic_accent():
+    color, modifier, base, orient, surface = _classify_tokens(
+        "@background[200] danger"
+    )
+    assert (color, surface) == ("danger", "background[200]")
+
+
+def test_value_tokens_are_position_free():
+    for s in ("#ffffff @#ff0000", "@#ff0000 #ffffff"):
+        color, _, _, _, surface = _classify_tokens(s)
+        assert (color, surface) == ("#ffffff", "#ff0000"), s
+
+
+def test_classify_style_name_recovers_value_tokens():
+    color, modifier, base, orient, surface = _classify_style_name(
+        "@#ff0000.#ffffff.TButton"
+    )
+    assert (color, surface, base) == ("#ffffff", "#ff0000", "button")
+
+
+def test_classify_style_name_recovers_ramp_tokens():
+    color, modifier, base, orient, surface = _classify_style_name(
+        "@background[200].primary[300].TLabel"
+    )
+    assert (color, surface, base) == ("primary[300]", "background[200]", "label")
+
+
+def test_value_token_name_round_trips_through_classify():
+    name = _build_ttkstyle_name("#ffffff", "", "", "button", "#ff0000")
+    assert name == "@#ff0000.#ffffff.TButton"
+    color, modifier, base, orient, surface = _classify_style_name(name)
+    assert _build_ttkstyle_name(color, modifier, orient, "button", surface) == name
+
+
+def test_dotless_value_token_bootstyle_is_not_a_style_name():
+    # a #hex / bracket bootstyle with no class segment stays on the loud path
+    assert not _looks_like_style_name("#2f2f2f")
+    assert not _looks_like_style_name("primary[300]")
+    assert not _looks_like_style_name("@light[200]")
+    # a built name (dotted) is still recognized as a style name
+    assert _looks_like_style_name("#2f2f2f.TButton")
+
+
+# --- loud-fail contract ---------------------------------------------------- #
+
+def test_malformed_value_token_warns(root):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ttk.Button(root, text="x", bootstyle="#ff00zz")
+    assert any("ff00zz" in str(w.message) for w in caught)
+
+
+def test_malformed_ramp_stop_warns(root):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ttk.Button(root, text="y", bootstyle="primary[123]")
+    assert any("123" in str(w.message) for w in caught)
+
+
+def test_strict_mode_raises_on_malformed_value_token(root):
+    set_bootstyle_strict(True)
+    try:
+        with pytest.raises(Exception):
+            ttk.Button(root, text="z", bootstyle="#ff00zz")
+    finally:
+        set_bootstyle_strict(False)
+
+
+# --- resolution through Colors.get ---------------------------------------- #
+
+def test_colors_get_resolves_hex(root):
+    colors = root.style.colors
+    assert colors.get("#2f2f2f") == "#2f2f2f"
+    assert colors.get("#f00") == "#ff0000"
+
+
+def test_colors_get_resolves_ramp(root):
+    colors = root.style.colors
+    assert colors.get("primary[500]") == colors.primary[500]
+    assert colors.get("primary[300]") == colors.primary[300]
+    assert colors.get("background[200]") == colors.bg[200]
+
+
+def test_colors_get_unknown_still_none(root):
+    assert root.style.colors.get("not_a_role") is None
+
+
+# --- delivery: build / lookup --------------------------------------------- #
+
+def test_hex_accent_button_builds_and_paints(root):
+    btn = ttk.Button(root, text="hex", bootstyle="#2f2f2f")
+    style_name = btn.cget("style")
+    assert style_name == "#2f2f2f.TButton"
+    assert _lookup(root, style_name, "background") == "#2f2f2f"
+
+
+def test_ramp_accent_button_builds_and_paints(root):
+    btn = ttk.Button(root, text="ramp", bootstyle="primary[300]")
+    style_name = btn.cget("style")
+    assert style_name == "primary[300].TButton"
+    assert _lookup(root, style_name, "background") == root.style.colors.primary[300]
+
+
+def test_value_surface_and_accent_deliver(root):
+    btn = ttk.Button(root, text="both", bootstyle="@#ff0000 #ffffff")
+    style_name = btn.cget("style")
+    assert style_name == "@#ff0000.#ffffff.TButton"
+    assert _lookup(root, style_name, "background") == "#ffffff"
+
+
+# --- theme-switch behavior ------------------------------------------------- #
+
+def test_ramp_is_theme_reactive_hex_is_frozen(root):
+    style = root.style
+    hex_btn = ttk.Button(root, text="hex", bootstyle="#2f2f2f")
+    ramp_btn = ttk.Button(root, text="ramp", bootstyle="primary[400]")
+    hex_name, ramp_name = hex_btn.cget("style"), ramp_btn.cget("style")
+
+    ramp_before = _lookup(root, ramp_name, "background")
+    style.theme_use(_other_theme(root))
+    root.update_idletasks()
+
+    # ramp re-resolves against the new theme's primary anchor
+    assert _lookup(root, ramp_name, "background") != ramp_before
+    assert _lookup(root, ramp_name, "background") == style.colors.primary[400]
+    # hex stays frozen
+    assert _lookup(root, hex_name, "background") == "#2f2f2f"
+
+
+# --- Tcl safety: brackets + hashes survive every engine path -------------- #
+
+def test_bracketed_hashed_style_name_is_tcl_safe(root):
+    style = root.style
+    btn = ttk.Button(root, text="tcl", bootstyle="@light[200] #abcdef")
+    name = btn.cget("style")
+    assert name == "@light[200].#abcdef.TButton"
+
+    # configure / map lookups (already exercised at build); layout + element
+    # enumeration must also accept the bracketed/hashed name without a TclError.
+    layout = root.tk.call("ttk::style", "layout", name)
+    assert layout  # non-empty layout returned
+    assert _lookup(root, name, "background") == "#abcdef"
+
+    # theme switch repaints the mounted widget through the same name
+    style.theme_use(_other_theme(root))
+    root.update_idletasks()
+    assert btn.cget("style") == name
+    assert _lookup(root, name, "background") == "#abcdef"

--- a/tests/test_surface_color.py
+++ b/tests/test_surface_color.py
@@ -79,12 +79,16 @@ def test_unknown_surface_raises_in_strict_mode(root):
         set_bootstyle_strict(prior)
 
 
-def test_raw_hex_surface_is_deferred(root):
-    """A raw hex is not yet a valid surface -- it warns and falls back."""
+def test_raw_hex_surface_resolves(root):
+    """A raw hex is a valid value-token surface -- it resolves verbatim."""
     b = _builder()
-    with pytest.warns(UserWarning):
-        value = b.resolve_surface("#123456")
-    assert value == b.colors.bg
+    assert b.resolve_surface("#123456") == "#123456"
+
+
+def test_ramp_surface_resolves(root):
+    """A ramp-addressed role surface resolves to that step of the role's ramp."""
+    b = _builder()
+    assert b.resolve_surface("light[200]") == b.colors.light[200]
 
 
 def test_card_surface_is_theme_reactive(root):


### PR DESCRIPTION
Extends the bootstyle grammar's two color-bearing slots with **value tokens** (additive; the closed vocabulary is unchanged):

- raw hex — `bootstyle="#2f2f2f"` (`#rgb` normalized to `#rrggbb`)
- ramp-addressed role — `bootstyle="primary[300]"`
- hex surface — `bootstyle="@#ff0000 #ffffff"`
- ramp surface — `bootstyle="@background[200] danger"`

A **ramp** token is semantic and re-resolves on a theme switch; a **raw hex** is a frozen snapshot (its derived hover/pressed/disabled/on-color states still recompute). Malformed tokens fail loudly like any unknown token (warn, or raise under strict mode). Value tokens are legal only in the color and surface slots.

Design brief confirmed via a design session (§10 settled). Implementation: value-token vocab + validators in constants; tokenizer classification in both dialects; `Colors.get` resolution; `resolve_surface`/`on_surface_fg` for value-token surfaces. Style names carrying `[`/`]`/`#` are Tcl-safe (all style-name use goes through `tk.call` args), covered by a build/map/layout/lookup/theme-switch regression test.

Adds `tests/test_bootstyle_value_tokens.py` (44) and `examples/value_token_preview.py`. Full suite green.

Note: docs (grammar-page section + reference-generator prose + typing) are a planned follow-up PR. A pre-existing durable-options theme-switch gap surfaced during testing was filed separately as #1298. Closes part of #1236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)