### PR TITLE
feat: __version__, the ttkb CLI, pre-root theme registration, and the #1322 density pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1990,25 +1990,58 @@ full 3.0 removal checklist until 3.0 is actually scoped.
 > rebuild line removed. Testing it properly would mean driving a scaled root in a
 > subprocess.
 >
-> **NEXT SESSION — `/code-review` the three fix commits (`d7561785..HEAD`), then
-> ship the branch.** The first four commits are already-reviewed context, not the
-> subject. It cannot be launched from inside a session (`disable-model-invocation`
-> — reserved for explicit user invocation), so the author runs `/code-review`.
-> Three questions worth putting in front of it, since the author of the fixes is
-> not a neutral judge of them:
+> **THE `/code-review` OF THE 10 COMMITS IS DONE (2026-08-06c) — 6 findings, 5
+> real and fixed in 3 commits, 1 rejected by probe. The branch now has 13
+> commits, still unpushed with no PR.** Gates after the fixes: suite **1033
+> passed, 5 skipped**; docs clean under `-W`; the strip-tags stray-backtick scan
+> clean. Precedent held for the fifth round running.
 >
-> 1. **`style/theme.py`** — module-level `itertools.count()` and a per-call defer
->    key. Anything the per-family key didn't have: unbounded queue growth, or
->    `register()` in a loop queueing duplicate work that all runs at flush?
-> 2. **`tests/conftest.py`** — the second `create_default_style()` call is safe
->    *only* because nothing is configured at session-root creation. That is the
->    claim to check, given it is demonstrably not idempotent later.
-> 3. **`tests/test_scaling.py`** — is a source-order guard reasonable here (the
->    repo has precedent), or papering over a claim that wants a real test?
+> | Fix commit | What the review found |
+> |---|---|
+> | `3dc6978a` `fix(tests): keep the CLI tests runnable on the 3.10 floor` | **HIGH.** `import tomllib` is **3.11+**, and `test_cli_api.py` imported it at module level — so on the `ubuntu/py3.10` CI job, the job whose comment says *"a 3.11+ only construct cannot slip in"*, the module died at **collection** and took all 12 tests with it. Parsed by hand now. Also guarded the unguarded `importlib.metadata.version` call, which raises under the supported `PYTHONPATH=src` — the one case `__version__` has a fallback for. |
+> | `21e88216` `test: prove the density pin against a scaled root` | **MEDIUM — the #1322 guard did not guard.** Answers handoff question 3: the source-order guard *was* papering over it. Both strings it searched for live **inside** `_pin_baseline_density`, so deleting the **call site** left it green; and its companion asserts `factor == 1.0`, which holds anyway on any standard-density box — every CI runner. The regression was undetectable everywhere it runs. |
+> | `ef0b9001` `docs: correct the python -m claim and the register-later snippet` | **2× LOW.** The CLI page promised *"every command also has a `python -m` spelling"* with **no entry for `version`** and no such module — a reader without the scripts dir on `PATH` had nothing to run (`python -m ttkbootstrap.cli <command>` is the real general fallback). And the theming guide's register-later snippet, `ttk.Theme(name="brand", ...).register()`, is a **SyntaxError**. |
 >
