### PR TITLE
chore: bump the version to 2.1.1

### DIFF
--- a/development/2_1_1_changes.md
+++ b/development/2_1_1_changes.md
@@ -3,7 +3,10 @@
 > The consolidated log of changes that alter behavior or appearance since
 > **2.1.0**, each with **what** changed and **why**. Same role its predecessors
 > (`2_1_changes.md`, `2_0_breaking_changes.md`) played: kept in `development/`
-> so it survives, and the source for the release notes when this ships.
+> so it survives, and the source for this release's notes.
+>
+> **A typing- and docs-only patch.** No runtime behavior changes: the shipped
+> stub is inert at import, and the one library file touched is a reference page.
 >
 > Scope is **relative to 2.1.0**. A regression introduced *and* fixed inside
 > this cycle never reached a user, so it belongs to the dev log in `CLAUDE.md`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ttkbootstrap"
-version = "2.1.0"
+version = "2.1.1"
 description = "A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps `pyproject.toml` to **2.1.1**, the first step of the release proper, and marks `development/2_1_1_changes.md` as this release's notes source.

A **typing- and docs-only patch.** The one user-visible change is #1328 / #1327: hovering a widget constructor shows that widget's parameters again, which 2.0 lost when the hand-written type stub was deleted. The shipped stub is inert at import, so there are no runtime behavior changes — the only library file the release touches is a reference page (`optionmenu.rst`, which was missing `command`).

Bumped on `master` at release time per the runbook, rather than on a release branch: 2.0.1 shipped its bump on a throwaway `release/2.0` and `master` kept claiming 2.0.0 for days afterwards.

## Release gates, already run

- Suite **992 passed, 5 skipped**; docs clean under `-W`.
- CI green on all four jobs for the merged change (Linux/Windows/macOS py3.13 + the py3.10 floor). Counts identical across platforms; py3.10's single extra skip is pre-existing on `master`.
- `dist/` emptied first — it still held the 2.1.0 wheel and sdist, which a bare `dist/*` upload would have tried to re-publish.
- `python -m build` + `twine check` **PASSED** on both artifacts.

## Artifact contents, since `twine check` only validates metadata

| Check | Result |
|---|---|
| wheel: vendored icon font | 5 files present |
| wheel: `py.typed` + `__init__.pyi` | both present |
| sdist: `docs/` or `development/` | none |
| sdist diff vs 2.1.0 | exactly `src/ttkbootstrap/__init__.pyi` and `tests/test_widget_stubs.py` added, nothing removed |

Sizes 546,216 / 590,236, up ~10K/13K on 2.1.0 — consistent with adding the stub.

## Clean-environment smoke test of the built wheel

Fresh 3.13 venv, installed from the local wheel: warning-free import, version reads 2.1.1, 30 themes, a live theme switch, the vendored icon font on disk, and `bootstyle="success"` resolving. Then the part that matters for this release — **type-checking against the installed package rather than the repo source**: valid code clean, and all six seeded typos caught from the site-packages stub.

## Not included

**#1322** stays open, so this does not close the `2.1.x` milestone. It is test-only and contributor-facing (four asset-geometry tests fail on a non-baseline-density display), so it does not gate a patch — say if you would rather it ride along.

## Remaining steps after this merges

Upload to PyPI (yours), then the annotated `v2.1.1` tag, the GitHub release from the change log, and a clean-environment `pip install ttkbootstrap==2.1.1` — with `--no-cache-dir`, since at 2.1.0 pip cached an empty index page and kept failing after the release was genuinely live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
