### PR TITLE
Themed in-library file dialog + opt-in routing (PR 1 of #1242)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -905,14 +905,30 @@ DONE.** Optional post-release polish only from here.
 > **Phase 3 — #1242** (in-house themed file dialog). Deliberately last: biggest
 > single build, most standalone (doesn't touch the seam), lowest urgency (dialog
 > works, just unthemed on X11), and the named DROP CANDIDATE if 2.1 must close
-> sooner — parks cleanly to 2.2 without stranding seam work.
->
-> **Remaining 2.1 = #1242 (themed file dialog) only** — #1298 is done (PR #1304).
-> **NEXT SESSION:** a **design session for #1242** (§10-style gate before any code;
-> prior art in `development/filedialogs/`). One design gate remains: #1242.
-> **Housekeeping this session:** closed **#1224** (filedialog white-on-white —
-> subsumed by #1242; the dark-mode base-style half was already fixed in #1239) and
-> **#1252** (v1 empty/clearable DateEntry — superseded by shipped #1253 + 3.0 #1276).
+> sooner — parks cleanly to 2.2 without stranding seam work. **Design gate DONE**
+> (2026-07-26, `development/2_1_file_dialog_design.md` CONFIRMED): reproduce
+> `tkfbox.tcl`'s layout with themed widgets (`ttk.Treeview` details view swaps the
+> unstyleable `IconList` Canvas); per-platform default + `native: bool|None`
+> override (X11 → themed, Win/macOS → native, `native=False` forces themed);
+> minimal chrome (no sidebar — that's 2.2+); overwrite-confirm via `Messagebox`.
+> **PR 1 (dialog + backend + opt-in seam) BUILT** on `feat/2.1-themed-file-dialog`
+> (not yet merged): `dialogs/filedialog.py` (themed `FileDialog`, all four modes,
+> pure-Python listing/filter/nav backend) + `native=` selector on the four
+> `Querybox.get_*` wrappers (native still the default; themed only when
+> `native=False` is forced — PR 2 flips `None` to X11-aware). Findings baked in
+> from a live demo (`examples/themed_file_dialog.py`): the selection background is
+> a neutral **gray** and `secondary` *equals* that gray in a light theme (contrast
+> 1.0), so a static icon color vanishes on select → **row icons swap color with
+> selection state** (`selectfg` when selected); default flush treeview rows are too
+> short → a dialog-scoped `Filedialog.Treeview` bumps `rowheight`; and Tk's file
+> dialogs return **forward-slash** paths on every platform → results go through
+> `Path.as_posix()` for drop-in parity. `tests/test_filedialog_api.py` (+43;
+> backend + routing + all four modes + the three findings). Suite **881 passed**.
+> **NEXT:** commit PR 1, then PR 2 (X11-default routing) + PR 3 (docs) per the
+> design's §9. **Housekeeping (prior session):** closed **#1224** (filedialog
+> white-on-white — subsumed by #1242; the dark-mode base-style half was already
+> fixed in #1239) and **#1252** (v1 empty/clearable DateEntry — superseded by
+> shipped #1253 + 3.0 #1276).
 >
 > **User-visible 2.1 changes are logged in `development/2_1_changes.md`** (the
 > running log, same role `2_0_breaking_changes.md` played for 2.0; it is the source

--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -25,6 +25,7 @@
 | **Notebook tab `padding` / `bordercolor` are now overridable** | Fix | this doc, below |
 | **`DateEntry(value=…)` — a nullable, clearable date field** | New | this doc, below |
 | **Bootstyle value tokens — raw hex + ramp accents & surfaces** | New | this doc, below |
+| **Themed file dialog — a theme-following open/save chooser** | New | this doc, below |
 
 There are **no API breaks in 2.1**: nothing was removed, and no call that worked
 in 2.0.0 fails. One change is visually noticeable without any code change (the
@@ -180,3 +181,37 @@ on the same kind of closed utility vocabulary.
 are never unregistered). The closed vocabulary and the ramp tokens are finite, so
 their styles plateau; the space of raw hex values is not, so an app that feeds
 many distinct hex values through `bootstyle` accumulates styles over its lifetime.
+
+---
+
+## Themed file dialog — a theme-following open/save chooser  *(New)*
+
+**What.** ttkbootstrap now ships an in-library file dialog that follows the active
+theme, reproducing the familiar layout of Tk's chooser (a directory bar, a file
+listing, a filename field + filetype selector, OK/Cancel) with themed widgets.
+The four `Querybox` file wrappers gain a `native` selector to choose it:
+
+```python
+# force the themed dialog anywhere (light or dark, it matches your app)
+path = ttk.Querybox.get_open_filename(native=False, filetypes=[("Text", "*.txt")])
+
+ttk.Querybox.get_open_filenames(native=False)   # multi-select -> tuple | None
+ttk.Querybox.get_save_filename(native=False, defaultextension=".txt")
+ttk.Querybox.get_directory(native=False)
+```
+
+`native=None` (the default) uses the native OS chooser as before; `native=True`
+forces it. The return contracts are unchanged — a path `str`, a `tuple[str, …]`
+for multi-select, or `None` on cancel.
+
+**Why.** On Windows and macOS the OS draws a great native chooser, but **X11 has
+no native dialog** — Tk falls back to a chooser whose central file list is an
+unstyleable white Canvas that ignores the theme (jarring in dark mode). The themed
+dialog replaces it. On X11 it will become the **default** (so a dark-themed Linux
+app stops flashing a white panel); on Windows/macOS the native chooser stays the
+default and the themed one is opt-in via `native=False`. Addresses #1242.
+
+**Scope note.** This first slice ships the dialog and the `native=` opt-in; the
+X11-by-default routing lands next in the same 2.1 cycle. Deliberately minimal
+(no bookmarks/places sidebar) — matching Tk's chooser; a sidebar is a later
+enhancement.

--- a/development/2_1_file_dialog_design.md
+++ b/development/2_1_file_dialog_design.md
@@ -1,0 +1,211 @@
+# ttkbootstrap 2.1 — in-house themed file dialog (design brief)
+
+> Design brief for a **themed, in-library file dialog** that replaces Tk's
+> unstyled `tkfbox.tcl` chooser on X11 (opt-in elsewhere). Tracked 2.1 issue
+> **#1242** (milestone 2.1). The last remaining 2.1 build and the designated
+> drop-candidate if the milestone must close sooner.
+>
+> **Status: CONFIRMED — design session held 2026-07-26; §10 settled (see below).**
+> Direction: **reproduce `tkfbox.tcl`'s layout with themed ttk widgets** rather
+> than invent a new dialog or lift the `development/filedialogs/` prior art.
+> Additive and backward-compatible — the native OS dialogs stay the default on
+> Windows/macOS. Implementation proceeds per the §9 PR shape.
+
+## 1. Motivation & author intent
+
+Every standard dialog ttkbootstrap surfaces is themed **except** the file
+dialog, because on Windows and macOS the OS draws it natively (and beautifully).
+On **X11 there is no native chooser** — Tk falls back to `tkfbox.tcl`, whose
+central file listing is a `::tk::IconList` **Canvas** with a hardcoded white
+panel that no ttk styling can reach. In a dark theme it's a jarring white slab;
+in any theme it ignores the palette entirely. (#1224 fixed the *surrounding*
+ttk chrome's dark-mode base styles; the Canvas itself remained unreachable,
+which is why #1224 was closed as subsumed by this issue.)
+
+The author's scoping call (verbatim intent): *"imitate what is already produced
+from `tkfbox.tcl` but with themed widgets."* So this is **not** a from-scratch
+dialog design — it is a faithful re-implementation of a layout users already
+know, with the one un-themeable widget swapped out and the backend moved from
+Tcl into Python.
+
+`Querybox` already exposes the four file operations as wrappers over
+`tkinter.filedialog` (`get_open_filename` / `get_open_filenames` /
+`get_save_filename` / `get_directory`, `dialogs/query.py:391`), each normalizing
+the stdlib `""`-on-cancel to `None`. Those stay the public entry points; only
+what they *call* changes on X11.
+
+## 2. The target — what `tkfbox.tcl` renders
+
+Three stacked regions inside a `ttk::frame` (from `tkfbox.tcl` `::tk::dialog::file::Create`):
+
+| Region | Contents | Themed today? |
+|---|---|---|
+| **Top bar** (`f1`, pack top fill-x) | `Directory:` label · path **menubutton** (`-direction flush`, textvariable = current path, dropdown of parent dirs) · **up-dir** button (image) | ✅ ttk |
+| **Center** (pack expand fill-both) | `::tk::IconList` — a **Canvas** icon grid of folder/file entries | ❌ **the white panel — the whole problem** |
+| **Bottom form** (`f2`, pack bottom fill-x, a `grid`) | Row 0: `File name:` label · **entry** · **OK** ; Row 1: `Files of type:` label · type **menubutton** · **Cancel** ; Row 2: `Show hidden` **checkbutton** (columnspan) | ✅ ttk |
+
+So "imitate with themed widgets" collapses to a small statement: **keep the
+layout, replace the one Canvas, drive it from Python.** Directory-chooser mode
+(`TkChooseDir`) is the same skeleton minus the filetype menubutton, with the
+name caption relabeled `Selection:`.
+
+## 3. The one hotspot — the center listing
+
+The only widget that must change is the `::tk::IconList` Canvas. **Recommended
+replacement: `ttk.Treeview` in details view** (columns: Name / Size / Modified),
+because:
+
+- It is already fully themed in-repo (`style/builders/treeview.py`) — palette,
+  hover, selection, row height all follow the active theme for free.
+- Folder/file glyphs come from the existing icon engine (`Assets.icon` /
+  `icon_element`), no new assets.
+- Details view is *more* informative than tkfbox's icon grid, and matches what
+  users expect from a modern chooser.
+- Multi-select (for `get_open_filenames`) is native to Treeview
+  (`selectmode="extended"`).
+
+The alternative — reproducing the icon-grid look with a themed Canvas/flow of
+labels — carries all the un-themed-Canvas risk we're trying to escape and buys
+nothing. **§10 decision, but Treeview is the strong default.**
+
+## 4. Widget mapping (tkfbox → themed)
+
+| tkfbox piece | ttkbootstrap themed equivalent |
+|---|---|
+| `::tk::IconList` (Canvas) | `ttk.Treeview` details view (Name/Size/Modified) |
+| path `ttk::menubutton` + `menu` | `ttk.Menubutton` + themed `ttk.Menu` (parent-path dropdown) |
+| up-dir `ttk::button` | `ttk.Button` with an icon glyph |
+| `File name:` `ttk::entry` | `ttk.Entry` |
+| `Files of type:` menubutton + menu | `ttk.Menubutton` / `OptionMenu` + themed `Menu` |
+| OK / Cancel `ttk::button` | `ttk.Button` (OK = default/accent) |
+| `Show hidden` `ttk::checkbutton` | `ttk.Checkbutton` |
+| toplevel `-class TkFDialog` | `ttk.Toplevel` (transient/modal to parent, `place_window_center`) |
+
+Everything on the right is already themed — the dialog inherits the active theme
+with no per-widget styling work.
+
+## 5. Backend logic (Python, not ported Tcl)
+
+Re-implement tkfbox's behaviors in Python (`os` / `pathlib`) rather than porting
+the Tcl globbing — it's cleaner and testable:
+
+- **Directory listing** — dirs first, then files; each row = glyph + name +
+  formatted size + mtime.
+- **Filetype filtering** — parse the standard `filetypes=[("Label", "*.ext"), …]`
+  contract (must match `tkinter.filedialog` exactly so callers don't change);
+  drive it from the type menubutton; support the `*`/`*.*` all-files entry.
+- **Hidden-file toggle** — the `Show hidden` checkbutton filters dotfiles (and
+  Windows hidden-attribute files) live.
+- **Navigation** — double-click a dir to descend; up-dir button; the path
+  menubutton lists ancestors for quick jumps; typing a path/name in the entry
+  and pressing Return navigates or selects (tkfbox `ActivateEnt`/`CompleteEnt`).
+- **Save mode** — `defaultextension`, `initialfile`, overwrite-confirm prompt
+  (reuse `Messagebox`).
+- **Directory mode** — no filetype row, listing shows dirs only, `Selection:`
+  caption.
+
+## 6. Public surface & routing
+
+No new public API surface if we can avoid it — the four `Querybox.get_*`
+wrappers stay the entry points and keep their `None`-on-cancel contract. What
+changes is the dispatch inside them:
+
+- **X11 → in-house dialog by default.** `tk.windowing_system() == "x11"` routes
+  to `dialogs/filedialog.py`.
+- **Windows / macOS → native OS dialog by default** (unchanged).
+- **Opt-in override** so anyone can force the themed dialog anywhere (its whole
+  point is theme consistency). Mechanism is a §10 decision — leading option: a
+  `native: bool | None` kwarg on each `Querybox.get_*` wrapper (`None` = per-
+  platform default, `False` = force in-house, `True` = force native), mirroring
+  the snake_case + Tk-passthrough conventions. A module-level default flag
+  (`set_native_filedialog(False)`) is the alternative / complement.
+
+New code lives in **`dialogs/filedialog.py`**; the class is not re-exported as a
+widget (it's reached through the facade), matching how `datepicker.py` sits
+behind `Querybox.get_date`.
+
+## 7. Return contracts (unchanged)
+
+| Wrapper | Returns | Cancel |
+|---|---|---|
+| `get_open_filename` | `str` path | `None` |
+| `get_open_filenames` | `tuple[str, …]` | `None` |
+| `get_save_filename` | `str` path | `None` |
+| `get_directory` | `str` path | `None` |
+
+The in-house dialog must produce byte-identical return values to the stdlib
+wrappers for the same selection, so callers are agnostic to which path drew the
+dialog.
+
+## 8. Risks & mitigations
+
+- **Scope creep into a file *manager*.** tkfbox has no bookmarks, no places
+  sidebar, no rename/delete. **Match that minimalism** for 2.1 (§10) — a places
+  sidebar is a 2.2+ enhancement, not a blocker.
+- **Filetype-contract drift.** The `filetypes` parsing must accept exactly what
+  `tkinter.filedialog` accepts, or existing callers break. Pin with tests over
+  the documented forms (extensions, `*`, macOS-style, multiple patterns).
+- **Modality / focus.** The dialog must be transient + grab-set to its parent
+  and return control cleanly (tkfbox uses a Tcl `vwait`; we use the same
+  wait-window pattern our other dialogs use, e.g. `Querybox`/`DatePickerDialog`).
+- **Headless testing.** The heavy lifting (listing, filtering, filetype parse,
+  path nav) is pure-Python and unit-testable without a display; the GUI wiring
+  gets the usual `root`-fixture smoke tests. Keep logic separable from widgets
+  for exactly this reason.
+- **Testability of the X11 route on this box.** Windows can't exercise the
+  auto-route, only the forced (`native=False`) path — so the opt-in override is
+  also our test seam. Worth an actual X11 eyeball before close.
+
+## 9. Suggested PR shape
+
+1. **PR 1 — backend + dialog, forced-only.** `dialogs/filedialog.py`: the
+   Treeview-based dialog + Python listing/filter/nav logic, reachable **only**
+   via a forced opt-in (`native=False`), all four modes. Headless tests for the
+   pure logic + smoke tests for construction. Native default unchanged, so zero
+   risk to existing callers.
+2. **PR 2 — platform routing.** Wire the X11-default / native-elsewhere dispatch
+   into the `Querybox.get_*` wrappers; document the `native=` override.
+3. **PR 3 — docs.** Fold into the Dialogs feature guide + `Querybox` reference:
+   the themed dialog, when it appears, and the override. Screenshots via the
+   harness (X11 render is the point).
+
+Splitting the forced dialog (PR 1) from the auto-route (PR 2) lets the build
+land and get reviewed without changing any default behavior.
+
+## 10. Open questions — SETTLED (design session, 2026-07-26)
+
+1. **Center widget → `ttk.Treeview` details view** (Name / Size / Modified),
+   per §3. The icon-grid reproduction is rejected — it re-imports the un-themed
+   Canvas risk we're escaping.
+2. **Chrome → match tkfbox's minimalism for 2.1** (path menu + up-dir only; no
+   places/bookmarks sidebar). A sidebar is explicitly wanted as a **future
+   update** (2.2+), not a 2.1 blocker.
+3. **Routing → per-platform default with a `native: bool | None` kwarg override.**
+   The in-house themed dialog is **NOT** the default everywhere. Matrix:
+
+   | Platform | Default | `native=True` | `native=False` |
+   |---|---|---|---|
+   | X11 | **themed (in-house)** | stdlib tkfbox | themed |
+   | Windows / macOS | **native OS** | native | themed (in-house) |
+
+   `native=None` (the default) selects the per-platform default; `native=False`
+   forces the themed dialog anywhere (for callers who want full theme
+   consistency); `native=True` forces the OS/stdlib dialog. Rationale: native
+   pickers on Win/macOS are the better citizen (OS recent-files, cloud, network
+   places, muscle memory, accessibility) and replacing them by default would be
+   a capability regression for a cosmetic gain — the same "good tkinter citizen /
+   native parity" posture as native menus and window chrome. X11 is pure upside
+   (no native chooser exists). A module-level global flag is **not** added now;
+   the kwarg is the single seam (and doubles as the test seam on Windows).
+4. **Save mode → reuse ttkbootstrap's `Messagebox`** for the overwrite-confirm;
+   `filetypes` / `defaultextension` behavior must match `tkinter.filedialog`
+   exactly (pinned by tests, §8).
+
+## 11. Out of scope
+
+- Replacing the native OS dialogs on Windows/macOS by default (native stays
+  default there; the themed dialog is opt-in).
+- A file *manager* feature set (rename/delete/new-folder, bookmarks sidebar,
+  network places) — 2.2+ if ever.
+- The color-dropper / other Canvas-based dialogs.
+- Any change to the `Querybox.get_*` return contracts.

--- a/examples/themed_file_dialog.py
+++ b/examples/themed_file_dialog.py
@@ -1,0 +1,79 @@
+"""Interactive demo of the themed in-library file dialog (2.1).
+
+Launches each of the four `Querybox` file operations through the *themed*
+dialog (`native=False`) so you can see it follow the active theme. Toggle the
+theme (top-right) and reopen a dialog to watch it re-render in light/dark.
+
+Run:  python examples/themed_file_dialog.py
+"""
+
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+
+
+class Demo(ttk.Frame):
+    def __init__(self, master):
+        super().__init__(master, padding=16)
+        self.pack(fill=BOTH, expand=YES)
+
+        header = ttk.Frame(self)
+        header.pack(fill=X, pady=(0, 12))
+        ttk.Label(header, text="Themed file dialog", font="-size 15 -weight bold").pack(side=LEFT)
+        ttk.Button(header, text="Toggle theme", bootstyle="secondary outline",
+                   command=self.toggle_theme).pack(side=RIGHT)
+
+        ttk.Label(self, text="Each button opens the in-library dialog (native=False):",
+                  bootstyle="secondary").pack(anchor=W, pady=(0, 8))
+
+        grid = ttk.Frame(self)
+        grid.pack(fill=X)
+        for i in range(2):
+            grid.columnconfigure(i, weight=1)
+        self._btn(grid, "Open file…", self.open_one, 0, 0)
+        self._btn(grid, "Open multiple…", self.open_many, 0, 1)
+        self._btn(grid, "Save as…", self.save_as, 1, 0)
+        self._btn(grid, "Choose directory…", self.choose_dir, 1, 1)
+
+        self.result = ttk.StringVar(value="(no selection yet)")
+        out = ttk.Labelframe(self, text="Result", padding=12, bootstyle="info")
+        out.pack(fill=X, pady=(14, 0))
+        ttk.Label(out, textvariable=self.result, wraplength=460,
+                  justify=LEFT).pack(anchor=W)
+
+    def _btn(self, master, text, cmd, r, c):
+        ttk.Button(master, text=text, command=cmd, bootstyle=PRIMARY).grid(
+            row=r, column=c, sticky=EW, padx=4, pady=4, ipady=4)
+
+    def _show(self, value):
+        self.result.set(repr(value))
+
+    def open_one(self):
+        self._show(ttk.Querybox.get_open_filename(
+            parent=self.winfo_toplevel(), native=False,
+            filetypes=[("Text files", "*.txt"), ("Python", "*.py *.pyw"),
+                       ("All files", "*.*")]))
+
+    def open_many(self):
+        self._show(ttk.Querybox.get_open_filenames(
+            parent=self.winfo_toplevel(), native=False))
+
+    def save_as(self):
+        self._show(ttk.Querybox.get_save_filename(
+            parent=self.winfo_toplevel(), native=False,
+            defaultextension=".txt",
+            filetypes=[("Text files", "*.txt"), ("All files", "*.*")]))
+
+    def choose_dir(self):
+        self._show(ttk.Querybox.get_directory(
+            parent=self.winfo_toplevel(), native=False))
+
+    def toggle_theme(self):
+        self.winfo_toplevel().toggle_theme()
+
+
+if __name__ == "__main__":
+    app = ttk.Window("Themed File Dialog — 2.1 demo", themename="bootstrap-light",
+                     size=(520, 420))
+    Demo(app)
+    app.place_window_center()
+    app.mainloop()

--- a/src/ttkbootstrap/dialogs/filedialog.py
+++ b/src/ttkbootstrap/dialogs/filedialog.py
@@ -1,0 +1,634 @@
+"""Themed, in-library file dialog (X11 default; opt-in elsewhere).
+
+This reproduces the layout of Tk's ``tkfbox.tcl`` chooser with themed ttk
+widgets so the dialog follows the active ttkbootstrap theme. On X11 there is no
+native chooser and Tk's fallback draws an unstyleable white Canvas panel (its
+``::tk::IconList``); this dialog replaces that panel with a themed
+``ttk.Treeview`` and drives navigation from Python instead of Tcl. On Windows
+and macOS the native OS dialog stays the default, and this dialog is reached via
+the ``native=False`` opt-in on the ``Querybox.get_*`` wrappers.
+
+The four modes mirror ``tkinter.filedialog``: open one file, open several, save
+as, and choose a directory. Callers reach them through
+``Querybox.get_open_filename`` / ``get_open_filenames`` / ``get_save_filename``
+/ ``get_directory``, which normalize a cancel to ``None``.
+
+The directory-listing / filetype-filtering / hidden-file logic is pure Python
+(module-level functions), kept separate from the widgets so it is unit-testable
+without a display.
+"""
+
+import fnmatch
+import os
+import tkinter
+from datetime import datetime
+from pathlib import Path
+from typing import Any, List, Optional, Sequence, Tuple, Union
+
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+from ttkbootstrap.localization import MessageCatalog
+from ttkbootstrap.style import Assets
+from ttkbootstrap.style.engine import Style
+from ttkbootstrap.internal.positioning import center_on_parent, ensure_on_screen
+from ttkbootstrap.utils import windowing_system
+from .message import Messagebox
+
+# Modes.
+OPEN = "open"
+SAVE = "save"
+DIRECTORY = "directory"
+
+# A dialog-only Treeview style so we can give the file listing taller rows
+# without disturbing any other treeview in the app.
+_ROW_STYLE = "Filedialog.Treeview"
+
+# Logical size of the row icons.
+_ICON_SIZE = 16
+
+# Glob patterns that mean "match everything", normalized to a single "*".
+_ALL_PATTERNS = frozenset(("*", "*.*", ""))
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python backend (no Tk) — filetype parsing, filtering, listing.
+# ---------------------------------------------------------------------------
+
+def _coerce_glob(pattern: str) -> str:
+    """Normalize one filetype pattern into an fnmatch glob.
+
+    Mirrors what ``tkinter.filedialog`` accepts: a bare extension (``.txt`` or
+    ``txt``) becomes ``*.txt``; ``*``/``*.*``/empty become ``*``; an already-
+    globbed pattern (``*.py``) is returned unchanged.
+    """
+    p = pattern.strip()
+    if p in _ALL_PATTERNS:
+        return "*"
+    if p.startswith("."):
+        return "*" + p
+    if "*" not in p and "?" not in p and "[" not in p:
+        # A bare extension token like "txt" — Tk treats it as a suffix.
+        return "*." + p
+    return p
+
+
+def _normalize_filetypes(
+    filetypes: Optional[Sequence[Tuple[str, Any]]],
+) -> List[Tuple[str, Tuple[str, ...]]]:
+    """Normalize the ``filetypes`` contract into ``(label, globs)`` pairs.
+
+    Accepts the stdlib forms — a sequence of ``(label, patterns)`` where
+    ``patterns`` is a single glob string, a whitespace/``;``-separated string of
+    globs, or a sequence of globs. Returns ``[]`` for a falsy ``filetypes`` (the
+    caller supplies the all-files default), so the parsing here matches
+    ``tkinter.filedialog`` and existing callers are unaffected by the route.
+    """
+    result: List[Tuple[str, Tuple[str, ...]]] = []
+    for label, patterns in filetypes or ():
+        if isinstance(patterns, str):
+            parts: Sequence[str] = patterns.replace(";", " ").split()
+        else:
+            parts = list(patterns)
+        globs = tuple(_coerce_glob(p) for p in parts) or ("*",)
+        result.append((label, globs))
+    return result
+
+
+def _matches(name: str, globs: Sequence[str]) -> bool:
+    """Does ``name`` match any glob in ``globs`` (case-insensitive)?"""
+    lname = name.lower()
+    return any(fnmatch.fnmatch(lname, g.lower()) for g in globs)
+
+
+def _is_hidden(name: str, path: str) -> bool:
+    """Is this entry hidden? Dotfiles everywhere; the hidden attribute on NT."""
+    if name.startswith("."):
+        return True
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            attrs = ctypes.windll.kernel32.GetFileAttributesW(str(path))
+            # -1 == INVALID_FILE_ATTRIBUTES; 0x2 == FILE_ATTRIBUTE_HIDDEN.
+            if attrs != -1 and attrs & 0x2:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+class _Entry:
+    """A directory listing row (name, absolute path, kind, size, mtime)."""
+
+    __slots__ = ("name", "path", "is_dir", "size", "mtime")
+
+    def __init__(self, name: str, path: str, is_dir: bool,
+                 size: Optional[int], mtime: Optional[float]) -> None:
+        self.name = name
+        self.path = path
+        self.is_dir = is_dir
+        self.size = size
+        self.mtime = mtime
+
+
+def _list_directory(
+    dirpath: str,
+    globs: Sequence[str],
+    *,
+    show_hidden: bool,
+    dirs_only: bool = False,
+) -> Tuple[List[_Entry], List[_Entry]]:
+    """Return ``(dirs, files)`` for ``dirpath``, each name-sorted.
+
+    ``globs`` filters files only — directories are always listed so the user can
+    navigate. Hidden entries are dropped unless ``show_hidden``. In
+    ``dirs_only`` mode (directory chooser) files are skipped entirely.
+    Unreadable entries are skipped; an unreadable ``dirpath`` yields ``([], [])``.
+    """
+    dirs: List[_Entry] = []
+    files: List[_Entry] = []
+    try:
+        with os.scandir(dirpath) as it:
+            for e in it:
+                try:
+                    is_dir = e.is_dir()
+                except OSError:
+                    continue
+                if not show_hidden and _is_hidden(e.name, e.path):
+                    continue
+                if is_dir:
+                    dirs.append(_Entry(e.name, e.path, True, None, _safe_mtime(e)))
+                elif not dirs_only and _matches(e.name, globs):
+                    size, mtime = _safe_stat(e)
+                    files.append(_Entry(e.name, e.path, False, size, mtime))
+    except OSError:
+        return [], []
+    dirs.sort(key=lambda x: x.name.lower())
+    files.sort(key=lambda x: x.name.lower())
+    return dirs, files
+
+
+def _safe_stat(entry: "os.DirEntry") -> Tuple[Optional[int], Optional[float]]:
+    try:
+        st = entry.stat()
+        return st.st_size, st.st_mtime
+    except OSError:
+        return None, None
+
+
+def _safe_mtime(entry: "os.DirEntry") -> Optional[float]:
+    try:
+        return entry.stat().st_mtime
+    except OSError:
+        return None
+
+
+def _ancestors(path: str) -> List[str]:
+    """Every path from ``path`` up to the filesystem root, nearest first."""
+    parts: List[str] = []
+    current = os.path.abspath(path)
+    while True:
+        parts.append(current)
+        parent = os.path.dirname(current)
+        if parent == current:
+            break
+        current = parent
+    return parts
+
+
+def _format_size(nbytes: Optional[int]) -> str:
+    """Human-readable file size (``''`` for directories / unknown)."""
+    if nbytes is None:
+        return ""
+    size = float(nbytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            return f"{int(size)} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return ""  # unreachable; keeps the type checker happy
+
+
+def _format_mtime(ts: Optional[float]) -> str:
+    if not ts:
+        return ""
+    try:
+        return datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
+    except (OSError, ValueError, OverflowError):
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# The dialog.
+# ---------------------------------------------------------------------------
+
+class FileDialog:
+    """A themed file chooser reproducing ``tkfbox.tcl``'s layout.
+
+    Not a public widget — construct it through the ``Querybox.get_*`` facade,
+    which selects native-vs-themed per platform and normalizes a cancel to
+    ``None``. Call :meth:`show` (which returns the result and also sets
+    :attr:`result`).
+
+    Result by mode: a path ``str`` for open-single / save / directory, a
+    ``tuple[str, ...]`` for open-multiple, and ``None`` on cancel.
+    """
+
+    def __init__(
+        self,
+        parent: Optional[tkinter.Misc] = None,
+        *,
+        title: Optional[str] = None,
+        mode: str = OPEN,
+        multiple: bool = False,
+        filetypes: Optional[Sequence[Tuple[str, Any]]] = None,
+        initialdir: Optional[str] = None,
+        initialfile: Optional[str] = None,
+        defaultextension: str = "",
+    ) -> None:
+        self._parent = parent
+        self._mode = mode
+        self._multiple = bool(multiple) and mode == OPEN
+        self._filetypes = _normalize_filetypes(filetypes)
+        self._defaultext = defaultextension
+        self._initialfile = initialfile or ""
+        self._cwd = os.path.abspath(initialdir or os.getcwd())
+        self._title = title or _default_title(mode)
+        self._result: Union[str, Tuple[str, ...], None] = None
+
+        # Built in _build(); the current filetype's globs default to all-files.
+        self._current_globs: Tuple[str, ...] = ("*",)
+        self._rows: dict = {}
+        self._toplevel: Optional[tkinter.Toplevel] = None
+
+    # -- public ------------------------------------------------------------
+
+    def show(
+        self, position: Optional[Tuple[int, int]] = None
+    ) -> Union[str, Tuple[str, ...], None]:
+        """Build, show modally, and return the result (also on :attr:`result`)."""
+        self._build()
+        self._navigate(self._cwd)
+        self._locate(position)
+        self._toplevel.deiconify()
+        self._name_entry.focus_set()
+        self._toplevel.grab_set()
+        self._toplevel.wait_window()
+        return self._result
+
+    @property
+    def result(self) -> Union[str, Tuple[str, ...], None]:
+        return self._result
+
+    # -- construction ------------------------------------------------------
+
+    def _build(self) -> None:
+        winsys = windowing_system(self._parent)
+        kwargs: dict = dict(
+            transient=self._parent,
+            title=self._title,
+            minsize=(480, 360),
+            iconify=True,
+        )
+        if winsys != "win32":
+            kwargs["window_type"] = "dialog"
+        self._toplevel = ttk.Toplevel(**kwargs)
+        self._toplevel.withdraw()  # reset the iconify state
+        self._toplevel.geometry("640x480")
+        self._toplevel.protocol("WM_DELETE_WINDOW", self._cancel)
+        self._toplevel.bind("<Escape>", lambda _: self._cancel())
+
+        self._path_var = ttk.StringVar(master=self._toplevel)
+        self._name_var = ttk.StringVar(master=self._toplevel, value=self._initialfile)
+        self._hidden_var = ttk.BooleanVar(master=self._toplevel, value=False)
+        self._type_var = ttk.StringVar(master=self._toplevel)
+
+        style = Style.get_instance()
+        assets = Assets(style)
+        colors = style.colors
+        # Row icons come in two variants — a normal one colored to read on the
+        # field background, and a "selected" one colored with `selectfg`. The
+        # selection background is a neutral gray that a static accent color can
+        # blend into (in a light theme `secondary` *is* the selection gray), so
+        # we swap the icon color with the selection state — see _update_row_icons.
+        self._folder_img = assets.icon("folder-fill", _ICON_SIZE, colors.warning)
+        self._file_img = assets.icon(
+            "file-earmark-text-fill", _ICON_SIZE, colors.get("secondary"))
+        self._folder_img_sel = assets.icon("folder-fill", _ICON_SIZE, colors.selectfg)
+        self._file_img_sel = assets.icon(
+            "file-earmark-text-fill", _ICON_SIZE, colors.selectfg)
+        self._up_img = assets.icon("arrow-90deg-up", _ICON_SIZE, colors.fg)
+
+        container = ttk.Frame(self._toplevel, padding=8)
+        container.pack(fill=BOTH, expand=YES)
+        self._build_topbar(container)
+        self._build_listing(container)
+        self._build_form(container)
+
+    def _build_topbar(self, master: tkinter.Misc) -> None:
+        bar = ttk.Frame(master)
+        bar.pack(side=TOP, fill=X, pady=(0, 6))
+        ttk.Label(bar, text=MessageCatalog.translate("Directory:")).pack(
+            side=LEFT, padx=(0, 6))
+        up = ttk.Button(bar, image=self._up_img, command=self._go_up)
+        up.pack(side=RIGHT, padx=(6, 0))
+        self._dir_mb = ttk.Menubutton(bar, textvariable=self._path_var)
+        self._dir_menu = ttk.Menu(self._dir_mb, tearoff=0)
+        self._dir_mb.configure(menu=self._dir_menu)
+        self._dir_mb.pack(side=LEFT, fill=X, expand=YES)
+
+    def _build_listing(self, master: tkinter.Misc) -> None:
+        frame = ttk.Frame(master)
+        frame.pack(side=TOP, fill=BOTH, expand=YES)
+        select = EXTENDED if self._multiple else BROWSE
+        tree = ttk.Treeview(
+            frame, columns=("size", "modified"), selectmode=select,
+            show=(TREE, HEADINGS))
+        # Give the listing taller rows than the default (flush) treeview so the
+        # icons sit comfortably. Scoped to a dialog-only style (inherits the
+        # themed Treeview colors) so no other treeview is affected. Row height is
+        # DPI-physical — the icon size and font linespace already are.
+        style = Style.get_instance()
+        icon_h = style.scaling.image_size(_ICON_SIZE)[1]
+        try:
+            linespace = int(tree.tk.call("font", "metrics", "TkDefaultFont", "-linespace"))
+        except tkinter.TclError:
+            linespace = icon_h
+        style.configure(_ROW_STYLE, rowheight=max(icon_h, linespace) + round(0.7 * linespace))
+        tree.configure(style=_ROW_STYLE)
+        tree.heading("#0", text=MessageCatalog.translate("Name"), anchor=W)
+        tree.heading("size", text=MessageCatalog.translate("Size"), anchor=W)
+        tree.heading("modified", text=MessageCatalog.translate("Modified"), anchor=W)
+        tree.column("#0", width=320, stretch=True)
+        tree.column("size", width=90, stretch=False, anchor=E)
+        tree.column("modified", width=140, stretch=False)
+        vsb = ttk.Scrollbar(frame, orient=VERTICAL, command=tree.yview)
+        tree.configure(yscrollcommand=vsb.set)
+        vsb.pack(side=RIGHT, fill=Y)
+        tree.pack(side=LEFT, fill=BOTH, expand=YES)
+        tree.bind("<<TreeviewSelect>>", self._on_select)
+        tree.bind("<Double-1>", self._on_activate)
+        tree.bind("<Return>", self._on_activate)
+        self._tree = tree
+
+    def _build_form(self, master: tkinter.Misc) -> None:
+        form = ttk.Frame(master)
+        form.pack(side=BOTTOM, fill=X, pady=(6, 0))
+        form.columnconfigure(1, weight=1)
+
+        name_label = (MessageCatalog.translate("Selection:")
+                      if self._mode == DIRECTORY
+                      else MessageCatalog.translate("File name:"))
+        ttk.Label(form, text=name_label, anchor=E).grid(
+            row=0, column=0, sticky=EW, padx=(0, 6), pady=3)
+        self._name_entry = ttk.Entry(form, textvariable=self._name_var)
+        self._name_entry.grid(row=0, column=1, sticky=EW, pady=3)
+        self._name_entry.bind("<Return>", lambda _: self._on_ok())
+        ok_text = MessageCatalog.translate("OK")
+        ttk.Button(form, text=ok_text, bootstyle=PRIMARY, command=self._on_ok).grid(
+            row=0, column=2, sticky=EW, padx=(6, 0), pady=3)
+
+        if self._mode != DIRECTORY:
+            ttk.Label(form, text=MessageCatalog.translate("Files of type:"),
+                      anchor=E).grid(row=1, column=0, sticky=EW, padx=(0, 6), pady=3)
+            type_mb = ttk.Menubutton(form, textvariable=self._type_var)
+            type_menu = ttk.Menu(type_mb, tearoff=0)
+            type_mb.configure(menu=type_menu)
+            type_mb.grid(row=1, column=1, sticky=EW, pady=3)
+            self._build_type_menu(type_menu)
+
+        cancel_text = MessageCatalog.translate("Cancel")
+        ttk.Button(form, text=cancel_text, command=self._cancel).grid(
+            row=1, column=2, sticky=EW, padx=(6, 0), pady=3)
+
+        ttk.Checkbutton(
+            form,
+            text=MessageCatalog.translate("Show hidden files"),
+            variable=self._hidden_var,
+            command=self._refresh,
+        ).grid(row=2, column=0, columnspan=2, sticky=W, pady=(6, 0))
+
+    def _build_type_menu(self, menu: tkinter.Menu) -> None:
+        types = self._filetypes or [
+            (MessageCatalog.translate("All Files"), ("*",))]
+        for label, globs in types:
+            display = _type_label(label, globs)
+            menu.add_command(
+                label=display,
+                command=lambda g=globs, d=display: self._set_filetype(g, d))
+        first_label, first_globs = types[0]
+        self._current_globs = first_globs
+        self._type_var.set(_type_label(first_label, first_globs))
+
+    # -- navigation & listing ---------------------------------------------
+
+    def _navigate(self, path: str) -> None:
+        self._cwd = os.path.abspath(path)
+        self._path_var.set(self._cwd)
+        self._rebuild_dir_menu()
+        self._refresh()
+
+    def _go_up(self) -> None:
+        self._navigate(os.path.dirname(self._cwd))
+
+    def _rebuild_dir_menu(self) -> None:
+        self._dir_menu.delete(0, END)
+        for anc in _ancestors(self._cwd):
+            self._dir_menu.add_command(
+                label=anc, command=lambda p=anc: self._navigate(p))
+
+    def _refresh(self) -> None:
+        tree = self._tree
+        tree.delete(*tree.get_children())
+        self._rows = {}
+        dirs, files = _list_directory(
+            self._cwd,
+            self._current_globs,
+            show_hidden=self._hidden_var.get(),
+            dirs_only=self._mode == DIRECTORY,
+        )
+        for e in dirs:
+            iid = tree.insert(
+                "", END, text=f" {e.name}", image=self._folder_img,
+                values=("", _format_mtime(e.mtime)))
+            self._rows[iid] = e
+        for e in files:
+            iid = tree.insert(
+                "", END, text=f" {e.name}", image=self._file_img,
+                values=(_format_size(e.size), _format_mtime(e.mtime)))
+            self._rows[iid] = e
+
+    def _set_filetype(self, globs: Tuple[str, ...], display: str) -> None:
+        self._current_globs = globs
+        self._type_var.set(display)
+        self._refresh()
+
+    # -- selection handlers ------------------------------------------------
+
+    def _selected_entries(self) -> List[_Entry]:
+        return [self._rows[iid] for iid in self._tree.selection()
+                if iid in self._rows]
+
+    def _update_row_icons(self) -> None:
+        """Recolor row icons by selection state.
+
+        A static icon color can vanish into the neutral selection background, so
+        selected rows use the `selectfg`-colored variant (which always contrasts
+        the selection) and the rest keep the field-background variant.
+        """
+        selected = set(self._tree.selection())
+        for iid, entry in self._rows.items():
+            if iid in selected:
+                img = self._folder_img_sel if entry.is_dir else self._file_img_sel
+            else:
+                img = self._folder_img if entry.is_dir else self._file_img
+            self._tree.item(iid, image=img)
+
+    def _on_select(self, event: Any = None) -> None:
+        self._update_row_icons()
+        sel = self._selected_entries()
+        if not sel:
+            return
+        if self._mode == DIRECTORY:
+            self._name_var.set(sel[0].path)
+            return
+        files = [e for e in sel if not e.is_dir]
+        if not files:
+            return
+        if self._multiple and len(files) > 1:
+            self._name_var.set(" ".join(_quote(e.name) for e in files))
+        else:
+            self._name_var.set(files[0].name)
+
+    def _on_activate(self, event: Any = None) -> None:
+        sel = self._selected_entries()
+        if not sel:
+            return
+        entry = sel[0]
+        if entry.is_dir:
+            self._navigate(entry.path)
+        elif self._mode != DIRECTORY:
+            self._on_ok()
+
+    # -- accept / cancel ---------------------------------------------------
+
+    def _on_ok(self) -> None:
+        if self._mode == DIRECTORY:
+            sel = self._selected_entries()
+            self._accept(sel[0].path if sel else self._cwd)
+            return
+
+        text = self._name_var.get().strip()
+        if text and not (self._multiple and " " in text):
+            candidate = text if os.path.isabs(text) else os.path.join(self._cwd, text)
+            candidate = os.path.abspath(candidate)
+            if os.path.isdir(candidate):
+                self._navigate(candidate)
+                return
+            if self._mode == SAVE:
+                candidate = self._apply_default_ext(candidate)
+                if os.path.exists(candidate) and not self._confirm_overwrite(candidate):
+                    return
+                self._accept(candidate)
+                return
+            # OPEN with a typed name.
+            if self._multiple:
+                self._accept((candidate,))
+                return
+            if os.path.exists(candidate):
+                self._accept(candidate)
+                return
+            self._toplevel.bell()
+            return
+
+        # No usable typed text — fall back to the tree selection.
+        files = [e for e in self._selected_entries() if not e.is_dir]
+        if not files:
+            self._toplevel.bell()
+            return
+        if self._multiple:
+            self._accept(tuple(e.path for e in files))
+        else:
+            self._accept(files[0].path)
+
+    def _apply_default_ext(self, path: str) -> str:
+        if self._defaultext and not os.path.splitext(path)[1]:
+            ext = self._defaultext
+            if not ext.startswith("."):
+                ext = "." + ext
+            return path + ext
+        return path
+
+    def _confirm_overwrite(self, path: str) -> bool:
+        name = os.path.basename(path)
+        prompt = MessageCatalog.translate("File already exists. Overwrite?")
+        answer = Messagebox.yesno(f"{name}\n\n{prompt}", parent=self._toplevel)
+        # Messagebox returns the (possibly localized) button text; compare against
+        # the same translation rather than a raw "Yes" so non-English locales work.
+        return answer == MessageCatalog.translate("Yes")
+
+    def _accept(self, result: Union[str, Tuple[str, ...]]) -> None:
+        # Match `tkinter.filedialog`, which returns forward-slash paths on every
+        # platform (including Windows) — so callers see the same string whichever
+        # dialog drew it.
+        if isinstance(result, tuple):
+            self._result = tuple(_to_tk_path(p) for p in result)
+        else:
+            self._result = _to_tk_path(result)
+        self._close()
+
+    def _cancel(self) -> None:
+        self._result = None
+        self._close()
+
+    def _close(self) -> None:
+        tl = self._toplevel
+        if tl is None:
+            return
+        try:
+            if tl.winfo_exists():
+                tl.grab_release()
+                tl.destroy()
+        except tkinter.TclError:
+            pass
+
+    # -- positioning -------------------------------------------------------
+
+    def _locate(self, position: Optional[Tuple[int, int]]) -> None:
+        tl = self._toplevel
+        tl.update_idletasks()
+        if position is not None:
+            try:
+                x, y = ensure_on_screen(tl, *position)
+                tl.geometry(f"+{x}+{y}")
+                return
+            except Exception:
+                pass
+        center_on_parent(tl, self._parent)
+
+
+def _default_title(mode: str) -> str:
+    if mode == DIRECTORY:
+        return MessageCatalog.translate("Select Directory")
+    if mode == SAVE:
+        return MessageCatalog.translate("Save As")
+    return MessageCatalog.translate("Open")
+
+
+def _type_label(label: str, globs: Sequence[str]) -> str:
+    """``"Text Files (*.txt)"`` — the filetype label with its patterns shown."""
+    if not globs or tuple(globs) == ("*",):
+        return f"{label} (*)"
+    return f"{label} ({' '.join(globs)})"
+
+
+def _quote(name: str) -> str:
+    return f'"{name}"' if " " in name else name
+
+
+def _to_tk_path(path: str) -> str:
+    """Forward-slash separators, matching what ``tkinter.filedialog`` returns.
+
+    Tk normalizes paths to ``/`` on every platform; ``Path.as_posix()`` does the
+    same (a no-op off Windows), handling drive letters and mixed separators.
+    """
+    return Path(path).as_posix()

--- a/src/ttkbootstrap/dialogs/query.py
+++ b/src/ttkbootstrap/dialogs/query.py
@@ -382,57 +382,108 @@ class Querybox:
         dialog.show(position)
         return dialog.result
 
-    # File dialogs. These wrap the *native* OS file dialogs
-    # (`tkinter.filedialog`) — the one standard dialog ttkbootstrap does not
-    # restyle, because the OS draws it. They live here so a file path is fetched
-    # through the same `Querybox.get_*` facade as every other value, and they
-    # normalize the stdlib "" -on-cancel to `None` to match that contract.
+    # File dialogs. These fetch a file path through the same `Querybox.get_*`
+    # facade as every other value, normalizing a cancel to `None`. Two dialogs
+    # back them: the *native* OS chooser (`tkinter.filedialog`) and a *themed*
+    # in-library one (`.filedialog.FileDialog`) that follows the active theme.
+    # The `native` keyword selects between them; `native=None` (the default)
+    # uses the native chooser for now. (PR 2 makes `None` platform-aware —
+    # themed on X11, where Tk's fallback draws an unstyleable white panel.)
 
     @staticmethod
-    def get_open_filename(parent: Optional[tkinter.Misc] = None, **kwargs: Any) -> Optional[str]:
+    def _use_native_filedialog(native: Optional[bool]) -> bool:
+        """Resolve the `native` selector to a native-vs-themed decision.
+
+        PR 1: native everywhere unless explicitly forced off (`native=False`).
+        The `native=None` default becomes platform-aware in PR 2.
+        """
+        return native is not False
+
+    @staticmethod
+    def _themed_filedialog(
+        parent: Optional[tkinter.Misc], *, mode: str, multiple: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Show the in-library themed chooser and return its result."""
+        from .filedialog import FileDialog
+
+        return FileDialog(
+            parent,
+            title=kwargs.get("title"),
+            mode=mode,
+            multiple=multiple,
+            filetypes=kwargs.get("filetypes"),
+            initialdir=kwargs.get("initialdir"),
+            initialfile=kwargs.get("initialfile"),
+            defaultextension=kwargs.get("defaultextension", ""),
+        ).show()
+
+    @staticmethod
+    def get_open_filename(
+        parent: Optional[tkinter.Misc] = None, *,
+        native: Optional[bool] = None, **kwargs: Any,
+    ) -> Optional[str]:
         """Show an *open file* dialog. Returns the chosen path, or ``None`` if
         cancelled.
 
-        Wraps ``tkinter.filedialog.askopenfilename``; forward its options
-        (``title``, ``filetypes``, ``initialdir``, ``initialfile``, ...) as
-        keyword arguments.
+        Forward the standard options (``title``, ``filetypes``, ``initialdir``,
+        ``initialfile``, ...) as keyword arguments. Pass ``native=False`` to
+        force the themed in-library dialog (``native=True`` forces the OS
+        chooser); the ``native=None`` default uses the OS chooser.
         """
-        if parent is not None:
-            kwargs["parent"] = parent
-        return filedialog.askopenfilename(**kwargs) or None
+        if Querybox._use_native_filedialog(native):
+            if parent is not None:
+                kwargs["parent"] = parent
+            return filedialog.askopenfilename(**kwargs) or None
+        return Querybox._themed_filedialog(parent, mode="open", **kwargs)
 
     @staticmethod
-    def get_open_filenames(parent: Optional[tkinter.Misc] = None, **kwargs: Any) -> Optional[Tuple[str, ...]]:
+    def get_open_filenames(
+        parent: Optional[tkinter.Misc] = None, *,
+        native: Optional[bool] = None, **kwargs: Any,
+    ) -> Optional[Tuple[str, ...]]:
         """Show an *open multiple files* dialog. Returns a tuple of paths, or
         ``None`` if cancelled.
 
-        Wraps ``tkinter.filedialog.askopenfilenames``.
+        Pass ``native=False`` to force the themed in-library dialog.
         """
-        if parent is not None:
-            kwargs["parent"] = parent
-        paths = filedialog.askopenfilenames(**kwargs)
-        return tuple(paths) if paths else None
+        if Querybox._use_native_filedialog(native):
+            if parent is not None:
+                kwargs["parent"] = parent
+            paths = filedialog.askopenfilenames(**kwargs)
+            return tuple(paths) if paths else None
+        return Querybox._themed_filedialog(parent, mode="open", multiple=True, **kwargs)
 
     @staticmethod
-    def get_save_filename(parent: Optional[tkinter.Misc] = None, **kwargs: Any) -> Optional[str]:
+    def get_save_filename(
+        parent: Optional[tkinter.Misc] = None, *,
+        native: Optional[bool] = None, **kwargs: Any,
+    ) -> Optional[str]:
         """Show a *save as* dialog. Returns the chosen path, or ``None`` if
         cancelled.
 
-        Wraps ``tkinter.filedialog.asksaveasfilename``; forward its options
-        (``title``, ``filetypes``, ``defaultextension``, ``initialfile``, ...)
-        as keyword arguments.
+        Forward the standard options (``title``, ``filetypes``,
+        ``defaultextension``, ``initialfile``, ...) as keyword arguments. Pass
+        ``native=False`` to force the themed in-library dialog.
         """
-        if parent is not None:
-            kwargs["parent"] = parent
-        return filedialog.asksaveasfilename(**kwargs) or None
+        if Querybox._use_native_filedialog(native):
+            if parent is not None:
+                kwargs["parent"] = parent
+            return filedialog.asksaveasfilename(**kwargs) or None
+        return Querybox._themed_filedialog(parent, mode="save", **kwargs)
 
     @staticmethod
-    def get_directory(parent: Optional[tkinter.Misc] = None, **kwargs: Any) -> Optional[str]:
+    def get_directory(
+        parent: Optional[tkinter.Misc] = None, *,
+        native: Optional[bool] = None, **kwargs: Any,
+    ) -> Optional[str]:
         """Show a *choose directory* dialog. Returns the chosen path, or ``None``
         if cancelled.
 
-        Wraps ``tkinter.filedialog.askdirectory``.
+        Pass ``native=False`` to force the themed in-library dialog.
         """
+        if not Querybox._use_native_filedialog(native):
+            return Querybox._themed_filedialog(parent, mode="directory", **kwargs)
         if parent is not None:
             kwargs["parent"] = parent
         return filedialog.askdirectory(**kwargs) or None

--- a/tests/test_filedialog_api.py
+++ b/tests/test_filedialog_api.py
@@ -1,0 +1,369 @@
+"""Tests for the themed in-library file dialog (`dialogs/filedialog.py`) and its
+`Querybox.get_*` routing.
+
+Two layers:
+
+* **Backend** — the pure-Python listing/filter/parse helpers, exercised without
+  a Tk root (no `root` fixture).
+* **Dialog** — build the dialog against the shared root and drive its internals
+  directly (select rows, hit OK/Cancel, navigate). `show()` is never called
+  because its `wait_window()` would block the headless suite; the accept/cancel
+  logic it wraps is what these assert.
+"""
+
+import os
+
+import pytest
+
+from ttkbootstrap.dialogs.filedialog import FileDialog
+from ttkbootstrap.dialogs import filedialog as fd
+from ttkbootstrap.dialogs.query import Querybox
+from ttkbootstrap.localization import MessageCatalog
+
+
+# ---------------------------------------------------------------------------
+# Backend — pure Python, no root.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("pattern, expected", [
+    (".txt", "*.txt"),
+    ("txt", "*.txt"),
+    ("*.py", "*.py"),
+    ("*.*", "*"),
+    ("*", "*"),
+    ("", "*"),
+    ("  .md  ", "*.md"),
+])
+def test_coerce_glob(pattern, expected):
+    assert fd._coerce_glob(pattern) == expected
+
+
+def test_normalize_filetypes_forms():
+    # string, tuple-of-globs, and the all-files entry all normalize.
+    got = fd._normalize_filetypes([
+        ("Text", "*.txt"),
+        ("Source", ("*.py", "*.pyw")),
+        ("Semi", "*.a;*.b"),
+        ("All", "*.*"),
+    ])
+    assert got == [
+        ("Text", ("*.txt",)),
+        ("Source", ("*.py", "*.pyw")),
+        ("Semi", ("*.a", "*.b")),
+        ("All", ("*",)),
+    ]
+
+
+def test_normalize_filetypes_empty():
+    assert fd._normalize_filetypes(None) == []
+    assert fd._normalize_filetypes([]) == []
+
+
+@pytest.mark.parametrize("name, globs, expected", [
+    ("a.TXT", ("*.txt",), True),      # case-insensitive
+    ("a.py", ("*.txt",), False),
+    ("a.py", ("*.txt", "*.py"), True),
+    ("anything", ("*",), True),
+])
+def test_matches(name, globs, expected):
+    assert fd._matches(name, globs) is expected
+
+
+def test_is_hidden_dotfile():
+    assert fd._is_hidden(".bashrc", "/home/x/.bashrc") is True
+    assert fd._is_hidden("readme.txt", "/home/x/readme.txt") is False
+
+
+@pytest.mark.parametrize("nbytes, expected", [
+    (None, ""),
+    (0, "0 B"),
+    (1023, "1023 B"),
+    (2048, "2.0 KB"),
+    (5 * 1024 * 1024, "5.0 MB"),
+])
+def test_format_size(nbytes, expected):
+    assert fd._format_size(nbytes) == expected
+
+
+def test_list_directory_filters_and_sorts(tmp_path):
+    (tmp_path / "b.txt").write_text("b")
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "keep.py").write_text("x")
+    (tmp_path / ".hidden.txt").write_text("h")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / ".dotdir").mkdir()
+
+    dirs, files = fd._list_directory(str(tmp_path), ("*.txt",), show_hidden=False)
+    assert [d.name for d in dirs] == ["sub"]              # dotdir filtered
+    assert [f.name for f in files] == ["a.txt", "b.txt"]  # keep.py filtered, sorted
+
+    # hidden shown
+    dirs_h, files_h = fd._list_directory(str(tmp_path), ("*.txt",), show_hidden=True)
+    assert ".dotdir" in [d.name for d in dirs_h]
+    assert ".hidden.txt" in [f.name for f in files_h]
+
+    # dirs_only skips files entirely (directory-chooser mode)
+    dirs_o, files_o = fd._list_directory(
+        str(tmp_path), ("*",), show_hidden=False, dirs_only=True)
+    assert [d.name for d in dirs_o] == ["sub"]
+    assert files_o == []
+
+
+def test_list_directory_unreadable_returns_empty():
+    dirs, files = fd._list_directory(
+        os.path.join(os.sep, "no", "such", "path", "xyz"), ("*",), show_hidden=False)
+    assert (dirs, files) == ([], [])
+
+
+def test_ancestors_reaches_root():
+    anc = fd._ancestors(os.getcwd())
+    assert anc[0] == os.path.abspath(os.getcwd())
+    # last element is its own parent (filesystem root / drive root)
+    assert os.path.dirname(anc[-1]) == anc[-1]
+
+
+def test_type_label():
+    assert fd._type_label("All", ("*",)) == "All (*)"
+    assert fd._type_label("Text", ("*.txt",)) == "Text (*.txt)"
+    assert fd._type_label("Src", ("*.py", "*.pyw")) == "Src (*.py *.pyw)"
+
+
+# ---------------------------------------------------------------------------
+# Routing — Querybox selects native vs themed.
+# ---------------------------------------------------------------------------
+
+def test_use_native_filedialog_selector():
+    # PR 1: native unless explicitly forced off.
+    assert Querybox._use_native_filedialog(None) is True
+    assert Querybox._use_native_filedialog(True) is True
+    assert Querybox._use_native_filedialog(False) is False
+
+
+def test_native_false_routes_to_themed(monkeypatch):
+    captured = {}
+
+    class _Fake:
+        def __init__(self, parent, **kwargs):
+            captured["parent"] = parent
+            captured["kwargs"] = kwargs
+
+        def show(self):
+            return "/picked/path"
+
+    monkeypatch.setattr("ttkbootstrap.dialogs.filedialog.FileDialog", _Fake)
+    out = Querybox.get_open_filename(
+        native=False, title="Pick", filetypes=[("Text", "*.txt")],
+        initialdir="/tmp")
+    assert out == "/picked/path"
+    assert captured["kwargs"]["mode"] == "open"
+    assert captured["kwargs"]["multiple"] is False
+    assert captured["kwargs"]["title"] == "Pick"
+    assert captured["kwargs"]["filetypes"] == [("Text", "*.txt")]
+
+
+def test_native_false_routes_multiple(monkeypatch):
+    seen = {}
+
+    class _Fake:
+        def __init__(self, parent, **kwargs):
+            seen.update(kwargs)
+
+        def show(self):
+            return ("/a", "/b")
+
+    monkeypatch.setattr("ttkbootstrap.dialogs.filedialog.FileDialog", _Fake)
+    out = Querybox.get_open_filenames(native=False)
+    assert out == ("/a", "/b")
+    assert seen["mode"] == "open" and seen["multiple"] is True
+
+
+# ---------------------------------------------------------------------------
+# Dialog — build against the shared root and drive the internals.
+# ---------------------------------------------------------------------------
+
+def _iid_for(dlg, name):
+    for iid, entry in dlg._rows.items():
+        if entry.name == name:
+            return iid
+    raise AssertionError(f"{name!r} not listed; have {[e.name for e in dlg._rows.values()]}")
+
+
+def _build(root, tmp_path, **kwargs):
+    dlg = FileDialog(root, initialdir=str(tmp_path), **kwargs)
+    dlg._build()
+    dlg._navigate(dlg._cwd)
+    return dlg
+
+
+def test_open_selecting_a_file_accepts_its_path(root, tmp_path):
+    target = tmp_path / "report.txt"
+    target.write_text("x")
+    (tmp_path / "other.py").write_text("y")
+
+    dlg = _build(root, tmp_path, mode="open",
+                 filetypes=[("Text", "*.txt")])
+    # only the .txt matched the active filter
+    assert set(e.name for e in dlg._rows.values()) == {"report.txt"}
+
+    dlg._tree.selection_set(_iid_for(dlg, "report.txt"))
+    dlg._on_select()
+    assert dlg._name_var.get() == "report.txt"
+    dlg._on_ok()
+    assert dlg._result == target.as_posix()
+
+
+def test_open_double_click_directory_navigates(root, tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "inner.txt").write_text("z")
+
+    dlg = _build(root, tmp_path, mode="open")
+    dlg._tree.selection_set(_iid_for(dlg, "sub"))
+    dlg._on_activate()  # double-click a directory descends into it
+    assert dlg._cwd == str(tmp_path / "sub")
+    assert "inner.txt" in [e.name for e in dlg._rows.values()]
+    assert dlg._result is None  # navigating is not accepting
+
+
+def test_open_nonexistent_typed_name_does_not_accept(root, tmp_path):
+    dlg = _build(root, tmp_path, mode="open")
+    dlg._name_var.set("ghost.txt")
+    dlg._on_ok()
+    assert dlg._result is None
+    assert dlg._toplevel.winfo_exists()  # dialog stayed open
+
+
+def test_go_up_navigates_to_parent(root, tmp_path):
+    (tmp_path / "sub").mkdir()
+    dlg = _build(root, tmp_path / "sub", mode="open")
+    dlg._go_up()
+    assert dlg._cwd == str(tmp_path)
+
+
+def test_save_new_name_accepts_joined_path(root, tmp_path):
+    dlg = _build(root, tmp_path, mode="save")
+    dlg._name_var.set("newfile.txt")
+    dlg._on_ok()
+    assert dlg._result == (tmp_path / "newfile.txt").as_posix()
+
+
+def test_save_applies_default_extension(root, tmp_path):
+    dlg = _build(root, tmp_path, mode="save", defaultextension=".txt")
+    dlg._name_var.set("noext")
+    dlg._on_ok()
+    assert dlg._result == (tmp_path / "noext.txt").as_posix()
+
+
+def test_save_overwrite_confirmed(root, tmp_path, monkeypatch):
+    existing = tmp_path / "dup.txt"
+    existing.write_text("old")
+    yes = MessageCatalog.translate("Yes")
+    monkeypatch.setattr(
+        "ttkbootstrap.dialogs.filedialog.Messagebox.yesno",
+        staticmethod(lambda *a, **k: yes))
+    dlg = _build(root, tmp_path, mode="save")
+    dlg._name_var.set("dup.txt")
+    dlg._on_ok()
+    assert dlg._result == existing.as_posix()
+
+
+def test_save_overwrite_declined_stays_open(root, tmp_path, monkeypatch):
+    (tmp_path / "dup.txt").write_text("old")
+    no = MessageCatalog.translate("No")
+    monkeypatch.setattr(
+        "ttkbootstrap.dialogs.filedialog.Messagebox.yesno",
+        staticmethod(lambda *a, **k: no))
+    dlg = _build(root, tmp_path, mode="save")
+    dlg._name_var.set("dup.txt")
+    dlg._on_ok()
+    assert dlg._result is None
+    assert dlg._toplevel.winfo_exists()
+
+
+def test_directory_mode_lists_only_dirs(root, tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "file.txt").write_text("x")
+    dlg = _build(root, tmp_path, mode="directory")
+    assert set(e.name for e in dlg._rows.values()) == {"sub"}
+
+
+def test_directory_selecting_returns_dir(root, tmp_path):
+    (tmp_path / "sub").mkdir()
+    dlg = _build(root, tmp_path, mode="directory")
+    dlg._tree.selection_set(_iid_for(dlg, "sub"))
+    dlg._on_select()
+    dlg._on_ok()
+    assert dlg._result == (tmp_path / "sub").as_posix()
+
+
+def test_directory_no_selection_returns_cwd(root, tmp_path):
+    dlg = _build(root, tmp_path, mode="directory")
+    dlg._on_ok()
+    assert dlg._result == tmp_path.as_posix()
+
+
+def test_cancel_returns_none(root, tmp_path):
+    (tmp_path / "a.txt").write_text("x")
+    dlg = _build(root, tmp_path, mode="open")
+    dlg._tree.selection_set(_iid_for(dlg, "a.txt"))
+    dlg._on_select()
+    dlg._cancel()
+    assert dlg._result is None
+
+
+def test_show_hidden_toggle_relists(root, tmp_path):
+    (tmp_path / "visible.txt").write_text("v")
+    (tmp_path / ".secret.txt").write_text("s")
+    dlg = _build(root, tmp_path, mode="open")
+    assert ".secret.txt" not in [e.name for e in dlg._rows.values()]
+    dlg._hidden_var.set(True)
+    dlg._refresh()
+    assert ".secret.txt" in [e.name for e in dlg._rows.values()]
+
+
+def test_result_uses_forward_slashes_like_native(root, tmp_path):
+    # tkinter.filedialog returns forward-slash paths on every platform; the
+    # themed dialog must match so callers are agnostic to which drew it.
+    target = tmp_path / "doc.txt"
+    target.write_text("x")
+    dlg = _build(root, tmp_path, mode="open")
+    dlg._tree.selection_set(_iid_for(dlg, "doc.txt"))
+    dlg._on_select()
+    dlg._on_ok()
+    assert "\\" not in dlg._result
+    assert dlg._result == target.as_posix()
+
+
+def test_row_icon_swaps_on_selection(root, tmp_path):
+    # A selected row uses the selectfg-colored icon variant so it never blends
+    # into the neutral selection background; deselected rows revert.
+    (tmp_path / "a.txt").write_text("a")
+    dlg = _build(root, tmp_path, mode="open")
+    iid = _iid_for(dlg, "a.txt")
+
+    assert dlg._tree.item(iid, "image")[0] == str(dlg._file_img)
+    dlg._tree.selection_set(iid)
+    dlg._on_select()
+    assert dlg._tree.item(iid, "image")[0] == str(dlg._file_img_sel)
+    dlg._tree.selection_remove(iid)
+    dlg._on_select()
+    assert dlg._tree.item(iid, "image")[0] == str(dlg._file_img)
+
+
+def test_listing_uses_taller_scoped_rowheight(root, tmp_path):
+    # The dialog's rows are taller than the default flush treeview, via a
+    # dialog-scoped style that leaves the global Treeview untouched.
+    dlg = _build(root, tmp_path, mode="open")
+    style = root.style
+    scoped = int(style.lookup("Filedialog.Treeview", "rowheight"))
+    base = int(style.lookup("Treeview", "rowheight"))
+    assert scoped > base
+
+
+def test_multiple_open_returns_tuple(root, tmp_path):
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+    dlg = _build(root, tmp_path, mode="open", multiple=True)
+    dlg._tree.selection_set(_iid_for(dlg, "a.txt"), _iid_for(dlg, "b.txt"))
+    dlg._on_select()
+    dlg._on_ok()
+    assert dlg._result == ((tmp_path / "a.txt").as_posix(), (tmp_path / "b.txt").as_posix())


### PR DESCRIPTION
First of three PRs for #1242 — a theme-following file dialog that replaces Tk's unstyleable `tkfbox.tcl` chooser (whose central `IconList` is a hardcoded white Canvas, jarring on X11 in dark mode). Design brief: `development/2_1_file_dialog_design.md` (CONFIRMED).

## What this PR does

- **`dialogs/filedialog.py`** — a themed `FileDialog` reproducing tkfbox's layout with themed ttk widgets: a directory bar (path menu + up), a **`ttk.Treeview` details view** (Name / Size / Modified) in place of the white Canvas, and a filename/filetype/OK-Cancel form. All four modes: open one, open many, save as, choose directory. The listing/filter/navigation backend is **pure Python** (module-level, unit-testable without a display).
- **`Querybox.get_*` routing seam** — a keyword-only `native: bool | None` selector on the four file wrappers. **Native stays the default everywhere in this PR** (themed only when `native=False` is forced); PR 2 makes `None` platform-aware (themed by default on X11). Return contracts are unchanged.

## Findings from a live demo, baked in (each pinned by a test)

- **Icon vanished on selection** — the selection background is a neutral gray, and `secondary` *is* that gray in a light theme (contrast 1.0). A static icon color can't win in all four field-bg/select-bg × light/dark cases, so **row icons swap color with the selection state** (`selectfg` when selected).
- **Rows too short** — a dialog-scoped `Filedialog.Treeview` style bumps `rowheight` (inherits the themed colors; leaves other treeviews untouched).
- **Path parity** — `tkinter.filedialog` returns forward-slash paths on every platform; results go through `Path.as_posix()` so a caller sees the same string whichever dialog drew it.

## Routing matrix (target; `None` becomes X11-aware in PR 2)

| Platform | Default | `native=True` | `native=False` |
|---|---|---|---|
| X11 | themed (PR 2) | stdlib tkfbox | themed |
| Windows / macOS | native OS | native | themed |

## Testing

- `tests/test_filedialog_api.py` (+43): backend (filetype parse, glob coerce, hidden filter, listing, formatting), routing, all four modes, and the three findings above.
- Full suite: **881 passed**, 3 skipped.
- Interactive demo: `examples/themed_file_dialog.py`.

## Not in this PR

- **PR 2** — flip `native=None` to X11-default routing.
- **PR 3** — docs (Dialogs feature guide + `Querybox` reference + screenshots).

Refs #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)