### PR TITLE
fix(window): track being shown rather than infer it from a reported size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1180,6 +1180,55 @@ s> on multi-head X11. #1311 has since **MERGED** (`c882c3db`).
 > `gh` is **not** installed, so PRs cannot be opened from here; this session's
 > merges were done locally and pushed to `master`.
 >
+> **Session 2026-07-28b (Windows box) — the demo opened off-centre; fixed, and
+> the verification gap that hid it closed. AWAITS A macOS + x11 RUN.**
+> `_unmapped_size` decided "has this window ever been shown?" with
+> `winfo_width() > 1`. That is x11 reasoning: there a never-mapped window really
+> does report 1x1, but on **win32 the root reports the size Tk started it at**,
+> so the demo centred a 600x200 box that maps at 846x696 — applied `+980+620`
+> instead of `+857+372`, ~123px right and 248px down. **Only the root is
+> affected** (a win32 Toplevel does report 1x1), which is why every existing
+> Toplevel-based test passed. Being shown is now *tracked* (`_ever_shown`, set
+> from the `<Map>`/`<Configure>` handler) rather than inferred, with the watch
+> installed in both `App.__init__` and `Toplevel.__init__`. A `/code-review`
+> then found three **pre-existing** defects in last session's size bookkeeping
+> (each reproduces at the branch base); two cheap ones were folded in — the
+> handler is gated on `winfo_ismapped()` so a **stale** map dispatched after a
+> newer `geometry()` cannot discard it, and it also listens to `<Configure>`
+> because a `geometry()` call on an already-shown window is realized at once and
+> otherwise never retires. The third (a user's `bind("<Map>", ...)` without
+> `add=True` clobbers the watch — LOW, pre-existing) was **deliberately left**;
+> the fix wanted a private bindtag plus a `destroy` override on every window,
+> which the author judged not worth the lifecycle surface. **File it if it ever
+> bites.**
+>
+> **WHAT STILL NEEDS RUNNING, on macOS (both Tk lines) and x11 (with and without
+> `screeninfo`):** `tools/verify_positioning.py` — now **7 checks**, whose
+> docstring explains why a green run on one box proves little — plus
+> `python -m pytest -q` (**924 passed, 3 skipped** on Windows) and an eyeball of
+> `python -m ttkbootstrap`. **The risk being checked is narrow:** on x11 old and
+> new code both fall through to the content-request path, so behaviour is
+> identical there; what is new is that a *shown-then-withdrawn* window returns
+> its realized size only if the flag got set, i.e. only if the event arrived.
+> Measured on Windows, `winfo_ismapped()` is already 1 in **both** handlers, and
+> the flag is still set with `<Map>` suppressed — so `<Configure>` backstops it
+> and the mechanism does not hinge on map timing, the part most likely to differ
+> under a window manager.
+>
+> **The verification gap is the more valuable lesson.** Check 6 (“centered
+> before first map”) passed against this bug the whole time, because it uses
+> `Toplevel(size=(600,400))` — the *explicitly sized* path, which this never
+> touched. Closing it took three attempts, each failing for a different reason
+> worth knowing: a `Toplevel` cannot reproduce it (win32 reports 1x1 there, so
+> the check must spawn a **subprocess** with its own never-shown root); and
+> content packed **straight into the root** lets Tk settle on the real size
+> before anyone measures, so the check must build into a frame **packed
+> afterwards**, as the demo does — variant A reads `winfo=(600,246)`==mapped,
+> variant B reads `(600,200)` vs mapped `(600,246)`. New **check 7** now reads
+> FAIL/5-of-7 at the branch base and PASS/7-of-7 with the fix. **Standing rule:
+> prove a new check fails against the bug by reverting the fix, never by reading
+> the code.**
+>
 > **NEXT — the rest of the pre-2.1 punch list:**
 > **bump `pyproject.toml` → 2.1.0** *at release time* (`master` tracks the current
 > release, so it correctly reads **2.0.1** now — do not bump early);

