### PR TITLE
Fix themed file dialog sizing + positioning on X11 (#1242)

### DIFF
--- a/src/ttkbootstrap/dialogs/filedialog.py
+++ b/src/ttkbootstrap/dialogs/filedialog.py
@@ -30,7 +30,11 @@ from ttkbootstrap.constants import *
 from ttkbootstrap.localization import MessageCatalog
 from ttkbootstrap.style import Assets
 from ttkbootstrap.style.engine import Style
-from ttkbootstrap.internal.positioning import center_on_parent, ensure_on_screen
+from ttkbootstrap.internal.positioning import (
+    center_on_parent,
+    center_on_screen,
+    ensure_on_screen,
+)
 from ttkbootstrap.utils import windowing_system
 from .message import Messagebox
 
@@ -289,14 +293,12 @@ class FileDialog:
         kwargs: dict = dict(
             transient=self._parent,
             title=self._title,
-            minsize=(480, 360),
             iconify=True,
         )
         if winsys != "win32":
             kwargs["window_type"] = "dialog"
         self._toplevel = ttk.Toplevel(**kwargs)
         self._toplevel.withdraw()  # reset the iconify state
-        self._toplevel.geometry("640x480")
         self._toplevel.protocol("WM_DELETE_WINDOW", self._cancel)
         self._toplevel.bind("<Escape>", lambda _: self._cancel())
 
@@ -326,6 +328,16 @@ class FileDialog:
         self._build_topbar(container)
         self._build_listing(container)
         self._build_form(container)
+
+        # Size from content, never a hardcoded height: platform font/padding
+        # differences (larger on X11) otherwise clip the bottom row. Open at a
+        # comfortable default but never smaller than the content needs, and don't
+        # let the window be shrunk to clip it.
+        self._toplevel.update_idletasks()
+        req_w = self._toplevel.winfo_reqwidth()
+        req_h = self._toplevel.winfo_reqheight()
+        self._toplevel.geometry(f"{max(640, req_w)}x{max(480, req_h)}")
+        self._toplevel.minsize(req_w, req_h)
 
     def _build_topbar(self, master: tkinter.Misc) -> None:
         bar = ttk.Frame(master)
@@ -606,11 +618,21 @@ class FileDialog:
         if position is not None:
             try:
                 x, y = ensure_on_screen(tl, *position)
-                tl.geometry(f"+{x}+{y}")
-                return
             except Exception:
-                pass
-        center_on_parent(tl, self._parent)
+                x, y = self._center()
+        else:
+            x, y = self._center()
+        # Apply the computed coordinates. Relying on the window manager to place
+        # a transient dialog works on Windows/macOS but not on X11, where an
+        # unplaced window lands at the virtual-desktop origin — between monitors
+        # on a multi-head setup.
+        tl.geometry(f"+{int(x)}+{int(y)}")
+
+    def _center(self) -> Tuple[int, int]:
+        """Coordinates that center the dialog over its parent (or the screen)."""
+        if self._parent is not None:
+            return center_on_parent(self._toplevel, self._parent)
+        return center_on_screen(self._toplevel)
 
 
 def _default_title(mode: str) -> str:

--- a/tests/test_filedialog_api.py
+++ b/tests/test_filedialog_api.py
@@ -389,6 +389,32 @@ def test_rowheight_not_captured_as_user_override(root, tmp_path):
     assert "Filedialog.Treeview" not in root.style._user_options
 
 
+def test_window_sizes_to_content_not_clipped(root, tmp_path):
+    # minsize is pinned to the content's requested size, so the window can never
+    # be shrunk to clip the bottom row -- the fix for the hardcoded-height clip
+    # that cut off the "show hidden" checkbutton where platform fonts run taller.
+    dlg = _build(root, tmp_path, mode="open")
+    tl = dlg._toplevel
+    tl.update_idletasks()
+    min_w, min_h = tl.wm_minsize()
+    assert min_h >= tl.winfo_reqheight()
+    assert min_h >= 300  # a real content height, not zero
+
+
+def test_locate_applies_center_over_parent(root, tmp_path):
+    # _locate must apply the centered coordinates, not rely on the window manager
+    # (which leaves an X11 transient at the virtual-desktop origin).
+    import re
+    from ttkbootstrap.internal.positioning import center_on_parent
+    dlg = _build(root, tmp_path, mode="open")
+    expected = center_on_parent(dlg._toplevel, root)
+    dlg._locate(None)
+    dlg._toplevel.update_idletasks()
+    m = re.search(r"\+(-?\d+)\+(-?\d+)$", dlg._toplevel.geometry())
+    assert m is not None
+    assert (int(m.group(1)), int(m.group(2))) == expected
+
+
 def test_multiple_open_returns_tuple(root, tmp_path):
     (tmp_path / "a.txt").write_text("a")
     (tmp_path / "b.txt").write_text("b")


### PR DESCRIPTION
Two cross-platform defects in the themed file dialog (#1242), found running it on **Linux**. These were committed just after #1306 had already merged, so they missed that merge — this PR lands them.

## Defects

1. **Bottom checkbutton clipped.** `_build` used a hardcoded `geometry("640x480")`. On X11 the larger fonts/padding (and the taller rows) push the form past 480px, cutting off the "Show hidden files" checkbutton. Now the window **sizes from content** — opens at a comfortable default but never smaller than `winfo_reqheight`, and pins `minsize` so it can't be shrunk to clip.

2. **Dialog opens between monitors.** `_locate` computed centered coordinates via `center_on_parent` but **never applied them** — it relied on the window manager to place the transient dialog. That works on Windows/macOS but not on X11, where an unplaced transient lands at the virtual-desktop origin (between monitors on a multi-head setup). Now the coordinates are applied explicitly (center on parent, or on screen when parentless).

## Note (latent)

The base `Dialog._locate` (dialogs/base.py) has the *same* unapplied-`center_on_parent` shape, so the other dialogs may mis-position on multi-monitor X11 too. Flagged for a separate pre-2.1 look — out of scope here.

## Testing

`tests/test_filedialog_api.py` +2 (minsize ≥ content height; `_locate` applies the centered coordinates). Full suite **889 passed**.

Refs #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)