### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ttkbootstrap"
-version = "2.1.1"
+version = "2.2.0"
 description = "A supercharged theme extension for tkinter that enables on-demand modern flat style themes inspired by Bootstrap."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
One line: `version = "2.1.1"` → `"2.2.0"`. Step 1 of the release runbook, on `master` per the convention that a release is cut from there.

## Pre-flight, all done on this branch

**Change log audited against the diff, not against itself.** `git diff v2.1.1..master` (excluding `CLAUDE.md`/`development/`) touches 25 files and every one is accounted for in `development/2_2_changes.md` — no gap like the one #1333's scrollbar fix left last time.

**Gates:** suite **1033 passed, 5 skipped**; docs build clean under `-W`.

**Artifacts.** `dist/` did still hold the 2.1.1 wheel and sdist, exactly as the runbook warns — emptied before building. `twine check` PASSED on both. Contents checked, since `twine check` only validates metadata:

- the wheel carries all five `ttkbootstrap/assets/icons/` members including `bootstrap.ttf` (the vendored-font failure that installs fine and dies at first render);
- `entry_points.txt` declares both `ttkb` and `ttkbootstrap` → `ttkbootstrap.cli:main`;
- the sdist has no `docs/` or `development/`. It does carry `tests/`, which is setuptools' default and byte-for-byte the same arrangement 2.1.1 shipped — `MANIFEST.in` is unchanged.

**Smoke-tested the built wheel in a clean venv before publishing**, rather than only after:

- `import ttkbootstrap` warning-free; `__version__` → `2.2.0`;
- both console scripts installed and `ttkb version` / `ttkbootstrap version` print `2.2.0`;
- 30 themes, a live theme switch, and an icon rendered from the vendored font (16×16);
- `bootstyle` value tokens (`primary[300]`, `#2f4f4f`) and `ghost`/`round toggle` variants build;
- **pre-root `Theme(...).register()`** — the 2.2 feature — selects via `App(theme="acme-light")` in a process where no root had ever existed;
- **`ttkb convert-theme`** end to end on a reconstructed 1.x `USER_THEMES` file: emitted module imports, registers, and `App(theme="acme-light")` selects it.

## What is left

Upload, tag `v2.2.0`, GitHub release, then the clean-env verify **with `--no-cache-dir`** (PyPI's JSON API and the simple index propagate separately, and pip caches the empty index page — this read as a broken release in both 2.1.0 and 2.1.1).

Note `ttkb version` cannot confirm this bump from a working checkout: an editable install reports the metadata it was built with, which is `2.0.0a1` here. The clean-env install is what confirms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