--- a/src/ttkbootstrap/window.py
+++ b/src/ttkbootstrap/window.py
@@ -201,7 +201,11 @@ class _BaseWindow(BusyMixin):
     # ever been sized by its content. Class-level so it is readable no matter
     # how early `geometry` is called during construction.
     _applied_size: Optional[Tuple[int, int]] = None
-    _map_watch: Optional[str] = None
+    _map_watch: Optional[list] = None
+    # Whether the window has been shown yet. Only a window that has been shown
+    # reports a real size, and there is nothing to read that off: on win32 a
+    # window that has never been mapped already reports Tk's initial size.
+    _ever_shown: bool = False
 
     @property
     def style(self) -> Style:
@@ -432,7 +436,7 @@ class _BaseWindow(BusyMixin):
             match = re.match(r"^(\d+)x(\d+)", newGeometry)
             if match:
                 self._applied_size = (int(match.group(1)), int(match.group(2)))
-                self._forget_size_once_shown()
+                self._watch_for_first_map()
             elif newGeometry == "":
                 # `geometry("")` hands the window back to its natural size, so
                 # whatever size we were remembering no longer applies.
@@ -441,23 +445,36 @@ class _BaseWindow(BusyMixin):
 
     wm_geometry = geometry
 
-    def _forget_size_once_shown(self) -> None:
-        """Drop the recorded size the next time the window is shown.
+    def _watch_for_first_map(self) -> None:
+        """Note when the window is shown, and drop any recorded size then.
 
         Whichever of the two sizes is *newer* is the right one, and this is how
         that ordering is kept without timestamps: a recorded size survives only
-        between the `geometry` call that set it and the next map. After the
-        window is shown its own realized size is the truth -- a window manager
-        resizes windows without going through `geometry` (maximize, tiling, a
-        frame drag) -- while a size recorded since the last map is a request
-        that has not taken effect yet.
+        until the window is next seen on screen. After that its own realized
+        size is the truth -- a window manager resizes windows without going
+        through `geometry` (maximize, tiling, a frame drag) -- while a size
+        recorded while it was hidden is a request that has not taken effect yet.
         """
         if self._map_watch is None:
-            self._map_watch = self.bind("<Map>", self._on_shown, add="+")
+            # `<Configure>` as well as `<Map>`, because a `geometry` call made
+            # while the window is already on screen is realized immediately --
+            # there is no next map to retire the record, and a later resize
+            # would leave the stale request winning forever.
+            self._map_watch = [
+                self.bind(sequence, self._on_shown, add="+")
+                for sequence in ("<Map>", "<Configure>")
+            ]
 
     def _on_shown(self, event: Any) -> None:
-        if event.widget is self:
-            self._applied_size = None
+        # The mapped check is what makes this safe: these events are dispatched
+        # when the event queue is drained, not when they occur, so a map the
+        # window has already been withdrawn from can arrive *after* a newer
+        # size was recorded. Such an event is stale by definition -- it reports
+        # a size the window no longer has -- and must not retire that record.
+        if event.widget is not self or not self.winfo_ismapped():
+            return
+        self._ever_shown = True
+        self._applied_size = None
 
     def _unmapped_size(self) -> Tuple[int, int]:
         """The size this window will map at, measured before it is mapped.
