### PR TITLE
Clamp the centered themed file dialog on-screen (#1242)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -939,16 +939,27 @@ DONE.** Optional post-release polish only from here.
 > them, so an X11 transient opened at the virtual-desktop origin (between
 > monitors) — now applies them explicitly. `tests/test_filedialog_api.py` totals
 > **51**. (Process note: a commit pushed to a PR branch *after* the PR is merged
-> does not land — verify the merge SHA includes your latest push.) **PR 3 (docs) BUILT**
-> on `docs/2.1-filedialog-guide`: rewrote the Dialogs-guide *File dialogs* section
-> (native-vs-themed + `native=`) + `Querybox` reference `native=` params + a themed
+> does not land — verify the merge SHA includes your latest push.) **PR 3 (docs)
+> MERGED (#1308):** rewrote the Dialogs-guide *File dialogs* section (native-vs
+> -themed + `native=`) + `Querybox` reference `native=` params + a themed
 > `dialogs-file` screenshot scene (light/dark, Windows-canonical capture — the
 > dialog body is platform-identical; a real-Linux recapture is an optional Track-B
-> follow-up). Docs build clean under `-W`. **NEXT:** open PR 3. **Two cross-platform
-> items the author flagged for SEPARATE pre-2.1 PRs** (NOT part of #1242): the
-> **menu border is missing on X11** (a themed-menu styling gap), and it's worth
-> checking whether the base `Dialog._locate` has the same *unapplied-coords*
-> multi-monitor bug the file dialog just fixed (the pattern looks identical).
+> follow-up). An adversarial `/review` of the #1307 fix found one MEDIUM defect,
+> fixed in **PR #1311 (OPEN at pause):** `_locate` clamped an explicit `position=`
+> through `ensure_on_screen` but applied the *centered* coords raw, so a parent
+> near a screen edge (or shorter than the ~480px dialog) could push the centered
+> dialog partly off-screen — now both paths are clamped. The review confirmed the
+> rest of #1307 sound and rated a ≤40px off-true-center (withdrawn-reqsize)
+> item cosmetic/won't-fix. **#1242 is COMPLETE and in `master`** (the design's
+> three PRs + two review-driven fixes); only #1311 awaits merge.
+> **Two cross-platform items filed as SEPARATE 2.1 issues** (NOT part of #1242,
+> found during this work): **#1309** — themed popup menu border missing on X11
+> (a `StyleBuilderTK` menu styling gap); **#1310** — base `Dialog._locate`
+> (`dialogs/base.py`) has the same *unapplied-`center_on_parent`-coords* bug the
+> file dialog just fixed, so Messagebox/Querybox/pickers may open between monitors
+> on multi-head X11. **NEXT (fresh session):** merge #1311; then #1309/#1310 are the
+> remaining pre-2.1 cross-platform cleanups. With #1242 done, 2.1 has **no open
+> feature work** — only these two polish issues.
 > **Housekeeping (prior session):** closed **#1224** (filedialog
 > white-on-white — subsumed by #1242; the dark-mode base-style half was already
 > fixed in #1239) and **#1252** (v1 empty/clearable DateEntry — superseded by

--- a/src/ttkbootstrap/dialogs/filedialog.py
+++ b/src/ttkbootstrap/dialogs/filedialog.py
@@ -615,13 +615,14 @@ class FileDialog:
     def _locate(self, position: Optional[Tuple[int, int]]) -> None:
         tl = self._toplevel
         tl.update_idletasks()
-        if position is not None:
-            try:
-                x, y = ensure_on_screen(tl, *position)
-            except Exception:
-                x, y = self._center()
-        else:
-            x, y = self._center()
+        x, y = position if position is not None else self._center()
+        # Clamp both paths on-screen: a parent near a screen edge (or shorter than
+        # the dialog) can otherwise push a centered dialog partly off-screen, which
+        # would defeat the content-sizing above by hiding the bottom controls.
+        try:
+            x, y = ensure_on_screen(tl, x, y)
+        except Exception:
+            pass
         # Apply the computed coordinates. Relying on the window manager to place
         # a transient dialog works on Windows/macOS but not on X11, where an
         # unplaced window lands at the virtual-desktop origin — between monitors

--- a/tests/test_filedialog_api.py
+++ b/tests/test_filedialog_api.py
@@ -403,16 +403,30 @@ def test_window_sizes_to_content_not_clipped(root, tmp_path):
 
 def test_locate_applies_center_over_parent(root, tmp_path):
     # _locate must apply the centered coordinates, not rely on the window manager
-    # (which leaves an X11 transient at the virtual-desktop origin).
+    # (which leaves an X11 transient at the virtual-desktop origin). The centered
+    # result is also clamped on-screen, so compare against the clamped value.
     import re
-    from ttkbootstrap.internal.positioning import center_on_parent
+    from ttkbootstrap.internal.positioning import center_on_parent, ensure_on_screen
     dlg = _build(root, tmp_path, mode="open")
-    expected = center_on_parent(dlg._toplevel, root)
+    cx, cy = center_on_parent(dlg._toplevel, root)
+    expected = ensure_on_screen(dlg._toplevel, cx, cy)
     dlg._locate(None)
     dlg._toplevel.update_idletasks()
     m = re.search(r"\+(-?\d+)\+(-?\d+)$", dlg._toplevel.geometry())
     assert m is not None
     assert (int(m.group(1)), int(m.group(2))) == expected
+
+
+def test_locate_clamps_offscreen_position(root, tmp_path):
+    # An explicit position that would put the dialog off-screen is pulled back,
+    # so the bottom controls can't be pushed off the edge.
+    import re
+    dlg = _build(root, tmp_path, mode="open")
+    dlg._locate((-5000, -5000))
+    dlg._toplevel.update_idletasks()
+    m = re.search(r"\+(-?\d+)\+(-?\d+)$", dlg._toplevel.geometry())
+    x, y = int(m.group(1)), int(m.group(2))
+    assert x > -5000 and y > -5000
 
 
 def test_multiple_open_returns_tuple(root, tmp_path):


### PR DESCRIPTION
Follow-up from an adversarial review of #1307 (the X11 sizing/positioning fix).

## The defect

`_locate` clamped an explicit `position=` argument through `ensure_on_screen`, but applied the **centered** coordinates raw. `center_on_parent` returns `parent_origin + offset` with no on-screen clamp, and when the dialog is taller than its parent the vertical offset is `0` — so the ~480px dialog pins to the parent's top-left and extends downward. If the parent sits low/right on its monitor, the bottom controls (OK / Cancel / "Show hidden files") get pushed off-screen — re-introducing exactly what the content-sizing half of #1307 set out to prevent.

## The fix

Route **both** paths (explicit position and centered) through `ensure_on_screen`, so a centered dialog near a screen edge is pulled back on-screen.

## Testing

- Updated `test_locate_applies_center_over_parent` to expect the clamped value.
- Added `test_locate_clamps_offscreen_position` (an off-screen request is pulled back).
- Full suite **890 passed**.

## Review notes

The same review confirmed the rest of #1307 is sound (the `_build`-before-`_navigate` ordering is safe; the `geometry` size/position split is correct) and rated one remaining item — centering uses the withdrawn window's requested size, so it can be ≤40px off true center — as cosmetic/won't-fix.

Refs #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)