### PR TITLE
docs: fix the release runbook's unsafe upload step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1814,7 +1814,16 @@ release is cut from `master`, so the version bump lands there naturally;
    RTD is unaffected; it installs fresh, so it reports the real version.
 2. Fold `development/2_<x>_changes.md` into the release notes.
 3. Run the gates: the full suite, and the docs build under `-W`.
-4. `python -m build`, then `twine check dist/*`, then `twine upload dist/*`.
+4. **Empty `dist/` first**, then `python -m build`, then `twine check dist/*`, then
+   upload **by explicit version glob** — `twine upload dist/ttkbootstrap-X.Y.Z*`.
+   `dist/` is gitignored, so it keeps whatever the last release built: at 2.1.0 it
+   still held the 2.0.0 wheel and sdist from July 19, and a bare `dist/*` upload
+   would have tried to re-publish 2.0.0 alongside the new version. Worth spending
+   a minute on the artifact while you are there — `twine check` validates metadata
+   but not contents, so confirm the wheel carries `ttkbootstrap/assets/icons/`
+   (the vendored Bootstrap Icons font is package data, and a wheel missing it
+   installs and then fails at first render) and that the sdist has no `docs/` or
+   `development/` in it.
 5. Annotated tag `vX.Y.Z`, plus a GitHub release titled the same way.
 6. Verify with a clean-environment `pip install ttkbootstrap==X.Y.Z`.
 


### PR DESCRIPTION
Found while running the 2.1.0 pre-flight, which is the good time to find it.

The runbook said:

> `python -m build`, then `twine check dist/*`, then `twine upload dist/*`

`dist/` is gitignored, so it keeps whatever the *previous* release built. At 2.1.0
it still held the **2.0.0** wheel and sdist from July 19, so `twine upload dist/*`
would have tried to re-publish 2.0.0 alongside the new version.

Now: **empty `dist/` first**, and upload by **explicit version glob**
(`twine upload dist/ttkbootstrap-X.Y.Z*`).

Also adds the artifact check `twine check` does *not* perform — it validates
metadata, not contents. A wheel missing the vendored Bootstrap Icons font under
`ttkbootstrap/assets/icons/` passes `twine check` and then fails at first render,
because that font is package data rather than code.

Verified by hand for the 2.1.0 artifacts:

- wheel: 116 entries, **5** under `assets/icons/` (`bootstrap.ttf`,
  `glyphmap.json`, `icon_metrics.json`, plus the font's own LICENSE/README), and
  all eight subpackages (`assets`, `dialogs`, `internal`, `localization`, `style`,
  `themes`, `utils`, `widgets`)
- sdist: 174 entries — `src` (132) and `tests` (35) plus metadata; **no** `docs/`,
  `development/`, `examples/` or `gallery/`
- `twine check`: PASSED on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)