### PR TITLE
fix(menu): never paint a menubar, whatever the Tk build does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,15 @@ jobs:
       # Which Tk line a runner carries is not something to assume: aqua's dpi
       # baseline and the scroll-event contract both differ between 8.6 and 9,
       # so record it per job rather than inferring it from the Python version.
+      # It reports the patchlevel too, which needs a real Tk interpreter and so
+      # needs the display -- hence the same Linux/non-Linux split as the suite.
+      - name: Report the Tk build (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a python tools/report_tk_build.py
+
       - name: Report the Tk build
-        run: python -c "import sys, tkinter; print(f'{sys.platform} python={sys.version.split()[0]} tcl={tkinter.TclVersion} tk={tkinter.TkVersion}')"
+        if: runner.os != 'Linux'
+        run: python tools/report_tk_build.py
 
       # screeninfo is deliberately NOT installed: it is optional at runtime, and
       # leaving it out exercises the fallback layout path (X11 Xinerama, then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -312,9 +312,14 @@ geometry, scaling, assets or event bindings should be read against them.
   `relief="solid"` is hardcoded black, and the 3D reliefs derive both shades from
   `-background`. The only route to a flat hairline is painting the *menu* in the
   border color and each *entry* in the surface color. That holds for a popup and
-  **not** a menu bar (whose entries cover only the left of the bar), and the two
-  separate themselves by waiting for `<Map>` — **Tk displays a menu bar through a
-  clone**, so the widget you style never maps.
+  **not** a menu bar (whose entries cover only the left of the bar), so a menu
+  bar must be refused explicitly — ask whether the menu is installed as a
+  window's `-menu` (or is the `-type menubar` clone). It used to be inferred
+  from `<Map>`, on the measurement that **Tk displays a menu bar through a
+  clone** so the widget you style never maps. **That is a property of the Tk
+  build, not a guarantee** — the Tk in CPython 3.13.15 maps it, which painted
+  every X11 menu bar in the border color. A behavioral Tk fact is worth
+  re-deriving before you lean on it.
 - **A style `lookup` can return a `_tkinter.Tcl_Obj`** once the style is *built*
   (`int()` rejects it, `str()` renders the number), and padding reads as `'10 4'`
   or `(10, 4)` depending on whether a rebuild has happened. Compare as numbers.
@@ -390,11 +395,19 @@ which one you are on rather than assuming:
   omitting it exercises the more fragile fallback layout path), and the Xvfb
   display is pinned to 96 dpi to be a standard-density screen.
 - **CI does not cover Tk 9 or anything visual.** Every runner is **Tk 8.6** — the
-  workflow reports the Tcl/Tk build per job rather than leaving it inferred from
-  the Python version, because 8.6-vs-9 is the split behind the aqua dpi baseline
-  and the scroll-event contract. Adding a Tk 9 job is not free: `setup-python`
-  ships no interpreter built against it. Visual gates stay manual and still need
-  the right box — see `tools/verify_positioning.py` and the screenshot harness.
+  workflow reports the Tcl/Tk build per job (`tools/report_tk_build.py`) rather
+  than leaving it inferred from the Python version, because 8.6-vs-9 is the split
+  behind the aqua dpi baseline and the scroll-event contract. Adding a Tk 9 job is
+  not free: `setup-python` ships no interpreter built against it. Visual gates stay
+  manual and still need the right box — see `tools/verify_positioning.py` and the
+  screenshot harness.
+- **The report includes the Tk *patchlevel*, and that is the point.** A CPython
+  **patch** release can change the Tk it links: 3.13.14 → 3.13.15 started mapping
+  menu bars and broke `test_a_never_posted_menu_is_not_painted` on ubuntu py3.13
+  alone. `master` had been green 8 days earlier on the same commit, so a red job on
+  a branch that touches no `src/` is worth a **control re-run of `master`'s own
+  workflow** before believing the branch caused it. Reporting only `tk=8.6` is what
+  hid the drift.
 
 ### Generators and manual gates (`tools/`)
 