@@ -469,11 +486,12 @@ class _BaseWindow(BusyMixin):
         """
         if self._applied_size is not None:
             return self._applied_size
-        # winfo_width/height report 1 until a window has been realized, so this
-        # distinguishes "shown at some point" from "never shown".
-        width, height = self.winfo_width(), self.winfo_height()
-        if width > 1 and height > 1:
-            return width, height
+        # Only a window that has been shown has a size to report. Asking Tk
+        # instead does not work: on x11 a never-mapped window reports 1x1, but
+        # on win32 it reports the size Tk started it at -- a plausible-looking
+        # number that has nothing to do with the size the content will map at.
+        if self._ever_shown:
+            return self.winfo_width(), self.winfo_height()
         # A window sized by its content has no request until Tk has computed
         # the layout, so measuring first would center against a stale one.
         self.update_idletasks()
@@ -662,6 +680,7 @@ class App(_BaseWindow, tkinter.Tk):
 
         super().__init__(**kwargs)
         self.winsys: str = utils.windowing_system(self)
+        self._watch_for_first_map()
 
         if scaling is not None:
             utils.enable_high_dpi_awareness(self, scaling)
@@ -850,6 +869,7 @@ class Toplevel(_BaseWindow, tkinter.Toplevel):
 
         super().__init__(**kwargs)
         self.winsys: str = utils.windowing_system(self)
+        self._watch_for_first_map()
 
         # On aqua, give a borderless popup type (tooltip/splash/...) a native
         # macOS window class instead of the default chrome, so it isn't drawn

--- a/tests/test_window_api.py
+++ b/tests/test_window_api.py
@@ -328,6 +328,79 @@ def test_place_window_center_before_first_map_uses_the_size_it_will_have(root):
     win.destroy()
 
 
+def test_unmapped_size_ignores_the_size_a_never_shown_window_reports(root):
+    # The size a window reports before it has ever been shown is not the size
+    # it will map at, and *which* windows report one is platform-dependent: a
+    # Toplevel says 1x1, but on win32 the root says whatever size Tk started it
+    # at -- a plausible number that passes any "is this realized yet" check
+    # made of winfo alone. That is why being shown is tracked rather than
+    # inferred, and why the reported size is forced here: the root is shared
+    # across the suite and has long since been mapped.
+    win = ttk.Toplevel(master=root)
+    win.withdraw()
+    ttk.Label(win, text="wide enough that the content decides the size").pack(
+        padx=40, pady=40
+    )
+    win.update_idletasks()
+    request = (win.winfo_reqwidth(), win.winfo_reqheight())
+    assert request != (600, 200), "the forced size has to be the wrong answer"
+
+    win.winfo_width = lambda: 600
+    win.winfo_height = lambda: 200
+    assert win._unmapped_size() == request
+    win.destroy()
+
+
+def test_being_shown_is_noticed(root):
+    # The flag is now the only evidence a window was realized, so the event
+    # that sets it has to actually arrive. (Asserting the predicted size
+    # against the realized one would be stricter than the contract: a tiling
+    # window manager sizes a new toplevel to the workspace regardless of what
+    # it asked for.)
+    win = ttk.Toplevel(master=root)
+    win.withdraw()
+    ttk.Label(win, text="x").pack()
+    win.update_idletasks()
+    assert not win._ever_shown
+    win.deiconify()
+    _settled(win)
+    assert win._ever_shown, "the window was shown and nothing noticed"
+    win.destroy()
+
+
+def test_a_stale_map_does_not_retire_a_newer_size(root):
+    # These events are dispatched when the event queue is drained, not when
+    # they occur, so a map the window has since been withdrawn from can arrive
+    # *after* a newer size was recorded. Retiring the record on that event
+    # discards the pending size and centers against one the window no longer
+    # has -- the "newer size wins" invariant, backwards.
+    win = ttk.Toplevel(master=root)
+    ttk.Label(win, text="x").pack()
+    _settled(win)
+    win.withdraw()
+    win.geometry("800x600")
+    # Delivered directly rather than by racing the queue: whether a real map is
+    # still pending after `update_idletasks` is a window-manager timing detail,
+    # and the rule under test ("an event that arrives while the window is not
+    # on screen is stale") holds regardless of how the event got there.
+    win.event_generate("<Map>", when="now")
+    assert win._unmapped_size() == (800, 600)
+    win.destroy()
+
+
+def test_a_size_applied_while_shown_is_not_a_pending_request(root):
+    # A `geometry` call on a window already on screen takes effect at once, so
+    # there is no next map to retire it. Left recorded, it would outlive any
+    # later resize and be preferred over the size the window really has.
+    win = ttk.Toplevel(master=root)
+    ttk.Label(win, text="x").pack()
+    _settled(win)
+    win.geometry("400x300")
+    _settled(win)
+    assert win._applied_size is None
+    win.destroy()
+
+
 # --------------------------------------------------------------------------
 # icon semantics
 # --------------------------------------------------------------------------

--- a/tools/verify_positioning.py
+++ b/tools/verify_positioning.py
@@ -1,14 +1,38 @@
-"""Cross-platform verification for #1310 / PR #1312 (dialog positioning).
+"""Cross-platform verification for window and dialog positioning.
 
-Run from the repo root on each platform:
+Run from the repo root on each platform -- Windows, macOS (aqua) and Linux
+(x11):
 
     PYTHONPATH=src python tools/verify_positioning.py
 
-Prints a PASS/FAIL line per check. Checks 4, 5 and 6 open real windows and need
-a human to look at them; everything else is automatic.
+Prints a PASS/FAIL line per check. Checks 4, 5, 6 and 7 open real windows;
+4, 5 and 6 want a human to look at them, the rest are automatic.
+
+WHY THIS IS PER-PLATFORM, AND WHY A GREEN RUN ON ONE BOX PROVES LITTLE
+
+Centering a window before it is shown means predicting the size it will map at,
+and what a window reports about itself before its first map differs by platform:
+x11 says 1x1, while win32 reports the size Tk started the window at -- a
+plausible-looking number that is not the size the content will map at. Any
+check that trusts what the window reports therefore passes on whichever
+platform it happens to be right about. That is not hypothetical: it is how the
+demo shipped opening off-centre on Windows while every test passed.
+
+Two consequences for anyone adding a check here. It has to fail against the bug
+it is meant to catch -- verify that by reverting the fix, not by reading the
+code. And the *shape* of the window matters as much as the platform: a root and
+a Toplevel report differently, and so do content packed straight into the root
+versus content packed after the root has settled (see check 7).
+
+There is no CI, so these runs are manual. On macOS run it against both Tk lines
+(8.6 and 9.0 -- the aqua scaling baseline moved in 9). On x11 run it twice,
+with and without `screeninfo` installed: that is the only way to exercise the
+Xinerama fallback in check 2.
 """
 import re
