### PR TITLE
Raise on an invalid color instead of returning None

### DIFF
--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -26,6 +26,7 @@
 | **`DateEntry(value=…)` — a nullable, clearable date field** | New | this doc, below |
 | **Bootstyle value tokens — raw hex + ramp accents & surfaces** | New | this doc, below |
 | **Themed file dialog — a theme-following open/save chooser** | New | this doc, below |
+| **`color_to_rgb` raises on an invalid color instead of returning `None`** | Fix | this doc, below |
 
 There are **no API breaks in 2.1**: nothing was removed, and no call that worked
 in 2.0.0 fails. One change is visually noticeable without any code change (the
@@ -217,3 +218,26 @@ dialog replaces it there. Addresses #1242.
 
 **Scope note.** Deliberately minimal (no bookmarks/places sidebar) — matching Tk's
 chooser; a sidebar is a later enhancement.
+
+---
+
+## `color_to_rgb` raises on an invalid color  *(Fix)*
+
+**What.** `color_to_rgb` (also exported at top level as `ttk.color_to_rgb`) now
+raises `ValueError` naming the offending value when it cannot parse a color. It
+used to swallow the error, print the string `this` to stdout, and return `None`:
+
+```python
+ttk.color_to_rgb("not-a-color")
+# 2.0.0: prints "this", returns None
+# 2.1:   ValueError: 'not-a-color' is not a valid hex color
+```
+
+**Who notices.** Anyone who reaches the function with a bad color — through
+`color_to_hsl`, `contrast_color`, `update_hsl_value`, or `Colors.hex_to_rgb`,
+which all route through it. Every caller unpacks the result into `r, g, b`, so
+the `None` surfaced as `TypeError: cannot unpack non-iterable NoneType object`
+with no indication of which color was at fault, plus stray output on stdout that
+no application asked for. The valid-color contract is unchanged.
+
+**Why.** A bare `except: print('this')` left over from 1.x.

--- a/src/ttkbootstrap/utils/color.py
+++ b/src/ttkbootstrap/utils/color.py
@@ -44,13 +44,19 @@ def color_to_rgb(color, model=HEX):
 
         tuple[int, int, int]:
             The rgb color values.
+
+    Raises:
+
+        ValueError:
+            The color is not valid for the given model.
     """
-    color_ = conform_color_model(color, model)    
+    color_ = conform_color_model(color, model)
     try:
         return ImageColor.getrgb(color_)
-    except:
-        print('this')
-    
+    except (ValueError, TypeError, AttributeError) as error:
+        raise ValueError(f"{color!r} is not a valid {model} color") from error
+
+
 def color_to_hex(color, model=RGB):
     """Convert color value to hex.
 

--- a/tests/test_utility_api.py
+++ b/tests/test_utility_api.py
@@ -101,3 +101,20 @@ def test_color_helpers_round_trip():
     from ttkbootstrap.utils.color import HEX, RGB
     assert ttk.color_to_rgb("#ff5733", model=HEX) == (255, 87, 51)
     assert ttk.color_to_hex((255, 87, 51), model=RGB) == "#ff5733"
+
+
+@pytest.mark.parametrize("bad", ["not-a-color", "#zzz", "", None])
+def test_color_to_rgb_raises_on_an_invalid_color(bad, capsys):
+    # It used to swallow the error, print a debug string, and return None -- so
+    # every caller (they all unpack the result) failed with an unrelated
+    # "cannot unpack non-iterable NoneType" and stray output on stdout.
+    with pytest.raises(ValueError, match="is not a valid"):
+        ttk.color_to_rgb(bad)
+    assert capsys.readouterr().out == ""
+
+
+def test_color_to_rgb_names_the_offending_color():
+    with pytest.raises(ValueError) as excinfo:
+        ttk.color_to_rgb("nope")
+    assert "'nope'" in str(excinfo.value)
+    assert excinfo.value.__cause__ is not None  # the underlying error is chained


### PR DESCRIPTION
`color_to_rgb` — a public export (`ttk.color_to_rgb`) — swallowed every parse
error with a bare `except`, printed the debug string `this` to stdout, and
returned `None`:

```python
ttk.color_to_rgb("not-a-color")
# before: prints "this", returns None
# after:  ValueError: 'not-a-color' is not a valid hex color
```

All five call sites unpack the result into `r, g, b` (`colorchooser` ×3,
`colordropper`, `Colors.hex_to_rgb`), so the `None` surfaced as
`TypeError: cannot unpack non-iterable NoneType object` — naming neither the
color nor the model — alongside output no application asked for. A 1.x leftover.

Now raises `ValueError` naming the offending value, with the underlying PIL error
chained. The valid-color contract is unchanged.

**Not a new crash path in the color chooser:** `on_entry_value_change` calls
`widget.validate()` before `sync_color_values`, so a half-typed hex never reaches
the function.

## Verification

- `tests/test_utility_api.py` +5: raises for `"not-a-color"`, `"#zzz"`, `""` and
  `None`; nothing on stdout; the message names the color and chains the cause.
- Suite **895 passed**, 3 skipped.

Logged in `development/2_1_changes.md`. The `Raises:` docstring section reaches
the published reference through autodoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)