### PR TITLE
docs: fix the 1.x icon and documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,26 +13,26 @@ English | [日本語](README_ja.md) | [中文](README_zh.md)
 ttkbootstrap is a Python library that enhances tkinter by providing modern, flat-style themes inspired by Bootstrap. Easily create stylish GUI applications with built-in themes, pre-defined widget styles, and more.
 
 ## Documentation
-👀 Check out the [documentation](https://ttkbootstrap.readthedocs.io/en/latest/).
+👀 Check out the [documentation](https://www.ttkbootstrap.org/en/version-1/).
 
 
 ![](https://raw.githubusercontent.com/israel-dryer/ttkbootstrap/master/docs/assets/themes/themes.gif)
 
 ## Features
 
-✔️ [**Built-in Themes**](https://ttkbootstrap.readthedocs.io/en/latest/themes/)   
+✔️ [**Built-in Themes**](https://www.ttkbootstrap.org/en/version-1/themes/)   
 Over a dozen curated dark and light themes.
 
-✔️ [**Pre-defined Styles:**](https://ttkbootstrap.readthedocs.io/en/latest/styleguide/)  
+✔️ [**Pre-defined Styles:**](https://www.ttkbootstrap.org/en/version-1/styleguide/)  
 Loads of beautiful pre-defined widget styles such as **outline** and **round toggle** buttons.
 
-✔️ [**Simple keyword API:**](https://ttkbootstrap.readthedocs.io/en/latest/gettingstarted/tutorial/#use-themed-widgets)  
+✔️ [**Simple keyword API:**](https://www.ttkbootstrap.org/en/version-1/gettingstarted/tutorial/#use-themed-widgets)  
 Apply colors and types using simple keywords such as **primary** and **striped** instead of the legacy approach of **primary.Striped.Horizontal.TProgressbar**. If you've used Bootstrap for web development, you are already familiar with this approach using css classes.
 
-✔️ [**Lots of new Widgets:**](https://ttkbootstrap.readthedocs.io/en/latest/api/widgets/dateentry/)  
+✔️ [**Lots of new Widgets:**](https://www.ttkbootstrap.org/en/version-1/api/widgets/dateentry/)  
 ttkbootstrap comes with several new beautifully designed widgets such as **Meter**, **DateEntry**, and **Floodgauge**. Additionally, **dialogs** are now themed and fully customizable.
 
-✔️ [**Built-in Theme Creator:**](https://ttkbootstrap.readthedocs.io/en/latest/themes/themecreator/)  
+✔️ [**Built-in Theme Creator:**](https://www.ttkbootstrap.org/en/version-1/themes/themecreator/)  
 Want to create your own theme? Easy! ttkboostrap includes a built-in **theme creator** that enables you to easily build, load, expore, and apply your own custom themes.
 
 ## Installation
@@ -68,7 +68,7 @@ Here is the desired result:
 
 ![Here is the result of the code used above:](beginningresult.png)
 
-For more detailed usage, please refer to the [**Getting Started page**](https://ttkbootstrap.readthedocs.io/en/latest/gettingstarted/tutorial/)
+For more detailed usage, please refer to the [**Getting Started page**](https://www.ttkbootstrap.org/en/version-1/gettingstarted/tutorial/)
 This page includes creating buttons, adding widgets, different styles and more. 
 
 The new keyword API is very flexible. The following examples all produce the same result:
@@ -105,7 +105,7 @@ those families alongside the constants above.
 We welcome contributions! If you'd like to contribute to ttkbootstrap, please check out our contributing guidelines.
 
 ## Links
-- **Documentation:** https://ttkbootstrap.readthedocs.io/en/latest/  
+- **Documentation:** https://www.ttkbootstrap.org/en/version-1/  
 - **GitHub:** https://github.com/israel-dryer/ttkbootstrap
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -79,7 +79,27 @@ The new keyword API is very flexible. The following examples all produce the sam
 
 ## Icons
 
-Add icons to your app buttons and labels using the [ttkbootstrap-icons](https://github.com/israel-dryer/ttkbootstrap-icons) library.
+1.x ships the `ttkbootstrap.icons` module, which holds two separate things:
+
+- `Icon` — base64-encoded PNGs: `Icon.info`, `Icon.warning`, `Icon.error` and
+  `Icon.question`, the alert images the message dialogs use, plus the
+  ttkbootstrap logo. Pass one to a dialog's `icon=`, or to `PhotoImage(data=...)`:
+
+  ```python
+  from ttkbootstrap.dialogs import MessageDialog
+  from ttkbootstrap.icons import Icon
+
+  dlg = MessageDialog("Ok or Cancel?", "Choose", icon=Icon.question)
+  dlg.show()
+  ```
+
+- `Emoji` — a catalog of Unicode emoji characters for use with `text=`. A
+  character shows only where the system font includes that glyph.
+
+For font-rendered icons that look the same on every platform — Bootstrap Icons,
+Font Awesome, Material, and more — the separate
+[tkinter-icons](https://github.com/israel-dryer/tkinter-icons) library adds
+those families alongside the constants above.
 
 ## Contributing
 We welcome contributions! If you'd like to contribute to ttkbootstrap, please check out our contributing guidelines.

--- a/README_ja.md
+++ b/README_ja.md
@@ -13,26 +13,26 @@
 ttkbootstrap は、Bootstrap にインスパイアされたモダンでフラットなスタイルのテーマを提供することで、tkinter を強化する Python ライブラリです。組み込みのテーマや事前定義されたウィジェットスタイルなどを活用して、スタイリッシュな GUI アプリケーションを簡単に作成できます。
 
 ## ドキュメント
-👀 [ドキュメント](https://ttkbootstrap.readthedocs.io/en/latest/)をご覧ください。
+👀 [ドキュメント](https://www.ttkbootstrap.org/en/version-1/)をご覧ください。
 
 
 ![](https://raw.githubusercontent.com/israel-dryer/ttkbootstrap/master/docs/assets/themes/themes.gif)
 
 ## 機能
 
-✔️ [**組み込みテーマ**](https://ttkbootstrap.readthedocs.io/en/latest/themes/)   
+✔️ [**組み込みテーマ**](https://www.ttkbootstrap.org/en/version-1/themes/)   
 厳選された12種類以上のダークテーマとライトテーマ。
 
-✔️ [**定義済みスタイル:**](https://ttkbootstrap.readthedocs.io/en/latest/styleguide/)  
+✔️ [**定義済みスタイル:**](https://www.ttkbootstrap.org/en/version-1/styleguide/)  
 **アウトライン**や**丸いトグル**ボタンなど、美しい定義済みウィジェットスタイルが多数用意されています。
 
-✔️ [**シンプルなキーワードAPI:**](https://ttkbootstrap.readthedocs.io/en/latest/gettingstarted/tutorial/#use-themed-widgets)  
+✔️ [**シンプルなキーワードAPI:**](https://www.ttkbootstrap.org/en/version-1/gettingstarted/tutorial/#use-themed-widgets)  
 **primary.Striped.Horizontal.TProgressbar**といった従来の記述方法の代わりに、**primary**や**striped**といったシンプルなキーワードを使って色やタイプを適用できます。Web開発でBootstrapを使用したことがある方なら、CSSクラスを使ったこのアプローチにはすでにお馴染みでしょう。
 
-✔️ [**多数の新しいウィジェット:**](https://ttkbootstrap.readthedocs.io/en/latest/api/widgets/dateentry/)  
+✔️ [**多数の新しいウィジェット:**](https://www.ttkbootstrap.org/en/version-1/api/widgets/dateentry/)  
 ttkbootstrap には、**Meter**、**DateEntry**、**Floodgauge** など、美しくデザインされた新しいウィジェットがいくつか含まれています。 さらに、**ダイアログ**もテーマ化され、完全にカスタマイズ可能になりました。
 
-✔️ [**組み込みのテーマ作成ツール:**](https://ttkbootstrap.readthedocs.io/en/latest/themes/themecreator/)  
+✔️ [**組み込みのテーマ作成ツール:**](https://www.ttkbootstrap.org/en/version-1/themes/themecreator/)  
 独自のテーマを作成したいですか？簡単です！ttkbootstrapには、独自のカスタムテーマを簡単に作成、読み込み、閲覧、適用できる組み込みの**テーマ作成ツール**が含まれています。
 
 ## インストール
@@ -68,7 +68,7 @@ root.mainloop()
 
 ![上記のコードの実行結果は以下の通りです:](beginningresult.png)
 
-より詳細な使用方法については、[**入門ページ**](https://ttkbootstrap.readthedocs.io/en/latest/gettingstarted/tutorial/)をご参照ください。
+より詳細な使用方法については、[**入門ページ**](https://www.ttkbootstrap.org/en/version-1/gettingstarted/tutorial/)をご参照ください。
 このページには、ボタンの作成、ウィジェットの追加、さまざまなスタイルなどが含まれています。 
 
 新しいキーワードAPIは非常に柔軟です。以下の例はいずれも同じ結果を生成します：
@@ -85,7 +85,7 @@ root.mainloop()
 皆様からの貢献を歓迎します！ttkbootstrapへの貢献をご希望の場合は、貢献ガイドラインをご確認ください。
 
 ## リンク
-- **ドキュメント:** https://ttkbootstrap.readthedocs.io/en/latest/  
+- **ドキュメント:** https://www.ttkbootstrap.org/en/version-1/  
 - **GitHub:** https://github.com/israel-dryer/ttkbootstrap
 
 ## サポート


### PR DESCRIPTION
Two README fixes on `release/v1`, both surfaced by discussion #1342.

## 1. The Icons section described only the external library

The section read, in full:

> Add icons to your app buttons and labels using the [ttkbootstrap-icons](https://github.com/israel-dryer/ttkbootstrap-icons) library.

It never mentioned `ttkbootstrap.icons` — which 1.x ships and still documents at `docs/en/api/icons/icon.md`. A 1.x user reading that on GitHub or the PyPI page can reasonably conclude the external library *replaced* the module, then go looking for an `Icon.question` equivalent that does not exist there. That is what happened in #1342.

The section now says what the module actually holds:

- **`Icon`** — base64-encoded PNGs (`Icon.info` / `.warning` / `.error` / `.question`, plus the logo), with a runnable `MessageDialog(icon=Icon.question)` example.
- **`Emoji`** — the Unicode character catalog, with the font-dependency caveat.

and presents `tkinter-icons` (its current name) as adding *further icon families alongside* them.

## 2. The documentation links pointed at the 2.x docs

Every doc link used `/en/latest/`, which serves the 2.x Sphinx docs — with 1.x mkdocs paths. So a reader on this branch was sent to documentation for a version they are not running, and `/en/latest/styleguide/` does not even 404: the redirect map lands it on the 2.x widget catalog, which is worse than a dead link.

They now point at `www.ttkbootstrap.org/en/version-1/`, the new domain and the version that matches this branch. Verified to resolve: `styleguide/`, `themes/`, `gettingstarted/tutorial/`, `api/widgets/dateentry/`.

`README_zh.md` is deliberately untouched — its links use an `/en/latest/zh/...` layout whose pages are not published on the new site under any path I could find, so a swap would relocate a broken link rather than fix one. Worth its own issue.

READMEs only; no code changes.