### PR TITLE
feat(themes): convert a 1.x custom theme to the 2.x Theme form

### DIFF
--- a/development/2_2_changes.md
+++ b/development/2_2_changes.md
@@ -1,0 +1,65 @@
+# 2.2 changes
+
+Scope: changes relative to **2.1.1**. Log entries here as they land, not at
+release time.
+
+---
+
+## Added
+
+### `python -m ttkbootstrap.convert_theme` — carry a 1.x custom theme forward
+
+A custom theme saved by ttkbootstrap 1.x now converts to the 2.x
+`Theme(...).register()` form with one command:
+
+```bash
+python -m ttkbootstrap.convert_theme user.py -o brand.py
+```
+
+It reads either input a 1.x user could be holding:
+
+- a **`user.py`** containing a `USER_THEMES` dict — what 1.x ttkcreator's
+  **Export** button produced (it copied the in-package `themes/user.py`), and
+  the file most people will actually have;
+- a **JSON** file in the `Style.load_user_themes` format.
+
+Every theme in the file converts, under a single `import`. Output goes to
+standard output, or to `-o <file>`.
+
+**What carries over:** the five accent anchors, the optional `secondary`, and
+the theme's `background`/`foreground`.
+
+**What does not, deliberately:**
+
+- The plumbing colors — `border`, `inputbg`, `inputfg`, `selectbg`, `selectfg`,
+  `active` — are dropped, because 2.x derives them from the anchors. This is the
+  same regeneration `theme_from_legacy_dict` applies to the built-in legacy
+  themes.
+- The opposite mode. A 1.x theme declares one mode, so the generated family
+  declares that one and leaves the other commented out rather than inventing
+  colors for it.
+
+Converted output is close but not pixel-identical: an accent is re-derived per
+mode for contrast, so a dark theme's authored `#6a5acd` resolves to `#887bd7`.
+
+The module is pure text transformation — no Tk, no display, importable and
+runnable headlessly. `tests/test_convert_theme.py` (+13) covers both input
+formats, the loud-failure paths, and an end-to-end check that the emitted
+Python actually registers a theme and styles real widgets.
+
+## Documentation
+
+- **Migrating to 2.0** gained *Saved themes move into your code*: the
+  `themes/user.py` store and ttkcreator's Import/Export buttons are gone, the
+  converter command, what carries over vs. what 2.x regenerates, and a note
+  that `Style.load_user_themes` still reads the 1.x JSON (thinner — verbatim
+  plumbing, single mode, nothing for `toggle_theme()` to flip to).
+  This removal shipped in 2.0 but was never written down; the gap is what
+  prompted the converter.
+- **Theming & Colors** gained a *Coming from 1.x* annotation under the visual
+  editor pointing at the converter.
+- **Reference › Theming** gained a *Converting a 1.x theme* section.
+- `Style.load_user_themes` had a one-line docstring (`"Load user themes saved
+  in json format"`) that never stated the file format; it now specifies the
+  JSON shape, the verbatim-colors/single-mode behavior, and points at the
+  converter.

--- a/development/2_2_changes.md
+++ b/development/2_2_changes.md
@@ -16,11 +16,14 @@ A custom theme saved by ttkbootstrap 1.x now converts to the 2.x
 python -m ttkbootstrap.convert_theme user.py -o brand.py
 ```
 
-It reads either input a 1.x user could be holding:
+It reads any input a 1.x user could be holding — ttkcreator had three save
+paths, and each one's artifact converts:
 
 - a **`user.py`** containing a `USER_THEMES` dict — what 1.x ttkcreator's
-  **Export** button produced (it copied the in-package `themes/user.py`), and
-  the file most people will actually have;
+  **Export** button produced (it copied the in-package `themes/user.py`);
+- a **`.py`** holding a `ThemeDefinition(...)` call — what its **Export theme
+  definition** wrote, and the one most likely to be sitting in a user's own
+  project, since the other two live inside the installed package;
 - a **JSON** file in the `Style.load_user_themes` format.
 
 Every theme in the file converts, under a single `import`. Output goes to
@@ -32,9 +35,16 @@ the theme's `background`/`foreground`.
 **What does not, deliberately:**
 
 - The plumbing colors — `border`, `inputbg`, `inputfg`, `selectbg`, `selectfg`,
-  `active` — are dropped, because 2.x derives them from the anchors. This is the
-  same regeneration `theme_from_legacy_dict` applies to the built-in legacy
-  themes.
+  `active` — are dropped, because `Theme` derives all six from the anchors and
+  the surface. (Not the same as `theme_from_legacy_dict`, which the built-in
+  legacy themes go through: that one regenerates only `border`, `inputbg` and
+  `active`, and passes the other three verbatim.)
+- The `light` and `dark` accents, because 2.x derives that pair from the
+  `neutral` ramp. A converted theme takes the default gray; `Theme(neutral=...)`
+  tunes it. Note `neutral` is the ramp *base*, not the pale `light` accent —
+  1.x's near-white `light` corresponds to ramp step `[100]`, so passing it
+  through as `neutral` would wash out `selectbg` and an uncolored `secondary`
+  along with it.
 - The opposite mode. A 1.x theme declares one mode, so the generated family
   declares that one and leaves the other commented out rather than inventing
   colors for it.
@@ -43,9 +53,10 @@ Converted output is close but not pixel-identical: an accent is re-derived per
 mode for contrast, so a dark theme's authored `#6a5acd` resolves to `#887bd7`.
 
 The module is pure text transformation — no Tk, no display, importable and
-runnable headlessly. `tests/test_convert_theme.py` (+13) covers both input
-formats, the loud-failure paths, and an end-to-end check that the emitted
-Python actually registers a theme and styles real widgets.
+runnable headlessly. `tests/test_convert_theme.py` (+23) covers all three input
+formats, the loud-failure paths, the escaping of what it emits, and an
+end-to-end check that the emitted Python actually registers a theme and styles
+real widgets.
 
 ## Documentation
 

--- a/docs/reference/theming.rst
+++ b/docs/reference/theming.rst
@@ -32,9 +32,10 @@ Legacy themes
 Converting a 1.x theme
 ----------------------
 
-A custom theme saved by 1.x — a ``user.py`` holding a ``USER_THEMES`` dict, or
-a JSON file for :meth:`~ttkbootstrap.Style.load_user_themes` — converts to the
-equivalent ``Theme(...).register()`` call:
+A custom theme saved by 1.x — a ``user.py`` holding a ``USER_THEMES`` dict, a
+``.py`` holding a ``ThemeDefinition(...)`` call, or a JSON file for
+:meth:`~ttkbootstrap.Style.load_user_themes` — converts to the equivalent
+``Theme(...).register()`` call:
 
 .. code-block:: bash
 