@@ -415,6 +428,8 @@ deleted and why the 3.0 shim list stays grep-discoverable).
   fallback layout path.
 - **`verify_hover.py`** — drives pyright over LSP and jedi. **PyCharm cannot be
   scripted**; check it by hand when a report names it.
+- **`report_tk_build.py`** — platform, Python, and the Tcl/Tk **patchlevel**. Run
+  it on a box before blaming its Tk for something; CI runs it per job.
 - **`docs/scripts/take_screenshots.py`** — scene files in
   `docs/screenshots/<page>.py` mirroring each page's own code blocks, captured
   per theme. PNGs keep the capture box's full pixel density and every rST image

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,10 +316,13 @@ geometry, scaling, assets or event bindings should be read against them.
   bar must be refused explicitly — ask whether the menu is installed as a
   window's `-menu` (or is the `-type menubar` clone). It used to be inferred
   from `<Map>`, on the measurement that **Tk displays a menu bar through a
-  clone** so the widget you style never maps. **That is a property of the Tk
-  build, not a guarantee** — the Tk in CPython 3.13.15 maps it, which painted
-  every X11 menu bar in the border color. A behavioral Tk fact is worth
-  re-deriving before you lean on it.
+  clone** so the widget you style never maps. **That is a property of the build,
+  not a guarantee** — under CPython 3.13.15 it maps, which painted every X11 menu
+  bar in the border color. **Not a Tk version difference**: CI's py3.10 job does
+  *not* map it on the same **Tk 8.6.14**, so the interpreter is part of it and
+  the exact mechanism is still unidentified. Which is the lesson — a behavioral
+  Tk fact is worth re-deriving rather than leaning on, and worth designing out
+  when the invariant can be asked for directly instead.
 - **A style `lookup` can return a `_tkinter.Tcl_Obj`** once the style is *built*
   (`int()` rejects it, `str()` renders the number), and padding reads as `'10 4'`
   or `(10, 4)` depending on whether a rebuild has happened. Compare as numbers.
@@ -401,13 +404,17 @@ which one you are on rather than assuming:
   not free: `setup-python` ships no interpreter built against it. Visual gates stay
   manual and still need the right box — see `tools/verify_positioning.py` and the
   screenshot harness.
-- **The report includes the Tk *patchlevel*, and that is the point.** A CPython
-  **patch** release can change the Tk it links: 3.13.14 → 3.13.15 started mapping
-  menu bars and broke `test_a_never_posted_menu_is_not_painted` on ubuntu py3.13
-  alone. `master` had been green 8 days earlier on the same commit, so a red job on
-  a branch that touches no `src/` is worth a **control re-run of `master`'s own
-  workflow** before believing the branch caused it. Reporting only `tk=8.6` is what
-  hid the drift.
+- **The report includes the Tk *patchlevel*, because `tk=8.6` is not a build.**
+  A CPython **patch** release can change behavior: 3.13.14 → 3.13.15 started
+  mapping menu bars and broke `test_a_never_posted_menu_is_not_painted` on ubuntu
+  py3.13 alone. The patchlevel then showed it is **not** a Tk-version story — both
+  ubuntu jobs run **Tk 8.6.14** and only the 3.13 one mapped — so record the build
+  and let it correct you rather than reasoning from the version string. Observed
+  spread: linux 8.6.14, win32 8.6.15, darwin 8.6.18.
+- **A red job on a branch that touches no `src/` deserves a control run.**
+  Re-run **`master`'s own workflow** before believing the branch caused it — CI
+  had not run on `master` for 8 days, and the identical failure there is what
+  established the drift in one step.
 
 ### Generators and manual gates (`tools/`)
 

--- a/development/2_2_1_changes.md
+++ b/development/2_2_1_changes.md
@@ -34,8 +34,8 @@ window, with the menu labels sitting on it. It now stays the surface color, and
 popup menus keep the themed 1px border they gained in 2.1.
 
 **Who notices.** Linux/X11 users of an app with a menu bar
