### PR TITLE
fix(menu): draw the themed popup border on x11

### DIFF
--- a/development/2_1_changes.md
+++ b/development/2_1_changes.md
@@ -30,6 +30,7 @@
 | **`place_window_center()` works before the window is shown** | Fix | this doc, below |
 | **`color_to_rgb` raises on an invalid color instead of returning `None`** | Fix | this doc, below |
 | **`DateEntry`'s dropdown stays aligned near a screen edge** | Fix | this doc, below |
+| **Popup menus have their themed border on Linux** | Fix | this doc, below |
 
 There are **no API breaks in 2.1**: nothing was removed, and no call that worked
 in 2.0.0 fails. One change is visually noticeable without any code change (the
@@ -358,3 +359,36 @@ point. The vertical axis already recognised this and passed `titlebar_height=0`;
 the horizontal one did not. Measured 9px out for a target at x=11, and only
 reachable when the parent window is near a screen edge, which is why it went
 unnoticed on a desktop where windows sit further in.
+
+---
+
+## Popup menus have their themed border on Linux  *(Fix)*
+
+**What.** A themed popup menu — a `Menubutton` or `OptionMenu` dropdown, a
+right-click menu, a cascade off the menu bar — now draws the same 1px
+`colors.border` hairline on Linux that it has always had elsewhere. It used to
+have no border at all there, so a menu read as a floating block of background
+against whatever was behind it.
+
+**Who notices.** Linux/X11 users only. Windows and macOS are untouched: both
+draw menus with native OS chrome, which supplies the border, and that is why the
+gap was Linux-only. The border follows the theme, in both light and dark.
+
+**Why.** The menu recipe set `borderwidth=0, relief="flat"`. On Windows and
+macOS a popup menu is a native OS menu, so the OS frame hid that; on X11 Tk draws
+the whole menu itself, so it meant literally no border.
+
+**Note for menu entry colors.** Tk gives `tk.Menu` no border color of its own —
+it has no `highlightthickness`, `relief="solid"` is hardcoded to black, and the
+3D reliefs derive both their shades from `-background`. The border is therefore
+painted by putting the *menu* background in `colors.border` and each entry in
+`colors.bg`; entries tile the whole interior of a popup, so only the 1px strip
+shows. Two consequences on Linux:
+
+- Entry colors are theme-managed, as they already are for a themed `Text`. An
+  entry given its own `background` keeps it; the rest follow the theme.
+- `menu.cget("background")` returns the border color rather than the surface
+  color. Read `style.colors.bg` for the surface.
+
+A menu used as a menu **bar** is unaffected — its entries cover only the left of
+the bar, so painting it would flood the rest.

--- a/src/ttkbootstrap/style/builders_tk.py
+++ b/src/ttkbootstrap/style/builders_tk.py
@@ -8,6 +8,27 @@ import tkinter as tk
 from ttkbootstrap.constants import *
 from ttkbootstrap.style.theme import Colors, ThemeDefinition, _accent_on_color
 
+# Carries the menu-border repaint. A bind tag of our own rather than a binding on
+# the widget, so a caller's own bind("<Map>") cannot displace it.
+_MENU_HAIRLINE_TAG = "TtkbootstrapMenuHairline"
+
+
+def _on_menu_map(event):
+    """Repaint a popup menu's border as it is posted.
+
+    Entries added since the last post inherit the menu background, so they would
+    come up in the border color; this catches them before the menu is drawn.
+    """
+    from ttkbootstrap.style.engine import Style
+
+    try:
+        builder = Style.get_instance()._get_builder_tk()
+        builder._paint_menu_hairline(event.widget)
+    except (AttributeError, tk.TclError):
+        # A menu torn down mid-post, or posted before a theme exists, keeps its
+        # plain background rather than failing the post.
+        pass
+
 
 class StyleBuilderTK:
     """Styles legacy tkinter widgets (not ttk) to match the active theme.
@@ -269,6 +290,11 @@ class StyleBuilderTK:
     def update_menu_style(self, widget: tk.Menu):
         """Update the menu style.
 
+        On x11 the popup also gets the themed 1px border -- see
+        `_paint_menu_hairline` for how it is drawn and why it waits for `<Map>`.
+        Windows and macOS draw menus with the native OS chrome, which supplies
+        the border, so they keep the borderless configuration.
+
         Parameters:
 
             widget (tkinter.Menu):
@@ -284,6 +310,57 @@ class StyleBuilderTK:
             relief="flat",
             borderwidth=0,
         )