--- a/docs/reference/theming.rst
+++ b/docs/reference/theming.rst
@@ -29,6 +29,21 @@ Legacy themes
 
 .. autofunction:: ttkbootstrap.install_legacy_themes
 
+Converting a 1.x theme
+----------------------
+
+A custom theme saved by 1.x — a ``user.py`` holding a ``USER_THEMES`` dict, or
+a JSON file for :meth:`~ttkbootstrap.Style.load_user_themes` — converts to the
+equivalent ``Theme(...).register()`` call:
+
+.. code-block:: bash
+
+   python -m ttkbootstrap.convert_theme user.py -o brand.py
+
+Pass ``-o`` to write a file, or omit it to print to standard output. Every
+theme in the file converts. See :doc:`Migrating to 2.0
+</user-guide/getting-started/migrating>` for what carries over.
+
 See also
 --------
 

--- a/docs/user-guide/feature-guides/theming.rst
+++ b/docs/user-guide/feature-guides/theming.rst
@@ -259,7 +259,8 @@ save into the library; your theme lives in your own code.
 
       python -m ttkbootstrap.convert_theme user.py -o brand.py
 
-   It reads either a 1.x ``user.py`` or a ``load_user_themes`` JSON file and
-   writes the equivalent ``Theme(...).register()`` call. See
+   It reads a 1.x ``user.py``, an exported ``ThemeDefinition(...)`` file, or a
+   ``load_user_themes`` JSON file, and writes the equivalent
+   ``Theme(...).register()`` call. See
    :doc:`Migrating to 2.0 </user-guide/getting-started/migrating>` for what
    carries over and what 2.x regenerates.

--- a/docs/user-guide/feature-guides/theming.rst
+++ b/docs/user-guide/feature-guides/theming.rst
@@ -246,3 +246,20 @@ Edit the accent anchors and the light/dark surfaces, preview against live
 widgets, then **Export theme (.py)** -- you get a ``Theme(...).register()``
 snippet (the same shape as above) to drop into your app. The editor doesn't
 save into the library; your theme lives in your own code.
+
+.. admonition:: Coming from 1.x
+   :class: note
+
+   1.x kept custom themes in a ``USER_THEMES`` dict inside the package
+   (``themes/user.py``) and moved them around with the editor's Import and
+   Export buttons. That store is gone. To bring an old theme forward, convert
+   the file you saved:
+
+   .. code-block:: bash
+
+      python -m ttkbootstrap.convert_theme user.py -o brand.py
+
+   It reads either a 1.x ``user.py`` or a ``load_user_themes`` JSON file and
+   writes the equivalent ``Theme(...).register()`` call. See
+   :doc:`Migrating to 2.0 </user-guide/getting-started/migrating>` for what
+   carries over and what 2.x regenerates.

--- a/docs/user-guide/getting-started/migrating.rst
+++ b/docs/user-guide/getting-started/migrating.rst
@@ -145,9 +145,9 @@ with ttkcreator's **Import** / **Export** buttons, which copied that file in and
 out. A theme now lives in your own code as a :class:`~ttkbootstrap.Theme` you
 register at startup, so it survives reinstalls and upgrades.
 
-To carry a 1.x theme across, convert the file you saved — either a ``user.py``
-from ttkcreator's old **Export**, or a JSON file you wrote for
-``load_user_themes``:
+To carry a 1.x theme across, convert the file you saved — a ``user.py`` from
+ttkcreator's old **Export**, a ``.py`` from its **Export theme definition**, or
+a JSON file you wrote for ``load_user_themes``:
 
 .. code-block:: bash
 
@@ -176,16 +176,19 @@ needs a live style — then select it by its generated variant name:
    ttk.Theme(name="midnight", ...).register()
    app.theme_use("midnight-dark")
 
-Your accents and that mode's background and foreground carry over verbatim. Two
-things deliberately do not:
+Your accents and that mode's background and foreground carry over verbatim.
+Three things deliberately do not:
 
 - **The plumbing colors** — ``border``, ``inputbg``, ``inputfg``, ``selectbg``,
-  ``selectfg``, and ``active`` are dropped, because 2.x derives them from the
-  anchors for consistent contrast. This is the same regeneration the built-in
-  legacy themes get.
+  ``selectfg``, and ``active`` are dropped, because 2.x derives all six from the
+  anchors and the surface for consistent contrast.
+- **The light and dark accents** — 2.x derives that pair from the neutral ramp,
+  so a converted theme takes the default gray. Set
+  :attr:`neutral <ttkbootstrap.Theme.neutral>` on the ``Theme`` call to tune it;
+  it is the ramp *base*, several steps darker than 1.x's near-white ``light``.
 - **The opposite mode** — a 1.x theme declares one, so the converted family
   declares that one and leaves the other commented out. Fill it in to get a
-  matched pair that :func:`toggle_theme <ttkbootstrap.Style.toggle_theme>` can
+  matched pair that :meth:`toggle_theme <ttkbootstrap.Style.toggle_theme>` can
   flip between.
 
 Expect the result to be very close rather than pixel-identical: an accent is

--- a/docs/user-guide/getting-started/migrating.rst
+++ b/docs/user-guide/getting-started/migrating.rst
@@ -136,6 +136,71 @@ instead, which draws from a bundled Bootstrap Icons font:
 If you passed a character to ``ToastNotification(icon=...)``, give it a Bootstrap
 Icons glyph name instead (for example ``icon="bell-fill"``).
 