-(`window.configure(menu=...)`), running a Python whose Tk maps menu bars —
-CPython **3.13.15** and later on the 3.13 line. Windows and macOS were never
+(`window.configure(menu=...)`), on a build that maps menu bars — CPython
+**3.13.15** is the one this was found on. Windows and macOS were never
 affected: both draw menu bars with native OS chrome, which the library does not
 touch. Nothing about an app's own code decided this, so an app that looked
 correct could start showing it purely from an interpreter upgrade.
@@ -49,8 +49,9 @@ rest.
 Popups and menu bars were told apart by waiting for `<Map>`. Tk displays a menu
 bar through a *clone*, so historically the widget the library styles never
 mapped and so never got painted. That held everywhere it was measured, but it is
-a property of the Tk build rather than a guarantee, and the Tk in CPython 3.13.15
-does map it.
+a property of the build rather than a guarantee: under CPython 3.13.15 it does
+map. Not a Tk version difference either — CI's 3.10 job does not map it on the
+very same Tk 8.6.14.
 
 A menu bar is now refused explicitly — the library asks whether the menu is
 installed as a window's menu bar rather than inferring it from mapping — so the

--- a/development/2_2_1_changes.md
+++ b/development/2_2_1_changes.md
@@ -1,0 +1,57 @@
+# ttkbootstrap 2.2.1 — notable changes
+
+> The consolidated log of changes that alter behavior or appearance since
+> **2.2.0**, each with **what** changed and **why**. Same role its predecessors
+> (`2_2_changes.md`, `2_1_1_changes.md`, `2_0_breaking_changes.md`) played: kept
+> in `development/` so it survives, and the source for this release's notes.
+>
+> Scope is **relative to 2.2.0**. A regression introduced *and* fixed inside this
+> cycle never reached a user, so it belongs to the dev log in `CLAUDE.md`, not
+> here.
+>
+> Legend: **API** = source-level break · **Visual** = appearance-only (no code
+> change needed) · **New** = additive · **Fix** = something that did not work
+> before now does.
+
+## Index
+
+Rows mirror the section headings below, in order.
+
+| Area | Kind |
+|---|---|
+| **Menu bars no longer take the menu border color on Linux** | Fix |
+
+There are **no API breaks**: nothing was removed, and no call that worked in
+2.2.0 fails.
+
+---
+
+## Menu bars no longer take the menu border color on Linux  *(Fix)*
+
+**What.** On Linux, an application menu bar could come up painted in the theme's
+border color instead of the surface color — a gray bar across the top of the
+window, with the menu labels sitting on it. It now stays the surface color, and
+popup menus keep the themed 1px border they gained in 2.1.
+
+**Who notices.** Linux/X11 users of an app with a menu bar
+(`window.configure(menu=...)`), running a Python whose Tk maps menu bars —
+CPython **3.13.15** and later on the 3.13 line. Windows and macOS were never
+affected: both draw menu bars with native OS chrome, which the library does not
+touch. Nothing about an app's own code decided this, so an app that looked
+correct could start showing it purely from an interpreter upgrade.
+
+**Why.** The border is drawn by putting the *menu* background in the border
+color and every *entry* in the surface color: a popup's entries tile its whole
+interior, so only the 1px strip is left showing. That trick is wrong for a menu
+bar, whose entries cover only the left of the bar — the border color floods the
+rest.
+
+Popups and menu bars were told apart by waiting for `<Map>`. Tk displays a menu
+bar through a *clone*, so historically the widget the library styles never
+mapped and so never got painted. That held everywhere it was measured, but it is
+a property of the Tk build rather than a guarantee, and the Tk in CPython 3.13.15
+does map it.
+
+A menu bar is now refused explicitly — the library asks whether the menu is
+installed as a window's menu bar rather than inferring it from mapping — so the
+behavior no longer depends on which Tk is underneath.

--- a/src/ttkbootstrap/style/builders_tk.py
+++ b/src/ttkbootstrap/style/builders_tk.py
@@ -13,6 +13,44 @@ from ttkbootstrap.style.theme import Colors, ThemeDefinition, _accent_on_color
 _MENU_HAIRLINE_TAG = "TtkbootstrapMenuHairline"
 
 
