### PR TITLE
fix: accept a Bootstrap Icons glyph name as a message dialog icon

### DIFF
--- a/development/2_2_2_changes.md
+++ b/development/2_2_2_changes.md
@@ -1,0 +1,60 @@
+# ttkbootstrap 2.2.2 — notable changes
+
+> The consolidated log of changes that alter behavior or appearance since
+> **2.2.1**, each with **what** changed and **why**. Same role its predecessors
+> (`2_2_1_changes.md`, `2_2_changes.md`, `2_0_breaking_changes.md`) played: kept
+> in `development/` so it survives, and the source for this release's notes.
+>
+> Scope is **relative to 2.2.1**. A regression introduced *and* fixed inside this
+> cycle never reached a user, so it belongs to the dev log in `CLAUDE.md`, not
+> here.
+>
+> Legend: **API** = source-level break · **Visual** = appearance-only (no code
+> change needed) · **New** = additive · **Fix** = something that did not work
+> before now does.
+
+## Index
+
+Rows mirror the section headings below, in order.
+
+| Area | Kind |
+|---|---|
+| **Message dialogs accept an icon glyph name** | Fix |
+
+There are **no API breaks**: nothing was removed, and no call that worked in
+2.2.1 fails.
+
+---
+
+## Message dialogs accept an icon glyph name  *(Fix)*
+
+**What.** `MessageDialog(icon=...)` and the `Messagebox` methods now accept a
+Bootstrap Icons glyph name, which is what the reference pages have always
+documented the option to be:
+
+```python
+Messagebox.okcancel("Ok or Cancel?", "Choose", icon="question-circle-fill")
+```
+
+Previously that warned — *"could not be loaded as an image name, base64 data, or
+file path"* — and the dialog opened with no icon at all. The four forms that
+already worked (a rendered `ttk.Icon(...)`, a `PhotoImage`, base64 image data, a
+file path) are unchanged, and an unusable value still warns and drops the icon
+rather than failing to open the dialog.
+
+**Who notices.** Anyone who passed `icon=` to a message dialog and got nothing.
+The `show_info` / `show_warning` / `show_error` / `show_question` defaults were
+never affected — those render their own glyph internally and only reached the
+broken path when a caller overrode `icon=`.
+
+**Why.** The option accepted a `str`, so it type-checked, and `ttk.Icon(...)`
+*returns* a `str` — an opaque Tk image name like `"pyimage24"`. Four different
+meanings shared one annotation, and the one form the parameter name advertises
+was the one that failed. Every other `icon=` in the library already takes a glyph
+name (`ttk.Button(icon="gear-fill")`, `ToastNotification(icon="bell-fill")`), so
+the dialogs were the sole exception.
+
+A bare glyph name renders at the same size as the built-in alert glyphs, in the
+theme foreground — a caller's glyph carries no semantics to map to a color, and
+guessing one would be wrong as often as right. `ttk.Icon("gear-fill", 40,
+"warning")` remains the way to ask for a specific size or color.

--- a/docs/reference/dialogs/dialog-classes.rst
+++ b/docs/reference/dialogs/dialog-classes.rst
@@ -136,7 +136,10 @@ width=50, parent=None, alert=False, default=None, padding=(20, 20), icon=None)``
      - Padding around the content.
    * - ``icon``
      - ``str``
-     - A Bootstrap Icons glyph name shown beside the message.
+     - A Bootstrap Icons glyph name shown beside the message (e.g.
+       ``"question-circle-fill"``). For a specific size or color, pass a
+       rendered ``ttk.Icon("gear-fill", 40, "warning")`` instead. A
+       ``PhotoImage``, base64 image data, or a file path also work.
 
 Methods
 ~~~~~~~

--- a/docs/reference/dialogs/messagebox.rst
+++ b/docs/reference/dialogs/messagebox.rst
@@ -36,7 +36,10 @@ keyword-only options:
        returns.
    * - ``icon``
      - ``str``
-     - A Bootstrap Icons glyph name shown beside the message.
+     - A Bootstrap Icons glyph name shown beside the message (e.g.
+       ``"question-circle-fill"``), replacing the default glyph on the
+       ``show_*`` methods. For a specific size or color, pass a rendered
+       ``ttk.Icon("gear-fill", 40, "warning")`` instead.
    * - ``localize``
      - ``bool``
      - Translate the standard button labels through the message catalog. Default