+Saved themes move into your code
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1.x saved custom themes into ``ttkbootstrap/themes/user.py`` — a module *inside*
+the installed package. That store and its ``USER_THEMES`` dict are gone, along
+with ttkcreator's **Import** / **Export** buttons, which copied that file in and
+out. A theme now lives in your own code as a :class:`~ttkbootstrap.Theme` you
+register at startup, so it survives reinstalls and upgrades.
+
+To carry a 1.x theme across, convert the file you saved — either a ``user.py``
+from ttkcreator's old **Export**, or a JSON file you wrote for
+``load_user_themes``:
+
+.. code-block:: bash
+
+   python -m ttkbootstrap.convert_theme user.py -o brand.py
+
+That writes a ready-to-run ``Theme(...).register()`` call:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   ttk.Theme(
+       name="midnight",
+       primary="#6a5acd", secondary="#6c757d",
+       success="#02b875", info="#17a2b8",
+       warning="#f0ad4e", danger="#d9534f",
+       dark=dict(background="#1c1c1c", foreground="#e9ecef"),
+   ).register()
+
+Paste it into your startup code, after the ``App`` exists — registering a theme
+needs a live style — then select it by its generated variant name:
+
+.. code-block:: python
+
+   app = ttk.App()
+   ttk.Theme(name="midnight", ...).register()
+   app.theme_use("midnight-dark")
+
+Your accents and that mode's background and foreground carry over verbatim. Two
+things deliberately do not:
+
+- **The plumbing colors** — ``border``, ``inputbg``, ``inputfg``, ``selectbg``,
+  ``selectfg``, and ``active`` are dropped, because 2.x derives them from the
+  anchors for consistent contrast. This is the same regeneration the built-in
+  legacy themes get.
+- **The opposite mode** — a 1.x theme declares one, so the converted family
+  declares that one and leaves the other commented out. Fill it in to get a
+  matched pair that :func:`toggle_theme <ttkbootstrap.Style.toggle_theme>` can
+  flip between.
+
+Expect the result to be very close rather than pixel-identical: an accent is
+re-derived per mode for contrast, so a dark theme's authored ``#6a5acd`` may
+resolve a step lighter.
+
+.. admonition:: Keeping the JSON instead
+   :class: note
+
+   ``Style.load_user_themes(path)`` still reads the 1.x JSON format, so an
+   existing file keeps working without conversion. It is the thinner path,
+   though: it takes all sixteen 1.x colors verbatim — including the plumbing
+   2.x would otherwise regenerate — and registers a single-mode theme, so
+   ``toggle_theme()`` has nothing to flip to. Prefer converting.
+
 Keyword-only constructors and renamed options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -183,7 +248,7 @@ removed in 3.0.
 - **Tuple and list bootstyle** — the canonical form is a single string.
   ``bootstyle=("primary", "outline")`` becomes ``bootstyle="primary outline"``. See
   :doc:`Styling with bootstyle </user-guide/foundations/bootstyle-grammar>`.
-- **The ``inverse-<color>`` modifier** — superseded by the ``@<color>`` **surface**
+- **The inverse-<color> modifier** — superseded by the ``@<color>`` **surface**
   token, which does the same thing (fills the label with the color and picks a
   contrasting text). ``bootstyle="inverse-primary"`` becomes ``bootstyle="@primary"``.
   See :doc:`Styling with bootstyle </user-guide/foundations/bootstyle-grammar>`.