+def _is_menubar(widget: tk.Menu) -> bool:
+    """True when `widget` is serving as a window's menubar.
+
+    Painting one floods the bar with the border color, because a menubar's
+    entries cover only its left. This used to be inferred from `<Map>` -- a
+    menubar is displayed through a clone, so the widget styled here did not map
+    -- but that is a property of the Tk build, not a guarantee: a menubar does
+    map on the Tk in CPython 3.13.15, which painted every X11 menubar. Ask
+    directly instead, so the invariant no longer depends on the Tk in use.
+
+    Two ways to serve as a menubar, since either widget may be the one that maps:
+    the menu installed as some window's ``-menu``, or the clone Tk displays for
+    it (``-type menubar``; the original stays ``normal``).
+
+    The windows checked are the menu's own toplevel, the root, and the root's
+    direct children -- not a walk of the whole tree. A cascade posts its submenu
+    on every hover, so this runs at pointer speed and cannot afford to
+    instantiate a wrapper for every widget in the app. That covers a menubar
+    built on the window it serves, which is how one is written; a menu parented
+    to one window and installed on a *nested* toplevel would be missed.
+    """
+    if str(widget.cget("type")) == "menubar":
+        return True
+    name = str(widget)
+    root = widget._root()
+    windows = [widget.winfo_toplevel(), root]
+    windows.extend(
+        w for w in root.winfo_children() if isinstance(w, tk.Toplevel)
+    )
+    for window in windows:
+        try:
+            if str(window.cget("menu")) == name:
+                return True
+        except tk.TclError:
+            continue  # not a window, or torn down mid-check
+    return False
+
+
 def _on_menu_map(event):
     """Repaint a popup menu's border as it is posted.
 
@@ -342,13 +380,17 @@ class StyleBuilderTK:
         popup, so only the 1px strip is left showing.
 
         That only holds for a popup. A menubar's entries cover just the left of
-        the bar, so the border color would flood the rest of it -- which is why
-        this waits for `<Map>`: a menu used as a menubar is displayed through a
-        clone, so the widget styled here never maps and never gets painted.
+        the bar, so the border color would flood the rest of it -- so a menubar
+        is refused here, at the one place that paints, rather than at each
+        caller. Waiting for `<Map>` is still what defers a popup's paint until it
+        is posted; it is no longer what keeps a menubar out (see `_is_menubar`).
 
         Entry colors are theme-managed, like those of a themed `Text`. An entry
         the user gave its own color keeps it; the rest follow the theme.
         """
+        if _is_menubar(widget):
+            return
+
         surface = self.colors.bg
         previous = getattr(widget, "_tb_menu_entry_bg", None)
         widget.configure(background=self.colors.border)

--- a/src/ttkbootstrap/style/builders_tk.py
+++ b/src/ttkbootstrap/style/builders_tk.py
@@ -19,9 +19,10 @@ def _is_menubar(widget: tk.Menu) -> bool:
     Painting one floods the bar with the border color, because a menubar's
     entries cover only its left. This used to be inferred from `<Map>` -- a
     menubar is displayed through a clone, so the widget styled here did not map
-    -- but that is a property of the Tk build, not a guarantee: a menubar does
-    map on the Tk in CPython 3.13.15, which painted every X11 menubar. Ask
-    directly instead, so the invariant no longer depends on the Tk in use.
+    -- but that is a property of the build, not a guarantee: on CI's x11 it does
+    map under CPython 3.13.15 and does not under 3.10.20, on the *same* Tk
+    (8.6.14), which painted every x11 menubar. Ask directly instead, so the
+    invariant no longer depends on what the interpreter and Tk happen to do.
 
     Two ways to serve as a menubar, since either widget may be the one that maps:
     the menu installed as some window's ``-menu``, or the clone Tk displays for

