### PR TITLE
Keep dialogs on one monitor when centering (#1310)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -957,13 +957,101 @@ DONE.** Optional post-release polish only from here.
 > (a `StyleBuilderTK` menu styling gap); **#1310** — base `Dialog._locate`
 > (`dialogs/base.py`) has the same *unapplied-`center_on_parent`-coords* bug the
 > file dialog just fixed, so Messagebox/Querybox/pickers may open between monitors
-> on multi-head X11. **NEXT (fresh session):** merge #1311; then #1309/#1310 are the
-> remaining pre-2.1 cross-platform cleanups. With #1242 done, 2.1 has **no open
-> feature work** — only these two polish issues.
+s> on multi-head X11. #1311 has since **MERGED** (`c882c3db`).
 > **Housekeeping (prior session):** closed **#1224** (filedialog
 > white-on-white — subsumed by #1242; the dark-mode base-style half was already
 > fixed in #1239) and **#1252** (v1 empty/clearable DateEntry — superseded by
 > shipped #1253 + 3.0 #1276).
+>
+> **Session 2026-07-27 — pre-release cleanup audit + the two bug fixes it and
+> #1310 called for. TWO PRs OPEN at pause: #1312 (dialog positioning) and #1313
+> (`color_to_rgb`).** A "what's left before 2.1" sweep found the repo green
+> (suite 890, docs clean) and produced the punch list below; the author then
+> asked for the bugs fixed.
+>
+> **#1313 (`fix/2.1-color-to-rgb-raises`, OPEN)** — `color_to_rgb`, a public
+> export, swallowed every parse error with a bare `except`, printed the debug
+> string `this` to stdout, and returned `None`. All five callers unpack into
+> `r, g, b`, so a bad color surfaced as *"cannot unpack non-iterable NoneType"*
+> naming neither the color nor the model. Now raises `ValueError` naming the
+> value, chaining the PIL error. Not a new crash path in the color chooser —
+> `on_entry_value_change` calls `widget.validate()` first. +5 tests.
+>
+> **#1312 (`fix/2.1-dialog-centering-multihead`, OPEN)** — fixes **#1310**, but
+> **the issue's filed premise was wrong**: base `Dialog._locate` *did* apply its
+> coordinates. The actual cause is that there are **two same-named
+> `center_on_parent` functions with opposite contracts** —
+> `internal/positioning.py` (pure, *returns* coords; used by datepicker +
+> filedialog) and `internal/utility.py` (*applies* geometry, no clamp) — and
+> `dialogs/base.py` was the last caller of the legacy one. Three defects, only
+> the first visible off X11: (a) it measured the dialog with
+> `winfo_width() or winfo_reqwidth()`, but **a dialog is withdrawn when it is
+> positioned and an unmapped window reports width 1 — which is truthy**, so the
+> fallback never ran and it centered a **1×1 box** (proven: the legacy helper
+> applies `1x1+393+416`); (b) it re-applied a `WxH` size along with the offset;
+> (c) it never clamped onto a monitor. `_locate` now runs the same
+> center → clamp → apply sequence as the file dialog. The legacy helper **stays**
+> — still reachable through the deprecated `ttkbootstrap.utility` shim until 3.0
+> — with a docstring saying which of the two first-party code uses.
+>
+> **Then a `/review` of the merged #1311 found a real MEDIUM defect that this
+> branch's fix shared, so it was folded in.** Both dialogs position while
+> withdrawn, so `_window_size` falls back to the **content request — not the size
+> the window will have**: FileDialog clamped against 578×445 but maps at 640×480
+> (the `_build` floor); MessageDialog clamped against 122×102 but maps at 250×102
+> (the `minsize` floor). Under-clamping left the right-hand column — the OK/Cancel
+> buttons — past the screen edge, on the `position=None` path every
+> `Querybox.get_*` wrapper uses. Fix: an optional **`size=` override** on
+> `center_on_screen`/`center_on_parent`/`ensure_on_screen`; base `Dialog` derives
+> a `_footprint()` from the minsize floor, `FileDialog` records the geometry
+> `_build` applies. The review's two LOW findings also landed: #1311 had moved the
+> `position` unpack outside the `try`, so `show(position=(1,2,3))` raised instead
+> of centering; and its off-screen test asserted only that the result *moved*.
+>
+> **Then the author pushed back on "we can't know the monitor layout without
+> `screeninfo`" — correctly, and the claim was wrong twice.** First for Windows
+> (Tk reports the primary screen and the virtual desktop as *different* numbers,
+> and the difference derives the grid — verified: it reproduces `screeninfo`'s
+> answer exactly). Then, more importantly, in general: **Tk exposes no monitor
+> enumeration on ANY platform, but the X server does.** `XineramaQueryScreens`
+> returns the count and every monitor's `x/y/w/h` in one call. So
+> `internal/positioning.py` now resolves the layout **screeninfo → X11 Xinerama
+> via ctypes → Tk vroot**, matching how the library already reaches Windows' DPI
+> and shell APIs (**the library has never used `subprocess`** — ctypes is the
+> house pattern; don't shell out to `xrandr`). The query is skipped off X11,
+> caches its own unavailability, and cannot raise. **Windows/macOS unchanged**;
+> macOS multi-monitor still needs `screeninfo` (`CGGetActiveDisplayList` is a
+> separate, undecided call). Suite **904**, and re-run with `screeninfo` forced
+> off (136) so the fallback path is exercised.
+>
+> **KEY FACT to keep (why any of this is needed):** on X11 `winfo screenwidth`
+> reports the **union of every display**, and `winfo vrootwidth` falls back to
+> that same value unless a virtual-root WM is running (nothing modern sets
+> `__SWM_VROOT`). So Tk's own metrics can never locate a monitor seam on X11 —
+> which is exactly why a clamp against them let a dialog straddle two screens.
+> Windows differs: `winfo screenwidth` is the primary monitor, `winfo vrootwidth`
+> the virtual desktop.
+>
+> **VERIFICATION IS OUTSTANDING — do not merge #1312 blind.** New
+> **`tools/verify_positioning.py`** prints a PASS/FAIL line per check plus the raw
+> metrics; **Windows is done (4/4, Tk 8.6.15, dual 2560×1440)**, X11 and macOS are
+> not. Full instructions are in a comment on **#1310**. The two checks that matter:
+> on **X11**, run it *twice* — the second time with `screeninfo` uninstalled, since
+> that is the only way to exercise the new Xinerama path; on **macOS**, check 3
+> (mapped size vs. the footprint we clamp against) is unverified and aqua chrome
+> could differ, as #1147 already caught once — plus a **Tk 9** run via
+> `/opt/homebrew/bin/python3.14`, since 9.0 moved the aqua scaling baseline.
+>
+> **NEXT — the rest of the pre-2.1 punch list** (from the audit; none started):
+> **bump `pyproject.toml` 2.0.0 → 2.1.0** (the only hardcoded version);
+> **close #1242** (complete in `master`); **#1309** (X11 menu border) is the last
+> open feature-ish issue; **prune 10 stale local branches** (8 show merged, and
+> `feat/2.1-filedialog-x11-default` / `fix/2.1-filedialog-center-clamp` only look
+> unmerged because they were squash-merged — their content is on `master`,
+> verified); **delete `development/filedialogs/` (18 files) + `scrolledframe/`**
+> (prior art now superseded by shipped code — the #1250 precedent); and a **Tk 9
+> run on the Mac** for the 2.1 geometry/asset work generally. `2_1_changes.md` was
+> checked complete against the merged PR list before any of this.
 >
 > **User-visible 2.1 changes are logged in `development/2_1_changes.md`** (the
 > running log, same role `2_0_breaking_changes.md` played for 2.0; it is the source
@@ -1238,7 +1326,11 @@ A virtualenv with an editable install lives at `.venv/` (Python 3.x on macOS;
   they are NOT collected by pytest.
 - Build docs: `python -m sphinx -b html -W -q -E docs <out>` (must exit 0 — the
   docs are kept warning-clean; RTD enforces `fail_on_warning`). Deps in
-  `docs/requirements.txt`. On this box use `.venv-home/Scripts/python.exe`.
+  `docs/requirements.txt`. **`.venv-home` belongs to the author's other Windows
+  profile** (its base interpreter lives under `C:\Users\Israel Dryer\...`), so it
+  is unusable from the `Logistiview` profile — the docs deps were installed into
+  `.venv` there on 2026-07-27. Use whichever venv matches the profile you are on;
+  neither is stale.
 
 ### Writing tests
 

--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -241,6 +241,12 @@ visible on Windows/macOS:
 - It never clamped the result onto a monitor. Windows and macOS window managers
   nudge a stray transient back on-screen; X11 does not.
 
+Centering and clamping now measure the size the dialog will actually have once
+mapped — its content request raised to the `minsize` floor the dialog pins. For a
+short message that floor is over 100px wider than the content asks for, and
+clamping against the smaller number leaves the dialog's right edge, where the
+buttons are, past the screen edge.
+
 The dialogs now use the same `internal.positioning` helpers (and the same
 center → clamp → apply order) the themed file dialog was fixed onto in 2.1, so
 all of the shipped dialogs place identically.

--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -26,6 +26,7 @@
 | **`DateEntry(value=…)` — a nullable, clearable date field** | New | this doc, below |
 | **Bootstyle value tokens — raw hex + ramp accents & surfaces** | New | this doc, below |
 | **Themed file dialog — a theme-following open/save chooser** | New | this doc, below |
+| **Dialogs stay on one monitor on multi-head Linux** | Fix | this doc, below |
 
 There are **no API breaks in 2.1**: nothing was removed, and no call that worked
 in 2.0.0 fails. One change is visually noticeable without any code change (the
@@ -217,3 +218,32 @@ dialog replaces it there. Addresses #1242.
 
 **Scope note.** Deliberately minimal (no bookmarks/places sidebar) — matching Tk's
 chooser; a sidebar is a later enhancement.
+
+---
+
+## Dialogs stay on one monitor on multi-head Linux  *(Fix)*
+
+**What.** `Messagebox`, `Querybox`, the date picker and the other shipped dialogs
+are now centered on their parent and clamped onto that parent's monitor. On a
+multi-monitor Linux (X11) desktop they could previously open straddling the seam
+between two screens, or offset down-right of where they belonged.
+
+**Why.** The base `Dialog` still used an older centering helper that predates the
+2.0 positioning work. Three things went wrong with it, and only the first is
+visible on Windows/macOS:
+
+- It read the dialog's size with `winfo_width() or winfo_reqwidth()`. A dialog is
+  still withdrawn when it is positioned, and an unmapped window reports a width
+  of **1** — which is truthy, so the fallback never ran. It centered a 1x1 box,
+  putting the dialog's top-left where its center belonged.
+- It re-applied a `WxH` size along with the offset, so positioning could resize a
+  dialog `build()` had already sized correctly.
+- It never clamped the result onto a monitor. Windows and macOS window managers
+  nudge a stray transient back on-screen; X11 does not.
+
+The dialogs now use the same `internal.positioning` helpers (and the same
+center → clamp → apply order) the themed file dialog was fixed onto in 2.1, so
+all of the shipped dialogs place identically.
+
+**Scope.** Positioning only — no signature, no return value, and no appearance
+change. An explicit `position=` was already clamped and is unaffected.

--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -254,10 +254,10 @@ all of the shipped dialogs place identically.
 **Scope.** Positioning only — no signature, no return value, and no appearance
 change. An explicit `position=` was already clamped and is unaffected.
 
-**Which screen a dialog is held on still depends on the optional `screeninfo`
-package.** With it installed, a dialog is clamped inside the monitor it opens on.
-Without it, `winfo_vroot*` reports one combined desktop spanning every monitor
-(on Windows and on X11 with Xinerama alike), so a dialog whose parent straddles
-the join between two screens is left straddling it. Centering is corrected either
-way — that half needs no monitor awareness — so the common case of a parent
-sitting on one screen is fixed regardless.
+**Multi-monitor placement no longer needs the optional `screeninfo` package on
+Linux.** Tk has no monitor enumeration on any platform — `winfo screenwidth` on
+X11 reports the union of every display — so the layout is now read from X11's
+Xinerama extension directly when `screeninfo` is not installed. A dialog is
+clamped inside the monitor it opens on instead of merely inside the combined
+desktop, which is what let one straddle the join between two screens.
+`screeninfo` is still used first when present, and Windows/macOS are unchanged.

--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -253,3 +253,11 @@ all of the shipped dialogs place identically.
 
 **Scope.** Positioning only — no signature, no return value, and no appearance
 change. An explicit `position=` was already clamped and is unaffected.
+
+**Which screen a dialog is held on still depends on the optional `screeninfo`
+package.** With it installed, a dialog is clamped inside the monitor it opens on.
+Without it, `winfo_vroot*` reports one combined desktop spanning every monitor
+(on Windows and on X11 with Xinerama alike), so a dialog whose parent straddles
+the join between two screens is left straddling it. Centering is corrected either
+way — that half needs no monitor awareness — so the common case of a parent
+sitting on one screen is fixed regardless.

--- a/docs/user-guide/feature-guides/dialogs.rst
+++ b/docs/user-guide/feature-guides/dialogs.rst
@@ -330,15 +330,8 @@ should appear next to the widget that opened it:
 
    dialog.show(position=(event.x_root, event.y_root))
 
-Either way the dialog is kept fully on screen.
-
-.. note::
-
-   Which screen it is kept on depends on the optional ``screeninfo`` package. With
-   it installed, a dialog is held inside the monitor it opens on; without it,
-   ttkbootstrap can only see one combined desktop, so on a multi-monitor setup a
-   dialog whose parent sits near the join between two screens can span both. See
-   :doc:`../getting-started/installation`.
+Either way the dialog is kept fully on screen, and on a multi-monitor setup it is
+held inside the monitor it opens on rather than spanning the join between two.
 
 **Run it without blocking.** Pass a ``command`` — a plain zero-argument callable
 run when a button is pressed — and show it with ``wait_for_result=False``. The

--- a/docs/user-guide/feature-guides/dialogs.rst
+++ b/docs/user-guide/feature-guides/dialogs.rst
@@ -330,6 +330,16 @@ should appear next to the widget that opened it:
 
    dialog.show(position=(event.x_root, event.y_root))
 
+Either way the dialog is kept fully on screen.
+
+.. note::
+
+   Which screen it is kept on depends on the optional ``screeninfo`` package. With
+   it installed, a dialog is held inside the monitor it opens on; without it,
+   ttkbootstrap can only see one combined desktop, so on a multi-monitor setup a
+   dialog whose parent sits near the join between two screens can span both. See
+   :doc:`../getting-started/installation`.
+
 **Run it without blocking.** Pass a ``command`` — a plain zero-argument callable
 run when a button is pressed — and show it with ``wait_for_result=False``. The
 call returns immediately and your callback fires when the user answers, which

--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -9,8 +9,11 @@ from tkinter import BaseWidget
 from typing import Any, Optional, Tuple
 
 import ttkbootstrap as ttk
-from ttkbootstrap.internal.utility import center_on_parent
-from ttkbootstrap.internal.positioning import ensure_on_screen
+from ttkbootstrap.internal.positioning import (
+    center_on_parent,
+    center_on_screen,
+    ensure_on_screen,
+)
 from ttkbootstrap.utils import windowing_system
 
 
@@ -43,9 +46,29 @@ class Dialog(BaseWidget):
         self._alert = alert
         self._initial_focus = None
 
+    def _center(self) -> Tuple[int, int]:
+        """Coordinates that center the dialog over its parent (or the screen)."""
+        parent = self._parent if self._parent is not None else self.master
+        if parent is not None:
+            return center_on_parent(self._toplevel, parent)
+        return center_on_screen(self._toplevel)
+
     def _locate(self) -> None:
+        """Center the dialog on its parent, clamped onto that monitor.
+
+        The coordinates are applied explicitly. Leaving a transient dialog to the
+        window manager works on Windows/macOS but not on X11, where an unplaced
+        window lands at the virtual-desktop origin -- between monitors on a
+        multi-head setup.
+        """
         toplevel = self._toplevel
-        center_on_parent(toplevel, self._parent)
+        toplevel.update_idletasks()
+        x, y = self._center()
+        try:
+            x, y = ensure_on_screen(toplevel, x, y)
+        except Exception:
+            pass
+        toplevel.geometry(f"+{int(x)}+{int(y)}")
 
     def show(self, position: Optional[Tuple[int, int]] = None, wait_for_result: bool = True) -> None:
         """Show the popup dialog.

--- a/src/ttkbootstrap/dialogs/base.py
+++ b/src/ttkbootstrap/dialogs/base.py
@@ -46,12 +46,27 @@ class Dialog(BaseWidget):
         self._alert = alert
         self._initial_focus = None
 
+    def _footprint(self) -> Tuple[int, int]:
+        """The size the dialog occupies once mapped.
+
+        A dialog is still withdrawn when it is positioned, so it has no realized
+        size and its *requested* size ignores the `minsize` floor `build` pins --
+        measuring that instead centers and clamps a smaller window than the one
+        the user sees.
+        """
+        toplevel = self._toplevel
+        min_width, min_height = toplevel.wm_minsize()
+        return (
+            max(toplevel.winfo_reqwidth(), min_width),
+            max(toplevel.winfo_reqheight(), min_height),
+        )
+
     def _center(self) -> Tuple[int, int]:
         """Coordinates that center the dialog over its parent (or the screen)."""
         parent = self._parent if self._parent is not None else self.master
         if parent is not None:
-            return center_on_parent(self._toplevel, parent)
-        return center_on_screen(self._toplevel)
+            return center_on_parent(self._toplevel, parent, size=self._footprint())
+        return center_on_screen(self._toplevel, size=self._footprint())
 
     def _locate(self) -> None:
         """Center the dialog on its parent, clamped onto that monitor.
@@ -65,7 +80,7 @@ class Dialog(BaseWidget):
         toplevel.update_idletasks()
         x, y = self._center()
         try:
-            x, y = ensure_on_screen(toplevel, x, y)
+            x, y = ensure_on_screen(toplevel, x, y, size=self._footprint())
         except Exception:
             pass
         toplevel.geometry(f"+{int(x)}+{int(y)}")
@@ -93,7 +108,7 @@ class Dialog(BaseWidget):
                 x, y = position
                 # Clamp so an explicit position near a screen edge doesn't push
                 # the dialog partly (or fully) off-screen.
-                x, y = ensure_on_screen(self._toplevel, x, y)
+                x, y = ensure_on_screen(self._toplevel, x, y, size=self._footprint())
                 self._toplevel.geometry(f'+{x}+{y}')
             except Exception:
                 self._locate()

--- a/src/ttkbootstrap/dialogs/filedialog.py
+++ b/src/ttkbootstrap/dialogs/filedialog.py
@@ -266,6 +266,8 @@ class FileDialog:
         self._current_globs: Tuple[str, ...] = ("*",)
         self._rows: dict = {}
         self._toplevel: Optional[tkinter.Toplevel] = None
+        # the size _build applies; positioning measures this, not the content
+        self._footprint: Optional[Tuple[int, int]] = None
 
     # -- public ------------------------------------------------------------
 
@@ -336,7 +338,11 @@ class FileDialog:
         self._toplevel.update_idletasks()
         req_w = self._toplevel.winfo_reqwidth()
         req_h = self._toplevel.winfo_reqheight()
-        self._toplevel.geometry(f"{max(640, req_w)}x{max(480, req_h)}")
+        # Remember the size actually applied: the window is still withdrawn when
+        # it is positioned, and this floor does not reach winfo_reqwidth, so
+        # centering and clamping would measure the smaller content size.
+        self._footprint = (max(640, req_w), max(480, req_h))
+        self._toplevel.geometry(f"{self._footprint[0]}x{self._footprint[1]}")
         self._toplevel.minsize(req_w, req_h)
 
     def _build_topbar(self, master: tkinter.Misc) -> None:
@@ -615,12 +621,15 @@ class FileDialog:
     def _locate(self, position: Optional[Tuple[int, int]]) -> None:
         tl = self._toplevel
         tl.update_idletasks()
-        x, y = position if position is not None else self._center()
+        try:
+            x, y = position if position is not None else self._center()
+        except (TypeError, ValueError):
+            x, y = self._center()  # a malformed position falls back to centering
         # Clamp both paths on-screen: a parent near a screen edge (or shorter than
         # the dialog) can otherwise push a centered dialog partly off-screen, which
         # would defeat the content-sizing above by hiding the bottom controls.
         try:
-            x, y = ensure_on_screen(tl, x, y)
+            x, y = ensure_on_screen(tl, x, y, size=self._footprint)
         except Exception:
             pass
         # Apply the computed coordinates. Relying on the window manager to place
@@ -632,8 +641,8 @@ class FileDialog:
     def _center(self) -> Tuple[int, int]:
         """Coordinates that center the dialog over its parent (or the screen)."""
         if self._parent is not None:
-            return center_on_parent(self._toplevel, self._parent)
-        return center_on_screen(self._toplevel)
+            return center_on_parent(self._toplevel, self._parent, size=self._footprint)
+        return center_on_screen(self._toplevel, size=self._footprint)
 
 
 def _default_title(mode: str) -> str:

--- a/src/ttkbootstrap/internal/positioning.py
+++ b/src/ttkbootstrap/internal/positioning.py
@@ -6,15 +6,21 @@ mechanisms ``Window``/``Toplevel`` and the dialogs need: center-on-screen,
 center-on-parent, and clamp-into-the-visible-monitor. Each is a pure geometry
 calculation returning ``(x, y)``; the caller applies the geometry string.
 
-Multi-monitor awareness is optional: if the third-party ``screeninfo`` package
-is importable we resolve the monitor under a point, otherwise we fall back to
-Tk's virtual-root dimensions (single logical screen). No new hard dependency —
-Pillow stays the only required runtime dep.
+Multi-monitor awareness comes from whichever source can answer, in order: the
+third-party ``screeninfo`` package when it is installed, then X11's Xinerama
+extension queried directly, then Tk's virtual-root dimensions (one logical
+screen). No new hard dependency — Pillow stays the only required runtime dep.
+
+Tk itself has no monitor enumeration on any platform: ``winfo screenwidth`` on
+X11 reports the union of every display, and ``winfo vrootwidth`` falls back to
+that same value unless a virtual-root window manager is running. The layout has
+to come from the platform.
 """
 from __future__ import annotations
 
+import sys
 import tkinter
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 try:
     from screeninfo import get_monitors  # type: ignore
@@ -24,27 +30,121 @@ except Exception:  # pragma: no cover - screeninfo is an optional extra
 
 Rect = Tuple[int, int, int, int]  # (x, y, width, height)
 
+# set once a Xinerama query has proved impossible, so we don't reload libraries
+# on every placement
+_XINERAMA_UNAVAILABLE = False
+
+
+def _load_library(name: str):  # pragma: no cover - X11 only
+    """Load a shared library by short name, or return None."""
+    import ctypes
+    import ctypes.util
+
+    candidates = (
+        ctypes.util.find_library(name),
+        f"lib{name}.so.6",
+        f"lib{name}.so.1",
+        f"lib{name}.so",
+    )
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            return ctypes.CDLL(candidate)
+        except OSError:
+            continue
+    return None
+
+
+def _xinerama_monitors() -> Optional[List[Rect]]:  # pragma: no cover - X11 only
+    """Monitor rects from X11's Xinerama extension, or None when unavailable.
+
+    Asks the X server directly, the way ``screeninfo`` does, so multi-monitor
+    placement works on a plain install. ctypes into a platform library is how
+    the rest of the library reaches Windows' DPI and shell APIs.
+    """
+    global _XINERAMA_UNAVAILABLE
+    if _XINERAMA_UNAVAILABLE or sys.platform in ("win32", "darwin", "cygwin"):
+        return None
+    try:
+        import ctypes
+
+        class _XineramaScreenInfo(ctypes.Structure):
+            _fields_ = [
+                ("screen_number", ctypes.c_int),
+                ("x", ctypes.c_short),
+                ("y", ctypes.c_short),
+                ("width", ctypes.c_short),
+                ("height", ctypes.c_short),
+            ]
+
+        xlib = _load_library("X11")
+        xinerama = _load_library("Xinerama")
+        if xlib is None or xinerama is None:
+            _XINERAMA_UNAVAILABLE = True
+            return None
+
+        xlib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+        xlib.XOpenDisplay.restype = ctypes.POINTER(ctypes.c_void_p)
+        xlib.XFree.argtypes = [ctypes.c_void_p]
+        xlib.XFree.restype = None
+
+        display = xlib.XOpenDisplay(b"")
+        if not display:
+            _XINERAMA_UNAVAILABLE = True
+            return None
+        try:
+            if not xinerama.XineramaIsActive(display):
+                # a single-head server answers no query; Tk's screen metrics are
+                # already correct there
+                _XINERAMA_UNAVAILABLE = True
+                return None
+            count = ctypes.c_int()
+            xinerama.XineramaQueryScreens.restype = ctypes.POINTER(_XineramaScreenInfo)
+            infos = xinerama.XineramaQueryScreens(display, ctypes.byref(count))
+            if not infos or count.value <= 0:
+                return None
+            try:
+                screens = ctypes.cast(
+                    infos, ctypes.POINTER(_XineramaScreenInfo * count.value)
+                ).contents
+                return [(s.x, s.y, s.width, s.height) for s in screens]
+            finally:
+                xlib.XFree(infos)
+        finally:
+            xlib.XCloseDisplay(display)
+    except Exception:
+        _XINERAMA_UNAVAILABLE = True
+        return None
+
+
+def _monitors() -> Optional[List[Rect]]:
+    """Every monitor's bounds, or None when the layout can't be determined."""
+    if _HAS_SCREENINFO:
+        try:
+            monitors = [(m.x, m.y, m.width, m.height) for m in get_monitors()]
+            if monitors:
+                return monitors
+        except Exception:
+            pass  # fall through to Xinerama rather than give up
+    return _xinerama_monitors()
+
 
 def _monitor_at_point(x: int, y: int) -> Optional[Rect]:
     """Return the ``(x, y, w, h)`` bounds of the monitor containing a point.
 
-    Returns ``None`` when ``screeninfo`` is unavailable so callers fall back to
-    Tk's screen/virtual-root metrics. When ``screeninfo`` is present but the
+    Returns ``None`` when no source can describe the layout, so callers fall
+    back to Tk's screen/virtual-root metrics. When the layout is known but the
     point is on no monitor, the first monitor is returned as a sane default.
     """
-    if not _HAS_SCREENINFO:
+    monitors = _monitors()
+    if not monitors:
         return None
-    try:
-        monitors = get_monitors()
-        for m in monitors:
-            if m.x <= x < m.x + m.width and m.y <= y < m.y + m.height:
-                return (m.x, m.y, m.width, m.height)
-        if monitors:
-            m = monitors[0]
-            return (m.x, m.y, m.width, m.height)
-    except Exception:
-        pass
-    return None
+    for rect in monitors:
+        mx, my, mw, mh = rect
+        if mx <= x < mx + mw and my <= y < my + mh:
+            return rect
+    return monitors[0]
 
 
 def _window_size(window: tkinter.Misc) -> Tuple[int, int]:

--- a/src/ttkbootstrap/internal/positioning.py
+++ b/src/ttkbootstrap/internal/positioning.py
@@ -63,7 +63,10 @@ def _window_size(window: tkinter.Misc) -> Tuple[int, int]:
     return window.winfo_reqwidth(), window.winfo_reqheight()
 
 
-def center_on_screen(window: tkinter.Misc) -> Tuple[int, int]:
+def center_on_screen(
+        window: tkinter.Misc,
+        size: Optional[Tuple[int, int]] = None,
+) -> Tuple[int, int]:
     """Coordinates that center ``window`` on the screen.
 
     With ``screeninfo`` installed, centers on the monitor under the mouse
@@ -73,10 +76,11 @@ def center_on_screen(window: tkinter.Misc) -> Tuple[int, int]:
     have a negative origin (e.g. a screen to the left of the primary), and a
     window larger than the monitor is pinned to its top-left rather than
     overflowing. Call ``update_idletasks()`` first for an accurate size — this
-    method does so as well.
+    method does so as well. ``size`` overrides the measured size for a window
+    that is not mapped yet (see :func:`center_on_parent`).
     """
     window.update_idletasks()
-    w_width, w_height = _window_size(window)
+    w_width, w_height = size if size is not None else _window_size(window)
     monitor = _monitor_at_point(window.winfo_pointerx(), window.winfo_pointery())
     if monitor:
         mx, my, mw, mh = monitor
@@ -93,11 +97,21 @@ def center_on_screen(window: tkinter.Misc) -> Tuple[int, int]:
     return int(x), int(y)
 
 
-def center_on_parent(window: tkinter.Misc, parent: tkinter.Misc) -> Tuple[int, int]:
-    """Coordinates (in screen space) that center ``window`` over ``parent``."""
+def center_on_parent(
+        window: tkinter.Misc,
+        parent: tkinter.Misc,
+        size: Optional[Tuple[int, int]] = None,
+) -> Tuple[int, int]:
+    """Coordinates (in screen space) that center ``window`` over ``parent``.
+
+    Pass ``size`` when the caller has just sized a window that is not mapped yet:
+    a floor applied through ``wm geometry`` or ``wm minsize`` does not reach
+    ``winfo_reqwidth``, so :func:`_window_size` would measure a smaller window
+    than the one the user ends up seeing.
+    """
     window.update_idletasks()
     parent.update_idletasks()
-    w_width, w_height = _window_size(window)
+    w_width, w_height = size if size is not None else _window_size(window)
     p_x = parent.winfo_rootx()
     p_y = parent.winfo_rooty()
     # actual occupied size, not the inflated content request (see _window_size)
@@ -157,6 +171,7 @@ def ensure_on_screen(
         y: int,
         padding: int = 20,
         titlebar_height: int = 60,
+        size: Optional[Tuple[int, int]] = None,
 ) -> Tuple[int, int]:
     """Clamp ``(x, y)`` so the window stays fully visible on its monitor.
 
@@ -165,9 +180,13 @@ def ensure_on_screen(
     on-screen. Uses the ``screeninfo`` monitor under the proposed point when
     available (so a window that legitimately belongs on a secondary monitor is
     not yanked back to the primary), else Tk's virtual-root bounds.
+
+    ``size`` overrides the measured size, for a window that is not mapped yet --
+    see :func:`center_on_parent`. Clamping against too small a size
+    under-corrects and leaves the window's far edge off-screen.
     """
     window.update_idletasks()
-    w_width, w_height = _window_size(window)
+    w_width, w_height = size if size is not None else _window_size(window)
 
     monitor = _monitor_at_point(x, y)
     if monitor:

--- a/src/ttkbootstrap/internal/utility.py
+++ b/src/ttkbootstrap/internal/utility.py
@@ -24,7 +24,14 @@ def get_image_name(image):
 
 
 def center_on_parent(win, parent=None):
-    """Center `win` on parent or over its master if not given"""
+    """Center `win` on parent or over its master if not given.
+
+    Legacy variant, kept reachable only through the deprecated
+    `ttkbootstrap.utility` shim (removed in 3.0): it applies the geometry itself
+    and does not clamp the result onto a monitor. First-party code uses the
+    same-named `ttkbootstrap.internal.positioning.center_on_parent`, which
+    returns coordinates for the caller to clamp and apply.
+    """
     win.update_idletasks()  # ensure geometry
     if parent is None:
         parent = getattr(win, 'master', None) or win  # root if no parent

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -316,11 +316,38 @@ def _built_dialog(root, message="hello", **kwargs):
     return dlg
 
 
-def _applied_position(dialog):
+def _locate_and_capture(dialog, *args):
+    """Run `_locate` and return the (x, y) it applied.
+
+    Record the call instead of reading `geometry()` back afterwards: on X11 the
+    readback is not the position that was just requested. A dialog is withdrawn
+    while it is positioned, and an unmapped window reports the placement the
+    window manager has in mind rather than the request (probed under XWayland:
+    a dialog asked for +4460+20 reads back +32+32); once mapped it tracks the
+    frame, not the client. What these tests are about is whether `_locate`
+    applies coordinates at all.
+    """
     import re
-    dialog._toplevel.update_idletasks()
-    m = re.search(r"\+(-?\d+)\+(-?\d+)$", dialog._toplevel.geometry())
-    assert m is not None, "no +x+y in the applied geometry"
+
+    toplevel = dialog._toplevel
+    applied = []
+    real = toplevel.geometry
+
+    def spy(spec=None):
+        # Only a set call carries a spec; a query would append None and break
+        # the parse below.
+        if spec is not None:
+            applied.append(spec)
+        return real(spec)
+
+    toplevel.geometry = spy
+    try:
+        dialog._locate(*args)
+    finally:
+        del toplevel.geometry
+    assert applied, "no geometry was applied"
+    m = re.search(r"\+(-?\d+)\+(-?\d+)$", applied[-1])
+    assert m is not None, f"no +x+y in the applied geometry {applied[-1]!r}"
     return int(m.group(1)), int(m.group(2))
 
 
@@ -336,8 +363,7 @@ def test_locate_applies_center_over_parent(root):
     expected = ensure_on_screen(
         dlg._toplevel, *center_on_parent(dlg._toplevel, root, size=size), size=size
     )
-    dlg._locate()
-    assert _applied_position(dlg) == expected
+    assert _locate_and_capture(dlg) == expected
     dlg.close()
 
 
@@ -368,8 +394,7 @@ def test_locate_without_a_parent_still_applies_a_position(root):
     # parent=None falls back to the dialog's master; it must still be placed.
     dlg = MessageDialog("hello")
     dlg.build()
-    dlg._locate()
-    x, y = _applied_position(dlg)
+    x, y = _locate_and_capture(dlg)
     assert x >= 0 and y >= 0
     dlg.close()
 
@@ -410,7 +435,6 @@ def test_locate_keeps_the_whole_footprint_on_screen(root):
     dlg = _built_dialog(root, message="ok")
     right_edge = root.winfo_vrootx() + root.winfo_vrootwidth()
     dlg._center = lambda: (right_edge - 10, 0)  # hard against the right edge
-    dlg._locate()
-    x, _ = _applied_position(dlg)
+    x, _ = _locate_and_capture(dlg)
     assert x + dlg._footprint()[0] <= right_edge
     dlg.close()

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -332,8 +332,9 @@ def test_locate_applies_center_over_parent(root):
     from ttkbootstrap.internal.positioning import center_on_parent, ensure_on_screen
 
     dlg = _built_dialog(root)
+    size = dlg._footprint()
     expected = ensure_on_screen(
-        dlg._toplevel, *center_on_parent(dlg._toplevel, root)
+        dlg._toplevel, *center_on_parent(dlg._toplevel, root, size=size), size=size
     )
     dlg._locate()
     assert _applied_position(dlg) == expected
@@ -384,4 +385,32 @@ def test_locate_applies_an_offset_only_geometry(root):
     dlg._locate()
     assert applied and all(spec.startswith("+") for spec in applied), applied
     del dlg._toplevel.geometry
+    dlg.close()
+
+
+def test_footprint_measures_the_mapped_size_not_the_content(root):
+    # A dialog is withdrawn when it is positioned, so it has no realized size,
+    # and its requested size ignores the minsize floor build() pins. Centering
+    # and clamping against the smaller content size misplaces the dialog by the
+    # difference -- for a short message that is over 100px of width.
+    dlg = _built_dialog(root, message="ok")
+    tl = dlg._toplevel
+    min_width, min_height = tl.wm_minsize()
+    assert tl.winfo_reqwidth() < min_width, "expected the minsize floor to bind"
+    assert dlg._footprint() == (
+        max(tl.winfo_reqwidth(), min_width),
+        max(tl.winfo_reqheight(), min_height),
+    )
+    dlg.close()
+
+
+def test_locate_keeps_the_whole_footprint_on_screen(root):
+    # Clamping against the content size reserves too little room and leaves the
+    # dialog's right edge -- where the buttons live -- past the screen edge.
+    dlg = _built_dialog(root, message="ok")
+    right_edge = root.winfo_vrootx() + root.winfo_vrootwidth()
+    dlg._center = lambda: (right_edge - 10, 0)  # hard against the right edge
+    dlg._locate()
+    x, _ = _applied_position(dlg)
+    assert x + dlg._footprint()[0] <= right_edge
     dlg.close()

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -302,3 +302,86 @@ def test_querybox_file_dialogs_normalize_cancel_to_none(monkeypatch):
     assert Querybox.get_save_filename() is None
     monkeypatch.setattr(query.filedialog, "askdirectory", lambda **kw: "")
     assert Querybox.get_directory() is None
+
+
+# --- positioning -----------------------------------------------------------
+#
+# `_locate` is exercised directly (never via `show()`, which blocks on
+# grab_set/wait_window); `build()` is all it needs.
+
+def _built_dialog(root, message="hello", **kwargs):
+    dlg = MessageDialog(message, parent=root, **kwargs)
+    dlg.build()
+    dlg._toplevel.update_idletasks()
+    return dlg
+
+
+def _applied_position(dialog):
+    import re
+    dialog._toplevel.update_idletasks()
+    m = re.search(r"\+(-?\d+)\+(-?\d+)$", dialog._toplevel.geometry())
+    assert m is not None, "no +x+y in the applied geometry"
+    return int(m.group(1)), int(m.group(2))
+
+
+def test_locate_applies_center_over_parent(root):
+    # _locate must apply the centered coordinates rather than leave placement to
+    # the window manager, which drops an X11 transient at the virtual-desktop
+    # origin -- between monitors on a multi-head setup. The centered result is
+    # also clamped onto the monitor, so compare against the clamped value.
+    from ttkbootstrap.internal.positioning import center_on_parent, ensure_on_screen
+
+    dlg = _built_dialog(root)
+    expected = ensure_on_screen(
+        dlg._toplevel, *center_on_parent(dlg._toplevel, root)
+    )
+    dlg._locate()
+    assert _applied_position(dlg) == expected
+    dlg.close()
+
+
+def test_centering_never_places_a_dialog_past_its_parent_origin(root):
+    # Centering a dialog that is wider or taller than its parent yields a
+    # negative offset; pinning it to the parent's origin keeps it from hanging
+    # off the parent's top-left, which on a multi-head X11 layout puts it on the
+    # neighboring screen or in the seam between the two.
+    from ttkbootstrap.internal.positioning import _window_size
+
+    # An own parent, not the shared session root, so "smaller than the dialog"
+    # holds no matter what earlier tests left the root requesting.
+    parent = ttk.Toplevel(root)
+    parent.withdraw()
+    parent.update_idletasks()
+    dlg = _built_dialog(root, message="a message wide enough to outgrow the parent")
+    dlg._parent = parent
+    assert dlg._toplevel.winfo_reqwidth() > _window_size(parent)[0]
+
+    x, y = dlg._center()
+    assert x >= parent.winfo_rootx()
+    assert y >= parent.winfo_rooty()
+    dlg.close()
+    parent.destroy()
+
+
+def test_locate_without_a_parent_still_applies_a_position(root):
+    # parent=None falls back to the dialog's master; it must still be placed.
+    dlg = MessageDialog("hello")
+    dlg.build()
+    dlg._locate()
+    x, y = _applied_position(dlg)
+    assert x >= 0 and y >= 0
+    dlg.close()
+
+
+def test_locate_applies_an_offset_only_geometry(root):
+    # The legacy helper re-applied a width x height along with the offset, so
+    # positioning could resize the dialog build() had already sized. Record the
+    # geometry calls rather than reading them back: a withdrawn toplevel reports
+    # its unmapped 1x1 size, not the size that was requested.
+    dlg = _built_dialog(root)
+    applied = []
+    dlg._toplevel.geometry = lambda spec=None: applied.append(spec)
+    dlg._locate()
+    assert applied and all(spec.startswith("+") for spec in applied), applied
+    del dlg._toplevel.geometry
+    dlg.close()

--- a/tests/test_filedialog_api.py
+++ b/tests/test_filedialog_api.py
@@ -408,8 +408,9 @@ def test_locate_applies_center_over_parent(root, tmp_path):
     import re
     from ttkbootstrap.internal.positioning import center_on_parent, ensure_on_screen
     dlg = _build(root, tmp_path, mode="open")
-    cx, cy = center_on_parent(dlg._toplevel, root)
-    expected = ensure_on_screen(dlg._toplevel, cx, cy)
+    size = dlg._footprint
+    cx, cy = center_on_parent(dlg._toplevel, root, size=size)
+    expected = ensure_on_screen(dlg._toplevel, cx, cy, size=size)
     dlg._locate(None)
     dlg._toplevel.update_idletasks()
     m = re.search(r"\+(-?\d+)\+(-?\d+)$", dlg._toplevel.geometry())
@@ -417,16 +418,56 @@ def test_locate_applies_center_over_parent(root, tmp_path):
     assert (int(m.group(1)), int(m.group(2))) == expected
 
 
-def test_locate_clamps_offscreen_position(root, tmp_path):
-    # An explicit position that would put the dialog off-screen is pulled back,
-    # so the bottom controls can't be pushed off the edge.
+def _applied_position(dlg):
     import re
-    dlg = _build(root, tmp_path, mode="open")
-    dlg._locate((-5000, -5000))
     dlg._toplevel.update_idletasks()
     m = re.search(r"\+(-?\d+)\+(-?\d+)$", dlg._toplevel.geometry())
-    x, y = int(m.group(1)), int(m.group(2))
-    assert x > -5000 and y > -5000
+    assert m is not None, "no +x+y in the applied geometry"
+    return int(m.group(1)), int(m.group(2))
+
+
+def test_locate_clamps_offscreen_position(root, tmp_path):
+    # An explicit position off the top-left is pulled back onto the screen, not
+    # merely nudged: assert the whole window lands within the visible bounds.
+    dlg = _build(root, tmp_path, mode="open")
+    dlg._locate((-5000, -5000))
+    x, y = _applied_position(dlg)
+    assert x >= dlg._toplevel.winfo_vrootx()
+    assert y >= dlg._toplevel.winfo_vrooty()
+
+
+def test_locate_clamps_against_the_applied_size(root, tmp_path):
+    # _build opens the dialog at a 640x480 floor, and it is still withdrawn when
+    # positioned -- so winfo_reqwidth is NOT the size it will have (it is smaller
+    # at build time, and drifts larger once _navigate fills the path entry).
+    # Clamping has to use the size _build applied, or the right-hand column
+    # holding the OK/Cancel buttons ends up past the screen edge.
+    from ttkbootstrap.internal.positioning import ensure_on_screen
+
+    dlg = _build(root, tmp_path, mode="open")
+    tl = dlg._toplevel
+    right_edge = tl.winfo_vrootx() + tl.winfo_vrootwidth()
+    target = (right_edge - 10, 0)  # hard against the right edge
+
+    dlg._locate(target)
+    assert _applied_position(dlg) == ensure_on_screen(tl, *target, size=dlg._footprint)
+    # the whole window fits, measured against the size it will actually have
+    assert _applied_position(dlg)[0] + dlg._footprint[0] <= right_edge
+
+
+def test_footprint_is_the_size_build_applied(root, tmp_path):
+    dlg = _build(root, tmp_path, mode="open")
+    assert dlg._footprint[0] >= 640 and dlg._footprint[1] >= 480
+
+
+def test_locate_falls_back_to_centering_for_a_malformed_position(root, tmp_path):
+    # A position that isn't an (x, y) pair centers the dialog rather than raising
+    # out of show().
+    dlg = _build(root, tmp_path, mode="open")
+    dlg._locate(None)
+    centered = _applied_position(dlg)
+    dlg._locate((1, 2, 3))  # not an (x, y) pair
+    assert _applied_position(dlg) == centered
 
 
 def test_multiple_open_returns_tuple(root, tmp_path):

--- a/tests/test_filedialog_api.py
+++ b/tests/test_filedialog_api.py
@@ -401,37 +401,58 @@ def test_window_sizes_to_content_not_clipped(root, tmp_path):
     assert min_h >= 300  # a real content height, not zero
 
 
+def _locate_and_capture(dlg, position):
+    """Run `_locate` and return the (x, y) it applied.
+
+    Record the call instead of reading `geometry()` back afterwards: on X11 the
+    readback is not the position that was just requested. A dialog is withdrawn
+    while it is positioned, and an unmapped window reports the placement the
+    window manager has in mind rather than the request (probed under XWayland:
+    a dialog asked for +4460+20 reads back +32+32); once mapped it tracks the
+    frame, not the client. What these tests are about is whether `_locate`
+    applies coordinates at all.
+    """
+    import re
+
+    tl = dlg._toplevel
+    applied = []
+    real = tl.geometry
+
+    def spy(spec=None):
+        # Only a set call carries a spec; a query would append None and break
+        # the parse below.
+        if spec is not None:
+            applied.append(spec)
+        return real(spec)
+
+    tl.geometry = spy
+    try:
+        dlg._locate(position)
+    finally:
+        del tl.geometry
+    assert applied, "no geometry was applied"
+    m = re.search(r"\+(-?\d+)\+(-?\d+)$", applied[-1])
+    assert m is not None, f"no +x+y in the applied geometry {applied[-1]!r}"
+    return int(m.group(1)), int(m.group(2))
+
+
 def test_locate_applies_center_over_parent(root, tmp_path):
     # _locate must apply the centered coordinates, not rely on the window manager
     # (which leaves an X11 transient at the virtual-desktop origin). The centered
     # result is also clamped on-screen, so compare against the clamped value.
-    import re
     from ttkbootstrap.internal.positioning import center_on_parent, ensure_on_screen
     dlg = _build(root, tmp_path, mode="open")
     size = dlg._footprint
     cx, cy = center_on_parent(dlg._toplevel, root, size=size)
     expected = ensure_on_screen(dlg._toplevel, cx, cy, size=size)
-    dlg._locate(None)
-    dlg._toplevel.update_idletasks()
-    m = re.search(r"\+(-?\d+)\+(-?\d+)$", dlg._toplevel.geometry())
-    assert m is not None
-    assert (int(m.group(1)), int(m.group(2))) == expected
-
-
-def _applied_position(dlg):
-    import re
-    dlg._toplevel.update_idletasks()
-    m = re.search(r"\+(-?\d+)\+(-?\d+)$", dlg._toplevel.geometry())
-    assert m is not None, "no +x+y in the applied geometry"
-    return int(m.group(1)), int(m.group(2))
+    assert _locate_and_capture(dlg, None) == expected
 
 
 def test_locate_clamps_offscreen_position(root, tmp_path):
     # An explicit position off the top-left is pulled back onto the screen, not
     # merely nudged: assert the whole window lands within the visible bounds.
     dlg = _build(root, tmp_path, mode="open")
-    dlg._locate((-5000, -5000))
-    x, y = _applied_position(dlg)
+    x, y = _locate_and_capture(dlg, (-5000, -5000))
     assert x >= dlg._toplevel.winfo_vrootx()
     assert y >= dlg._toplevel.winfo_vrooty()
 
@@ -449,10 +470,10 @@ def test_locate_clamps_against_the_applied_size(root, tmp_path):
     right_edge = tl.winfo_vrootx() + tl.winfo_vrootwidth()
     target = (right_edge - 10, 0)  # hard against the right edge
 
-    dlg._locate(target)
-    assert _applied_position(dlg) == ensure_on_screen(tl, *target, size=dlg._footprint)
+    applied = _locate_and_capture(dlg, target)
+    assert applied == ensure_on_screen(tl, *target, size=dlg._footprint)
     # the whole window fits, measured against the size it will actually have
-    assert _applied_position(dlg)[0] + dlg._footprint[0] <= right_edge
+    assert applied[0] + dlg._footprint[0] <= right_edge
 
 
 def test_footprint_is_the_size_build_applied(root, tmp_path):
@@ -464,10 +485,8 @@ def test_locate_falls_back_to_centering_for_a_malformed_position(root, tmp_path)
     # A position that isn't an (x, y) pair centers the dialog rather than raising
     # out of show().
     dlg = _build(root, tmp_path, mode="open")
-    dlg._locate(None)
-    centered = _applied_position(dlg)
-    dlg._locate((1, 2, 3))  # not an (x, y) pair
-    assert _applied_position(dlg) == centered
+    centered = _locate_and_capture(dlg, None)
+    assert _locate_and_capture(dlg, (1, 2, 3)) == centered  # not an (x, y) pair
 
 
 def test_multiple_open_returns_tuple(root, tmp_path):

--- a/tests/test_window_api.py
+++ b/tests/test_window_api.py
@@ -457,3 +457,64 @@ def test_on_close_on_app_root_veto(root):
     _fire_close(root)
     assert calls == [1] and root.winfo_exists()
     root.protocol("WM_DELETE_WINDOW", "")  # reset so the shared root is untouched
+
+
+# --- monitor discovery -----------------------------------------------------
+#
+# Tk exposes no monitor enumeration on any platform, so the layout comes from
+# screeninfo when installed and from X11's Xinerama extension otherwise. The
+# ctypes query itself needs a real X server; these cover the chain around it.
+
+def test_xinerama_query_is_skipped_off_x11(monkeypatch):
+    # It must not try to load libX11 on Windows or macOS.
+    import sys
+
+    loaded = []
+    monkeypatch.setattr(positioning, "_load_library", lambda name: loaded.append(name))
+    for platform in ("win32", "darwin", "cygwin"):
+        monkeypatch.setattr(positioning, "_XINERAMA_UNAVAILABLE", False)
+        monkeypatch.setattr(sys, "platform", platform)
+        assert positioning._xinerama_monitors() is None
+    assert loaded == []
+
+
+def test_monitors_falls_back_to_xinerama_without_screeninfo(monkeypatch):
+    layout = [(0, 0, 1920, 1080), (1920, 0, 2560, 1440)]
+    monkeypatch.setattr(positioning, "_HAS_SCREENINFO", False)
+    monkeypatch.setattr(positioning, "_xinerama_monitors", lambda: layout)
+    assert positioning._monitors() == layout
+    # and a point resolves to the monitor that contains it, not the first one
+    assert positioning._monitor_at_point(2000, 500) == (1920, 0, 2560, 1440)
+
+
+def test_monitors_falls_back_when_screeninfo_raises(monkeypatch):
+    layout = [(0, 0, 1920, 1080)]
+    monkeypatch.setattr(positioning, "_HAS_SCREENINFO", True)
+    monkeypatch.setattr(
+        positioning, "get_monitors", lambda: (_ for _ in ()).throw(RuntimeError("no display")),
+        raising=False,
+    )
+    monkeypatch.setattr(positioning, "_xinerama_monitors", lambda: layout)
+    assert positioning._monitors() == layout
+
+
+def test_monitor_at_point_returns_none_when_no_source_answers(monkeypatch):
+    monkeypatch.setattr(positioning, "_HAS_SCREENINFO", False)
+    monkeypatch.setattr(positioning, "_xinerama_monitors", lambda: None)
+    assert positioning._monitor_at_point(10, 10) is None
+
+
+def test_clamp_uses_the_monitor_under_the_point_not_the_whole_desktop(root, monkeypatch):
+    # The case that motivated this: two monitors side by side, a window that
+    # would straddle the join. Clamping against the combined desktop leaves it
+    # straddling; clamping against the monitor pulls it fully onto one screen.
+    monkeypatch.setattr(positioning, "_HAS_SCREENINFO", False)
+    monkeypatch.setattr(
+        positioning, "_xinerama_monitors", lambda: [(0, 0, 1920, 1080), (1920, 0, 1920, 1080)]
+    )
+    top = ttk.Toplevel(title="child", size=(400, 200))
+    top.update_idletasks()
+    # ask to sit across the seam at x=1920
+    x, _ = positioning.ensure_on_screen(top, 1800, 300, size=(400, 200))
+    assert x + 400 <= 1920, "the window should be pulled fully onto the left monitor"
+    top.destroy()

--- a/tools/verify_positioning.py
+++ b/tools/verify_positioning.py
@@ -1,0 +1,105 @@
+"""Cross-platform verification for #1310 / PR #1312 (dialog positioning).
+
+Run from the repo root on each platform:
+
+    PYTHONPATH=src python tools/verify_positioning.py
+
+Prints a PASS/FAIL line per check. Checks 4 and 5 open real windows and need a
+human to look at them; everything else is automatic.
+"""
+import re
+import sys
+
+import ttkbootstrap as ttk
+from ttkbootstrap.dialogs.message import MessageDialog
+from ttkbootstrap.internal import positioning as p
+
+results = []
+
+
+def check(name, ok, detail="", always_show=False):
+    results.append((name, ok))
+    show = detail and (always_show or not ok)
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}{'  -- ' + detail if show else ''}")
+
+
+app = ttk.App(title="positioning verification")
+app.geometry("420x220+80+80")
+app.update()
+winsys = ttk.windowing_system(app)
+print(f"\nplatform={sys.platform}  windowingsystem={winsys}  tk={app.tk.call('info', 'patchlevel')}")
+print(f"screeninfo installed: {p._HAS_SCREENINFO}")
+print(f"Tk screen : {app.winfo_screenwidth()}x{app.winfo_screenheight()}")
+print(f"Tk vroot  : {app.winfo_vrootwidth()}x{app.winfo_vrootheight()} "
+      f"at ({app.winfo_vrootx()},{app.winfo_vrooty()})\n")
+
+# --- 1. monitor discovery --------------------------------------------------
+monitors = p._monitors()
+print(f"monitors seen: {monitors}")
+check("1. a monitor layout is discoverable", bool(monitors),
+      "none found -- everything below falls back to the combined desktop")
+
+# --- 2. the new Xinerama path specifically (X11 only) ----------------------
+if winsys == "x11":
+    p._XINERAMA_UNAVAILABLE = False
+    xin = p._xinerama_monitors()
+    print(f"xinerama says: {xin}")
+    check("2. Xinerama answers directly (the no-screeninfo path)", bool(xin))
+    if xin and monitors and p._HAS_SCREENINFO:
+        check("2b. Xinerama agrees with screeninfo", sorted(xin) == sorted(monitors),
+              f"xinerama={sorted(xin)} screeninfo={sorted(monitors)}", always_show=True)
+else:
+    check("2. Xinerama path is skipped off X11", p._xinerama_monitors() is None)
+
+# --- 3. footprint == the size the dialog actually maps at ------------------
+dlg = MessageDialog("ok", parent=app)
+dlg.build()
+footprint = dlg._footprint()
+dlg._toplevel.deiconify()
+dlg._toplevel.wait_visibility()
+dlg._toplevel.update()
+mapped = (dlg._toplevel.winfo_width(), dlg._toplevel.winfo_height())
+check("3. footprint matches the mapped size", footprint == mapped,
+      f"footprint={footprint} mapped={mapped}", always_show=True)
+dlg.close()
+
+# --- 4. a dialog lands fully inside one monitor ----------------------------
+if monitors:
+    # park the app so a centered dialog would cross the join between two screens
+    seams = sorted({m[0] for m in monitors if m[0] != min(x for x, _, _, _ in monitors)})
+    if seams:
+        seam = seams[0]
+        app.geometry(f"420x220+{seam - 210}+200")
+        app.update()
+        d = MessageDialog("Am I fully on one screen?", parent=app)
+        d.build()
+        d._locate()
+        m = re.search(r"\+(-?\d+)\+(-?\d+)$", d._toplevel.geometry())
+        x = int(m.group(1))
+        w = d._footprint()[0]
+        inside = any(mx <= x and x + w <= mx + mw for mx, _, mw, _ in monitors)
+        check("4. a dialog near a seam stays inside one monitor", inside,
+              f"dialog spans {x}..{x + w}, seam at {seam}", always_show=True)
+        d._toplevel.deiconify()
+        d._toplevel.update()
+        print("    -> LOOK: the dialog above should sit wholly on one screen.")
+        app.after(2500, d.close)
+        app.update()
+        try:
+            d.close()
+        except Exception:
+            pass
+    else:
+        check("4. a dialog near a seam stays inside one monitor", True, "single monitor -- n/a")
+
+# --- 5. the themed file dialog (X11 default) -------------------------------
+print("\n[MANUAL] 5. themed file dialog -- run this and confirm it opens fully")
+print("            on-screen with the OK/Cancel buttons visible:\n")
+print("    python -c \"import ttkbootstrap as ttk; app=ttk.App(); "
+      "print(ttk.Querybox.get_open_filename(native=False, parent=app))\"\n")
+
+failed = [n for n, ok in results if not ok]
+print(f"\n{len(results) - len(failed)}/{len(results)} automatic checks passed")
+if failed:
+    print("failed: " + "; ".join(failed))
+app.destroy()


### PR DESCRIPTION
Fixes #1310.

The base `Dialog` centered through `internal.utility.center_on_parent` — an older
helper predating the 2.0 positioning work, of which `dialogs/base.py` was the last
caller. Three defects, only the first visible off X11:

- **It centered a 1×1 box.** The helper measured the dialog with
  `winfo_width() or winfo_reqwidth()`. A dialog is still withdrawn when it is
  positioned, and an unmapped window reports a width of **1** — truthy, so the
  `reqwidth` fallback never ran. The dialog's top-left landed where its center
  belonged. Confirmed by running the new tests against the legacy helper: it
  applies `1x1+393+416`.
- **It re-applied a `WxH` size** along with the offset, so positioning could
  resize a dialog `build()` had already sized.
- **It never clamped onto a monitor.** Windows and macOS nudge a stray transient
  back on-screen; X11 leaves it straddling the seam between two monitors.

`_locate` now runs the same center → clamp → apply sequence the themed file
dialog was fixed onto in #1307/#1311, using `internal.positioning`: center on the
parent (pinned to the parent's origin when the dialog is the larger of the two),
clamp with `ensure_on_screen`, apply an **offset-only** geometry. So every shipped
dialog places identically.

The legacy helper stays where it is — still reachable through the deprecated
`ttkbootstrap.utility` shim until 3.0 — with a docstring saying which of the two
same-named functions first-party code uses.

## Verification

- `tests/test_dialogs_api.py` +4, exercising `_locate`/`_center` directly (never
  `show()`, which blocks on `grab_set`/`wait_window`). Two of them fail against
  the legacy helper.
- Suite **894 passed**, 3 skipped.

## Scope

Positioning only — no signature, return value, or appearance change. An explicit
`position=` was already clamped and is untouched. Logged in
`development/2_1_changes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)