--- a/docs/user-guide/getting-started/migrating.rst
+++ b/docs/user-guide/getting-started/migrating.rst
@@ -111,27 +111,48 @@ If you prefer explicit imports, the full paths still work too —
 ``from ttkbootstrap.widgets.tableview import Tableview`` and
 ``from ttkbootstrap.dialogs import Messagebox``.
 
-Character-icon constants removed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ttkbootstrap.icons module is removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``ttkbootstrap.icons`` module of named character constants (``Emoji`` and
-``Icon``) is removed. Those constants were just Unicode characters, and a character
-only appears if the user's system font happens to include that glyph — so they were
-never reliable across platforms, which is why the catalog is gone.
+The ``ttkbootstrap.icons`` module is removed. It held two unrelated things, and
+each has its own replacement.
 
-You can still use a literal character yourself if you want to — any widget accepts
+``Emoji`` was a catalog of Unicode characters. A character only appears if the
+user's system font includes that glyph, so the catalog was never reliable across
+platforms. You can still use a literal character yourself — any widget accepts
 ``text=`` — with the same font-dependent caveat:
 
 .. code-block:: python
 
    ttk.Label(app, text="🔔").pack()   # shows only where the system font has it
 
-For an icon that renders the same everywhere and follows the theme, use ``icon=``
-instead, which draws from a bundled Bootstrap Icons font:
+``Icon`` was a handful of base64-encoded PNGs: ``Icon.info``, ``Icon.warning``,
+``Icon.error`` and ``Icon.question`` — the four alert images the message dialogs
+drew on — plus the ttkbootstrap logo. Fixed images cannot follow a theme or scale
+to a display, which is why they gave way to font glyphs.
+
+Both are replaced by ``icon=``, which draws from a bundled Bootstrap Icons font —
+theme-following, crisp at any size, and identical on every platform:
 
 .. code-block:: python
 
    ttk.Button(app, text="Add", icon="plus-lg", bootstyle="success").pack()
+
+The dialogs take the same glyph names. The four ``ttk.Messagebox.show_*`` methods
+render their alert glyph for you, so a call that relied on the old default needs
+no change at all; pass ``icon=`` only to override it:
+
+.. code-block:: python
+
+   ttk.Messagebox.okcancel("Ok or Cancel?", "Choose", icon="question-circle-fill")
+
+For a specific size or color, render the glyph first with
+``ttk.Icon(name, size, color)`` and pass the result:
+
+.. code-block:: python
+
+   glyph = ttk.Icon("question-circle-fill", 40, "warning")
+   ttk.Messagebox.okcancel("Ok or Cancel?", "Choose", icon=glyph)
 
 If you passed a character to ``ToastNotification(icon=...)``, give it a Bootstrap
 Icons glyph name instead (for example ``icon="bell-fill"``).

--- a/src/ttkbootstrap/dialogs/message.py
+++ b/src/ttkbootstrap/dialogs/message.py
@@ -3,7 +3,7 @@
 import textwrap
 import tkinter
 import warnings
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import ttkbootstrap as ttk
 from ttkbootstrap.constants import *
@@ -12,10 +12,14 @@ from ttkbootstrap.style._compat import warn_deprecated
 from .base import Dialog
 
 
+# The glyph size used by every dialog icon -- the four default alert glyphs below
+# and a caller's ``icon="<glyph name>"``, so a custom glyph carries the same
+# visual weight as the built-in ones.
+_ICON_SIZE = 30
+
 # The default alert glyphs for the four Messagebox.show_* dialogs, rendered from
 # the built-in Bootstrap-Icons font (theme-matched and recolorable). Replaces the
 # base64 PNG constants from the removed ``ttkbootstrap.icons`` module (2.0).