--- a/tests/test_menu_border.py
+++ b/tests/test_menu_border.py
@@ -105,11 +105,12 @@ def test_a_menubar_that_maps_is_still_not_painted(root, x11):
     """The same guard, forced instead of trusted.
 
     The test above only shows the menubar went unpainted *because it never
-    mapped* -- and that is a property of the Tk build, not a guarantee. Tk
-    displays a menubar through a clone, so historically the widget styled here
-    did not map; on the Tk in CPython 3.13.15 it does, which painted every X11
-    menubar in the border color. Deliver the `<Map>` by hand so the refusal is
-    asserted on every box regardless of what the local Tk does.
+    mapped* -- and that is a property of the build, not a guarantee. Tk displays
+    a menubar through a clone, so historically the widget styled here did not
+    map; under CPython 3.13.15 it does, which painted every x11 menubar in the
+    border color. Not the Tk version either: CI's 3.10 job does not map it on
+    the same Tk 8.6.14. Deliver the `<Map>` by hand so the refusal is asserted
+    on every box regardless of what the local build does.
     """
     menubar = ttk.Menu(root)
     menubar.add_cascade(label="File")

--- a/tests/test_menu_border.py
+++ b/tests/test_menu_border.py
@@ -16,10 +16,12 @@ against real pixels on X11 (``xwd`` capture of a posted menu, all four edges
 reading exactly ``colors.border``); a headless suite cannot post and capture.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 import ttkbootstrap as ttk
-from ttkbootstrap.style.builders_tk import _MENU_HAIRLINE_TAG
+from ttkbootstrap.style.builders_tk import _MENU_HAIRLINE_TAG, _on_menu_map
 from ttkbootstrap.style.scaling import Scaling
 
 
@@ -87,8 +89,7 @@ def test_a_never_posted_menu_is_not_painted(root, x11):
     """The guard that keeps a menubar intact.
 
     A menubar's entries cover only the left of the bar, so painting it would
-    flood the rest with the border color. Tk displays a menubar through a
-    *clone*, so the widget styled here never maps -- and only a map paints.
+    flood the rest with the border color.
     """
     menubar = ttk.Menu(root)
     menubar.add_cascade(label="File")
@@ -98,6 +99,42 @@ def test_a_never_posted_menu_is_not_painted(root, x11):
         assert not getattr(menubar, "_tb_menu_hairline", False)
     finally:
         root.configure(menu="")
+
+
+def test_a_menubar_that_maps_is_still_not_painted(root, x11):
+    """The same guard, forced instead of trusted.
+
+    The test above only shows the menubar went unpainted *because it never
+    mapped* -- and that is a property of the Tk build, not a guarantee. Tk
+    displays a menubar through a clone, so historically the widget styled here
+    did not map; on the Tk in CPython 3.13.15 it does, which painted every X11
+    menubar in the border color. Deliver the `<Map>` by hand so the refusal is
+    asserted on every box regardless of what the local Tk does.
+    """
+    menubar = ttk.Menu(root)
+    menubar.add_cascade(label="File")
+    root.configure(menu=menubar)
+    try:
+        _on_menu_map(SimpleNamespace(widget=menubar))
+        assert str(menubar.cget("background")) == root.style.colors.bg
+        assert not getattr(menubar, "_tb_menu_hairline", False)
+    finally:
+        root.configure(menu="")
+
+
+def test_a_mapped_popup_is_painted(root, x11):
+    """The positive control for the guard above.
+
+    Refusing to paint a menubar is only correct if a popup arriving down the
+    same path still gets its border -- otherwise the guard could be over-broad
+    and no test would notice.
+    """
+    popup = ttk.Menu(root)
+    popup.add_command(label="Open")
+
+    _on_menu_map(SimpleNamespace(widget=popup))
+    assert str(popup.cget("background")) == root.style.colors.border
+    assert popup._tb_menu_hairline is True
 
 
 def test_entries_follow_a_theme_switch(root, x11):

