### PR TITLE
docs: point at www.ttkbootstrap.org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/israel-dryer/ttkbootstrap/discussions/new
     about: "Ask a question in the discussion forum"
   - name: Documentation
-    url: https://ttkbootstrap.readthedocs.io/en/latest/
+    url: https://www.ttkbootstrap.org/en/latest/
     about: "ttkbootstrap's documentation"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ ttk.Entry(app, bootstyle="success")
 Add a modifier or a type for variants: `"info outline"`, `"success round toggle"`,
 `"warning striped"`. The vocabulary is closed, so a typo fails loudly instead of
 silently doing nothing. See the
-[bootstyle grammar](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/foundations/bootstyle-grammar.html)
+[bootstyle grammar](https://www.ttkbootstrap.org/en/latest/user-guide/foundations/bootstyle-grammar.html)
 for the full reference.
 
 ## Themes
@@ -92,7 +92,7 @@ app.toggle_theme()                # flip light <-> dark
 ```
 
 Browse them in the
-[themes gallery](https://ttkbootstrap.readthedocs.io/en/latest/themes.html).
+[themes gallery](https://www.ttkbootstrap.org/en/latest/themes.html).
 
 Design your own with the bundled editor — pick colors, preview them on live
 widgets, and export a `Theme(...)` snippet for your app:
@@ -112,13 +112,13 @@ Installing ttkbootstrap installs `ttkb`:
 | `ttkb convert-theme <file>` | Convert a 1.x theme file to the 2.x `Theme(...)` form |
 | `ttkb creator` | Open ttkcreator, the theme designer |
 
-See the [command-line reference](https://ttkbootstrap.readthedocs.io/en/latest/reference/cli.html).
+See the [command-line reference](https://www.ttkbootstrap.org/en/latest/reference/cli.html).
 
 ## Documentation
 
-- **[Documentation](https://ttkbootstrap.readthedocs.io/en/latest/)** — guides, the widget catalog, and the API reference.
-- **[Build your first app](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/getting-started/build-your-first-app.html)** — a step-by-step walkthrough.
-- **[Migrating to 2.0](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/getting-started/migrating.html)** — upgrading from 1.x.
+- **[Documentation](https://www.ttkbootstrap.org/en/latest/)** — guides, the widget catalog, and the API reference.
+- **[Build your first app](https://www.ttkbootstrap.org/en/latest/user-guide/getting-started/build-your-first-app.html)** — a step-by-step walkthrough.
+- **[Migrating to 2.0](https://www.ttkbootstrap.org/en/latest/user-guide/getting-started/migrating.html)** — upgrading from 1.x.
 - **[Release notes](https://github.com/israel-dryer/ttkbootstrap/releases)** — what changed in each version.
 
 ## Upgrading from 1.x
@@ -127,7 +127,7 @@ See the [command-line reference](https://ttkbootstrap.readthedocs.io/en/latest/r
 `bootstyle` grammar, a new theme catalog, and `App` alongside `Window`. Most code
 keeps working: legacy theme names and older spellings are accepted with a
 deprecation warning. The
-[Migrating to 2.0](https://ttkbootstrap.readthedocs.io/en/latest/user-guide/getting-started/migrating.html)
+[Migrating to 2.0](https://www.ttkbootstrap.org/en/latest/user-guide/getting-started/migrating.html)
 guide sorts every change into breaking / deprecated / notable / new.
 
 Custom themes moved out of the package and into your own code. To bring one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = ["pillow>=10,<13"]
 
 [project.urls]
 Homepage = "https://github.com/israel-dryer/ttkbootstrap"
-Documentation = "https://ttkbootstrap.readthedocs.io/en/latest/"
+Documentation = "https://www.ttkbootstrap.org/en/latest/"
 
 [project.scripts]
 # Two names for one command: `ttkbootstrap` is guessable from the package name,

--- a/src/ttkbootstrap/__init__.py
+++ b/src/ttkbootstrap/__init__.py
@@ -35,7 +35,7 @@ behavior (so that *vanilla* `tkinter.ttk`/`tkinter` widgets accept
 of a class you do not control, use `bootify(cls)` or `apply_bootstyle(widget,
 bootstyle)`.
 
-For more information, see: https://ttkbootstrap.readthedocs.io/
+For more information, see: https://www.ttkbootstrap.org/
 """
 from importlib.metadata import (
     PackageNotFoundError as _PackageNotFoundError,


### PR DESCRIPTION
The documentation site moved to its own domain. This swaps the 10 remaining links.

The custom domain preserves Read the Docs' path structure, so each change is a host swap with the path untouched. Verified before swapping:

- `https://www.ttkbootstrap.org/` — loads the 2.x landing page
- `https://www.ttkbootstrap.org/en/latest/themes.html` — loads the themes gallery
- `https://www.ttkbootstrap.org/en/version-1/` — still serves the 1.x mkdocs docs

## What changed

| File | Why it matters |
| --- | --- |
| `README.md` (7) | GitHub landing page and the PyPI long description |
| `pyproject.toml` | the `Documentation` URL, which is the link PyPI shows in its sidebar |
| `src/ttkbootstrap/__init__.py` | the package docstring |
| `.github/ISSUE_TEMPLATE/config.yml` | the docs link on the new-issue chooser |

The notes under `development/` keep the `readthedocs.io` host — they are a record of what was true when written, not live links.

`release/v1`'s README carries two more; those are handled in #1344 against that branch.