+        if self.style.scaling.windowing_system == "x11":
+            self._arm_menu_hairline(widget)
+
+    def _arm_menu_hairline(self, widget: tk.Menu):
+        """Reserve the border strip and arrange for it to be painted on `<Map>`.
+
+        The width is set now so posting the menu never has to re-run its
+        geometry; while the strip is still the surface color it is invisible.
+        """
+        widget.configure(borderwidth=self.style.scaling.logical(1))
+
+        if _MENU_HAIRLINE_TAG not in widget.bindtags():
+            widget.bindtags((_MENU_HAIRLINE_TAG,) + widget.bindtags())
+        if not widget.tk.call("bind", _MENU_HAIRLINE_TAG):
+            widget.bind_class(_MENU_HAIRLINE_TAG, "<Map>", _on_menu_map)
+
+        # A menu already posted once keeps its border across a theme change;
+        # one that has never been posted waits, so a menubar is never painted.
+        if getattr(widget, "_tb_menu_hairline", False):
+            self._paint_menu_hairline(widget)
+
+    def _paint_menu_hairline(self, widget: tk.Menu):
+        """Draw the themed 1px border around a popup menu.
+
+        Tk gives `tk.Menu` no border color of its own: it has no
+        `highlightthickness`, `relief="solid"` is hardcoded to black, and the 3D
+        reliefs derive their two shades from `-background`. The one way to a flat
+        border in `colors.border` is to paint the *menu* in the border color and
+        every entry in the surface color -- entries tile the whole interior of a
+        popup, so only the 1px strip is left showing.
+
+        That only holds for a popup. A menubar's entries cover just the left of
+        the bar, so the border color would flood the rest of it -- which is why
+        this waits for `<Map>`: a menu used as a menubar is displayed through a
+        clone, so the widget styled here never maps and never gets painted.
+
+        Entry colors are theme-managed, like those of a themed `Text`. An entry
+        the user gave its own color keeps it; the rest follow the theme.
+        """
+        surface = self.colors.bg
+        previous = getattr(widget, "_tb_menu_entry_bg", None)
+        widget.configure(background=self.colors.border)
+
+        end = widget.index("end")
+        for index in range(0 if end is None else end + 1):
+            current = str(widget.entrycget(index, "background"))
+            if not current or current == previous:
+                widget.entryconfigure(index, background=surface)
+
+        widget._tb_menu_entry_bg = surface
+        widget._tb_menu_hairline = True
 
     def update_labelframe_style(self, widget: tk.LabelFrame):
         """Update the labelframe style.

--- a/tests/test_menu_border.py
+++ b/tests/test_menu_border.py
@@ -1,0 +1,139 @@
+"""The themed popup-menu border (issue #1309).
+
+Tk gives ``tk.Menu`` no border color of its own, so the border is painted by
+putting the *menu* background in ``colors.border`` and every entry in
+``colors.bg`` -- entries tile the whole interior of a popup, leaving only the
+1px strip showing. See ``StyleBuilderTK._paint_menu_hairline``.
+
+Only x11 needs it: Windows and macOS draw menus with native OS chrome, which
+supplies the border. The builder picks the path from a single
+``scaling.windowing_system`` probe, so **both** branches are exercised by forcing
+that probe rather than by trusting the host -- otherwise a developer on Linux
+tests only the x11 branch and a developer on macOS only the other one.
+
+These assert the configuration the painter applies. The border was verified
+against real pixels on X11 (``xwd`` capture of a posted menu, all four edges
+reading exactly ``colors.border``); a headless suite cannot post and capture.
+"""
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap.style.builders_tk import _MENU_HAIRLINE_TAG
+from ttkbootstrap.style.scaling import Scaling
+
+
+def _force_windowing_system(monkeypatch, name):
+    """Make the style builder believe it is running on `name`."""
+    monkeypatch.setattr(
+        Scaling, "windowing_system", property(lambda self: name)
+    )
+
+
+def _paint(root, menu):
+    """Paint `menu` as posting it would, without needing a display."""
+    builder = root.style._get_builder_tk()
+    builder._paint_menu_hairline(menu)
+
+
+@pytest.fixture
+def x11(monkeypatch):
+    _force_windowing_system(monkeypatch, "x11")
+
+
+def test_menu_reserves_the_border_strip_on_x11(root, x11):
+    menu = ttk.Menu(root)
+    assert int(menu.cget("borderwidth")) == root.style.scaling.logical(1)
+    assert _MENU_HAIRLINE_TAG in menu.bindtags()
+
+
+@pytest.mark.parametrize("system", ["win32", "aqua"])
+def test_native_platforms_keep_the_borderless_menu(root, monkeypatch, system):
+    """Windows and macOS get the OS's own menu chrome; we must not touch it."""
+    _force_windowing_system(monkeypatch, system)
+    menu = ttk.Menu(root)
+    assert int(menu.cget("borderwidth")) == 0
+    assert _MENU_HAIRLINE_TAG not in menu.bindtags()
+    assert str(menu.cget("background")) == root.style.colors.bg
+
+
+def test_painting_draws_the_border_in_the_theme_border_color(root, x11):
+    menu = ttk.Menu(root)
+    menu.add_command(label="Open")
+    menu.add_separator()
+    menu.add_command(label="Save")
+    _paint(root, menu)
+
+    colors = root.style.colors
+    assert str(menu.cget("background")) == colors.border
+    for index in range(menu.index("end") + 1):
+        assert str(menu.entrycget(index, "background")) == colors.bg
+
+
+def test_an_entry_added_after_theming_does_not_show_the_border_color(root, x11):
+    """Entries inherit the menu background, so a late entry would come up in the
+    border color; the repaint on ``<Map>`` catches it before the menu is drawn."""
+    menu = ttk.Menu(root)
+    menu.add_command(label="Open")
+    _paint(root, menu)
+
+    menu.add_command(label="Added later")
+    assert str(menu.entrycget(1, "background")) == ""  # inherits: would be border
+    _paint(root, menu)
+    assert str(menu.entrycget(1, "background")) == root.style.colors.bg
+
+
+def test_a_never_posted_menu_is_not_painted(root, x11):
+    """The guard that keeps a menubar intact.
+
+    A menubar's entries cover only the left of the bar, so painting it would
+    flood the rest with the border color. Tk displays a menubar through a
+    *clone*, so the widget styled here never maps -- and only a map paints.
+    """
+    menubar = ttk.Menu(root)
+    menubar.add_cascade(label="File")
+    root.configure(menu=menubar)
+    try:
+        assert str(menubar.cget("background")) == root.style.colors.bg
+        assert not getattr(menubar, "_tb_menu_hairline", False)
+    finally:
+        root.configure(menu="")
+
+
+def test_entries_follow_a_theme_switch(root, x11):
+    menu = ttk.Menu(root)
+    menu.add_command(label="Open")
+    _paint(root, menu)
+
+    root.style.theme_use("bootstrap-dark")
+    colors = root.style.colors
+    assert str(menu.cget("background")) == colors.border
+    assert str(menu.entrycget(0, "background")) == colors.bg
+
+
+def test_an_entry_given_its_own_color_keeps_it(root, x11):
+    menu = ttk.Menu(root)
+    menu.add_command(label="Plain")
+    menu.add_command(label="Custom")
+    menu.entryconfigure(1, background="#ff0000")
+    _paint(root, menu)
+
+    assert str(menu.entrycget(0, "background")) == root.style.colors.bg
+    assert str(menu.entrycget(1, "background")) == "#ff0000"
+
+
+def test_repainting_is_idempotent(root, x11):
+    menu = ttk.Menu(root)
+    menu.add_command(label="Open")
+    for _ in range(3):
+        _paint(root, menu)
+    colors = root.style.colors
+    assert str(menu.cget("background")) == colors.border
+    assert str(menu.entrycget(0, "background")) == colors.bg
+
+
+def test_an_empty_menu_paints_without_error(root, x11):
+    """``index("end")`` is None for a menu with no entries."""
+    menu = ttk.Menu(root)
+    _paint(root, menu)
+    assert str(menu.cget("background")) == root.style.colors.border


### PR DESCRIPTION
Fixes #1309.

A themed popup menu had no border on Linux — a `Menubutton` or `OptionMenu` dropdown, a right-click menu, a cascade off the menu bar all read as a floating block of background against whatever was behind them.

## Root cause

The menu recipe set `borderwidth=0, relief="flat"`. On Windows and macOS a popup is a **native OS menu** whose own frame supplied the border, so the setting was invisible there; on x11 Tk draws the whole menu itself, so it meant literally no border. Confirmed by capturing a posted menu — all four edges read the background exactly.

The fix is gated on the windowing system, so Windows and macOS keep the configuration they have today.

## Why it takes an indirect route

Tk gives `tk.Menu` no border color of its own. All three candidates were measured against a real posted menu rather than assumed:

| candidate | measured | usable |
|---|---|---|
| `highlightthickness` | option does not exist on `Menu` | — |
| `relief="solid"` | `#000000`, hardcoded in Tk | not themable |
| 3D reliefs (`raised`/`sunken`/`ridge`/`groove`) | two shades derived from `-background` (`#e6e6e6` / `#999999` on light) | a bevel, not a hairline |

The one route to a flat `colors.border` hairline is to paint the *menu* in the border color and each entry in the surface color: entries tile the whole interior of a popup, so only the 1px strip is left showing.

## Why the paint waits for `<Map>`

That holds for a popup and **not** for a menu bar, whose entries cover only the left of the bar — painting one floods the rest with the border color (measured: an entire menubar filled `#d6d6d6`).

Rather than try to detect menu bars — unreliable, since `Menu(app)` → `configure(menu=…)` means a menu is not yet a menubar when it is styled — the paint waits for `<Map>`. Tk displays a menu bar through a **clone**, so the widget styled here never maps and is never painted, and the two cases separate themselves with nothing to detect.

The same hook catches entries added *after* the menu was themed. Those inherit the menu background and would otherwise come up in the border color; they are stamped on the way to being shown. The repaint rides a bind tag of its own, so a caller's `bind("<Map>")` cannot displace it.

## Behavior change (Linux only)

Logged in `development/2_1_changes.md`:

- Menu entry colors become **theme-managed**, as they already are for a themed `Text`. An entry given its own `background` keeps it; the rest follow the theme across a switch.
- `menu.cget("background")` returns the **border** color rather than the surface color. Read `style.colors.bg` for the surface.

## Verification

Verified on X11 against real pixels — Pillow's X11 grab and `xwd -root` both fail under WSLg, so per-window XWD dumps were parsed directly:

- all four edges read exactly `colors.border`, in light **and** dark
- through `post`, `tk_popup`, a `Menubutton` dropdown and an `OptionMenu`
- menu bar left intact; a menubar's own cascade submenu still gets the border
- correct repaint across a theme switch; hover/active highlight unaffected; a user-set entry color survives

The 10 headless tests in `tests/test_menu_border.py` assert the configuration the painter applies and **force the windowing-system probe both ways** (the #1229 convention), so neither branch depends on the host. All 10 were mutation-tested — 5 deliberate breaks of the fix, 5 caught.

Suite: **929 passed, 4 skipped** (919 baseline + 10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