-_ALERT_ICON_SIZE = 30
 _ALERT_ICONS = {
     "info": ("info-circle-fill", "info"),
     "warning": ("exclamation-triangle-fill", "warning"),
@@ -27,7 +31,7 @@ _ALERT_ICONS = {
 def _alert_icon(kind: str) -> str:
     """Render one alert glyph to a cached Tk image name (see ``_ALERT_ICONS``)."""
     name, color = _ALERT_ICONS[kind]
-    return ttk.Icon(name, _ALERT_ICON_SIZE, color)
+    return ttk.Icon(name, _ICON_SIZE, color)
 
 
 class MessageDialog(Dialog):
@@ -53,7 +57,7 @@ class MessageDialog(Dialog):
             alert: bool = False,
             default: Optional[str] = None,
             padding: "tuple[int, int] | int" = (20, 20),
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             **kwargs: Any,
     ) -> None:
         """Create a message dialog.
@@ -98,10 +102,12 @@ class MessageDialog(Dialog):
                 Padding around the message content. Can be a single int or
                 tuple (horizontal, vertical) (default=(20, 20)).
 
-            icon (str):
-                Optional icon to display. Can be an already-rendered Tk image
-                name (e.g. from ``ttk.Icon(...)``), base64 image data, or a
-                file path.
+            icon (str | PhotoImage):
+                Optional icon to display beside the message. Can be a Bootstrap
+                Icons glyph name (e.g. ``"question-circle-fill"``, rendered in the
+                theme foreground), an already-rendered Tk image name from
+                ``ttk.Icon(...)`` -- which is how to ask for a specific size or
+                color -- a ``PhotoImage``, base64 image data, or a file path.
 
             **kwargs (Dict):
                 Additional keyword arguments. Supports 'localize' (bool)
@@ -156,18 +162,26 @@ class MessageDialog(Dialog):
     def _create_icon_label(self, container: tkinter.Misc) -> "Optional[ttk.Label]":
         """Build the icon Label from ``self._icon``, or None if it is unusable.
 
-        ``self._icon`` may be, in order of preference, an already-rendered Tk
-        image name (e.g. from ``ttk.Icon(...)`` -- the four default alert icons),
-        base64 image data, or a file path. Setting ``image=`` to a string that
-        is not an existing image raises ``TclError``, so an image name and base64
-        data disambiguate cleanly with no string sniffing.
+        ``self._icon`` may be, in order of preference, a ``PhotoImage`` or an
+        already-rendered Tk image name (e.g. from ``ttk.Icon(...)`` -- the four
+        default alert icons), a Bootstrap Icons glyph name, base64 image data, or
+        a file path. Each form fails loudly for the next to try -- ``image=``
+        raises ``TclError`` for a string that is not an existing image, and
+        ``ttk.Icon`` raises ``ValueError`` for an unknown glyph name -- so they
+        disambiguate cleanly with no string sniffing.
         """
         # Each candidate yields the image to hand to ``image=``. A rendered
         # ttk.Icon is a Tk image name (a str, pinned alive by the engine cache);
         # the data/file forms build a PhotoImage that must be retained on the
         # dialog (bound below) so it is not garbage-collected.
+        #
+        # The glyph name renders in the theme foreground: a caller's glyph carries
+        # no semantics we could map to a color, unlike the four alert glyphs whose
+        # colors are assigned by _ALERT_ICONS. ttk.Icon(...) remains the way to ask
+        # for a specific size or color.
         candidates = (
             lambda: self._icon,
+            lambda: ttk.Icon(self._icon, _ICON_SIZE),
             lambda: ttk.PhotoImage(data=self._icon),
             lambda: ttk.PhotoImage(file=self._icon),
         )
@@ -181,7 +195,8 @@ class MessageDialog(Dialog):
             return label
         warnings.warn(
             f"MessageDialog icon {self._icon!r} could not be loaded as an image "
-            "name, base64 data, or file path; no icon will be shown.",
+            "name, a Bootstrap Icons glyph name, base64 data, or a file path; "
+            "no icon will be shown.",
             UserWarning,
             stacklevel=2,
         )
@@ -260,6 +275,10 @@ class Messagebox:
 
     Every method takes ``(message, title, *, parent, alert, position,
     buttons, icon, localize)``; ``parent`` and ``alert`` are keyword-only.
+
+    ``icon`` is a Bootstrap Icons glyph name (e.g. ``"question-circle-fill"``),
+    and replaces the default glyph on the ``show_*`` methods. See
+    `MessageDialog` for the other image forms it accepts.
     """
 
     @staticmethod
@@ -271,7 +290,7 @@ class Messagebox:
             alert: bool = False,
             position: Optional[Tuple[int, int]] = None,
             buttons: Optional[List[str]] = None,
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
@@ -298,7 +317,7 @@ class Messagebox:
             alert: bool = True,
             position: Optional[Tuple[int, int]] = None,
             buttons: Optional[List[str]] = None,
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
@@ -325,7 +344,7 @@ class Messagebox:
             alert: bool = True,
             position: Optional[Tuple[int, int]] = None,
             buttons: Optional[List[str]] = None,
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
@@ -352,7 +371,7 @@ class Messagebox:
             alert: bool = False,
             position: Optional[Tuple[int, int]] = None,
             buttons: Optional[List[str]] = None,
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
@@ -379,7 +398,7 @@ class Messagebox:
             alert: bool = False,
             position: Optional[Tuple[int, int]] = None,
             buttons: Optional[List[str]] = None,
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
@@ -406,7 +425,7 @@ class Messagebox:
             alert: bool = False,
             position: Optional[Tuple[int, int]] = None,
             buttons: Optional[List[str]] = None,
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
@@ -433,7 +452,7 @@ class Messagebox:
             alert: bool = False,
             position: Optional[Tuple[int, int]] = None,
             buttons: Optional[List[str]] = None,
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
@@ -460,7 +479,7 @@ class Messagebox:
             alert: bool = False,
             position: Optional[Tuple[int, int]] = None,
             buttons: Optional[List[str]] = None,
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:
@@ -487,7 +506,7 @@ class Messagebox:
             alert: bool = False,
             position: Optional[Tuple[int, int]] = None,
             buttons: Optional[List[str]] = None,
-            icon: Optional[str] = None,
+            icon: "Optional[Union[str, tkinter.PhotoImage]]" = None,
             localize: bool = True,
             **kwargs: Any,
     ) -> Optional[str]:

--- a/tests/test_dialogs_api.py
+++ b/tests/test_dialogs_api.py
@@ -5,6 +5,7 @@ deprecations, and re-exports -- WITHOUT opening a modal dialog. The dialog
 facades block on ``grab_set``/``wait_window`` when shown, so nothing here calls
 ``.show()``; the modal appearance is left to the manual visual gate.
 """
+import base64
 import inspect
 import warnings
 
@@ -12,6 +13,7 @@ import pytest
 
 import ttkbootstrap as ttk
 from ttkbootstrap.dialogs import Messagebox, Querybox
+from ttkbootstrap.dialogs import message as message_mod
 from ttkbootstrap.dialogs.base import Dialog
 from ttkbootstrap.dialogs.message import MessageDialog
 from ttkbootstrap.dialogs.query import QueryDialog
@@ -141,6 +143,106 @@ def test_command_tuple_form_is_deprecated_and_unwrapped(root):
         dialog = MessageDialog(message="x", parent=root, command=(fn, "label"))
     # the callable is unwrapped from the legacy (callable, label) tuple
     assert dialog._command is fn
+
+
+# --- MessageDialog icon forms (#1342) --------------------------------------
+
+# A 1x1 transparent GIF, the smallest thing Tk's photo image reader accepts --
+# used to exercise the base64-data and file-path forms.
+_ONE_PIXEL_GIF = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+
+
+def _icon_label(root, icon):
+    """Build the icon Label the way create_body does, without showing a dialog."""
+    dialog = MessageDialog(message="x", parent=root, icon=icon)
+    return dialog._create_icon_label(root)
+
+
+def _image_name(label):
+    """The Tk image name on a Label -- cget yields a 1-tuple for a PhotoImage."""
+    value = label.cget("image")
+    if isinstance(value, (tuple, list)):
+        value = value[0] if value else ""
+    return str(value)
+
+
+def test_icon_accepts_a_bootstrap_glyph_name(root):
+    # The form the reference pages have always documented ("a Bootstrap Icons
+    # glyph name"), and which used to warn and show nothing.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        label = _icon_label(root, "question-circle-fill")
+    assert label is not None
+    assert _image_name(label)
+
+
+def test_glyph_name_renders_at_the_dialog_size_in_the_theme_foreground(root):
+    # The defaults a bare glyph name implies. ttk.Icon dedupes on
+    # (name, size, color), so an identical call returns the same image name --
+    # asserting the icon IS Icon(name, _ICON_SIZE) pins both the size and the
+    # foreground color (no semantic color is guessed from the glyph name).
+    label = _icon_label(root, "gear-fill")
+    expected = ttk.Icon("gear-fill", message_mod._ICON_SIZE)
+    assert _image_name(label) == expected
+
+
+def test_a_custom_glyph_matches_the_built_in_alert_glyph_size(root):
+    # A caller's glyph should carry the same visual weight as the glyph
+    # show_info/show_error render for themselves.
+    custom = _image_name(_icon_label(root, "gear-fill"))
+    alert = message_mod._alert_icon("info")
+    width = lambda name: root.tk.call("image", "width", name)
+    assert width(custom) == width(alert)
+
+
+def test_icon_accepts_a_rendered_icon_image_name(root):
+    # The pre-#1342 form -- an explicit ttk.Icon(...), which stays the way to
+    # ask for a non-default size or color -- keeps working unchanged.
+    rendered = ttk.Icon("question-circle-fill", 40, "warning")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        label = _icon_label(root, rendered)
+    assert _image_name(label) == rendered
+
+
+def test_icon_accepts_a_photoimage_object(root):
+    photo = ttk.PhotoImage(data=_ONE_PIXEL_GIF)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        label = _icon_label(root, photo)
+    assert _image_name(label) == str(photo)
+
+
+def test_icon_accepts_base64_image_data(root):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        label = _icon_label(root, _ONE_PIXEL_GIF)
+    assert label is not None
+
+
+def test_icon_accepts_a_file_path(root, tmp_path):
+    path = tmp_path / "icon.gif"
+    path.write_bytes(base64.b64decode(_ONE_PIXEL_GIF))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        label = _icon_label(root, str(path))
+    assert label is not None
+
+
+def test_an_unusable_icon_still_warns_and_shows_no_icon(root):
+    # An unknown glyph name is not silently swallowed by the new candidate:
+    # ttk.Icon raises ValueError, the remaining forms fail, and the dialog is
+    # built without an icon rather than failing to open.
+    with pytest.warns(UserWarning, match="could not be loaded"):
+        assert _icon_label(root, "not-a-real-glyph-name") is None
+
+
+@pytest.mark.parametrize("method", _MESSAGEBOX_METHODS)
+def test_messagebox_icon_annotation_admits_more_than_str(method):
+    # `icon: str` was true but useless -- ttk.Icon returns a str too, so all of
+    # the accepted string forms and the rejected one shared a single type.
+    annotation = inspect.signature(getattr(Messagebox, method)).parameters["icon"].annotation
+    assert "PhotoImage" in str(annotation)
 
 
 # --- ColorChoice dedupe ----------------------------------------------------


### PR DESCRIPTION
Closes the gap raised in discussion #1342.

## The problem

`MessageDialog(icon=...)` and every `Messagebox` method accepted an already-rendered Tk image name, a `PhotoImage`, base64 data, or a file path — but *not* a Bootstrap Icons glyph name, which is what both reference pages have always documented the option to be. So the obvious call warned and opened the dialog with no icon:

```python
Messagebox.okcancel("Ok or Cancel?", "Choose", icon="question-circle-fill")
```

The option is annotated `str`, so it type-checks, and `ttk.Icon(...)` *returns* a `str` too — an opaque Tk image name like `"pyimage24"`. Four different meanings shared one annotation, and the one form the parameter name advertises was the one that failed. Every other `icon=` in the library already takes a glyph name (`ttk.Button(icon="gear-fill")`, `ToastNotification(icon="bell-fill")`), so the dialogs were the sole exception.

## The change

A glyph name is added to the existing candidate chain in `_create_icon_label`. No string sniffing is involved: `image=` raises `TclError` for a string that is not an existing image and `ttk.Icon` raises `ValueError` for an unknown glyph name, so the forms disambiguate by failing for the next one to try.

A bare glyph name renders at **size 30, in the theme foreground**:

- **30** is the size the four built-in alert glyphs already use, so a caller's glyph carries the same visual weight as the one `show_info` / `show_error` render for themselves.
- **Theme foreground** because a caller's glyph carries no semantics to map to a color. The built-ins get semantic colors from a hand-written mapping we control; guessing one for an arbitrary glyph would be wrong as often as right.

`ttk.Icon("gear-fill", 40, "warning")` remains the way to ask for a specific size or color, and every form that worked before still works. An unusable value still warns and drops the icon rather than failing to open the dialog.

Color is deliberately **not** encoded as `"question-circle-fill:info"`, which would read as consistent with the `"OK:primary"` button convention in the same class — `icon=` also accepts a file path, and on Windows that is `C:/icons/foo.png`. Splitting on `:` would break a currently-working input.

## Tests

Nine tests in `tests/test_dialogs_api.py` covering all five accepted forms, the unusable-value warning, and the size/color defaults. The three glyph-name tests were confirmed to fail with the new candidate removed, rather than by reading the code.

## Docs

The two reference tables now show how to reach a specific size or color. Neither needed correcting on the glyph name itself — they already described the behavior this PR implements.