--- a/src/ttkbootstrap/convert_theme.py
+++ b/src/ttkbootstrap/convert_theme.py
@@ -1,0 +1,207 @@
+"""Convert a ttkbootstrap 1.x theme file into a 2.x ``Theme(...).register()`` snippet.
+
+Run it on a theme file saved by 1.x -- a ``user.py`` holding a ``USER_THEMES``
+dict (what 1.x ttkcreator exported), or a JSON file in the
+``Style.load_user_themes`` format -- and it prints Python you paste into your
+own app::
+
+    python -m ttkbootstrap.convert_theme mythemes.json
+    python -m ttkbootstrap.convert_theme user.py -o brand.py
+
+The five accent anchors, the optional secondary accent, and the theme's
+background/foreground carry over. `border`, `inputbg`, `inputfg`, `selectbg`,
+`selectfg`, and `active` are dropped: 2.x derives them from the anchors. A 1.x
+theme declares one mode, so the generated family declares that mode and leaves
+the opposite one commented out.
+"""
+import argparse
+import ast
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+#: 1.x color keys that carry over to a `Theme` anchor of the same name.
+_ACCENT_KEYS = ("primary", "success", "info", "warning", "danger")
+
+#: 1.x color keys the 2.x engine derives rather than reads.
+_DERIVED_KEYS = ("border", "inputbg", "inputfg", "selectbg", "selectfg", "active")
+
+
+def load_legacy_themes(path):
+    """Read a 1.x theme file and return its ``{name: spec}`` mapping.
+
+    Parameters:
+
+        path (str or Path):
+            A ``.json`` file in the ``Style.load_user_themes`` format, or a
+            ``.py`` file defining a ``USER_THEMES`` dict.
+
+    Returns:
+
+        dict:
+            Each 1.x spec, keyed by theme name.
+    """
+    path = Path(path)
+    text = path.read_text(encoding="utf-8")
+    if path.suffix == ".py":
+        themes = _themes_from_python(text, path)
+    else:
+        themes = _themes_from_json(text)
+    if not themes:
+        raise ValueError(f"{path}: no themes found.")
+    return themes
+
+
+def _themes_from_json(text):
+    """Return ``{name: spec}`` from a ``load_user_themes``-format JSON file."""
+    data = json.loads(text)
+    entries = data.get("themes", data) if isinstance(data, dict) else data
+    if isinstance(entries, dict):
+        return dict(entries)
+    themes = {}
+    for entry in entries:
+        themes.update(entry)
+    return themes
+
+
+def _themes_from_python(text, path):
+    """Return ``{name: spec}`` from a 1.x ``user.py``-style theme store."""
+    tree = ast.parse(text, filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "USER_THEMES" in names or "STANDARD_THEMES" in names:
+            return dict(ast.literal_eval(node.value))
+    raise ValueError(f"{path}: no USER_THEMES assignment found.")
+
+
+def _mode(name, spec):
+    """Return the theme's ``light``/``dark`` mode."""
+    mode = spec.get("mode") or spec.get("type")
+    if mode not in ("light", "dark"):
+        raise ValueError(
+            f"theme {name!r}: expected a 'mode' (or 1.x 'type') of 'light' or "
+            f"'dark', got {mode!r}."
+        )
+    return mode
+
+
+def _colors(name, spec):
+    """Return the theme's color mapping, checking the keys conversion needs."""
+    colors = spec.get("colors")
+    if not isinstance(colors, dict):
+        raise ValueError(f"theme {name!r}: missing a 'colors' mapping.")
+    missing = [k for k in _ACCENT_KEYS + ("bg", "fg") if not colors.get(k)]
+    if missing:
+        raise ValueError(
+            f"theme {name!r}: missing color(s) {', '.join(missing)}."
+        )
+    return colors
+
+
+def theme_snippet(name, spec):
+    """Render one 1.x theme spec as a ``ttk.Theme(...).register()`` call.
+
+    Parameters:
+
+        name (str):
+            The theme name; becomes the family name, so the call registers
+            ``<name>-light`` or ``<name>-dark``.
+
+        spec (dict):
+            A 1.x spec — ``{'type': 'light'|'dark', 'colors': {...}}``.
+
+    Returns:
+
+        str:
+            The rendered call, without a trailing newline.
+    """
+    mode = _mode(name, spec)
+    colors = _colors(name, spec)
+    other = "dark" if mode == "light" else "light"
+
+    primary = f'primary="{colors["primary"]}"'
+    if colors.get("secondary"):
+        primary += f', secondary="{colors["secondary"]}"'
+    lines = [
+        "ttk.Theme(",
+        f'    name="{name}",',
+        f"    {primary},",
+        f'    success="{colors["success"]}", info="{colors["info"]}",',
+        f'    warning="{colors["warning"]}", danger="{colors["danger"]}",',
+        f'    {mode}=dict(background="{colors["bg"]}", '
+        f'foreground="{colors["fg"]}"),',
+        f"    # {other}=dict(background=..., foreground=...),"
+        f"  # 1.x theme was {mode}-only",
+        ").register()",
+    ]
+    return "\n".join(lines)
+
+
+def convert(path):
+    """Convert a 1.x theme file into a runnable Python module.
+
+    Parameters:
+
+        path (str or Path):
+            The 1.x ``.json`` or ``.py`` theme file.
+
+    Returns:
+
+        str:
+            Python source registering every theme in the file.
+    """
+    themes = load_legacy_themes(path)
+    dropped = ", ".join(_DERIVED_KEYS[:-1]) + f", and {_DERIVED_KEYS[-1]}"
+    note = textwrap.wrap(
+        f"The 1.x {dropped} values are dropped; 2.x derives them from the "
+        f"anchors below.",
+        width=75,
+    )
+    header = [
+        f"# Converted from {Path(path).name} by "
+        f"python -m ttkbootstrap.convert_theme.",
+        "#",
+        *(f"# {line}" for line in note),
+        "# Call register() once, after creating your App.",
+        "",
+        "import ttkbootstrap as ttk",
+        "",
+        "",
+    ]
+    blocks = [theme_snippet(name, spec) for name, spec in themes.items()]
+    return "\n".join(header) + "\n\n".join(blocks) + "\n"
+
+
+def main(argv=None):
+    """Run the command-line converter."""
+    parser = argparse.ArgumentParser(
+        prog="python -m ttkbootstrap.convert_theme",
+        description="Convert a ttkbootstrap 1.x theme file into a 2.x "
+                    "Theme(...).register() snippet.",
+    )
+    parser.add_argument(
+        "file", help="a 1.x theme file (.json, or a .py USER_THEMES store)"
+    )
+    parser.add_argument(
+        "-o", "--output", help="write to this file instead of standard output"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        source = convert(args.file)
+    except (OSError, ValueError, json.JSONDecodeError, SyntaxError) as error:
+        parser.exit(2, f"{parser.prog}: {error}\n")
+
+    if args.output:
+        Path(args.output).write_text(source, encoding="utf-8")
+        print(f"Wrote {args.output}", file=sys.stderr)
+    else:
+        sys.stdout.write(source)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ttkbootstrap/convert_theme.py
+++ b/src/ttkbootstrap/convert_theme.py
@@ -1,18 +1,20 @@
 """Convert a ttkbootstrap 1.x theme file into a 2.x ``Theme(...).register()`` snippet.
 
 Run it on a theme file saved by 1.x -- a ``user.py`` holding a ``USER_THEMES``
-dict (what 1.x ttkcreator exported), or a JSON file in the
-``Style.load_user_themes`` format -- and it prints Python you paste into your
-own app::
+dict, a ``.py`` holding the ``ThemeDefinition(...)`` call ttkcreator's *Export
+theme definition* wrote, or a JSON file in the ``Style.load_user_themes``
+format -- and it prints Python you paste into your own app::
 
     python -m ttkbootstrap.convert_theme mythemes.json
     python -m ttkbootstrap.convert_theme user.py -o brand.py
 
 The five accent anchors, the optional secondary accent, and the theme's
 background/foreground carry over. `border`, `inputbg`, `inputfg`, `selectbg`,
-`selectfg`, and `active` are dropped: 2.x derives them from the anchors. A 1.x
-theme declares one mode, so the generated family declares that mode and leaves
-the opposite one commented out.
+`selectfg`, and `active` are dropped: 2.x derives them from the anchors. The
+`light` and `dark` accents are dropped too: 2.x derives that pair from the
+`neutral` ramp, which you set with `Theme(neutral=...)`. A 1.x theme declares
+one mode, so the generated family declares that mode and leaves the opposite
+one commented out.
 """
 import argparse
 import ast
@@ -27,6 +29,19 @@ _ACCENT_KEYS = ("primary", "success", "info", "warning", "danger")
 #: 1.x color keys the 2.x engine derives rather than reads.
 _DERIVED_KEYS = ("border", "inputbg", "inputfg", "selectbg", "selectfg", "active")
 
+#: 1.x accent keys 2.x derives from the `neutral` ramp instead.
+_NEUTRAL_KEYS = ("light", "dark")
+
+
+def _literal(value):
+    """Render a value as a Python string literal, escaping what it contains.
+
+    JSON string escapes are a subset of Python's, so `json.dumps` gives a
+    double-quoted literal that survives a quote or a backslash in a theme name
+    or a color -- the generated file is source we tell people to run.
+    """
+    return json.dumps(str(value))
+
 
 def load_legacy_themes(path):
     """Read a 1.x theme file and return its ``{name: spec}`` mapping.
@@ -35,7 +50,8 @@ def load_legacy_themes(path):
 
         path (str or Path):
             A ``.json`` file in the ``Style.load_user_themes`` format, or a
-            ``.py`` file defining a ``USER_THEMES`` dict.
+            ``.py`` file defining a ``USER_THEMES`` dict or a
+            ``ThemeDefinition(...)`` call.
 
     Returns:
 
@@ -47,38 +63,104 @@ def load_legacy_themes(path):
     if path.suffix == ".py":
         themes = _themes_from_python(text, path)
     else:
-        themes = _themes_from_json(text)
+        themes = _themes_from_json(text, path)
     if not themes:
         raise ValueError(f"{path}: no themes found.")
     return themes
 
 
-def _themes_from_json(text):
+def _themes_from_json(text, path):
     """Return ``{name: spec}`` from a ``load_user_themes``-format JSON file."""
     data = json.loads(text)
     entries = data.get("themes", data) if isinstance(data, dict) else data
     if isinstance(entries, dict):
         return dict(entries)
+    if not isinstance(entries, list):
+        raise ValueError(
+            f"{path}: expected a theme mapping or a list of them, got "
+            f"{type(entries).__name__}."
+        )
     themes = {}
     for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"{path}: expected each entry to be a theme mapping, got "
+                f"{type(entry).__name__}."
+            )
         themes.update(entry)
     return themes
 
 
 def _themes_from_python(text, path):
-    """Return ``{name: spec}`` from a 1.x ``user.py``-style theme store."""
+    """Return ``{name: spec}`` from a 1.x ``user.py`` store or a ttkcreator
+    ``ThemeDefinition`` export."""
     tree = ast.parse(text, filename=str(path))
+    themes = {}
     for node in tree.body:
         if not isinstance(node, ast.Assign):
             continue
         names = [t.id for t in node.targets if isinstance(t, ast.Name)]
         if "USER_THEMES" in names or "STANDARD_THEMES" in names:
-            return dict(ast.literal_eval(node.value))
-    raise ValueError(f"{path}: no USER_THEMES assignment found.")
+            store = ast.literal_eval(node.value)
+            if not isinstance(store, dict):
+                raise ValueError(
+                    f"{path}: expected USER_THEMES to be a mapping of themes, "
+                    f"got {type(store).__name__}."
+                )
+            return dict(store)
+        call = _theme_definition_call(node.value)
+        if call is not None:
+            themes.update(_spec_from_definition(call, path))
+    if themes:
+        return themes
+    raise ValueError(
+        f"{path}: found neither a USER_THEMES assignment nor a "
+        "ThemeDefinition(...) call."
+    )
+
+
+def _theme_definition_call(node):
+    """Return the node when it is a ``ThemeDefinition(...)`` call, else None."""
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    name = (
+        func.attr if isinstance(func, ast.Attribute)
+        else getattr(func, "id", None)
+    )
+    return node if name == "ThemeDefinition" else None
+
+
+def _spec_from_definition(call, path):
+    """Return ``{name: spec}`` from ttkcreator's *Export theme definition* file.
+
+    That export writes ``ThemeDefinition(name=..., themetype=...,
+    colors={...})``. 1.x took those three positionally as ``(name, colors,
+    themetype)``, with `themetype` defaulting to light, so both spellings are
+    read.
+    """
+    args = dict(zip(("name", "colors", "themetype"), call.args))
+    args.update({kw.arg: kw.value for kw in call.keywords if kw.arg})
+    try:
+        name = ast.literal_eval(args["name"])
+        colors = ast.literal_eval(args["colors"])
+    except KeyError as error:
+        raise ValueError(
+            f"{path}: ThemeDefinition(...) is missing {error.args[0]}."
+        ) from None
+    mode = "light"
+    if "themetype" in args:
+        mode = ast.literal_eval(args["themetype"])
+    return {name: {"type": mode, "colors": colors}}
 
 
 def _mode(name, spec):
     """Return the theme's ``light``/``dark`` mode."""
+    if not isinstance(spec, dict):
+        raise ValueError(
+            f"theme {name!r}: expected a spec mapping, got "
+            f"{type(spec).__name__}."
+        )
     mode = spec.get("mode") or spec.get("type")
     if mode not in ("light", "dark"):
         raise ValueError(
@@ -122,17 +204,19 @@ def theme_snippet(name, spec):
     colors = _colors(name, spec)
     other = "dark" if mode == "light" else "light"
 
-    primary = f'primary="{colors["primary"]}"'
+    primary = f"primary={_literal(colors['primary'])}"
     if colors.get("secondary"):
-        primary += f', secondary="{colors["secondary"]}"'
+        primary += f", secondary={_literal(colors['secondary'])}"
     lines = [
         "ttk.Theme(",
-        f'    name="{name}",',
+        f"    name={_literal(name)},",
         f"    {primary},",
-        f'    success="{colors["success"]}", info="{colors["info"]}",',
-        f'    warning="{colors["warning"]}", danger="{colors["danger"]}",',
-        f'    {mode}=dict(background="{colors["bg"]}", '
-        f'foreground="{colors["fg"]}"),',
+        f"    success={_literal(colors['success'])}, "
+        f"info={_literal(colors['info'])},",
+        f"    warning={_literal(colors['warning'])}, "
+        f"danger={_literal(colors['danger'])},",
+        f"    {mode}=dict(background={_literal(colors['bg'])}, "
+        f"foreground={_literal(colors['fg'])}),",
         f"    # {other}=dict(background=..., foreground=...),"
         f"  # 1.x theme was {mode}-only",
         ").register()",
@@ -157,7 +241,9 @@ def convert(path):
     dropped = ", ".join(_DERIVED_KEYS[:-1]) + f", and {_DERIVED_KEYS[-1]}"
     note = textwrap.wrap(
         f"The 1.x {dropped} values are dropped; 2.x derives them from the "
-        f"anchors below.",
+        f"anchors below. So are the {' and '.join(_NEUTRAL_KEYS)} accents; 2.x "
+        f"derives that pair from the neutral ramp, which Theme(neutral=...) "
+        f"sets.",
         width=75,
     )
     header = [
@@ -183,7 +269,9 @@ def main(argv=None):
                     "Theme(...).register() snippet.",
     )
     parser.add_argument(
-        "file", help="a 1.x theme file (.json, or a .py USER_THEMES store)"
+        "file",
+        help="a 1.x theme file (.json, or a .py USER_THEMES / ThemeDefinition "
+             "store)",
     )
     parser.add_argument(
         "-o", "--output", help="write to this file instead of standard output"
@@ -192,11 +280,12 @@ def main(argv=None):
 
     try:
         source = convert(args.file)
-    except (OSError, ValueError, json.JSONDecodeError, SyntaxError) as error:
+        if args.output:
+            Path(args.output).write_text(source, encoding="utf-8")
+    except (OSError, ValueError, SyntaxError) as error:
         parser.exit(2, f"{parser.prog}: {error}\n")
 
     if args.output:
-        Path(args.output).write_text(source, encoding="utf-8")
         print(f"Wrote {args.output}", file=sys.stderr)
     else:
         sys.stdout.write(source)

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -951,7 +951,19 @@ class Style(ttk.Style):
         self.register_theme(theme)
 
     def load_user_themes(self, file):
-        """Load user themes saved in json format"""
+        """Register themes from a 1.x JSON theme file.
+
+        The file holds ``{"themes": [{"<name>": {"type": "light"|"dark",
+        "colors": {...}}}]}`` with the sixteen 1.x color keys, taken verbatim.
+        Each theme registers under its own name as a single mode. To convert a
+        1.x theme into a light/dark `Theme` family whose plumbing colors are
+        regenerated, run ``python -m ttkbootstrap.convert_theme`` instead.
+
+        Parameters:
+
+            file (str):
+                Path to the JSON theme file.
+        """
         with open(file, encoding='utf-8') as f:
             data = json.load(f)
             themes = data['themes']

--- a/tests/test_convert_theme.py
+++ b/tests/test_convert_theme.py
@@ -1,0 +1,185 @@
+"""Tests for the 1.x -> 2.x theme converter (`ttkbootstrap.convert_theme`)."""
+import json
+
+import pytest
+
+import ttkbootstrap as ttk
+from ttkbootstrap import convert_theme
+
+LEGACY_COLORS = {
+    "primary": "#6a5acd",
+    "secondary": "#6c757d",
+    "success": "#02b875",
+    "info": "#17a2b8",
+    "warning": "#f0ad4e",
+    "danger": "#d9534f",
+    "light": "#ADB5BD",
+    "dark": "#2b2b2b",
+    "bg": "#1c1c1c",
+    "fg": "#e9ecef",
+    "selectbg": "#555555",
+    "selectfg": "#ffffff",
+    "border": "#333333",
+    "inputfg": "#e9ecef",
+    "inputbg": "#2b2b2b",
+    "active": "#3a3a3a",
+}
+
+
+def legacy_spec(mode="dark", **overrides):
+    """A 1.x theme spec, optionally with colors removed or replaced."""
+    colors = dict(LEGACY_COLORS)
+    colors.update(overrides)
+    return {"type": mode, "colors": colors}
+
+
+def write_user_py(tmp_path, themes, name="user.py"):
+    """Write the exact file 1.x ttkcreator produced: ``USER_THEMES = <json>``."""
+    path = tmp_path / name
+    path.write_text(
+        "USER_THEMES = " + json.dumps(themes, indent=4), encoding="utf-8"
+    )
+    return path
+
+
+def write_json(tmp_path, themes, name="themes.json"):
+    """Write a file in the ``Style.load_user_themes`` format."""
+    path = tmp_path / name
+    payload = {"themes": [{n: spec} for n, spec in themes.items()]}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_converts_the_1x_ttkcreator_export(tmp_path):
+    """A ``USER_THEMES`` .py — what 1.x exported — converts to a Theme call."""
+    path = write_user_py(tmp_path, {"midnight": legacy_spec("dark")})
+    source = convert_theme.convert(path)
+
+    assert 'name="midnight"' in source
+    assert 'primary="#6a5acd"' in source
+    assert 'secondary="#6c757d"' in source
+    assert 'dark=dict(background="#1c1c1c", foreground="#e9ecef")' in source
+    assert source.rstrip().endswith(").register()")
+
+
+def test_converts_the_load_user_themes_json(tmp_path):
+    """The hand-written JSON format converts to the same anchors."""
+    path = write_json(tmp_path, {"midnight": legacy_spec("dark")})
+    source = convert_theme.convert(path)
+
+    assert 'name="midnight"' in source
+    assert 'primary="#6a5acd"' in source
+    assert 'dark=dict(background="#1c1c1c", foreground="#e9ecef")' in source
+
+
+def test_the_absent_mode_is_commented_not_invented(tmp_path):
+    """A 1.x theme has one mode; the other is left for the user to fill in."""
+    path = write_user_py(tmp_path, {"daylight": legacy_spec("light")})
+    source = convert_theme.convert(path)
+
+    assert 'light=dict(background="#1c1c1c"' in source
+    assert "# dark=dict(background=..., foreground=...)" in source
+
+
+def test_engine_derived_colors_are_not_emitted(tmp_path):
+    """2.x derives these from the anchors, so carrying them over would lie."""
+    path = write_user_py(tmp_path, {"midnight": legacy_spec()})
+    source = convert_theme.convert(path)
+
+    for key in convert_theme._DERIVED_KEYS:
+        assert f"{key}=" not in source
+    # the dropped values themselves must not appear either
+    assert "#555555" not in source     # selectbg
+    assert "#333333" not in source     # border
+
+
+def test_a_theme_without_a_secondary_omits_the_token(tmp_path):
+    """`secondary` is optional on `Theme`; it derives from the neutral ramp."""
+    spec = legacy_spec()
+    del spec["colors"]["secondary"]
+    path = write_user_py(tmp_path, {"midnight": spec})
+    source = convert_theme.convert(path)
+
+    assert "secondary=" not in source
+    assert 'primary="#6a5acd",' in source
+
+
+def test_every_theme_in_the_file_converts_under_one_import(tmp_path):
+    path = write_user_py(
+        tmp_path,
+        {"midnight": legacy_spec("dark"), "daylight": legacy_spec("light")},
+    )
+    source = convert_theme.convert(path)
+
+    assert source.count("import ttkbootstrap as ttk") == 1
+    assert source.count(").register()") == 2
+    assert 'name="midnight"' in source and 'name="daylight"' in source
+
+
+def test_a_missing_color_names_the_theme_and_the_key(tmp_path):
+    spec = legacy_spec()
+    del spec["colors"]["warning"]
+    path = write_user_py(tmp_path, {"midnight": spec})
+
+    with pytest.raises(ValueError, match="midnight.*warning"):
+        convert_theme.convert(path)
+
+
+def test_a_missing_mode_is_loud(tmp_path):
+    path = write_user_py(tmp_path, {"midnight": {"colors": LEGACY_COLORS}})
+
+    with pytest.raises(ValueError, match="midnight"):
+        convert_theme.convert(path)
+
+
+def test_a_py_file_without_user_themes_is_loud(tmp_path):
+    path = tmp_path / "notthemes.py"
+    path.write_text("COLORS = {}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="USER_THEMES"):
+        convert_theme.convert(path)
+
+
+def test_cli_writes_the_requested_file(tmp_path):
+    source_file = write_user_py(tmp_path, {"midnight": legacy_spec()})
+    out = tmp_path / "brand.py"
+
+    assert convert_theme.main([str(source_file), "-o", str(out)]) == 0
+    assert 'name="midnight"' in out.read_text(encoding="utf-8")
+
+
+def test_cli_prints_to_stdout(tmp_path, capsys):
+    source_file = write_user_py(tmp_path, {"midnight": legacy_spec()})
+
+    convert_theme.main([str(source_file)])
+
+    assert 'name="midnight"' in capsys.readouterr().out
+
+
+def test_cli_exits_with_an_error_on_a_bad_file(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        convert_theme.main([str(bad)])
+    assert excinfo.value.code == 2
+
+
+def test_the_converted_snippet_registers_and_renders(root, tmp_path):
+    """The end of the pipe: the emitted Python runs and themes real widgets."""
+    path = write_user_py(tmp_path, {"convertedtheme": legacy_spec("dark")})
+    source = convert_theme.convert(path)
+
+    exec(compile(source, "converted.py", "exec"), {})
+
+    style = root.style
+    assert "convertedtheme-dark" in style.theme_names()
+
+    style.theme_use("convertedtheme-dark")
+    assert style.theme_mode == "dark"
+
+    # the 2.x engine derives the plumbing the 1.x file no longer supplies
+    assert style.colors.border and style.colors.inputbg
+    ttk.Button(root, text="ok", bootstyle="primary").pack()
+    ttk.Entry(root).pack()
+    root.update_idletasks()

--- a/tests/test_convert_theme.py
+++ b/tests/test_convert_theme.py
@@ -1,4 +1,5 @@
 """Tests for the 1.x -> 2.x theme converter (`ttkbootstrap.convert_theme`)."""
+import ast
 import json
 
 import pytest
@@ -50,6 +51,38 @@ def write_json(tmp_path, themes, name="themes.json"):
     return path
 
 
+def write_definition_py(tmp_path, name, spec, filename="brand_theme.py"):
+    """Write what 1.x ttkcreator's *Export theme definition* button produced."""
+    path = tmp_path / filename
+    rows = "".join(
+        f'        "{k}": "{v}",\n' for k, v in spec["colors"].items()
+    )
+    path.write_text(
+        "from ttkbootstrap.style import ThemeDefinition\n\n"
+        "theme = ThemeDefinition(\n"
+        f'    name="{name}",\n'
+        f'    themetype="{spec["type"]}",\n'
+        "    colors={\n" + rows + "    },\n)\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def theme_calls(source):
+    """The `ttk.Theme(...)` calls in generated output, parsed."""
+    return [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "attr", None) == "Theme"
+    ]
+
+
+def theme_keywords(source):
+    """The keyword arguments the generated `ttk.Theme(...)` call passes."""
+    return {kw.arg: kw.value for kw in theme_calls(source)[0].keywords}
+
+
 def test_converts_the_1x_ttkcreator_export(tmp_path):
     """A ``USER_THEMES`` .py — what 1.x exported — converts to a Theme call."""
     path = write_user_py(tmp_path, {"midnight": legacy_spec("dark")})
@@ -72,6 +105,28 @@ def test_converts_the_load_user_themes_json(tmp_path):
     assert 'dark=dict(background="#1c1c1c", foreground="#e9ecef")' in source
 
 
+def test_converts_the_ttkcreator_theme_definition_export(tmp_path):
+    """1.x had a third save path: a .py holding a ThemeDefinition(...) call."""
+    path = write_definition_py(tmp_path, "brand", legacy_spec("dark"))
+    source = convert_theme.convert(path)
+
+    assert 'name="brand"' in source
+    assert 'primary="#6a5acd"' in source
+    assert 'dark=dict(background="#1c1c1c", foreground="#e9ecef")' in source
+
+
+def test_a_theme_definition_without_a_themetype_is_light(tmp_path):
+    """1.x `ThemeDefinition(name, colors, themetype=LIGHT)` defaulted to light."""
+    path = tmp_path / "brand_theme.py"
+    path.write_text(
+        f"theme = ThemeDefinition(name='brand', colors={LEGACY_COLORS!r})\n",
+        encoding="utf-8",
+    )
+    source = convert_theme.convert(path)
+
+    assert "light=dict(background=" in source
+
+
 def test_the_absent_mode_is_commented_not_invented(tmp_path):
     """A 1.x theme has one mode; the other is left for the user to fill in."""
     path = write_user_py(tmp_path, {"daylight": legacy_spec("light")})
@@ -91,6 +146,24 @@ def test_engine_derived_colors_are_not_emitted(tmp_path):
     # the dropped values themselves must not appear either
     assert "#555555" not in source     # selectbg
     assert "#333333" not in source     # border
+
+
+def test_the_neutral_ramp_accents_are_not_emitted(tmp_path):
+    """2.x derives `light`/`dark` from the neutral ramp, so they don't carry.
+
+    `neutral` is the ramp *base*; 1.x's near-white `light` is ramp step [100].
+    Passing that through would wash out `selectbg` and an uncolored `secondary`
+    along with it, so the converter emits no `neutral` at all.
+    """
+    spec = legacy_spec(light="#f8f9fa", dark="#343a40")
+    path = write_user_py(tmp_path, {"midnight": spec})
+    source = convert_theme.convert(path)
+
+    assert "#f8f9fa" not in source and "#343a40" not in source
+    assert "neutral" not in theme_keywords(source)
+    # a silent drop is the failure mode; the generated header has to say so
+    header = "\n".join(l for l in source.splitlines() if l.startswith("#"))
+    assert "light and dark" in header and "neutral" in header
 
 
 def test_a_theme_without_a_secondary_omits_the_token(tmp_path):
@@ -116,6 +189,29 @@ def test_every_theme_in_the_file_converts_under_one_import(tmp_path):
     assert 'name="midnight"' in source and 'name="daylight"' in source
 
 
+def test_a_quote_in_a_theme_name_still_compiles(tmp_path):
+    """1.x only stripped spaces from a theme name, so a quote reaches us."""
+    path = write_user_py(tmp_path, {'my "cool" theme': legacy_spec()})
+    source = convert_theme.convert(path)
+
+    compile(source, "converted.py", "exec")
+    name = theme_keywords(source)["name"]
+    assert ast.literal_eval(name) == 'my "cool" theme'
+
+
+def test_a_color_value_cannot_smuggle_in_code(tmp_path):
+    """Generated output is a file we tell people to run: escape what we emit."""
+    payload = '#fff", neutral=__import__("os").getcwd() and "#000'
+    path = write_user_py(tmp_path, {"midnight": legacy_spec(primary=payload)})
+    source = convert_theme.convert(path)
+
+    compile(source, "converted.py", "exec")
+    keywords = theme_keywords(source)
+    # the payload stays one inert string; it does not become a second keyword
+    assert "neutral" not in keywords
+    assert ast.literal_eval(keywords["primary"]) == payload
+
+
 def test_a_missing_color_names_the_theme_and_the_key(tmp_path):
     spec = legacy_spec()
     del spec["colors"]["warning"]
@@ -132,11 +228,11 @@ def test_a_missing_mode_is_loud(tmp_path):
         convert_theme.convert(path)
 
 
-def test_a_py_file_without_user_themes_is_loud(tmp_path):
+def test_a_py_file_with_neither_shape_is_loud(tmp_path):
     path = tmp_path / "notthemes.py"
     path.write_text("COLORS = {}\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="USER_THEMES"):
+    with pytest.raises(ValueError, match="USER_THEMES.*ThemeDefinition"):
         convert_theme.convert(path)
 
 
@@ -163,6 +259,42 @@ def test_cli_exits_with_an_error_on_a_bad_file(tmp_path):
     with pytest.raises(SystemExit) as excinfo:
         convert_theme.main([str(bad)])
     assert excinfo.value.code == 2
+
+
+def test_cli_exits_when_the_output_path_is_unwritable(tmp_path):
+    """An unwritable -o is a user error, not a traceback."""
+    source_file = write_user_py(tmp_path, {"midnight": legacy_spec()})
+
+    with pytest.raises(SystemExit) as excinfo:
+        convert_theme.main(
+            [str(source_file), "-o", str(tmp_path / "no" / "such" / "dir.py")]
+        )
+    assert excinfo.value.code == 2
+
+
+@pytest.mark.parametrize(
+    "name, text",
+    [
+        ("themes.json", '{"themes": null}'),
+        ("themes.json", '{"themes": [1, 2]}'),
+        ("user.py", "USER_THEMES = [1, 2]\n"),
+    ],
+)
+def test_cli_exits_on_a_parseable_but_wrong_shaped_file(tmp_path, name, text):
+    """Valid JSON/Python of the wrong shape still exits, not raises."""
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        convert_theme.main([str(path)])
+    assert excinfo.value.code == 2
+
+
+def test_a_spec_that_is_not_a_mapping_names_the_theme(tmp_path):
+    path = write_user_py(tmp_path, {"midnight": "not a spec"})
+
+    with pytest.raises(ValueError, match="midnight"):
+        convert_theme.convert(path)
 
 
 def test_the_converted_snippet_registers_and_renders(root, tmp_path):


### PR DESCRIPTION
## Why

2.0 removed the in-package user theme store (`themes/user.py` and its `USER_THEMES` dict) along with ttkcreator's **Import** / **Export** buttons — but the migration guide never said so, and offered no path forward for a theme someone had already saved. That documentation gap is what prompted this.

## What

`python -m ttkbootstrap.convert_theme` reads any artifact a 1.x user could be holding and emits the equivalent `Theme(...).register()` call:

```bash
python -m ttkbootstrap.convert_theme user.py -o brand.py
python -m ttkbootstrap.convert_theme themes.json
```

1.x ttkcreator had **three** save paths, and each one's artifact converts:

- a **`user.py`** holding `USER_THEMES` — what 1.x ttkcreator's Export produced. Checking `release/v1` settled which artifact matters: `save_theme` wrote `'USER_THEMES = ' + json.dumps(...)` into the in-package file and Export `shutil.copyfile`'d it, so the contents are JSON but the file is a `.py`. That is the **only** `json.dump*` call in all of 1.x `src/` — no 1.x code ever wrote a `.json`.
- a **`.py`** holding a `ThemeDefinition(name=..., themetype=..., colors={...})` call — what ttkcreator's **Export theme definition** wrote, and the one most likely to be sitting in a user's own project, since the other two live inside the installed package. Both the keyword and the 1.x positional `(name, colors, themetype)` spellings are read, with `themetype` defaulting to light as 1.x did.
- a **JSON** file in the `Style.load_user_themes` format (hand-written only).

Every theme in the file converts under one import; output goes to stdout or `-o`.

Everything interpolated into the generated file is escaped through `json.dumps` (its string escapes are a subset of Python's, so the double-quoted output style is unchanged). The output is source we tell people to run, and 1.x only did `name.lower().replace(" ", "")`, so a quote in a theme name reaches us intact.

### What carries over, and what does not

Accents, the optional `secondary`, and the mode's background/foreground carry over verbatim. Deliberately dropped:

- **Plumbing colors** (`border`, `inputbg`, `inputfg`, `selectbg`, `selectfg`, `active`) — `Theme` derives all six from the anchors and the surface. Note this is *not* the same as `theme_from_legacy_dict`, which the built-in legacy themes go through: that one regenerates only `border`, `inputbg` and `active`, and passes the other three verbatim.
- **The `light` and `dark` accents** — 2.x derives that pair from the `neutral` ramp, so a converted theme takes the default gray and `Theme(neutral=...)` tunes it. Deliberately *not* mapped from 1.x's `light`: `neutral` is the ramp **base**, while 1.x's `light` is a near-white (`litera`, ttkcreator's default base, ships `#F8F9FA`) corresponding to ramp step `[100]`. Passing it through as `neutral` would wash out `selectbg` and an uncolored `secondary` along with it.
- **The opposite mode** — a 1.x theme declares one, so the generated family declares that one and leaves the other commented out rather than inventing colors.

Output is close but not pixel-identical: an accent is re-derived per mode for contrast (a dark theme's authored `#6a5acd` resolves to `#887bd7`).

The module is pure text transformation — no Tk, no display.

## Docs

- **Migrating to 2.0** — new *Saved themes move into your code*: the removal, the command, what carries over, and a note that `Style.load_user_themes` still reads the 1.x JSON but is the thinner path (verbatim plumbing, single mode, nothing for `toggle_theme()` to flip to).
- **Theming & Colors** — a *Coming from 1.x* annotation under the visual editor.
- **Reference › Theming** — a *Converting a 1.x theme* section.
- `Style.load_user_themes` had a one-line docstring that never stated the file format; it now specifies the JSON shape and the single-mode behavior.
- Fixes a pre-existing nested-inline-markup leak in the migration guide (a literal inside `**bold**` leaks its double backticks; `-W` does not flag it).

## Review round

A `/code-review` found six defects; all six are fixed in `a65d55e3`, and each new test was confirmed to fail against the unfixed converter rather than verified by reading the code.

- **MEDIUM** — every value was interpolated into the generated Python raw. A quote in a theme name emitted a file that would not compile; a crafted color value could close the string and append its own keyword argument, which then executed on import. Now escaped (above).
- **MEDIUM** — ttkcreator's *Export theme definition* file was rejected outright. Now read (above).
- **MEDIUM** — the docs claimed parity with `theme_from_legacy_dict`, which was wrong for three of the six keys. Claim replaced, not narrowed (above).
- **MEDIUM** — the `light`/`dark` accents were dropped silently and the drop list did not mention them. Now documented in the generated header, the migration guide and the change log. *The review's proposed `light` → `neutral` mapping was itself wrong* — it rested on `_DEFAULT_NEUTRAL` matching `#adb5bd`, which is this PR's own test fixture, not real 1.x data.
- **LOW** — the `-o` write sat outside the `try`, so an unwritable path raised a bare `FileNotFoundError`; and shape errors in parseable input (`{"themes": null}`, `USER_THEMES = [1, 2]`) reached `TypeError`. Input shape is now validated where it is read, so the `except` tuple stays precise; `json.JSONDecodeError` goes, being a `ValueError` already.
- **LOW** — a `:func:` role on `Style.toggle_theme`, which is a method. The Python domain maps `func` only to `objtype: function`, so the target never resolved and, with `nitpicky` off, rendered as unlinked text under a clean `-W` build. Verified in the built HTML.

## Gates

- Suite **1015 passed, 5 skipped** (`tests/test_convert_theme.py` 13 → 23) — all three input formats, the loud-failure paths, the escaping of what it emits, and an end-to-end test that the emitted Python registers a theme and styles real widgets.
- Docs build clean under `-W`, and the rendered HTML re-scanned for markup leaks.
- Trial-merged onto `master` together with #1333 and re-gated on the combined result, which neither PR's own CI covers.

## Noted, not fixed

`docs/reference/api/scrollbar.rst:44` has the same class of `-W`-invisible defect from a different cause: ``` ``first``..``last``` ``` — the second literal's start-string is not preceded by whitespace, so it never parses. Unrelated file, fixed in #1333.