### PR TITLE
docs(scrollbar): fix the literal that never parsed in set()

### DIFF
--- a/docs/reference/api/scrollbar.rst
+++ b/docs/reference/api/scrollbar.rst
@@ -41,7 +41,7 @@ Methods
 .. py:method:: set(first, last)
    :noindex:
 
-   Set the thumb to span the fractions ``first``..``last``; wired as the
+   Set the thumb to span the fractions ``first`` to ``last``; wired as the
    scrolled widget's ``xscrollcommand``/``yscrollcommand``.
 
    :returns: ``None``.


### PR DESCRIPTION
## What

`docs/reference/api/scrollbar.rst:44` shipped visible backticks to the rendered page. The `set` method spec reads:

```rst
Set the thumb to span the fractions ``first``..``last``; wired as the
```

and renders as:

> Set the thumb to span the fractions `first`..\`\`last\`\`; wired as the scrolled widget's `xscrollcommand`…

## Why it happens

rST only begins inline markup when the start-string is preceded by whitespace or one of a small set of openers (`-` `:` `/` `'` `"` `<` `(` `[` `{`). A `.` is not among them, so ` ``last`` ` was never recognized as markup and its backticks became text. The *closing* backticks of `first` are fine — an end-string may be followed by punctuation.

Fixed by reading the range as prose: ``` ``first`` to ``last`` ```.

## Note for future docs work

This is a **third** class of rST defect that `-W` does not flag, alongside the two already recorded (nested inline markup inside `**bold**`, and a line block inside a list-table cell needing a preceding blank line). A clean `-W` build is not evidence that the markup parsed — the rendered HTML has to be read.

Found by scanning every built page for `` `` `` surviving into the body text. After this and the migration-guide fix in #1332, that scan is clean across the whole site.

## Gates

Docs build clean under `-W`; rendered HTML re-checked (this page now leak-free, and the only remaining hit on this branch is the migration guide, whose fix lives in #1332).