### PR TITLE
fix(style): re-apply durable overrides when re-visiting a built theme (#1298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -883,18 +883,33 @@ DONE.** Optional post-release polish only from here.
 > **already-visited** theme (the theme walk only rebuilds *mounted* styles; the
 > first visit's eager `create_default_style` masks it). Low severity, self-heals on
 > first visit.
+> **#1298 (durable theme-switch re-apply) is DONE (PR #1304, OPEN at handoff).**
+> Root cause was exactly as filed: `theme_use`'s existing-theme branch
+> (`super().theme_use` + walk) rebuilds only *mounted* styles, so a durable
+> override on an unmounted style kept the recipe default in an already-built
+> theme's style DB (the first-visit `create_default_style` masked it → order
+> -dependent). Fix: new `_reapply_user_options_for_theme(themename)` in
+> `style/engine.py`, called in the existing-theme branch right after
+> `super().theme_use` — replays `_user_options` across the target theme's
+> registered styles (ancestor merge most-specific-wins + un-namespaced globals
+> like `"Sash"`; excludes derived icon styles; writes via `_build_configure` so
+> replays aren't re-captured). Mirrors `_reapply_user_options` but theme-scoped.
+> Regression test `test_override_reaches_previsited_theme` pre-visits the target
+> theme before setting the override (reads 5 without the fix, 3 with). Suite
+> **838 passed**; an adversarial `/review` of the diff found no defects (ordering
+> vs. the later walk is idempotent; the loop is guarded + fires only on repeat
+> visits). No `2_1_changes.md` entry — the durable "survives a theme switch"
+> guarantee is a new-in-2.1 feature that never shipped, so this pre-release gap is
+> a dev-log/PR item, not a user-facing changelog line.
+>
 > **Phase 3 — #1242** (in-house themed file dialog). Deliberately last: biggest
 > single build, most standalone (doesn't touch the seam), lowest urgency (dialog
 > works, just unthemed on X11), and the named DROP CANDIDATE if 2.1 must close
 > sooner — parks cleanly to 2.2 without stranding seam work.
 >
-> **Remaining 2.1 = #1298 (durable theme-switch re-apply) and #1242 (themed file
-> dialog).** **NEXT SESSION:** start with **#1298** — small and a real bug, but it
-> touches the durable/engine seam (the heavily-reviewed #1284–#1286 cluster), so
-> proceed carefully and add a regression test for the pre-visited-theme case (repro:
-> `theme_use(dark); theme_use(light); configure("TEntry", padding=3); theme_use(dark)`
-> → padding reverts). Then a **design session for #1242** (§10-style gate before any
-> code; prior art in `development/filedialogs/`). One design gate remains: #1242.
+> **Remaining 2.1 = #1242 (themed file dialog) only** — #1298 is done (PR #1304).
+> **NEXT SESSION:** a **design session for #1242** (§10-style gate before any code;
+> prior art in `development/filedialogs/`). One design gate remains: #1242.
 > **Housekeeping this session:** closed **#1224** (filedialog white-on-white —
 > subsumed by #1242; the dark-mode base-style half was already fixed in #1239) and
 > **#1252** (v1 empty/clearable DateEntry — superseded by shipped #1253 + 3.0 #1276).

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -314,6 +314,12 @@ class Style(ttk.Style):
         if themename in existing_themes:
             self.theme = self._theme_definitions.get(themename)
             super().theme_use(themename)
+            # Repeat visit to an already-built theme: the walk below only
+            # rebuilds styles that mounted widgets reference, so a durable
+            # override on a style with no mounted widget is never replayed into
+            # this theme's style DB. Replay them here so an override survives a
+            # switch to any previously-visited theme, not just a first visit.
+            self._reapply_user_options_for_theme(themename)
         # setup a new theme
         elif themename in self._theme_names:
             self.theme = self._theme_definitions.get(themename)
@@ -773,6 +779,35 @@ class Style(ttk.Style):
                     handled.add(name)
             if merged:
                 self._build_configure(built_style, **merged)
