### PR TITLE
ci: add macOS to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
             python: "3.13"
           - os: windows-latest
             python: "3.13"
+          # aqua is the third windowing system and behaves differently enough to
+          # have had its own fixes (the Tk 9 dpi baseline, native popup chrome,
+          # the busy no-op). Its positioning work is still hand-verified.
+          - os: macos-latest
+            python: "3.13"
           # The floor declared in pyproject.toml, so a 3.11+ only construct
           # cannot slip in.
           - os: ubuntu-latest
@@ -60,6 +65,12 @@ jobs:
           python -m pip install -e .
           python -m pip install pytest
 
+      # Which Tk line a runner carries is not something to assume: aqua's dpi
+      # baseline and the scroll-event contract both differ between 8.6 and 9,
+      # so record it per job rather than inferring it from the Python version.
+      - name: Report the Tk build
+        run: python -c "import sys, tkinter; print(f'{sys.platform} python={sys.version.split()[0]} tcl={tkinter.TclVersion} tk={tkinter.TkVersion}')"
+
       # screeninfo is deliberately NOT installed: it is optional at runtime, and
       # leaving it out exercises the fallback layout path (X11 Xinerama, then
       # Tk's own screen metrics), which is the more fragile of the two.
@@ -73,8 +84,10 @@ jobs:
         if: runner.os == 'Linux'
         run: xvfb-run -a -s "-screen 0 1280x1024x24 -dpi 96" python -m pytest -q
 
-      - name: Run the suite (Windows)
-        if: runner.os == 'Windows'
+      # Windows and macOS both have a real window server, so no display to set
+      # up -- Tk talks to win32 and to aqua directly.
+      - name: Run the suite
+        if: runner.os != 'Linux'
         run: python -m pytest -q
 
   docs:


### PR DESCRIPTION
Follow-up to #1317, which deliberately left macOS out to avoid a day-one flaky
matrix. aqua is the third windowing system and has needed its own fixes — the Tk 9
dpi baseline, native popup chrome, the `busy` no-op that cannot be emulated — so
leaving it out meant the one platform whose positioning work is still
hand-verified had no automated gate at all.

**It passed on the first run**, with no aqua-specific accommodation:

| Job | Tcl/Tk | Result |
|---|---|---|
| `ubuntu-latest, py3.13` | 8.6 | 934 passed, 3 skipped |
| `windows-latest, py3.13` | 8.6 | 934 passed, 3 skipped |
| **`macos-latest, py3.13`** | **8.6** | **934 passed, 3 skipped** |
| `ubuntu-latest, py3.10` | 8.6 | 933 passed, 4 skipped |
| `docs (-W)` | — | exit 0 |

Identical counts across all three windowing systems, which is the useful signal:
the suite's platform branches are forced probes (the #1229 convention) rather than
`skipif`, so every platform runs the whole matrix and the numbers should match.
macOS was the slowest at 10s, still trivial.

### Notes

- **No display setup.** Windows and macOS both have a real window server, so Tk
  talks to win32 and aqua directly. That let the two run steps collapse into one
  `runner.os != 'Linux'` step rather than growing a third.
- **Reports the Tcl/Tk build per job.** Which Tk line a runner carries is not
  inferable from the Python version, and 8.6 vs 9 is exactly the split behind the
  aqua scaling baseline and the scroll-event contract. Now stated per run instead
  of assumed — and the answer is that **every runner is Tk 8.6**, so CI does not
  cover Tk 9 on any platform. Worth its own decision; Tk 9 stays a manual step.

### What this does not cover

`tools/verify_positioning.py` — the checks that open real windows for a human to
look at, including check 7. Those remain a manual per-platform run. CI now proves
the headless suite passes on aqua; it cannot prove a window landed where it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)