--- a/tools/report_tk_build.py
+++ b/tools/report_tk_build.py
@@ -1,0 +1,35 @@
+"""Print the Tcl/Tk build a box actually carries.
+
+Which Tk line a runner has is not something to assume: aqua's dpi baseline and
+the scroll-event contract both differ between 8.6 and 9. The *patchlevel*
+matters too -- a CPython patch release can change the Tk it links, and that is a
+real behavior change, not a version-string detail. 3.13.14 -> 3.13.15 started
+mapping menubars, which painted every X11 menubar in the border color; CI
+reported only ``tk=8.6`` for both, so the drift was invisible for 8 days.
+
+Needs a display, because the patchlevel comes from a real Tk interpreter --
+``tkinter.Tcl()`` would load Tcl without Tk and report the wrong thing. Run it
+under ``xvfb-run`` on x11.
+"""
+import sys
+import tkinter
+
+
+def main() -> None:
+    root = tkinter.Tk()
+    try:
+        patchlevel = root.tk.call("info", "patchlevel")
+    finally:
+        root.destroy()
+
+    print(
+        f"{sys.platform} "
+        f"python={sys.version.split()[0]} "
+        f"tcl={tkinter.TclVersion} "
+        f"tk={tkinter.TkVersion} "
+        f"patchlevel={patchlevel}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes the ubuntu py3.13 CI failure, which is a real X11 defect rather than a test problem.

## The bug

On Linux, an application menu bar could render painted in the theme's **border color** instead of the surface color — a gray bar across the top of the window with the menu labels sitting on it.

The themed menu border works by putting the *menu* background in `colors.border` and every *entry* in `colors.bg`: a popup's entries tile its whole interior, so only the 1px strip shows. A menu bar's entries cover only the left of the bar, so the border color floods the rest.

Popups and menu bars were told apart by waiting for `<Map>` — Tk displays a menu bar through a clone, so the widget we style never mapped. That held everywhere it was measured, but it is a property of the build, not a guarantee. **Under CPython 3.13.15 it maps.**

## Why it surfaced now

Nothing in the repo changed. `master` was green on Aug 6 and red on Aug 14 on the same commit — I re-ran master's own workflow as a control to confirm the branch under test was not the cause.

| Run | Python | Result |
|---|---|---|
| Aug 6, master | 3.13.**14** | pass |
| Aug 14, master (control re-run) | 3.13.**15** | fail |

The py3.10 job stayed on 3.10.20 and still passes, which is why only one job of four went red.

**It is not a Tk version story.** My first reading was that 3.13.15 links a newer Tk; the patchlevel reporting added in this PR refutes that. Both ubuntu jobs run the **same Tk 8.6.14**, and only the 3.13 one maps a menu bar. The interpreter is part of it and the precise mechanism is still unidentified — which is exactly why the fix stops depending on mapping rather than special-casing a version.

Observed spread now that it is reported: linux 8.6.14, win32 8.6.15, darwin 8.6.18.

## The fix

Refuse a menu bar explicitly, at the single place that paints, by asking whether the menu is installed as a window's `-menu` (or is the `-type menubar` clone Tk displays) — instead of inferring it from mapping. `<Map>` still defers a popup's paint until it is posted; it no longer decides what a menu bar is. The invariant now holds regardless of the build underneath.

The check deliberately is **not** a whole-tree walk: a cascade posts its submenu on every hover, so it runs at pointer speed. It checks the menu's own toplevel, the root, and the root's direct children — which covers a menu bar built on the window it serves. The bound is documented in the docstring.

## Tests

The existing test only showed the menu bar went unpainted *because it never mapped*, which is exactly the assumption that stopped holding. Two tests are added that force the `<Map>` by hand, so the refusal is asserted on every box regardless of the local build:

- a menu bar that maps is still not painted
- **positive control:** a popup down the same path still gets its border, so the guard cannot be over-broad without a test noticing

Verified to fail against the bug by reverting the guard — reproduces CI's exact `'#d6d6d6' != '#ffffff'` on Windows, no drifted build needed. Suite: 1035 passed, 5 skipped, and the three py3.13 jobs report identical counts.

## CI

The workflow reported only `tk=8.6` for both 3.13.14 and 3.13.15, which is what left 8 days of drift invisible. It now reports the **patchlevel** via `tools/report_tk_build.py`, run under `xvfb-run` on Linux since the patchlevel needs a real Tk interpreter. That report is what corrected the diagnosis above within one run.

`CLAUDE.md` is updated: the "a menu bar never maps" entry under Platform & Tk facts was a measured fact stated with confidence, and it has now been falsified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