+        for name, opts in self._user_options.items():
+            if name not in handled and opts:
+                self._build_configure(name, **opts)
+
+    def _reapply_user_options_for_theme(self, themename):
+        """Replay durable overrides across a theme's registered styles.
+
+        Used when `theme_use` re-visits an already-built theme (the walk only
+        rebuilds mounted styles, so unmounted ones keep the recipe defaults in
+        this theme's style DB). Each registered style gets its base-class
+        ancestors merged most-specific-wins, and any recorded name not covered
+        that way -- an un-namespaced global like ``"Sash"``, or a base whose
+        widget has not mounted under this theme -- is restored onto its own
+        name. Mirrors `_reapply_user_options` but scoped to a whole theme.
+        """
+        if not self._user_options:
+            return
+        handled = set()
+        for style in list(self._theme_styles.get(themename, ())):
+            if style in self._derived_styles:
+                continue
+            merged = {}
+            for name in self._style_ancestors(style):
+                opts = self._user_options.get(name)
+                if opts:
+                    merged.update(opts)
+                    handled.add(name)
+            if merged:
+                self._build_configure(style, **merged)
         for name, opts in self._user_options.items():
             if name not in handled and opts:
                 self._build_configure(name, **opts)

--- a/tests/test_durable_style_options.py
+++ b/tests/test_durable_style_options.py
@@ -79,6 +79,19 @@ def test_override_fans_out_to_new_variant_after_switch(root):
     assert _padding(root, "info.TEntry") == 3
 
 
+def test_override_reaches_previsited_theme(root):
+    # An override reaches a theme that was already visited (and built) BEFORE
+    # the override was set. The repeat visit takes theme_use's existing-theme
+    # branch (walk, not rebuild), so without the theme-scoped replay an override
+    # on an unmounted style would keep the recipe default there (#1298).
+    style = root.style
+    style.theme_use("bootstrap-dark")   # pre-visit + build the target theme
+    style.theme_use("bootstrap-light")  # leave it
+    style.configure("TEntry", padding=3)
+    style.theme_use("bootstrap-dark")   # repeat visit -> existing-theme branch
+    assert _padding(root, "TEntry") == 3
+
+
 def test_base_class_override_reaches_variant(root):
     # never touch the base style itself; the variant must still inherit it
     root.style.configure("TButton", focusthickness=7)


### PR DESCRIPTION
## Summary

Fixes #1298. A durable `style.configure()` override (the #1238/#1279 layer) was **not re-applied** when `theme_use()` switched to an *already-built* theme, if no widget of that style was currently mounted.

### Root cause

A repeat visit takes `theme_use`'s existing-theme branch (`super().theme_use` + theme walk). The walk only rebuilds `(theme, style)` pairs that **mounted** widgets reference, so a durable override on an unmounted style kept the recipe default in that theme's style DB. The eager `create_default_style()` on a theme's *first* visit masked the gap — which is why it was order-dependent (the value-token tests that pre-visited `bootstrap-dark` first exposed it).

### Fix

`src/ttkbootstrap/style/engine.py`:
- New `_reapply_user_options_for_theme(themename)` — replays `_user_options` across the target theme's registered styles (base-class ancestors merged most-specific-wins, plus un-namespaced globals like `"Sash"`). Mirrors `_reapply_user_options` but scoped to a whole theme instead of one just-built style; excludes derived (icon) styles, writes via the internal `_build_configure` so replays aren't re-captured.
- Called in the existing-theme branch of `theme_use`, right after `super().theme_use(themename)`.

### Test

`test_override_reaches_previsited_theme` pre-visits the target theme *before* setting the override (the exact repro). Confirmed it reads `5` without the fix and `3` with it.

### Verification

- Full suite: **838 passed, 3 skipped** (+1 new test; no `nl.msg` flake).
- Adversarial `/review` over the diff: no defects — correctness, consistency with `_reapply_user_options`, ordering vs. the theme walk (idempotent), performance (guarded, only fires on repeat visits), and edge cases all clear.

No `2_1_changes.md` entry: the durable-options "survives a theme switch" guarantee is a *new-in-2.1* feature that never shipped to a user, so this pre-release gap belongs in the dev log/PR, not the user-facing changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)