+import subprocess
 import sys
+import textwrap
 import time
 import tkinter
 
@@ -172,6 +196,73 @@ print("    -> LOOK: that window should already be centered when it appears, and"
 print("             should not flash or jump on the way in.")
 hold(probe)
 probe.destroy()
+
+# --- 7. a content-sized ROOT, centered before its first map ----------------
+# This is the demo's case (`python -m ttkbootstrap`) and the one check 6 misses:
+# check 6 passes a size, which is remembered and used directly, while a window
+# sized only by its content has to be measured. What a window reports before
+# its first map is platform-specific -- x11 says 1x1, but win32 reports the
+# size Tk started it at, a plausible number unrelated to the size the content
+# will map at -- so a check that trusts it silently passes on the platform it
+# is right on. It must be a *root*: on win32 a Toplevel does report 1x1, so a
+# Toplevel version of this check passes even against the bug. Hence a separate
+# process -- this one's root has long since been shown.
+#
+# The structure matters as much as the sizing: the content goes into a frame
+# that is packed *afterwards*, exactly as the demo builds itself. Packing
+# straight into the root instead lets Tk settle the root on the real size
+# before anyone measures it, and the check then passes even against the bug.
+_child = textwrap.dedent("""
+    import ttkbootstrap as ttk
+    app = ttk.App(title="content-sized root", minsize=(600, 0))
+    app.withdraw()
+    bag = ttk.Frame(app)
+    for i in range(6):
+        ttk.Button(bag, text=f"a reasonably wide button {i}").pack(padx=30, pady=6)
+    app.update_idletasks()      # the root settles at its default size here
+    bag.pack(fill="both", expand=True)
+    predicted = app._unmapped_size()
+    applied = []
+    _g = app.geometry
+    app.geometry = lambda spec=None: (
+        applied.append(spec) if spec is not None else None) or _g(spec)
+    app.place_window_center()
+    del app.geometry
+    app.deiconify()
+    app.update_idletasks()
+    app.update()
+    print("RESULT", predicted[0], predicted[1],
+          app.winfo_width(), app.winfo_height(), applied[-1])
+""")
+_proc = subprocess.run([sys.executable, "-c", _child], capture_output=True, text=True)
+_line = next((ln for ln in _proc.stdout.splitlines() if ln.startswith("RESULT")), None)
+if _line is None:
+    check("7. a content-sized root is measured, not guessed", False,
+          f"the child process reported nothing ({_proc.stderr.strip()[:200]})",
+          always_show=True)
+else:
+    _, pw, ph, mw_, mh_, spec = _line.split(maxsplit=5)
+    predicted, mapped = (int(pw), int(ph)), (int(mw_), int(mh_))
+    check("7. a content-sized root is measured, not guessed", predicted == mapped,
+          f"predicted={predicted[0]}x{predicted[1]} "
+          f"mapped={mapped[0]}x{mapped[1]}", always_show=True)
+
+    coords = re.search(r"\+(-?\d+)\+(-?\d+)$", spec)
+    if coords is None:
+        check("7b. a content-sized root is centered", False,
+              f"no +x+y was applied ({spec})", always_show=True)
+    else:
+        ax, ay = int(coords.group(1)), int(coords.group(2))
+        monitor = p._monitor_at_point(ax, ay)
+        if monitor:
+            mx, my, mw, mh = monitor
+        else:
+            mx, my = 0, 0
+            mw, mh = app.winfo_screenwidth(), app.winfo_screenheight()
+        want = (mx + (mw - mapped[0]) // 2, my + (mh - mapped[1]) // 2)
+        check("7b. a content-sized root is centered", (ax, ay) == want,
+              f"applied=({ax},{ay}) want={want} "
+              f"mapped={mapped[0]}x{mapped[1]}", always_show=True)
 
 failed = [n for n, ok in results if not ok]
 print(f"\n{len(results) - len(failed)}/{len(results)} automatic checks passed")


### PR DESCRIPTION
`_unmapped_size` decided "has this window ever been shown?" with
`winfo_width() > 1`. That is x11 reasoning — there a never-mapped window really
does report 1x1 — but **win32 reports a plausible size unrelated to what the
content will map at**, so the inference fires falsely and skips the rest of the
measurement.

Two consequences, both reproducible on Windows:

- `python -m ttkbootstrap` opened off-centre. The demo centred a 600x200 box
  that maps at 846x696, applying `+980+620` instead of `+857+372`.
- **`master`'s suite is red on Windows.**
  `test_unmapped_size_falls_back_to_content_raised_to_minsize` returns the
  content request `(14, 19)` instead of the `minsize` floor `(500, 300)`,
  because after `update_idletasks()` a withdrawn win32 *Toplevel* also reports a
  realized size. So the gap is not root-only, and it is why the Linux suite went
  green while Windows did not.

Being shown is now *tracked* (`_ever_shown`, set from the `<Map>`/`<Configure>`
handler) rather than inferred, with the watch installed in both `App.__init__`
and `Toplevel.__init__`. A `/code-review` found three pre-existing defects in
the preceding size bookkeeping; the two cheap ones are folded in — the handler
is gated on `winfo_ismapped()` so a stale map dispatched after a newer
`geometry()` cannot discard it, and it also listens to `<Configure>` because a
`geometry()` call on an already-shown window is realized at once and otherwise
never retires. The third (a user's `bind("<Map>", ...)` without `add=True`
clobbers the watch — LOW, pre-existing) was deliberately left; the fix wanted a
private bindtag plus a `destroy` override on every window.

`tools/verify_positioning.py` grows **check 7**, which reads FAIL at the branch
base and PASS with the fix. Closing that gap was the more valuable part: check 6
had passed against this bug the whole time because it uses the explicitly-sized
path, which the bug never touched.

### Gates

- Suite on Windows: **934 passed, 3 skipped** (master: 929 passed, **1 failed**).
- Docs build under `-W`: exit 0.

### Still outstanding

A macOS (both Tk lines) and x11 (with and without `screeninfo`) run of
`verify_positioning.py` check 7. The risk is narrow: on x11 old and new code
both fall through to the content-request path, so behaviour is identical there;
what is new is that a shown-then-withdrawn window returns its realized size only
if the flag got set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)