-> **Then:** fold in any fixes, open the PR against `master` with the **`2.2`
+> **The rejected finding, and it is the [[#1332 lesson]] a third time.** The
+> review called `ttkb version` importing the whole package a defect — on a Python
+> without `_tkinter` it dies instead of printing the version, and the docs call it
+> *"what to quote in a bug report"*. The **diagnosis is right and the fix it
+> proposed cannot work**: `ttkbootstrap.cli` *is inside the package*, so the entry
+> point `ttkbootstrap.cli:main` runs `__init__.py` before a line of `cli.py`
+> executes. Probed with a `MetaPathFinder` blocking `_tkinter`: the failure is at
+> `from ttkbootstrap.cli import main` itself. Nothing internal to `cli.py` can
+> change that; only moving the CLI out of the package would, which is not worth a
+> top-level module in site-packages. `pip show ttkbootstrap` already answers it.
+>
+> **How the new density test works, since the obvious versions don't.** Bring the
+> root up scaled by patching `tkinter.Tk.__init__` to call `tk scaling 2.0` right
+> after the real init — that is *before* `Style` builds, i.e. genuinely the
+> contributor's situation. Run it in a **subprocess** (the session shares one root
+> and one `Style` singleton) and drive **conftest's own fixture** via
+> `_session_root.__wrapped__()` rather than a copy of its body, which is what
+> makes the **call site** part of what is under test. Proven to fail with either
+> half removed, alone *and* in the full suite. Two traps: the generator must be
+> **held in a name** or it is collected on the spot and its teardown destroys the
+> root mid-measurement; and padding must be compared **as numbers** — `lookup`
+> returns `'10 4'` or `(10, 4)` depending on whether the style has been rebuilt,
+> so the same root reads differently alone vs. in-suite (the `Tcl_Obj` trait
+> already recorded above, in its tuple guise).
+>
+> **Handoff questions 1 and 2 came back clean, with reasons.** `style/theme.py`:
+> `config.defer` applies immediately once a `Style` exists, and
+> `flush_pending_config()` runs in `Style.__init__` **after** `Style.instance = self`
+> and **before** `theme_use(theme)`, so `_register`'s unguarded `get_instance()`
+> cannot see `None` and `App(theme="brand-light")` resolves; queue growth is
+> bounded by "themes registered before a root exists," and duplicate `register()`
+> calls are idempotent. `tests/conftest.py`: the claim holds **at session-root
+> creation** — `_user_options` is empty, builders write through `_build_configure`
+> so nothing is captured as a durable override, and `element_create` is
+> idempotent. The fragility was in the test, not the conftest change.
+>
+> **NEXT: ship the branch.** Open the PR against `master` with the **`2.2`
 > milestone set** (on the PR, not just the issue), and move **#1322** off `2.1.x`
-> onto `2.2` since it is fixed here — closing `2.1.x` out.
+> onto `2.2` since it is fixed here — closing `2.1.x` out. Then the release
+> runbook.
 >
 > **Unrelated, noticed in passing — a pre-existing test-isolation leak.** Something
 > in the suite leaves `Link.TButton` padding at `40 2`. Invisible unless a test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2038,10 +2038,59 @@ full 3.0 removal checklist until 3.0 is actually scoped.
 > so nothing is captured as a durable override, and `element_create` is
 > idempotent. The fragility was in the test, not the conftest change.
 >
-> **NEXT: ship the branch.** Open the PR against `master` with the **`2.2`
+> **NEXT SESSION — a TARGETED `/code-review` of the three fix commits
+> (`3dc6978a..ef0b9001`), then ship.** The author runs it; it cannot be launched
+> from inside a session (`disable-model-invocation`). The first ten commits are
+> already-reviewed context, not the subject — and `78d3b045` is this CLAUDE.md
+> entry, so it is not either.
+>
+> **Scope it to the two test files.** **No library runtime code changed in that
+> range**: `cli.py` got a docstring, `pyproject.toml` a comment, and two docs
+> pages were corrected. Nothing ships differently, so the whole risk surface is
+> `tests/test_scaling.py` and `tests/test_cli_api.py`. Say so up front, or the
+> review spends its budget re-reading the CLI.
+>
+> **The two questions worth putting in front of it**, since the author of the
+> fixes is not a neutral judge of them:
+>
+> 1. **`tests/test_scaling.py`** — the new
+>    `test_conftest_pins_a_scaled_display_back_to_baseline` is the **only test in
+>    the suite that builds a real Tk root out-of-process**, and it does three
+>    unusual things at once: patches `tkinter.Tk.__init__` to force
+>    `tk scaling 2.0`, drives conftest's fixture through
+>    `_session_root.__wrapped__()` (a **pytest implementation detail**), and holds
+>    the generator so teardown does not destroy the root mid-measurement. Is that
+>    a reasonable way to test this, or too clever? Note the `__wrapped__`
+>    dependency fails *loudly* (`AttributeError`) if pytest ever changes it, which
+>    is the safe direction — but it is still internals.
+> 2. **`tests/test_cli_api.py`** — the hand-rolled `[project.scripts]` parse that
+>    replaced `tomllib`. It is deliberately not a TOML parser, so the question is
+>    whether it can degrade *silently*. **Already probed, and it cannot** — the
+>    expected dict is a non-empty literal, so an empty parse cannot self-cancel:
+>    a missing section raises `IndexError`, single-quoted values yield `{}`, and a
+>    following `[project.scripts.foo]` subtable truncates — all three fail the
+>    assertion loudly. Worth a second opinion on whether a 3-line parse is the
+>    right call at all versus a `tomli` fallback with a skip on 3.10, but the
+>    silent-failure concern is closed.
+>
+> **What CI already answers, so the review need not.** The portability risk in
+> question 1 — subprocess Tk under `xvfb-run`, and on aqua — is covered directly
+> by opening the PR: all four jobs (Linux, Windows, macOS, the py3.10 floor) run
+> on it. **Open the PR first and let CI run in parallel with the review.** The
+> py3.10 job is exactly what would have caught the `tomllib` bug.
+>
+> **Then ship:** fold in any fixes, open the PR against `master` with the **`2.2`
 > milestone set** (on the PR, not just the issue), and move **#1322** off `2.1.x`
 > onto `2.2` since it is fixed here — closing `2.1.x` out. Then the release
-> runbook.
+> runbook under *Dev environment & commands*, whose four live traps (stale
+> `dist/`, the local docs build reporting `2.0.0a1`, `twine check` not validating
+> contents, `--no-cache-dir` on the verify) are listed in the 2.2 STATUS banner
+> at the top of this section.
+>
+> **Gates at handoff** (Windows box, `78d3b045`): suite **1033 passed, 5
+> skipped**; docs clean under `-W`; strip-tags stray-backtick scan clean. Branch
+> `feat/2.2-version-and-cli`, **13 commits, unpushed, no PR**. Both halves of the
+> #1322 fix verified to fail when removed, alone *and* in the full suite.
 >
 > **Unrelated, noticed in passing — a pre-existing test-isolation leak.** Something
 > in the suite leaves `Link.TButton` padding at `40 2`. Invisible unless a test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2005,13 +2005,25 @@ full 3.0 removal checklist until 3.0 is actually scoped.
 > **The rejected finding, and it is the [[#1332 lesson]] a third time.** The
 > review called `ttkb version` importing the whole package a defect — on a Python
 > without `_tkinter` it dies instead of printing the version, and the docs call it
-> *"what to quote in a bug report"*. The **diagnosis is right and the fix it
-> proposed cannot work**: `ttkbootstrap.cli` *is inside the package*, so the entry
-> point `ttkbootstrap.cli:main` runs `__init__.py` before a line of `cli.py`
-> executes. Probed with a `MetaPathFinder` blocking `_tkinter`: the failure is at
-> `from ttkbootstrap.cli import main` itself. Nothing internal to `cli.py` can
-> change that; only moving the CLI out of the package would, which is not worth a
-> top-level module in site-packages. `pip show ttkbootstrap` already answers it.
+> *"what to quote in a bug report"*. It is dead **twice over**, and the second
+> reason is the one to keep.
+>
+> **AUTHOR RULING (2026-08-06c): there is nothing here worth fixing.** Without
+> `_tkinter` the user cannot render a single widget — ttkbootstrap does nothing
+> for them at all, so a version string is not what they need. The
+> `No module named '_tkinter'` traceback **is** the diagnosis (their problem is
+> the install, not a ttkbootstrap bug), and `pip show ttkbootstrap` answers the
+> version anyway. **Do not "fix" this by moving the CLI out of the package.**
+>
+> The mechanical reason came first and still holds: the **diagnosis is right and
+> the fix the review proposed cannot work**, because `ttkbootstrap.cli` *is inside
+> the package* — the entry point `ttkbootstrap.cli:main` runs `__init__.py` before
+> a line of `cli.py` executes, so no lazy import or direct metadata read inside
+> `cli.py` changes anything. Probed with a `MetaPathFinder`: the failure is at
+> `from ttkbootstrap.cli import main` itself. **Note `_tkinter` is the C
+> extension, not the `tkinter` package** — `tkinter/__init__.py:38` imports it, so
+> blocking either produces the same failure; `_tkinter` is the one actually absent
+> in the real case (a distro shipping the stdlib package without `python3-tk`).
 >
 > **How the new density test works, since the obvious versions don't.** Bring the
 > root up scaled by patching `tkinter.Tk.__init__` to call `tk scaling 2.0` right

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1782,6 +1782,14 @@ full 3.0 removal checklist until 3.0 is actually scoped.
 > under *Dev environment & commands* (bump `pyproject.toml` on `master`, fold in
 > `development/2_2_changes.md`, gates, build, upload, tag).
 >
+> **SUPERSEDED (2026-08-06b): the release is no longer the next thing.** An
+> unmerged branch, `feat/2.2-version-and-cli`, now carries four more 2.2 items —
+> `__version__`, the `ttkb` CLI, pre-root `Theme.register()`, and the #1322 fix —
+> plus the review round that followed. **Land that branch first**; the release
+> runbook below is still correct and still next after it. See the two 2026-08-06
+> session entries at the end of this section for the branch's state and what the
+> next session owes it.
+>
 > **HANDOFF — THE NEXT SESSION IS THE 2.2 RELEASE** (final checks, then ship).
 > Set up 2026-08-05; everything below was verified on the Windows box at
 > `e05a9deb`, so start by confirming nothing moved rather than re-deriving it.
@@ -1952,34 +1960,60 @@ full 3.0 removal checklist until 3.0 is actually scoped.
 > doable, and a live demonstration that the theme converter works; the CLI and its
 > docs came out of that conversation.
 >
-> **NEXT SESSION: `/code-review` each commit on this branch, one at a time.**
-> The commits are deliberately single-purpose and in dependency order, so review
-> them in order and treat each as its own change rather than reviewing the branch
-> diff as a whole:
+> **THE `/code-review` OF THOSE 7 COMMITS IS DONE (2026-08-06b) — 4 findings, all
+> real, all fixed in 3 follow-up commits. The branch now has 10 commits, still
+> unpushed with no PR.** Gates after the fixes: suite **1033 passed, 5 skipped**;
+> docs clean under `-W`. Precedent held for the fourth round running — a careful
+> self-review had missed every one.
 >
-> | Commit | Subject | What to look hardest at |
-> |---|---|---|
-> | `dcf5cc9f` | `feat: report the installed version as ttkbootstrap.__version__` | The metadata read and its fallback; whether the stub declaration is the *only* place a public assignment can go missing |
-> | `ac47d008` | `feat(cli): add the ttkb command` | New public surface: argparse wiring, the shared `add_arguments`/`run` seam, the `main()` refactors on the two `__main__` modules, exit codes |
-> | `39599d2c` | `fix(themes): register a theme before the app exists` | The behavior change — deferral ordering vs. `theme_use`, eager validation, whether anything relied on the old `RuntimeError`, `install_legacy_themes` warning placement |
-> | `1141a202` | `test: pin the test root to baseline density` (#1322) | Whether pinning *after* the root is built leaves any eagerly-built style asserted elsewhere |
-> | `2af76d56` | `docs: document the ttkb command line` | Prose accuracy against the shipped CLI; the `ttkb`-everywhere rule |
-> | `2ec003f0` | `docs: point at tkinter-icons` | Trivial; confirm no stale link survives |
-> | *(last)* | `docs(dev): record the 2.2 additions` | That the change log matches what actually shipped |
+> | Fix commit | What the review found |
+> |---|---|
+> | `3530c673` `fix(themes): keep every pre-root theme registration` | **MEDIUM.** The deferral commit keyed the queue on the *family name*, and the seam keeps one applier per key — so two `register()` calls splitting a family across separate `Theme` objects collapsed to the last. Probed: pre-root `['acme-dark']` vs post-root `['beta-dark','beta-light']`, i.e. **the queue changed the answer**, silently, surfacing only as `theme_use` raising later. Now a key per call. |
+> | `40642e23` `fix(cli): only claim ttkcreator is missing when it is` | **LOW.** The `try` wrapped an import that executes all of ttkcreator, so an `ImportError` from *inside* it reported "ttkcreator is not installed". Narrowed to `ModuleNotFoundError` naming ttkcreator itself; anything else re-raises. Trailing newline too. |
+> | `e6e2b617` `test: rebuild the eager styles at the pinned density` | **LOW.** #1322 was only half fixed: the pin lands after `Window()`, so the styles `create_default_style` builds on the way up stayed sized to the host. Re-running it re-sizes them — the recipes are invoked unconditionally, the build-once check is at the call site (probed: stale `10 4` → `15 6` at `tk scaling 2.0`). |
 >
-> **Precedent worth honoring:** the last three `/code-review` rounds on this repo
-> each found real defects a careful self-review had missed, and in two of them the
-> artifact was *wrong* rather than merely narrow (#1332's unescaped interpolation;
-> #1328's `Menu` rebuilt from the mixin, discarding five public methods). Two of
-> the commits here are exactly that shape — new public surface (`cli.py`) and a
-> behavior change to an existing API (`register()`). Also remember
-> [[the #1332 lesson]]: a review finding is a hypothesis with a reproduction
-> attached; the reproduction proves the *defect*, which does not make the proposed
-> *fix* right. Probe any recommendation against real data before implementing it.
+> **A counter, not `id(self)`.** The review proposed keying on `id(self)`, as
+> `on_theme_change` does for callbacks. **`Theme(...).register()` need not keep a
+> reference**, so the object can be collected and its id reused by the next theme
+> — reinstating the very collision. `itertools.count()` in `theme.py` instead.
+> ([[the #1332 lesson]] again: the reproduction proves the *defect*, not the
+> proposed *fix*.)
 >
-> After the reviews: fold any fixes in, then open the PR against `master` with the
-> **`2.2` milestone set** (on the PR, not just the issue), and move **#1322** off
-> `2.1.x` onto `2.2` since it is fixed here — closing `2.1.x` out.
+> **The #1322 guard is asserted on conftest's SOURCE, and that is a deliberate
+> compromise worth re-examining.** The first version read the eight eager styles'
+> geometry, re-ran `create_default_style`, and compared — it **passed alone and
+> failed in the full suite**, because it mutates global style state mid-run and
+> some earlier test leaks a `Link.TButton` padding of `40 2` that the rebuild
+> reset. So `create_default_style` is idempotent at session start (nothing has
+> been configured yet) but **NOT** once styles carry overrides. The replacement
+> asserts the pin precedes the rebuild in conftest's text, proven to fail with the
+> rebuild line removed. Testing it properly would mean driving a scaled root in a
+> subprocess.
+>
+> **NEXT SESSION — `/code-review` the three fix commits (`d7561785..HEAD`), then
+> ship the branch.** The first four commits are already-reviewed context, not the
+> subject. It cannot be launched from inside a session (`disable-model-invocation`
+> — reserved for explicit user invocation), so the author runs `/code-review`.
+> Three questions worth putting in front of it, since the author of the fixes is
+> not a neutral judge of them:
+>
+> 1. **`style/theme.py`** — module-level `itertools.count()` and a per-call defer
+>    key. Anything the per-family key didn't have: unbounded queue growth, or
+>    `register()` in a loop queueing duplicate work that all runs at flush?
+> 2. **`tests/conftest.py`** — the second `create_default_style()` call is safe
+>    *only* because nothing is configured at session-root creation. That is the
+>    claim to check, given it is demonstrably not idempotent later.
+> 3. **`tests/test_scaling.py`** — is a source-order guard reasonable here (the
+>    repo has precedent), or papering over a claim that wants a real test?
+>
+> **Then:** fold in any fixes, open the PR against `master` with the **`2.2`
+> milestone set** (on the PR, not just the issue), and move **#1322** off `2.1.x`
+> onto `2.2` since it is fixed here — closing `2.1.x` out.
+>
+> **Unrelated, noticed in passing — a pre-existing test-isolation leak.** Something
+> in the suite leaves `Link.TButton` padding at `40 2`. Invisible unless a test
+> re-runs a builder mid-suite, which is how it surfaced. Not caused by this branch;
+> worth a look sometime, not a release gate.
 >
 > **(1) `ttkbootstrap.__version__`** — read from the installed metadata
 > (`importlib.metadata.version`), so `pyproject.toml` stays the one place the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1815,12 +1815,10 @@ full 3.0 removal checklist until 3.0 is actually scoped.
 >   the simple index propagate separately, and pip caches the empty index page —
 >   this bit both 2.1.0 and 2.1.1, each time reading as a broken release.
 >
-> **Two decisions the release needs, neither made.** (1) **`ttk.__version__` does
-> not exist** and never has — `import ttkbootstrap; ttkbootstrap.__version__`
-> raises `AttributeError`, which is a common reflex. It is additive and 2.2 is a
-> feature release, so this is the natural window; it was noted at 2.1.0 and left
-> unfiled. Author's call whether to include it or ship without. (2) **#1322's
-> milestone**, below. `.pypirc` is present at the repo root.
+> **Two decisions the release needed — both now made** (2026-08-06 session,
+> below): **`ttk.__version__` is IN** (it never existed before), and **#1322 is
+> FIXED**, so it moves to the `2.2` milestone rather than a `2.2.x` bucket.
+> `.pypirc` is present at the repo root.
 >
 > **One milestone chore belongs to that release: #1322 must come off `2.1.x`.**
 > A patch is cut from `master` and `release/*` is only for superseded majors, so
@@ -1944,6 +1942,128 @@ full 3.0 removal checklist until 3.0 is actually scoped.
 > ``` `` ```** — it catches all three classes at once. After #1332 + #1333 that
 > scan is clean across the whole site. A clean `-W` build is still not evidence
 > the markup parsed.
+>
+> **Session 2026-08-06 — four more things landed on 2.2 before the release, on
+> the branch `feat/2.2-version-and-cli` (7 commits, not pushed, no PR yet).**
+> Gates: suite **1031 passed, 5 skipped**; docs clean under `-W`; the strip-tags
+> stray-backtick scan clean; **every commit independently green** (verified in a
+> worktree with `PYTHONPATH` pinned — an editable install otherwise wins over a
+> worktree's own `src/`). The author asked for `__version__`, #1322 if it was
+> doable, and a live demonstration that the theme converter works; the CLI and its
+> docs came out of that conversation.
+>
+> **NEXT SESSION: `/code-review` each commit on this branch, one at a time.**
+> The commits are deliberately single-purpose and in dependency order, so review
+> them in order and treat each as its own change rather than reviewing the branch
+> diff as a whole:
+>
+> | Commit | Subject | What to look hardest at |
+> |---|---|---|
+> | `dcf5cc9f` | `feat: report the installed version as ttkbootstrap.__version__` | The metadata read and its fallback; whether the stub declaration is the *only* place a public assignment can go missing |
+> | `ac47d008` | `feat(cli): add the ttkb command` | New public surface: argparse wiring, the shared `add_arguments`/`run` seam, the `main()` refactors on the two `__main__` modules, exit codes |
+> | `39599d2c` | `fix(themes): register a theme before the app exists` | The behavior change — deferral ordering vs. `theme_use`, eager validation, whether anything relied on the old `RuntimeError`, `install_legacy_themes` warning placement |
+> | `1141a202` | `test: pin the test root to baseline density` (#1322) | Whether pinning *after* the root is built leaves any eagerly-built style asserted elsewhere |
+> | `2af76d56` | `docs: document the ttkb command line` | Prose accuracy against the shipped CLI; the `ttkb`-everywhere rule |
+> | `2ec003f0` | `docs: point at tkinter-icons` | Trivial; confirm no stale link survives |
+> | *(last)* | `docs(dev): record the 2.2 additions` | That the change log matches what actually shipped |
+>
+> **Precedent worth honoring:** the last three `/code-review` rounds on this repo
+> each found real defects a careful self-review had missed, and in two of them the
+> artifact was *wrong* rather than merely narrow (#1332's unescaped interpolation;
+> #1328's `Menu` rebuilt from the mixin, discarding five public methods). Two of
+> the commits here are exactly that shape — new public surface (`cli.py`) and a
+> behavior change to an existing API (`register()`). Also remember
+> [[the #1332 lesson]]: a review finding is a hypothesis with a reproduction
+> attached; the reproduction proves the *defect*, which does not make the proposed
+> *fix* right. Probe any recommendation against real data before implementing it.
+>
+> After the reviews: fold any fixes in, then open the PR against `master` with the
+> **`2.2` milestone set** (on the PR, not just the issue), and move **#1322** off
+> `2.1.x` onto `2.2` since it is fixed here — closing `2.1.x` out.
+>
+> **(1) `ttkbootstrap.__version__`** — read from the installed metadata
+> (`importlib.metadata.version`), so `pyproject.toml` stays the one place the
+> literal lives, matching what `docs/conf.py` already did. **It also has to be
+> declared in `__init__.pyi`**: a `.pyi` replaces the module for type checkers,
+> and the stub generator's `_reexports` pass sources every name from an *import
+> statement* in `__init__.py`, so an assignment is invisible to it. Proven both
+> ways with pyright — `reportAttributeAccessIssue` without the declaration, `str`
+> with it. The line lives in `_HEADER` in `tools/generate_widget_stubs.py`. The
+> flip side of reading metadata is that it reports what was **installed**, so an
+> editable install lags a bump; that is why no test asserts it against
+> `pyproject.toml`, and why **`ttkb version` cannot confirm the release bump
+> without a reinstall** — the same trap the runbook already records for the docs
+> build. (`.venv-home` on this box reports `2.0.0a1`; `.venv314`, which `python`
+> resolves to, reports `2.1.1`.)
+>
+> **(2) The `ttkb` command line** (`src/ttkbootstrap/cli.py`, new
+> `docs/reference/cli.rst`, `tests/test_cli_api.py` +12) — `version` · `demo` ·
+> `convert-theme` · `creator`, installed under **two** `[project.scripts]` names
+> (`ttkb` and `ttkbootstrap`) per the author's choice. Each subcommand already
+> existed as its own `python -m` invocation that nothing surfaced; all of those
+> still work. The converter's arguments moved into a shared
+> `convert_theme.add_arguments`/`run` pair so the two spellings cannot drift, and
+> `__main__.py` (demo) and `ttkcreator/__main__.py` grew a `main()` instead of
+> bare `if __name__` blocks. **Standing docs rule, memory-saved:
+> [[feedback_docs_use_ttkb_cli_spelling]] — the docs say `ttkb <command>`
+> everywhere**, even where another spelling works; the alternatives are stated
+> once, in a note on the CLI page. README updated to match, and its
+> `ttkbootstrap-icons` link repointed at **`tkinter-icons`**, the extension's
+> current name (verified live: repo + PyPI both exist).
+>
+> **(3) `Theme(...).register()` now works before the App exists** — found by
+> actually running a converted theme rather than reading it. It raised
+> `RuntimeError: No Style instance yet`, which made the natural top-of-file form
+> impossible *and* made a custom theme unusable as an `App(theme=...)` argument:
+> registration needed the app, and the app needed the name. It now queues on the
+> **deferred-config seam that already existed for this exact shape**
+> (`utils/config.defer`, the `set_default_button` tenant) — and because
+> `flush_pending_config()` runs in `Style.__init__` *before* `theme_use(theme)`,
+> `import brand; ttk.App(theme="acme-light")` just works. The theme is still
+> **validated eagerly** at the `register()` call, so a missing anchor raises where
+> it is written rather than out of a window constructor. `install_legacy_themes()`
+> got the same treatment and still warns from the call site. Three tests in
+> `test_theme_anchor.py`; the two docs pages that said "register after the App
+> exists" were rewritten.
+>
+> **(4) #1322 is FIXED** — `tests/conftest.py` pins the shared root to
+> `Scaling.baseline` (4/3, or 1.0 on aqua before Tk 9), which is the issue's own
+> suggested fix. **Reproduced before fixing**: forcing `tk scaling 2.0` in the
+> fixture produced exactly the four filed failures with the issue's 144-dpi
+> numbers — `(23,23)`, `(60,8)`. With the pin the **whole suite passes at 1.0,
+> 1.4, 1.6667 and 2.0**, so the fix is density-independent rather than
+> Windows-shaped. Pinned *after* the root is built (`Window()` makes the root and
+> the `Style` together); the handful of eagerly-built styles carry the host's
+> density, and empirically nothing asserts their geometry. New
+> `test_test_root_runs_at_baseline_density` guards the invariant. **The milestone
+> chore still applies**: move #1322 off `2.1.x` (to `2.2`, since it is now fixed)
+> and close that milestone out, or it becomes unreachable when `master` reads
+> 2.2.0.
+>
+> **The converter demonstration** (the author's third ask) ran end-to-end on real
+> 1.x artifacts reconstructed from `release/v1`'s own save code — a `USER_THEMES`
+> `user.py`, a `ThemeDefinition(...)` export, and a `load_user_themes` JSON, built
+> from two shipped 1.x specs. All three converted; the generated module was
+> imported and rendered light and dark. Two findings came out of *running* it, not
+> reading it: the registration bug in (3), and that the generated header stopped a
+> step short — it now names the registered variant (`app = ttk.App(theme="acme
+> -light")`), since the 2.x name is `<family>-<mode>`, not the 1.x name.
+>
+> **`development/2_2_changes.md` is updated for all four** (new *Testing*
+> section). The release notes source is therefore current as of this work — but
+> re-run `git diff v2.1.1..master` before the release, as the handoff says.
+>
+> **Two process notes from assembling the branch.** (a) **The Bash tool is not
+> PowerShell** — `git commit -m @'…'@` there passes a literal `@` as the first
+> line of the message, which is how the first commit got a stray `@` subject
+> (fixed by `--amend -F`). Write the message to a file and use `-F`; it sidesteps
+> every quoting difference between the two shells. (b) Splitting mixed files
+> across single-purpose commits without interactive staging is done by
+> *temporarily reverting* the other thread's hunk, committing, and re-applying it
+> in the later commit — three files needed it here (`README.md`,
+> `feature-guides/theming.rst`, `migrating.rst`) plus the converter's generated
+> header, which could only claim `App(theme=…)` once the deferral commit made it
+> true.
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ ttk.Button(app, text="Settings", icon="gear-fill", bootstyle="primary")
 ```
 
 Need other icon families — Font Awesome, Material, Lucide, and more? The
-[ttkbootstrap-icons](https://github.com/israel-dryer/ttkbootstrap-icons) extension
-is still available and adds installable icon providers alongside the built-in set.
+[tkinter-icons](https://github.com/israel-dryer/tkinter-icons) extension adds
+sixteen icon sets (61,000+ icons) alongside the built-in set.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ tkinter's, and everything you already know about tkinter still applies.
 python -m pip install ttkbootstrap
 ```
 
+Then see it running — this opens a window with every widget and a theme picker:
+
+```bash
+ttkb demo
+```
+
 ## Quickstart
 
 ```python
@@ -88,6 +94,26 @@ app.toggle_theme()                # flip light <-> dark
 Browse them in the
 [themes gallery](https://ttkbootstrap.readthedocs.io/en/latest/themes.html).
 
+Design your own with the bundled editor — pick colors, preview them on live
+widgets, and export a `Theme(...)` snippet for your app:
+
+```bash
+ttkb creator
+```
+
+## Command line
+
+Installing ttkbootstrap installs `ttkb`:
+
+| Command | What it does |
+| --- | --- |
+| `ttkb version` | Print the installed version |
+| `ttkb demo` | Open the widget demo |
+| `ttkb convert-theme <file>` | Convert a 1.x theme file to the 2.x `Theme(...)` form |
+| `ttkb creator` | Open ttkcreator, the theme designer |
+
+See the [command-line reference](https://ttkbootstrap.readthedocs.io/en/latest/reference/cli.html).
+
 ## Documentation
 
 - **[Documentation](https://ttkbootstrap.readthedocs.io/en/latest/)** — guides, the widget catalog, and the API reference.
@@ -103,6 +129,13 @@ keeps working: legacy theme names and older spellings are accepted with a
 deprecation warning. The
 [Migrating to 2.0](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/getting-started/migrating.html)
 guide sorts every change into breaking / deprecated / notable / new.
+
+Custom themes moved out of the package and into your own code. To bring one
+forward, convert the file 1.x saved:
+
+```bash
+ttkb convert-theme user.py -o brand.py
+```
 
 ## Icons
 

--- a/development/2_2_changes.md
+++ b/development/2_2_changes.md
@@ -58,8 +58,87 @@ formats, the loud-failure paths, the escaping of what it emits, and an
 end-to-end check that the emitted Python actually registers a theme and styles
 real widgets.
 
+### `ttkbootstrap.__version__`
+
+`import ttkbootstrap; ttkbootstrap.__version__` raised `AttributeError` — it had
+never existed, in any release. It now reports the installed distribution's
+version, read from the package metadata so `pyproject.toml` stays the one place
+the literal lives. The consequence of reading metadata is that it reports what
+was *installed*: an editable install keeps whatever metadata it was built with
+until it is reinstalled.
+
+It is also declared in the type stub. A `.pyi` replaces the module for type
+checkers, and the stub's re-export pass sources every name from an import
+statement in `__init__.py`; `__version__` is an assignment, so without an
+explicit declaration `ttk.__version__` was an attribute error under pyright even
+though it worked at runtime.
+
+### The `ttkb` command line
+
+Installing ttkbootstrap now installs a command — under two names, `ttkb` and
+`ttkbootstrap`, that run the same thing:
+
+| Command | What it does |
+| --- | --- |
+| `ttkb version` | Print the installed version |
+| `ttkb demo` | Open the widget demo (was `python -m ttkbootstrap`) |
+| `ttkb convert-theme <file>` | Convert a 1.x theme file (was `python -m ttkbootstrap.convert_theme`) |
+| `ttkb creator` | Open ttkcreator (was `python -m ttkcreator`) |
+
+Each of those already existed as its own `python -m` invocation, which nothing
+surfaced; every `python -m` spelling still works, and is what to use when the
+scripts directory is not on `PATH`. The converter's arguments are defined once
+and shared by both spellings, so they cannot drift apart. New
+`docs/reference/cli.rst`; `tests/test_cli_api.py` (+12).
+
+### Registering a theme before the app exists
+
+`Theme(...).register()` raised `RuntimeError: No Style instance yet` unless an
+`App` was already running — but a theme is declared at the top of a file, which
+is exactly where no app exists. Worse, it made the theme unusable as an
+`App(theme=...)` argument: registration needed the app, and the app needed the
+name. It now queues on the existing deferred-config seam (the one
+`set_default_button` uses) and registers when the root comes up, which is early
+enough for `App(theme="brand-light")` to select it. Registering with an app
+already running still applies immediately.
+
+```python
+import ttkbootstrap as ttk
+import brand                       # a converted theme module
+
+app = ttk.App(theme="acme-light")  # selectable straight away
+```
+
+The theme is still *validated* at the `register()` call, so a missing anchor
+raises where it is written rather than later out of a window constructor.
+`install_legacy_themes()` gained the same treatment, and keeps warning from the
+call site whether or not the work is deferred.
+
+## Testing
+
+- **The suite is density-independent** (#1322). Four asset-geometry tests assert
+  exact unscaled pixel sizes, so they passed only where the scaling factor was
+  exactly 1.0 — a contributor on Windows at 125% (the factory default on most
+  laptops) got four one-pixel failures on a clean checkout. The shared root is
+  now pinned to standard density in `tests/conftest.py`, rather than four
+  assertions being patched: that covers any other test carrying the same latent
+  assumption, and demotes CI's `-dpi 96` from load-bearing to belt-and-braces.
+  Verified by simulating 1.0, 1.4, 1.6667 and 2.0 — the whole suite passes at
+  every one, and the four failures reproduce exactly as filed with the pin
+  removed. `test_test_root_runs_at_baseline_density` pins the invariant.
+
 ## Documentation
 
+- **Reference › Command line** is a new page: the four subcommands, what each
+  one replaces, and the two-names/`python -m` note.
+- **Installation** and **Theming & Colors** now reach the demo and ttkcreator
+  through `ttkb demo` / `ttkb creator`; the converter is `ttkb convert-theme`
+  everywhere.
+- **Theming & Colors** and **Migrating to 2.0** no longer say a theme must be
+  registered after the `App` exists — they show the top-of-file form.
+- The **icons** guide and the README now point at
+  [tkinter-icons](https://github.com/israel-dryer/tkinter-icons), the extension's
+  current name (it was `ttkbootstrap-icons`).
 - **Migrating to 2.0** gained *Saved themes move into your code*: the
   `themes/user.py` store and ttkcreator's Import/Export buttons are gone, the
   converter command, what carries over vs. what 2.x regenerates, and a note

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -19,8 +19,10 @@ Run ``ttkb`` with no arguments, or ``ttkb <command> --help``, for usage.
    The command installs under two names — ``ttkb`` and ``ttkbootstrap`` — that
    run the same thing.
 
-   Every command also has a ``python -m`` spelling, which is what to use when
-   your environment's scripts directory is not on ``PATH``.
+   When your environment's scripts directory is not on ``PATH``, run the same
+   commands as ``python -m ttkbootstrap.cli <command>``. The demo, converter and
+   theme designer each also keep the individual ``python -m`` spelling they had
+   before, listed below.
 
 Commands
 --------

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -1,0 +1,134 @@
+Command line
+============
+
+Installing ttkbootstrap installs a command, ``ttkb``, for the things that are
+not library calls: reporting the version, opening the demo, converting a 1.x
+theme, and launching the theme designer.
+
+.. code-block:: bash
+
+   ttkb version
+   ttkb demo
+   ttkb convert-theme user.py -o brand.py
+   ttkb creator
+
+Run ``ttkb`` with no arguments, or ``ttkb <command> --help``, for usage.
+
+.. note::
+
+   The command installs under two names — ``ttkb`` and ``ttkbootstrap`` — that
+   run the same thing.
+
+   Every command also has a ``python -m`` spelling, which is what to use when
+   your environment's scripts directory is not on ``PATH``.
+
+Commands
+--------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Command
+     - What it does
+   * - ``ttkb version``
+     - Print the installed version, e.g. ``2.2.0``. Same value as
+       ``ttkbootstrap.__version__``.
+   * - ``ttkb demo``
+     - Open the widget demo: every themed widget on one window, with a theme
+       picker. Same as ``python -m ttkbootstrap``.
+   * - ``ttkb convert-theme``
+     - Convert a ttkbootstrap 1.x theme file into the 2.x
+       ``Theme(...).register()`` form. Same as
+       ``python -m ttkbootstrap.convert_theme``.
+   * - ``ttkb creator``
+     - Open ttkcreator, the theme designer. Same as ``python -m ttkcreator``.
+
+version
+-------
+
+.. code-block:: bash
+
+   $ ttkb version
+   2.2.0
+
+Prints the version of the installed distribution — the same string as
+``ttkbootstrap.__version__``, and what to quote in a bug report.
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+
+   print(ttk.__version__)
+
+demo
+----
+
+.. code-block:: bash
+
+   ttkb demo
+
+Opens a window showing the widget set under the current theme, with a picker
+that switches themes live. It is a good first check that your install works and
+a quick way to see what a theme looks like before choosing one.
+
+convert-theme
+-------------
+
+.. code-block:: bash
+
+   ttkb convert-theme <file> [-o <output>]
+
+Reads a theme file saved by ttkbootstrap 1.x and writes the equivalent 2.x
+``Theme(...).register()`` call. All three artifacts 1.x could produce are
+accepted:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - File
+     - Where it came from
+   * - ``user.py`` (a ``USER_THEMES`` dict)
+     - ttkcreator's *Save* and *Export all themes*
+   * - ``.py`` (a ``ThemeDefinition(...)`` call)
+     - ttkcreator's *Export theme definition*
+   * - ``.json``
+     - the :meth:`~ttkbootstrap.Style.load_user_themes` format
+
+Every theme in the file converts. Output goes to standard output, or to the
+file named by ``-o``.
+
+.. code-block:: bash
+
+   $ ttkb convert-theme user.py -o brand.py
+   Wrote brand.py
+
+Import the generated module and the themes are available by name:
+
+.. code-block:: python
+
+   import ttkbootstrap as ttk
+   import brand  # registers the converted themes
+
+   app = ttk.App(theme="acme-light")
+
+See :doc:`Migrating to 2.0 </user-guide/getting-started/migrating>` for what
+carries over and what 2.x derives instead.
+
+creator
+-------
+
+.. code-block:: bash
+
+   ttkb creator
+
+Opens ttkcreator: edit a theme's accent, neutral, and background colors, preview
+the result on live widgets, and export a ``Theme(...).register()`` snippet to
+drop into your own app.
+
+See also
+--------
+
+- :doc:`theming` — the ``Theme`` class the converter and ttkcreator both emit.
+- :doc:`/user-guide/getting-started/migrating` — the 1.x to 2.0 migration guide.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -112,6 +112,13 @@ The lookup layer:
       The mouse-pointer names the ``cursor`` option accepts — the common set,
       the full portable list, and the platform-specific pointers.
 
+   .. grid-item-card:: Command line
+      :link: cli
+      :link-type: doc
+
+      The ``ttkb`` command — print the version, open the demo, convert a 1.x
+      theme, and launch the theme designer.
+
 .. toctree::
    :hidden:
 
@@ -130,3 +137,4 @@ The lookup layer:
    capabilities/index
    events/index
    cursors
+   cli

--- a/docs/reference/theming.rst
+++ b/docs/reference/theming.rst
@@ -39,7 +39,7 @@ A custom theme saved by 1.x — a ``user.py`` holding a ``USER_THEMES`` dict, a
 
 .. code-block:: bash
 
-   python -m ttkbootstrap.convert_theme user.py -o brand.py
+   ttkb convert-theme user.py -o brand.py
 
 Pass ``-o`` to write a file, or omit it to print to standard output. Every
 theme in the file converts. See :doc:`Migrating to 2.0

--- a/docs/user-guide/feature-guides/icons.rst
+++ b/docs/user-guide/feature-guides/icons.rst
@@ -192,9 +192,9 @@ Other icon sets
 
 The bundled font is Bootstrap Icons. If you need another family — Font Awesome,
 Material, Ionicons, Lucide, and more — the optional
-`ttkbootstrap-icons <https://github.com/israel-dryer/ttkbootstrap-icons>`__
-extension adds installable icon providers for your tkinter/ttkbootstrap app,
-alongside the built-in set described here.
+`tkinter-icons <https://github.com/israel-dryer/tkinter-icons>`__ extension adds
+sixteen icon sets to your tkinter/ttkbootstrap app, alongside the built-in set
+described here.
 
 .. seealso::
 

--- a/docs/user-guide/feature-guides/theming.rst
+++ b/docs/user-guide/feature-guides/theming.rst
@@ -220,7 +220,14 @@ running works too, and takes effect immediately:
 
 .. code-block:: python
 
-   ttk.Theme(name="brand", ...).register()
+   ttk.Theme(
+       name="brand",
+       primary="#593196", success="#13b955", info="#009cdc",
+       warning="#efa31d", danger="#fc3939",
+       light=dict(background="#ffffff", foreground="#17141f"),
+       dark=dict(background="#17141f", foreground="#e9ecef"),
+   ).register()
+
    app.theme_use("brand-light")
 
 Registering a theme generates a ``<name>-light`` and ``<name>-dark`` variant for

--- a/docs/user-guide/feature-guides/theming.rst
+++ b/docs/user-guide/feature-guides/theming.rst
@@ -197,13 +197,11 @@ Defining a theme
 
 Build a :class:`~ttkbootstrap.Theme` from its anchors and register it. The five
 accents are the mid-tone of each color; ``light``/``dark`` each give a background
-and foreground. Registration needs a running app (a style must exist first):
+and foreground. Register it and it is selectable by name, like any built-in:
 
 .. code-block:: python
 
    import ttkbootstrap as ttk
-
-   app = ttk.App()
 
    ttk.Theme(
        name="brand",
@@ -213,8 +211,17 @@ and foreground. Registration needs a running app (a style must exist first):
        dark=dict(background="#17141f", foreground="#e9ecef"),
    ).register()
 
-   app.theme_use("brand-light")   # registered as brand-light and brand-dark
+   app = ttk.App(theme="brand-light")   # registered as brand-light and brand-dark
    app.mainloop()
+
+Declaring the theme at the top of the file, before the app exists, is the
+normal case — that is where a theme belongs. Registering after the app is
+running works too, and takes effect immediately:
+
+.. code-block:: python
+
+   ttk.Theme(name="brand", ...).register()
+   app.theme_use("brand-light")
 
 Registering a theme generates a ``<name>-light`` and ``<name>-dark`` variant for
 whichever surfaces you declared, so it drops straight into the light/dark
@@ -257,7 +264,7 @@ save into the library; your theme lives in your own code.
 
    .. code-block:: bash
 
-      python -m ttkbootstrap.convert_theme user.py -o brand.py
+      ttkb convert-theme user.py -o brand.py
 
    It reads a 1.x ``user.py``, an exported ``ThemeDefinition(...)`` file, or a
    ``load_user_themes`` JSON file, and writes the equivalent

--- a/docs/user-guide/feature-guides/theming.rst
+++ b/docs/user-guide/feature-guides/theming.rst
@@ -220,6 +220,10 @@ running works too, and takes effect immediately:
 
 .. code-block:: python
 
+   import ttkbootstrap as ttk
+
+   app = ttk.App()
+
    ttk.Theme(
        name="brand",
        primary="#593196", success="#13b955", info="#009cdc",
@@ -229,6 +233,7 @@ running works too, and takes effect immediately:
    ).register()
 
    app.theme_use("brand-light")
+   app.mainloop()
 
 Registering a theme generates a ``<name>-light`` and ``<name>-dark`` variant for
 whichever surfaces you declared, so it drops straight into the light/dark

--- a/docs/user-guide/feature-guides/theming.rst
+++ b/docs/user-guide/feature-guides/theming.rst
@@ -247,7 +247,7 @@ To design a theme interactively rather than by hand, run the bundled editor:
 
 .. code-block:: bash
 
-   python -m ttkcreator
+   ttkb creator
 
 Edit the accent anchors and the light/dark surfaces, preview against live
 widgets, then **Export theme (.py)** -- you get a ``Theme(...).register()``

--- a/docs/user-guide/getting-started/installation.rst
+++ b/docs/user-guide/getting-started/installation.rst
@@ -108,7 +108,7 @@ demo window with a theme picker and a sample of every widget:
 
 .. code-block:: bash
 
-   python -m ttkbootstrap
+   ttkb demo
 
 Or write the smallest possible app yourself:
 

--- a/docs/user-guide/getting-started/migrating.rst
+++ b/docs/user-guide/getting-started/migrating.rst
@@ -151,7 +151,7 @@ a JSON file you wrote for ``load_user_themes``:
 
 .. code-block:: bash
 
-   python -m ttkbootstrap.convert_theme user.py -o brand.py
+   ttkb convert-theme user.py -o brand.py
 
 That writes a ready-to-run ``Theme(...).register()`` call:
 

--- a/docs/user-guide/getting-started/migrating.rst
+++ b/docs/user-guide/getting-started/migrating.rst
@@ -167,14 +167,14 @@ That writes a ready-to-run ``Theme(...).register()`` call:
        dark=dict(background="#1c1c1c", foreground="#e9ecef"),
    ).register()
 
-Paste it into your startup code, after the ``App`` exists — registering a theme
-needs a live style — then select it by its generated variant name:
+Import that module — or paste the call into your startup code — and select the
+theme by its generated variant name:
 
 .. code-block:: python
 
-   app = ttk.App()
-   ttk.Theme(name="midnight", ...).register()
-   app.theme_use("midnight-dark")
+   import brand   # registers midnight-dark
+
+   app = ttk.App(theme="midnight-dark")
 
 Your accents and that mode's background and foreground carry over verbatim.
 Three things deliberately do not:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ Documentation = "https://ttkbootstrap.readthedocs.io/en/latest/"
 
 [project.scripts]
 # Two names for one command: `ttkbootstrap` is guessable from the package name,
-# `ttkb` is what anyone types twice. Every subcommand also keeps its `python -m`
-# spelling, which is what to use when the scripts directory is not on PATH.
+# `ttkb` is what anyone types twice. When the scripts directory is not on PATH,
+# `python -m ttkbootstrap.cli <command>` runs the same thing.
 ttkbootstrap = "ttkbootstrap.cli:main"
 ttkb = "ttkbootstrap.cli:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,13 @@ dependencies = ["pillow>=10,<13"]
 Homepage = "https://github.com/israel-dryer/ttkbootstrap"
 Documentation = "https://ttkbootstrap.readthedocs.io/en/latest/"
 
+[project.scripts]
+# Two names for one command: `ttkbootstrap` is guessable from the package name,
+# `ttkb` is what anyone types twice. Every subcommand also keeps its `python -m`
+# spelling, which is what to use when the scripts directory is not on PATH.
+ttkbootstrap = "ttkbootstrap.cli:main"
+ttkb = "ttkbootstrap.cli:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -37,6 +37,8 @@ bootstyle)`.
 
 For more information, see: https://ttkbootstrap.readthedocs.io/
 """
+from importlib.metadata import PackageNotFoundError, version as _distribution_version
+
 from tkinter import (
     Menu as _tkMenu, Text as _tkText, Canvas as _tkCanvas, Tk as _tkTk,
     Frame as _tkFrame, Label as _tkLabel,
@@ -99,6 +101,20 @@ from ttkbootstrap.utils import (
     Fonts,
     set_global_family,
 )
+
+try:
+    #: The installed distribution's version, e.g. `"2.2.0"`.
+    #
+    # Read from the installed metadata rather than written here, so
+    # `pyproject.toml` stays the one place the version literal lives. The
+    # consequence is that this reports what was *installed*: an editable install
+    # keeps whatever metadata it was built with until it is reinstalled.
+    __version__ = _distribution_version("ttkbootstrap")
+except PackageNotFoundError:
+    # Running from a source tree that was never installed (e.g. PYTHONPATH=src)
+    # -- there is no metadata to read, and guessing one would be worse than
+    # saying so.
+    __version__ = "unknown"
 
 
 # --------------------------------------------------------------------------- #

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -37,7 +37,10 @@ bootstyle)`.
 
 For more information, see: https://ttkbootstrap.readthedocs.io/
 """
-from importlib.metadata import PackageNotFoundError, version as _distribution_version
+from importlib.metadata import (
+    PackageNotFoundError as _PackageNotFoundError,
+    version as _distribution_version,
+)
 
 from tkinter import (
     Menu as _tkMenu, Text as _tkText, Canvas as _tkCanvas, Tk as _tkTk,
@@ -110,7 +113,7 @@ try:
     # consequence is that this reports what was *installed*: an editable install
     # keeps whatever metadata it was built with until it is reinstalled.
     __version__ = _distribution_version("ttkbootstrap")
-except PackageNotFoundError:
+except _PackageNotFoundError:
     # Running from a source tree that was never installed (e.g. PYTHONPATH=src)
     # -- there is no metadata to read, and guessing one would be worse than
     # saying so.

--- a/src/ttkbootstrap/__init__.pyi
+++ b/src/ttkbootstrap/__init__.pyi
@@ -21,6 +21,10 @@ from typing import Any, Callable
 
 from ttkbootstrap.style import AutoStyleMixin as AutoStyleMixin, BootMixin as BootMixin
 
+# Assigned in `__init__.py` rather than imported, so `_reexports` -- which
+# sources every name from an import statement -- cannot reach it.
+__version__: str
+
 from tkinter import Canvas as _tkinterCanvas
 from tkinter import Frame as _tkinterFrame
 from tkinter import Label as _tkinterLabel

--- a/src/ttkbootstrap/__main__.py
+++ b/src/ttkbootstrap/__main__.py
@@ -139,7 +139,8 @@ def setup_demo(app: ttk.App, theme: str):
     return bag, gc
 
 
-if __name__ == "__main__":
+def main():
+    """Open the widget demo. Also what `ttkb demo` runs."""
     app = ttk.App("ttkbootstrap widget demo", minsize=(600, 0))
     # Hide it before building the UI, not after: a window is placed by its
     # window manager, and once it has been mapped, re-showing it is a fresh
@@ -159,3 +160,8 @@ if __name__ == "__main__":
     app.deiconify()
 
     app.mainloop()
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ttkbootstrap/cli.py
+++ b/src/ttkbootstrap/cli.py
@@ -1,0 +1,119 @@
+"""The `ttkb` command line.
+
+One entry point for the things ttkbootstrap ships that are not library calls:
+the version, the widget demo, the 1.x theme converter, and ttkcreator. Each was
+reachable before only as its own `python -m ...` invocation, which nothing
+surfaced.
+
+The command installs under two names -- `ttkb` and `ttkbootstrap` -- that run
+the same thing. Every `python -m` spelling still works, and is what to reach for
+when the scripts directory is not on PATH::
+
+    ttkb version
+    ttkb demo
+    ttkb convert-theme user.py -o brand.py
+    ttkb creator
+"""
+import argparse
+import sys
+
+from ttkbootstrap import __version__
+
+
+def _run_version(args, parser):
+    """Print the installed version."""
+    print(__version__)
+    return 0
+
+
+def _run_demo(args, parser):
+    """Open the widget demo."""
+    from ttkbootstrap.__main__ import main
+
+    return main()
+
+
+def _run_creator(args, parser):
+    """Open ttkcreator."""
+    try:
+        from ttkcreator.__main__ import main
+    except ImportError as error:
+        # ttkcreator ships alongside ttkbootstrap but is a separate top-level
+        # package, so it can be absent from a trimmed install.
+        parser.exit(2, f"{parser.prog}: ttkcreator is not installed ({error}).\n")
+    return main()
+
+
+def _run_convert_theme(args, parser):
+    """Convert a 1.x theme file."""
+    from ttkbootstrap import convert_theme
+
+    return convert_theme.run(args, parser)
+
+
+def build_parser():
+    """Return the `ttkb` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="ttkb",
+        description="Command-line utilities for ttkbootstrap.",
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version=__version__
+    )
+    commands = parser.add_subparsers(dest="command", metavar="<command>")
+
+    version = commands.add_parser(
+        "version",
+        help="print the installed ttkbootstrap version",
+        description="Print the installed ttkbootstrap version.",
+    )
+    version.set_defaults(func=_run_version, parser=version)
+
+    demo = commands.add_parser(
+        "demo",
+        help="open the widget demo",
+        description="Open the widget demo -- every themed widget on one "
+                    "window, with a theme picker.",
+    )
+    demo.set_defaults(func=_run_demo, parser=demo)
+
+    # Imported lazily elsewhere, but the description and arguments are shared
+    # here so the two spellings of the converter cannot drift apart.
+    from ttkbootstrap import convert_theme
+
+    convert = commands.add_parser(
+        "convert-theme",
+        help="convert a 1.x theme file to the 2.x Theme(...) form",
+        description=convert_theme.DESCRIPTION,
+    )
+    convert_theme.add_arguments(convert)
+    convert.set_defaults(func=_run_convert_theme, parser=convert)
+
+    creator = commands.add_parser(
+        "creator",
+        help="open ttkcreator, the theme designer",
+        description="Open ttkcreator: edit a theme's colors, preview the "
+                    "result live, and export a Theme(...).register() snippet.",
+    )
+    creator.set_defaults(func=_run_creator, parser=creator)
+
+    return parser
+
+
+def main(argv=None):
+    """Run the `ttkb` command line."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if getattr(args, "func", None) is None:
+        # No subcommand. argparse can require one, but the error it prints on
+        # its own names the missing argument rather than showing what is
+        # available -- and a bare `ttkb` is someone asking exactly that.
+        parser.print_help()
+        return 2
+    # Each subparser records itself, so a failing command names itself in its
+    # usage line rather than the bare `ttkb`.
+    return args.func(args, args.parser)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ttkbootstrap/cli.py
+++ b/src/ttkbootstrap/cli.py
@@ -37,9 +37,14 @@ def _run_creator(args, parser):
     """Open ttkcreator."""
     try:
         from ttkcreator.__main__ import main
-    except ImportError as error:
+    except ModuleNotFoundError as error:
         # ttkcreator ships alongside ttkbootstrap but is a separate top-level
-        # package, so it can be absent from a trimmed install.
+        # package, so it can be absent from a trimmed install. Only report that
+        # when ttkcreator itself is what is missing -- an import failing *inside*
+        # it is a different problem, and saying "not installed" would send the
+        # user after a package they already have.
+        if error.name not in ("ttkcreator", "ttkcreator.__main__"):
+            raise
         parser.exit(2, f"{parser.prog}: ttkcreator is not installed ({error}).\n")
     return main()
 

--- a/src/ttkbootstrap/cli.py
+++ b/src/ttkbootstrap/cli.py
@@ -6,8 +6,8 @@ reachable before only as its own `python -m ...` invocation, which nothing
 surfaced.
 
 The command installs under two names -- `ttkb` and `ttkbootstrap` -- that run
-the same thing. Every `python -m` spelling still works, and is what to reach for
-when the scripts directory is not on PATH::
+the same thing, and `python -m ttkbootstrap.cli <command>` runs it too, which is
+what to reach for when the scripts directory is not on PATH::
 
     ttkb version
     ttkb demo

--- a/src/ttkbootstrap/convert_theme.py
+++ b/src/ttkbootstrap/convert_theme.py
@@ -5,8 +5,11 @@ dict, a ``.py`` holding the ``ThemeDefinition(...)`` call ttkcreator's *Export
 theme definition* wrote, or a JSON file in the ``Style.load_user_themes``
 format -- and it prints Python you paste into your own app::
 
-    python -m ttkbootstrap.convert_theme mythemes.json
-    python -m ttkbootstrap.convert_theme user.py -o brand.py
+    ttkb convert-theme mythemes.json
+    ttkb convert-theme user.py -o brand.py
+
+The module stays runnable as ``python -m ttkbootstrap.convert_theme``, which is
+what to use when the scripts directory is not on PATH.
 
 The five accent anchors, the optional secondary accent, and the theme's
 background/foreground carry over. `border`, `inputbg`, `inputfg`, `selectbg`,
@@ -247,8 +250,7 @@ def convert(path):
         width=75,
     )
     header = [
-        f"# Converted from {Path(path).name} by "
-        f"python -m ttkbootstrap.convert_theme.",
+        f"# Converted from {Path(path).name} by ttkb convert-theme.",
         "#",
         *(f"# {line}" for line in note),
         "# Call register() once, after creating your App.",
@@ -261,13 +263,19 @@ def convert(path):
     return "\n".join(header) + "\n\n".join(blocks) + "\n"
 
 
-def main(argv=None):
-    """Run the command-line converter."""
-    parser = argparse.ArgumentParser(
-        prog="python -m ttkbootstrap.convert_theme",
-        description="Convert a ttkbootstrap 1.x theme file into a 2.x "
-                    "Theme(...).register() snippet.",
-    )
+#: One-line summary, shared by this module's parser and the `ttkb` subcommand.
+DESCRIPTION = (
+    "Convert a ttkbootstrap 1.x theme file into a 2.x Theme(...).register() "
+    "snippet."
+)
+
+
+def add_arguments(parser):
+    """Add the converter's arguments to `parser`.
+
+    Shared with the `ttkb convert-theme` subcommand so the two spellings cannot
+    drift apart.
+    """
     parser.add_argument(
         "file",
         help="a 1.x theme file (.json, or a .py USER_THEMES / ThemeDefinition "
@@ -276,8 +284,11 @@ def main(argv=None):
     parser.add_argument(
         "-o", "--output", help="write to this file instead of standard output"
     )
-    args = parser.parse_args(argv)
+    return parser
 
+
+def run(args, parser):
+    """Convert the file named by `args`, reporting failures through `parser`."""
     try:
         source = convert(args.file)
         if args.output:
@@ -290,6 +301,15 @@ def main(argv=None):
     else:
         sys.stdout.write(source)
     return 0
+
+
+def main(argv=None):
+    """Run the command-line converter."""
+    parser = argparse.ArgumentParser(
+        prog="python -m ttkbootstrap.convert_theme", description=DESCRIPTION
+    )
+    add_arguments(parser)
+    return run(parser.parse_args(argv), parser)
 
 
 if __name__ == "__main__":

--- a/src/ttkbootstrap/convert_theme.py
+++ b/src/ttkbootstrap/convert_theme.py
@@ -249,11 +249,18 @@ def convert(path):
         f"sets.",
         width=75,
     )
+    # A registered theme is selectable by name, and the name is `<family>-<mode>`
+    # rather than the 1.x name -- so show it. Naming the first theme names the
+    # one they just converted.
+    first, first_spec = next(iter(themes.items()))
+    registered = f"{first}-{_mode(first, first_spec)}"
     header = [
         f"# Converted from {Path(path).name} by ttkb convert-theme.",
         "#",
         *(f"# {line}" for line in note),
-        "# Call register() once, after creating your App.",
+        "#",
+        "# Import this module, then select the theme by name:",
+        f"#     app = ttk.App(theme={_literal(registered)})",
         "",
         "import ttkbootstrap as ttk",
         "",

--- a/src/ttkbootstrap/style/engine.py
+++ b/src/ttkbootstrap/style/engine.py
@@ -957,7 +957,7 @@ class Style(ttk.Style):
         "colors": {...}}}]}`` with the sixteen 1.x color keys, taken verbatim.
         Each theme registers under its own name as a single mode. To convert a
         1.x theme into a light/dark `Theme` family whose plumbing colors are
-        regenerated, run ``python -m ttkbootstrap.convert_theme`` instead.
+        regenerated, run ``ttkb convert-theme`` instead.
 
         Parameters:
 

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -6,6 +6,7 @@ name/colors/light-or-dark container the style engine consumes), and `Theme`
 from a handful of accent colors). Lowest layer of the `style` package.
 """
 import colorsys
+import itertools
 from collections.abc import Mapping
 from dataclasses import dataclass, fields, replace
 from functools import lru_cache
@@ -40,6 +41,12 @@ _SHADE_WEIGHTS = {
     900: 0.80,
     950: 0.90,
 }
+
+# Distinguishes one queued pre-root registration from the next. A counter and
+# not `id(self)`, because `Theme(...).register()` need not keep a reference --
+# the object can be collected and its id reused by the next theme, which is the
+# very collision the unique key exists to prevent.
+_register_calls = itertools.count()
 
 
 def _normalize_color(color: str) -> str:
@@ -926,8 +933,13 @@ class Theme:
         # local import breaks the theme <- utils cycle (utils imports style)
         from ttkbootstrap.utils import config
 
+        # A key per call, not per family: the seam keeps only the last applier
+        # for a key, so keying on the name would drop one of two `register()`
+        # calls that split a family across separate `Theme` objects -- which
+        # both take effect once the root exists.
         config.defer(
-            f"register_theme:{self.name}", lambda: self._register(definitions)
+            f"register_theme:{self.name}:{next(_register_calls)}",
+            lambda: self._register(definitions),
         )
         return self
 

--- a/src/ttkbootstrap/style/theme.py
+++ b/src/ttkbootstrap/style/theme.py
@@ -904,28 +904,42 @@ class Theme:
         return [d for d in (self._definition("light"), self._definition("dark")) if d]
 
     def register(self):
-        """Register the generated variants on the live `Style` singleton.
+        """Register the generated variants so the theme can be selected by name.
 
         Returns this theme so ``theme = Theme(...).register()`` reads cleanly.
-        Raises `RuntimeError` if no `Style` has been created yet.
-        """
-        # local import breaks the theme<-engine cycle (engine imports theme)
-        from ttkbootstrap.style.engine import Style
 
-        style = Style.get_instance()
-        if style is None:
-            raise RuntimeError(
-                "No Style instance yet; create an App/Style before registering "
-                "a Theme, or add it to the built-in catalog."
-            )
+        A theme is declared at the top of a file, where the app root does not
+        exist yet. Registering before the root is therefore the normal case: the
+        variants are queued and registered when the root comes up, early enough
+        that ``App(theme="<name>-light")`` selects one. With a root already
+        running they register immediately.
+
+        The theme is validated here either way, so a missing anchor or an empty
+        family raises at the `register()` call rather than later, out of a
+        window constructor.
+        """
         definitions = self.to_definitions()
         if not definitions:
             raise ValueError(
                 f"Theme {self.name!r} defines neither a 'light' nor a 'dark' block."
             )
+        # local import breaks the theme <- utils cycle (utils imports style)
+        from ttkbootstrap.utils import config
+
+        config.defer(
+            f"register_theme:{self.name}", lambda: self._register(definitions)
+        )
+        return self
+
+    @staticmethod
+    def _register(definitions):
+        """Register already-generated definitions on the live `Style`."""
+        # local import breaks the theme<-engine cycle (engine imports theme)
+        from ttkbootstrap.style.engine import Style
+
+        style = Style.get_instance()
         for definition in definitions:
             style.register_theme(definition)
-        return self
 
     @classmethod
     def from_existing(cls, base: "Theme", *, name: str, **overrides) -> "Theme":

--- a/src/ttkbootstrap/themes/legacy.py
+++ b/src/ttkbootstrap/themes/legacy.py
@@ -82,19 +82,15 @@ def install_legacy_themes(style=None) -> None:
     `DeprecationWarning`: the legacy names are a migration convenience, not the
     2.0 catalog.
 
+    Called before the app root exists -- the natural place, at the top of a
+    file -- the registration is queued and runs when the root comes up, early
+    enough that ``App(theme="darkly")`` selects one.
+
     Parameters:
         style: The `Style` to register onto; defaults to the live singleton.
     """
-    if style is None:
-        # local import breaks the themes<-engine import cycle
-        from ttkbootstrap.style.engine import Style
-
-        style = Style.get_instance()
-        if style is None:
-            raise RuntimeError(
-                "No Style instance yet; create an App/Style before calling "
-                "install_legacy_themes()."
-            )
+    # Warn from the call site whether or not the work is deferred: the
+    # deprecation is about the names this caller is asking for.
     warnings.warn(
         "Legacy (pre-2.0) theme names are a migration convenience and are "
         "planned for removal in 3.0; prefer the 2.0 catalog "
@@ -102,6 +98,22 @@ def install_legacy_themes(style=None) -> None:
         DeprecationWarning,
         stacklevel=2,
     )
+    if style is not None:
+        _install_legacy_themes(style)
+        return
+    # local import breaks the themes<-utils import cycle
+    from ttkbootstrap.utils import config
+
+    config.defer("install_legacy_themes", _install_legacy_themes)
+
+
+def _install_legacy_themes(style=None) -> None:
+    """Register every legacy theme not already registered on `style`."""
+    if style is None:
+        # local import breaks the themes<-engine import cycle
+        from ttkbootstrap.style.engine import Style
+
+        style = Style.get_instance()
     for name, spec in STANDARD_THEMES.items():
         if name in style._theme_names:
             continue

--- a/src/ttkcreator/__main__.py
+++ b/src/ttkcreator/__main__.py
@@ -562,6 +562,11 @@ class DemoWidgets(ttk.Frame):
         sb.pack(fill=X, pady=5, expand=YES)
 
 
+def main():
+    """Open the theme creator. Also what `ttkb creator` runs."""
+    ThemeCreator().mainloop()
+    return 0
+
+
 if __name__ == "__main__":
-    creator = ThemeCreator()
-    creator.mainloop()
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,11 +37,14 @@ def _pin_baseline_density(app):
     Tk 9, which reports 1.0 for the same standard density.
 
     Pinned after the root is built, since `Window()` creates the root and the
-    `Style` together. The handful of styles built eagerly at that point carry
-    the host's density; every asset a test builds, and every style built lazily
-    on first use, comes after this.
+    `Style` together -- so the handful of styles `create_default_style` builds
+    eagerly are already sized to the host. Running it again re-runs those
+    recipes at the pinned density (the recipes are invoked unconditionally; the
+    build-once check is at the call site), leaving nothing sized to the display.
+    Every other style is built lazily on first use, i.e. after this.
     """
     app.tk.call("tk", "scaling", Scaling.for_widget(app).baseline)
+    Style.get_instance()._get_builder().create_default_style()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,29 @@ import pytest
 
 import ttkbootstrap as ttk
 from ttkbootstrap.style import Style
+from ttkbootstrap.style.scaling import Scaling
+
+
+def _pin_baseline_density(app):
+    """Pin the test root to standard density, so `Scaling.factor` is exactly 1.
+
+    Assets and pixel geometry scale to the display -- that is the point -- so a
+    test asserting an exact pixel size is really asserting a display. On a
+    scaled screen (Windows at 125%, the factory default on most laptops) four
+    such tests failed on a clean checkout, with a one-pixel assertion and no
+    hint why. Pinning the shared root covers any other test carrying the same
+    latent assumption, and demotes CI's `-dpi 96` from load-bearing to
+    belt-and-braces.
+
+    `baseline` rather than a literal: it is 4/3 everywhere except aqua before
+    Tk 9, which reports 1.0 for the same standard density.
+
+    Pinned after the root is built, since `Window()` creates the root and the
+    `Style` together. The handful of styles built eagerly at that point carry
+    the host's density; every asset a test builds, and every style built lazily
+    on first use, comes after this.
+    """
+    app.tk.call("tk", "scaling", Scaling.for_widget(app).baseline)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -31,6 +54,7 @@ def _session_root():
     """
     Style.instance = None
     app = ttk.Window()
+    _pin_baseline_density(app)
     app.withdraw()
     app.update_idletasks()
     try:

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -1,0 +1,46 @@
+"""Tests for `ttkbootstrap.__version__`."""
+import importlib.metadata
+import subprocess
+import sys
+from pathlib import Path
+
+import ttkbootstrap as ttk
+
+REPO = Path(__file__).parent.parent
+
+
+def test_version_is_the_installed_distribution_version():
+    # Read from the installed metadata rather than written into the source, so
+    # pyproject.toml stays the one place the literal lives. The consequence is
+    # that this reports what was *installed* -- an editable install keeps the
+    # metadata it was built with -- so it is NOT asserted against pyproject.
+    assert isinstance(ttk.__version__, str) and ttk.__version__
+    assert ttk.__version__ == importlib.metadata.version("ttkbootstrap")
+
+
+def test_version_is_declared_in_the_type_stub():
+    # A .pyi replaces the module for type checkers, and the stub's re-export
+    # pass sources every name from an import statement in __init__.py --
+    # __version__ is an assignment, so it has to be declared explicitly or
+    # `ttk.__version__` is an attribute error under mypy/pyright (verified).
+    stub = (REPO / "src" / "ttkbootstrap" / "__init__.pyi").read_text(
+        encoding="utf-8")
+    assert "__version__: str" in stub
+
+
+def test_version_survives_missing_metadata():
+    # Running from a source tree that was never installed (PYTHONPATH=src) has
+    # no metadata to read; the import must still work. In a subprocess because
+    # ttkbootstrap is already imported here -- and the patch has to land before
+    # the import, since `from importlib.metadata import version` binds then.
+    code = (
+        "import importlib.metadata as m\n"
+        "def missing(name): raise m.PackageNotFoundError(name)\n"
+        "m.version = missing\n"
+        "import ttkbootstrap\n"
+        "print(ttkbootstrap.__version__)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "unknown"

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -1,13 +1,51 @@
-"""Tests for `ttkbootstrap.__version__`."""
+"""Tests for `ttkbootstrap.__version__` and the `ttkb` command line.
+
+The CLI is a thin dispatcher: what is worth pinning is that every subcommand is
+reachable, that `convert-theme` behaves identically to its `python -m` spelling,
+and that a failing command names itself rather than the bare `ttkb`.
+"""
 import importlib.metadata
+import json
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
+import pytest
+
 import ttkbootstrap as ttk
+from ttkbootstrap import cli, convert_theme
 
 REPO = Path(__file__).parent.parent
 
+LEGACY_THEME = {
+    "acme": {
+        "type": "light",
+        "colors": {
+            "primary": "#6a5acd", "secondary": "#6c757d", "success": "#02b875",
+            "info": "#17a2b8", "warning": "#f0ad4e", "danger": "#d9534f",
+            "light": "#ADB5BD", "dark": "#2b2b2b",
+            "bg": "#ffffff", "fg": "#212529",
+            "selectbg": "#555555", "selectfg": "#ffffff", "border": "#ced4da",
+            "inputfg": "#212529", "inputbg": "#ffffff", "active": "#e5e5e5",
+        },
+    }
+}
+
+
+@pytest.fixture
+def legacy_file(tmp_path):
+    """A 1.x ``user.py`` store to convert."""
+    path = tmp_path / "user.py"
+    path.write_text(
+        "USER_THEMES = " + json.dumps(LEGACY_THEME, indent=4), encoding="utf-8"
+    )
+    return path
+
+
+# --------------------------------------------------------------------------
+# __version__
+# --------------------------------------------------------------------------
 
 def test_version_is_the_installed_distribution_version():
     # Read from the installed metadata rather than written into the source, so
@@ -44,3 +82,88 @@ def test_version_survives_missing_metadata():
         [sys.executable, "-c", code], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "unknown"
+
+
+# --------------------------------------------------------------------------
+# entry points
+# --------------------------------------------------------------------------
+
+def test_pyproject_installs_both_console_scripts():
+    data = tomllib.loads((REPO / "pyproject.toml").read_text(encoding="utf-8"))
+    scripts = data["project"]["scripts"]
+    assert scripts == {
+        "ttkbootstrap": "ttkbootstrap.cli:main",
+        "ttkb": "ttkbootstrap.cli:main",
+    }
+
+
+def test_every_subcommand_is_reachable():
+    parser = cli.build_parser()
+    choices = parser._subparsers._group_actions[0].choices
+    assert set(choices) == {"version", "demo", "convert-theme", "creator"}
+    for name, subparser in choices.items():
+        args = subparser.parse_args([] if name != "convert-theme" else ["f.py"])
+        assert callable(args.func)
+        assert args.parser is subparser  # so errors name the subcommand
+
+
+# --------------------------------------------------------------------------
+# dispatch
+# --------------------------------------------------------------------------
+
+def test_version_command_prints_the_version(capsys):
+    assert cli.main(["version"]) == 0
+    assert capsys.readouterr().out.strip() == ttk.__version__
+
+
+def test_bare_ttkb_prints_help_and_fails(capsys):
+    # argparse can require a subcommand, but its error names the missing
+    # argument rather than showing what is available -- and a bare `ttkb` is
+    # someone asking exactly that.
+    assert cli.main([]) == 2
+    out = capsys.readouterr().out
+    for command in ("version", "demo", "convert-theme", "creator"):
+        assert command in out
+
+
+@pytest.mark.parametrize("command, module, attribute", [
+    ("demo", "ttkbootstrap.__main__", "main"),
+    ("creator", "ttkcreator.__main__", "main"),
+])
+def test_gui_commands_call_their_entry_point(command, module, attribute,
+                                             monkeypatch):
+    # The launchers open a window and block, so the dispatch is what is tested;
+    # that the target exists at all is the half that silently rots.
+    import importlib
+
+    target = importlib.import_module(module)
+    calls = []
+    monkeypatch.setattr(target, attribute, lambda: calls.append(command) or 0)
+    assert cli.main([command]) == 0
+    assert calls == [command]
+
+
+# --------------------------------------------------------------------------
+# convert-theme, through the CLI
+# --------------------------------------------------------------------------
+
+def test_convert_theme_matches_the_module_spelling(legacy_file, capsys):
+    assert cli.main(["convert-theme", str(legacy_file)]) == 0
+    through_cli = capsys.readouterr().out
+    assert convert_theme.main([str(legacy_file)]) == 0
+    assert capsys.readouterr().out == through_cli
+    assert 'ttk.Theme(' in through_cli
+
+
+def test_convert_theme_writes_the_output_file(legacy_file, tmp_path, capsys):
+    out = tmp_path / "brand.py"
+    assert cli.main(["convert-theme", str(legacy_file), "-o", str(out)]) == 0
+    assert "ttk.Theme(" in out.read_text(encoding="utf-8")
+    assert f"Wrote {out}" in capsys.readouterr().err
+
+
+def test_convert_theme_failure_names_the_subcommand(tmp_path, capsys):
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(["convert-theme", str(tmp_path / "missing.py")])
+    assert exit_info.value.code == 2
+    assert capsys.readouterr().err.startswith("ttkb convert-theme:")

--- a/tests/test_cli_api.py
+++ b/tests/test_cli_api.py
@@ -6,9 +6,9 @@ and that a failing command names itself rather than the bare `ttkb`.
 """
 import importlib.metadata
 import json
+import re
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
 
 import pytest
@@ -53,7 +53,16 @@ def test_version_is_the_installed_distribution_version():
     # that this reports what was *installed* -- an editable install keeps the
     # metadata it was built with -- so it is NOT asserted against pyproject.
     assert isinstance(ttk.__version__, str) and ttk.__version__
-    assert ttk.__version__ == importlib.metadata.version("ttkbootstrap")
+    try:
+        installed = importlib.metadata.version("ttkbootstrap")
+    except importlib.metadata.PackageNotFoundError:
+        # Running from a source tree that was never installed (PYTHONPATH=src)
+        # is a supported way to import the package, and the one case
+        # `__version__` falls back for -- so read it as the fallback, not a
+        # failure. `test_version_survives_missing_metadata` covers it directly.
+        assert ttk.__version__ == "unknown"
+    else:
+        assert ttk.__version__ == installed
 
 
 def test_version_is_declared_in_the_type_stub():
@@ -89,8 +98,12 @@ def test_version_survives_missing_metadata():
 # --------------------------------------------------------------------------
 
 def test_pyproject_installs_both_console_scripts():
-    data = tomllib.loads((REPO / "pyproject.toml").read_text(encoding="utf-8"))
-    scripts = data["project"]["scripts"]
+    # Read by hand rather than with `tomllib`, which is 3.11+ -- pyproject
+    # declares 3.10 as the floor and CI runs a job on it, so a module-level
+    # `import tomllib` would take this whole file down there.
+    text = (REPO / "pyproject.toml").read_text(encoding="utf-8")
+    section = text.split("\n[project.scripts]\n", 1)[1].split("\n[", 1)[0]
+    scripts = dict(re.findall(r'^(\S+)\s*=\s*"([^"]+)"', section, re.M))
     assert scripts == {
         "ttkbootstrap": "ttkbootstrap.cli:main",
         "ttkb": "ttkbootstrap.cli:main",

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -152,6 +152,14 @@ def test_public_utility_reuses_root_service():
     assert utils.scale_size(root, [22, 6]) == [33, 9]
 
 
+def test_test_root_runs_at_baseline_density(root):
+    # Every exact-pixel assertion in the suite presupposes it. The shared root
+    # is pinned in conftest so a contributor on a scaled display (Windows at
+    # 125%, the factory default on most laptops) gets the same numbers as CI
+    # rather than four one-pixel failures on a clean checkout. See #1322.
+    assert Scaling.for_widget(root).factor == 1.0
+
+
 def test_style_builder_utility_and_assets_share_root_service(root):
     builder = StyleBuilderTTK(build=False)
     assert builder.style.scaling is Scaling.for_widget(root)

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -160,6 +160,17 @@ def test_test_root_runs_at_baseline_density(root):
     assert Scaling.for_widget(root).factor == 1.0
 
 
+def test_eagerly_built_styles_are_rebuilt_at_the_pinned_density():
+    # The pin can only land after `Window()`, which builds a handful of styles
+    # on the way up -- so conftest re-runs those recipes afterward. Drop that
+    # and #1322 is only half fixed: those styles alone stay sized to the
+    # contributor's display. Asserted on the source because the effect is
+    # invisible on a standard-density box, which is where this mostly runs.
+    source = (Path(__file__).parent / "conftest.py").read_text(encoding="utf-8")
+    assert "create_default_style()" in source
+    assert source.index('"tk", "scaling"') < source.index("create_default_style()")
+
+
 def test_style_builder_utility_and_assets_share_root_service(root):
     builder = StyleBuilderTTK(build=False)
     assert builder.style.scaling is Scaling.for_widget(root)

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,5 +1,7 @@
 """Root-bound scaling and asset-geometry regression tests."""
 import ast
+import subprocess
+import sys
 import tkinter
 from math import floor
 from pathlib import Path
@@ -160,15 +162,55 @@ def test_test_root_runs_at_baseline_density(root):
     assert Scaling.for_widget(root).factor == 1.0
 
 
-def test_eagerly_built_styles_are_rebuilt_at_the_pinned_density():
-    # The pin can only land after `Window()`, which builds a handful of styles
-    # on the way up -- so conftest re-runs those recipes afterward. Drop that
-    # and #1322 is only half fixed: those styles alone stay sized to the
-    # contributor's display. Asserted on the source because the effect is
-    # invisible on a standard-density box, which is where this mostly runs.
-    source = (Path(__file__).parent / "conftest.py").read_text(encoding="utf-8")
-    assert "create_default_style()" in source
-    assert source.index('"tk", "scaling"') < source.index("create_default_style()")
+def _button_padding(widget):
+    """`TButton`'s padding as plain numbers.
+
+    Tk hands a length list back as a string or as a tuple of pixel objects
+    depending on whether the style has been rebuilt since it was configured, so
+    the representation is not comparable across two roots -- the numbers are.
+    """
+    value = widget.tk.call("ttk::style", "lookup", "TButton", "-padding")
+    return [int(str(part)) for part in
+            (value.split() if isinstance(value, str) else value)]
+
+
+def test_conftest_pins_a_scaled_display_back_to_baseline(root):
+    # #1322 in the situation it was filed from: a contributor whose display is
+    # scaled. Both halves of the fix have to hold -- the pin itself, and the
+    # rebuild of the styles `Window()` already built on the way up at the host's
+    # density. Neither can be observed on a standard-density box, which is every
+    # CI runner and most dev machines, so the root is brought up scaled here.
+    #
+    # In a subprocess because the session shares one root and one Style
+    # singleton, and through conftest's own fixture rather than a copy of it, so
+    # that removing either half is what fails (verified both ways).
+    code = (
+        "import sys, tkinter\n"
+        f"sys.path.insert(0, {str(Path(__file__).parent)!r})\n"
+        "_real = tkinter.Tk.__init__\n"
+        "def scaled(self, *a, **k):\n"
+        "    _real(self, *a, **k)\n"
+        "    self.tk.call('tk', 'scaling', 2.0)\n"
+        "tkinter.Tk.__init__ = scaled\n"
+        "import conftest\n"
+        "from ttkbootstrap.style.scaling import Scaling\n"
+        # Held, or the generator is collected here and its teardown destroys
+        # the root before it can be measured.
+        "session = conftest._session_root.__wrapped__()\n"
+        "app = next(session)\n"
+        "pad = app.tk.call('ttk::style', 'lookup', 'TButton', '-padding')\n"
+        "pad = pad.split() if isinstance(pad, str) else pad\n"
+        "print(Scaling.for_widget(app).factor, '|',\n"
+        "      *[int(str(part)) for part in pad])\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    factor, padding = result.stdout.split("|")
+
+    assert float(factor) == 1.0, "the shared root must be pinned to baseline"
+    assert [int(v) for v in padding.split()] == _button_padding(root), (
+        "the eagerly built styles must be rebuilt at the pinned density")
 
 
 def test_style_builder_utility_and_assets_share_root_service(root):

--- a/tests/widget_styles/test_theme_anchor.py
+++ b/tests/widget_styles/test_theme_anchor.py
@@ -223,7 +223,7 @@ def test_register_queues_before_the_root_and_applies_on_flush(root, monkeypatch)
     try:
         monkeypatch.setattr(Style, "instance", None)
         Theme.from_existing(BOOTSTRAP, name="preroot").register()
-        assert "register_theme:preroot" in config._pending
+        assert any(k.startswith("register_theme:preroot:") for k in config._pending)
         assert "preroot-light" not in style._theme_names  # queued, not applied
 
         monkeypatch.undo()
@@ -231,6 +231,29 @@ def test_register_queues_before_the_root_and_applies_on_flush(root, monkeypatch)
         assert {"preroot-light", "preroot-dark"} <= style._theme_names
         style.theme_use("preroot-dark")
         assert style.theme.name == "preroot-dark"
+    finally:
+        config._pending.clear()
+        config._pending.update(pending_before)
+        _drop_themes(style, before)
+
+
+def test_two_pre_root_registrations_of_one_family_both_survive(root, monkeypatch):
+    # The seam keeps one applier per key, so keying the queue on the family name
+    # would silently drop the first of two `register()` calls that split a
+    # family across separate `Theme` objects -- and with a root already up both
+    # calls take effect. The queue must not change the answer.
+    style = root.style
+    before = set(style._theme_names)
+    pending_before = dict(config._pending)
+    config._pending.clear()
+    try:
+        monkeypatch.setattr(Style, "instance", None)
+        Theme.from_existing(BOOTSTRAP, name="split", dark=None).register()
+        Theme.from_existing(BOOTSTRAP, name="split", light=None).register()
+
+        monkeypatch.undo()
+        config.flush_pending_config()
+        assert {"split-light", "split-dark"} <= style._theme_names
     finally:
         config._pending.clear()
         config._pending.update(pending_before)

--- a/tests/widget_styles/test_theme_anchor.py
+++ b/tests/widget_styles/test_theme_anchor.py
@@ -10,6 +10,7 @@ import warnings
 import pytest
 
 import ttkbootstrap as ttk
+from ttkbootstrap.style import Style
 from ttkbootstrap.style.theme import (
     Colors,
     Theme,
@@ -23,6 +24,7 @@ from ttkbootstrap.style.theme import (
 from ttkbootstrap.themes.builtin import BOOTSTRAP, CURATED_THEMES
 from ttkbootstrap.themes.legacy import theme_from_legacy_dict
 from ttkbootstrap.themes.standard import STANDARD_THEMES
+from ttkbootstrap.utils import config
 
 
 def sample_theme():
@@ -197,6 +199,84 @@ def test_user_theme_spec_builds_and_registers(root):
                 style._theme_styles.pop(name, None)
                 style._theme_objects.pop(name, None)
         style.theme_use("bootstrap-light")
+
+
+def _drop_themes(style, before):
+    """Unregister every theme registered since `before` and reset the theme."""
+    for name in list(style._theme_names):
+        if name not in before:
+            style._theme_names.discard(name)
+            style._theme_definitions.pop(name, None)
+            style._theme_styles.pop(name, None)
+            style._theme_objects.pop(name, None)
+    style.theme_use("bootstrap-light")
+
+
+def test_register_queues_before_the_root_and_applies_on_flush(root, monkeypatch):
+    # A theme is declared at the top of a file, where no root exists yet. It
+    # queues on the deferred-config seam and registers when the root comes up --
+    # before Style.__init__ selects its theme, so App(theme=...) can name it.
+    style = root.style
+    before = set(style._theme_names)
+    pending_before = dict(config._pending)
+    config._pending.clear()
+    try:
+        monkeypatch.setattr(Style, "instance", None)
+        Theme.from_existing(BOOTSTRAP, name="preroot").register()
+        assert "register_theme:preroot" in config._pending
+        assert "preroot-light" not in style._theme_names  # queued, not applied
+
+        monkeypatch.undo()
+        config.flush_pending_config()
+        assert {"preroot-light", "preroot-dark"} <= style._theme_names
+        style.theme_use("preroot-dark")
+        assert style.theme.name == "preroot-dark"
+    finally:
+        config._pending.clear()
+        config._pending.update(pending_before)
+        _drop_themes(style, before)
+
+
+def test_register_validates_at_the_call_site_even_without_a_root(monkeypatch):
+    # Deferring the registration must not defer the error: a bad theme has to
+    # raise where it is declared, not later out of a window constructor.
+    monkeypatch.setattr(Style, "instance", None)
+    pending_before = dict(config._pending)
+    config._pending.clear()
+    try:
+        with pytest.raises(ValueError, match="neither a 'light' nor a 'dark'"):
+            Theme(name="empty", primary="#0d6efd", success="#198754",
+                  info="#0dcaf0", warning="#ffc107", danger="#dc3545").register()
+        with pytest.raises(ValueError, match="missing accent anchor"):
+            Theme(name="bare",
+                  light=dict(background="#fff", foreground="#000")).register()
+        assert not config._pending  # nothing queued by a failed register()
+    finally:
+        config._pending.clear()
+        config._pending.update(pending_before)
+
+
+def test_install_legacy_themes_queues_before_the_root(root, monkeypatch):
+    style = root.style
+    before = set(style._theme_names)
+    pending_before = dict(config._pending)
+    config._pending.clear()
+    try:
+        monkeypatch.setattr(Style, "instance", None)
+        # the deprecation is about the names this caller asked for, so it warns
+        # from the call site whether or not the work is deferred
+        with pytest.warns(DeprecationWarning, match="Legacy"):
+            ttk.install_legacy_themes()
+        assert "install_legacy_themes" in config._pending
+        assert "darkly" not in style._theme_names
+
+        monkeypatch.undo()
+        config.flush_pending_config()
+        assert set(STANDARD_THEMES) <= style._theme_names
+    finally:
+        config._pending.clear()
+        config._pending.update(pending_before)
+        _drop_themes(style, before)
 
 
 def test_from_existing_overrides_and_rejects_unknown_tokens():

--- a/tools/generate_widget_stubs.py
+++ b/tools/generate_widget_stubs.py
@@ -258,6 +258,10 @@ from PIL.ImageTk import PhotoImage as PilImage
 from typing import Any, Callable
 
 from ttkbootstrap.style import AutoStyleMixin as AutoStyleMixin, BootMixin as BootMixin
+
+# Assigned in `__init__.py` rather than imported, so `_reexports` -- which
+# sources every name from an import statement -- cannot reach it.
+__version__: str
 '''
 
 


### PR DESCRIPTION
Four more 2.2 items before the release, plus the two review rounds they earned.

## `ttkbootstrap.__version__`

Read from the installed metadata (`importlib.metadata.version`), so `pyproject.toml` stays the one place the version literal lives — matching what `docs/conf.py` already did. `import ttkbootstrap; ttkbootstrap.__version__` is a common reflex and raised `AttributeError` in every release to date.

It also has to be declared in `__init__.pyi`: a `.pyi` replaces the module for type checkers, and the stub generator's `_reexports` pass sources every name from an *import statement*, so an assignment is invisible to it. Proven both ways with pyright — `reportAttributeAccessIssue` without the declaration, `str` with it.

The flip side of reading metadata is that it reports what was **installed**, so an editable install lags a bump. That is why no test asserts it against `pyproject.toml`, and why `ttkb version` cannot confirm a release bump without a reinstall — the same trap the release runbook already records for the docs build.

## The `ttkb` command line

New `src/ttkbootstrap/cli.py`, `docs/reference/cli.rst`, `tests/test_cli_api.py` (+12). Four subcommands — `version` · `demo` · `convert-theme` · `creator` — installed under two `[project.scripts]` names, `ttkb` and `ttkbootstrap`.

- Each subcommand already existed as its own `python -m` invocation that nothing surfaced. All of those still work.
- The converter's arguments moved into a shared `convert_theme.add_arguments`/`run` pair so the two spellings cannot drift.
- `__main__.py` (demo) and `ttkcreator/__main__.py` grew a `main()` instead of bare `if __name__` blocks.
- The docs say `ttkb <command>` everywhere; the alternative spellings are stated once, in a note on the CLI page.
- README updated to match, and its `ttkbootstrap-icons` link repointed at **`tkinter-icons`**, the extension's current name (verified live: repo and PyPI both exist).

## `Theme(...).register()` before the app exists

Found by actually running a converted theme rather than reading it. It raised `RuntimeError: No Style instance yet`, which made the natural top-of-file form impossible *and* made a custom theme unusable as an `App(theme=...)` argument: registration needed the app, and the app needed the name.

It now queues on the deferred-config seam that already existed for this shape (`utils/config.defer`, the `set_default_button` tenant). Because `flush_pending_config()` runs in `Style.__init__` *before* `theme_use(theme)`, `import brand; ttk.App(theme="acme-light")` just works. The theme is still **validated eagerly** at the `register()` call, so a missing anchor raises where it is written rather than out of a window constructor. `install_legacy_themes()` got the same treatment and still warns from the call site.

## #1322 — the test root now runs at baseline density

Fixes #1322. `tests/conftest.py` pins the shared root to `Scaling.baseline`, which is the issue's own suggested fix. Reproduced before fixing: forcing `tk scaling 2.0` in the fixture produced exactly the four filed failures with the issue's 144-dpi numbers. With the pin the whole suite passes at 1.0, 1.4, 1.6667 and 2.0, so the fix is density-independent rather than Windows-shaped.

## The review rounds

Three `/code-review` passes over the stack found 10 real defects between them, every one reproduced by probe before acting. The load-bearing ones:

- **Pre-root registration dropped themes.** The deferral keyed the queue on the *family name* and the seam keeps one applier per key, so two `register()` calls splitting a family across separate `Theme` objects collapsed to the last — silently, surfacing only as `theme_use` raising later. A counter, not `id(self)`: `Theme(...).register()` need not keep a reference, so the object can be collected and its id reused by the next theme, reinstating the collision.
- **`import tomllib` is 3.11+** and `test_cli_api.py` imported it at module level — so on the `ubuntu/py3.10` job, the job whose comment says *"a 3.11+ only construct cannot slip in"*, the module died at collection and took all 12 tests with it.
- **The #1322 guard did not guard.** Its first form asserted the pin precedes the rebuild in conftest's *text*; both strings it searched for live inside `_pin_baseline_density`, so deleting the **call site** left it green. It now brings a root up scaled in a subprocess and drives conftest's own fixture, and both halves are proven to fail when removed, alone and in the full suite.
- `ttkb`'s `try` wrapped an import that executes all of ttkcreator, so an `ImportError` from inside it reported "ttkcreator is not installed".
- `PackageNotFoundError` leaked into the public namespace — `ttkbootstrap.PackageNotFoundError` resolved at runtime while the generated stub never declared it, i.e. working code a type checker rejects.

## Gates

Suite **1033 passed, 5 skipped**; docs clean under `-W`; the strip-tags stray-backtick scan clean. `development/2_2_changes.md` covers all four items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
