### PR TITLE
ci: publish from the pushed tag via PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,89 @@
+name: Publish
+
+# Releasing used to be a hand sequence on a developer box: build, twine check,
+# eyeball the wheel, upload with a long-lived token from a gitignored .pypirc.
+# Every step of that was per-machine -- 2.2.0 and 2.2.1 shipped from different
+# accounts with different tooling installed -- and the artifact that reached PyPI
+# was whatever that box happened to produce.
+#
+# Now the pushed tag is the trigger and the only human steps are the version
+# bump, the change log and the tag itself. Uploading uses PyPI Trusted
+# Publishing: GitHub mints a short-lived OIDC token for this workflow, so there
+# is no API token to store or rotate.
+#
+# `workflow_dispatch` runs everything except the upload, which is how to
+# exercise this file without tagging.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: build, audit and publish
+    runs-on: ubuntu-latest
+
+    # Declared so PyPI's trusted publisher can be scoped to it. Configure the
+    # publisher on PyPI with: owner israel-dryer, repository ttkbootstrap,
+    # workflow publish.yml, environment pypi.
+    environment: pypi
+
+    permissions:
+      contents: read
+      id-token: write   # mints the OIDC token Trusted Publishing exchanges
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      # A tag can point at any commit, including one CI never ran. The suite
+      # needs a display and Tk's shared libraries, same as in ci.yml.
+      - name: Install Tk and a virtual display
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends xvfb tk
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest build twine
+
+      - name: Run the suite
+        run: xvfb-run -a -s "-screen 0 1280x1024x24 -dpi 96" python -m pytest -q
+
+      - name: Build
+        run: python -m build --outdir dist
+
+      # twine check reads metadata only, and never opens the archives.
+      - name: Check the metadata
+        run: python -m twine check dist/*
+
+      # tools/check_dist.py opens them: the vendored icon font and the type stub
+      # are package data whose absence is invisible until a user hits it. On a
+      # tag it also asserts the built version matches the tag, so a tag pushed
+      # without the pyproject bump fails here instead of publishing the wrong
+      # version.
+      - name: Audit the artifacts
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            python tools/check_dist.py dist --expect-version "${GITHUB_REF_NAME#v}"
+          else
+            python tools/check_dist.py dist
+          fi
+
+      # Only a tag publishes. A dispatch run stops here, having proved the
+      # build, the suite and the artifact contents.
+      - name: Publish to PyPI
+        if: github.ref_type == 'tag'
+        uses: pypa/gh-action-pypi-publish@v1.14.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,11 @@ requirement, and why a small value tweak usually beats restructuring layout.
 > unwound at release time. If the next release turns out to be a minor, retarget
 > the open `2.2.2` milestone rather than leaving work in it.
 >
-> **Publishing is still manual, and should not stay that way.** 2.2.1 was built
-> and uploaded by hand from a developer box; the standing intent is to build and
-> publish from the **tag** in CI for the next release. See "Releasing" below.
+> **Publishing is no longer manual.** 2.2.1 was built and uploaded by hand from a
+> developer box; 2.2.2 adds `.github/workflows/publish.yml`, which builds and
+> publishes from the pushed **tag** through PyPI Trusted Publishing. 2.2.2 is its
+> first real run, so watch it rather than assuming — the upload is the one step
+> with no undo. See "Releasing" below.
 
 ### The 2.x line
 
@@ -406,7 +408,8 @@ which one you are on rather than assuming:
   VS Code/Pylance renders) and **jedi** for signature + `bootstyle=`
   completion. **PyCharm is not covered and cannot be scripted** — check it by
   hand when a report names it, as #1327 did.
-- **CI runs the two automatable gates** (`.github/workflows/ci.yml`, #1317) on
+- **CI runs the two automatable gates** (`.github/workflows/ci.yml`, #1317 — the
+  other workflow, `publish.yml`, fires only on a pushed tag) on
   push to `master` and every PR: the suite on **all three windowing systems** —
   Linux, Windows and macOS on py3.13, plus the py3.10 floor from
   `pyproject.toml` (macOS added in #1319) — and the docs under `-W`.
@@ -458,6 +461,10 @@ deleted and why the 3.0 shim list stays grep-discoverable).
   scripted**; check it by hand when a report names it.
 - **`report_tk_build.py`** — platform, Python, and the Tcl/Tk **patchlevel**. Run
   it on a box before blaming its Tk for something; CI runs it per job.
+- **`check_dist.py`** — opens a built wheel and sdist and asserts what
+  `twine check` cannot see: the package data is in the wheel, the sdist has no
+  docs, and the version is the one expected. The publish workflow runs it; see
+  "Releasing".
 - **`docs/scripts/take_screenshots.py`** — scene files in
   `docs/screenshots/<page>.py` mirroring each page's own code blocks, captured
   per theme. PNGs keep the capture box's full pixel density and every rST image
@@ -478,29 +485,44 @@ color or asset change should be checked against the matching one.
 
 ### Releasing
 
-No CI publishes; the upload is manual, with credentials in a gitignored
-repo-root `.pypirc`. **`master` is always the most recent release** — a patch
-release is cut from `master`, so the version bump lands there naturally;
-`release/*` exists only for *superseded* majors.
+**The pushed tag publishes** (`.github/workflows/publish.yml`, added at 2.2.2).
+It runs the suite, builds, `twine check`s, audits the archives
+(`tools/check_dist.py`) and uploads through **PyPI Trusted Publishing** — GitHub
+mints a short-lived OIDC token for that one workflow, so no API token is stored
+anywhere. Nothing is built on a developer box any more; the human steps are the
+bump, the change log, the tag and the GitHub release.
 
-**The intent is to retire this manual path**: build and publish from the pushed
-**tag** in CI (Trusted Publishing, no long-lived token), leaving only the bump,
-the change log and the tag as human steps. Not done yet — the checklist below is
-still the live procedure.
+**`master` is always the most recent release** — a patch release is cut from
+`master`, so the version bump lands there naturally; `release/*` exists only for
+*superseded* majors.
 
-**Building is per-box, and the Windows two-account split bites here.** `dist/`
-and `.pytest_cache/` in this checkout are owned by whichever account last built;
-from the other one they cannot be deleted or even `Get-Acl`'d, so step 4's
-"empty `dist/` first" simply fails. Build to a throwaway `--outdir` instead —
-which satisfies the same intent (no stale artifact in the upload set) more
-strongly than emptying does. `dist/` therefore still holds superseded wheels, so
-the **explicit version glob on upload is load-bearing, not belt-and-braces**.
-`build` and `twine` are also **not** installed in every venv — 2.2.0 shipped from
-the other profile's, and `.venv` needed `pip install build twine` at 2.2.1.
+**A dispatch run is the dry run.** `gh workflow run publish.yml` does everything
+except the upload, which is gated on `github.ref_type == 'tag'` — so the workflow
+itself can be exercised without spending a version number.
+
+**`tools/check_dist.py` opens the archives, which `twine check` never does.** It
+asserts the wheel carries the vendored icon font, the ttk element rasters,
+`py.typed` and the generated stub — each package data whose absence is invisible
+until a user hits it (a wheel without the font installs fine and dies at first
+render; 2.0 shipped with no stub at all) — and that the sdist carries no `docs/`,
+`development/`, `examples/` or `gallery/`. It takes `--expect-version`, which on a
+tag run is the tag, so a tag pushed without the bump fails the release instead of
+publishing the wrong version. Worth running against a local build too:
+`python tools/check_dist.py <dir> [--expect-version X.Y.Z]`.
+
+**Building by hand still works and is still per-box.** `dist/` and
+`.pytest_cache/` in this checkout are owned by whichever Windows account last
+built; from the other one they cannot be deleted or even `Get-Acl`'d, so
+"empty `dist/` first" simply fails — build to a throwaway `--outdir` instead. That
+also means `dist/` keeps superseded wheels, so a by-hand upload needs an
+**explicit version glob** (`twine upload dist/ttkbootstrap-X.Y.Z*`); a bare
+`dist/*` at 2.1.0 would have tried to re-publish the 2.0.0 artifacts sitting
+there. `build` and `twine` are **not** installed in every venv.
 
 1. Bump `version` in `pyproject.toml`, **at release time, on `master`**. It is the
    only place the version is written — nothing under `src/`, `docs/` or `tools/`
-   hardcodes it. 2.0.1 shipped its bump on a throwaway `release/2.0` branch and
+   hardcodes it, and the workflow checks the built version against the tag.
+   2.0.1 shipped its bump on a throwaway `release/2.0` branch and
    `master` kept claiming 2.0.0 for days — don't repeat that branch.
    `docs/conf.py` reads the *installed* distribution's version through
    `importlib.metadata` into `release`/`version`. Neither is rendered anywhere
@@ -510,18 +532,14 @@ the other profile's, and `.venv` needed `pip install build twine` at 2.2.1.
    built with, and this checkout's has read **2.0.0a1** for the whole 2.x cycle.
    RTD is unaffected; it installs fresh, so it reports the real version.
 2. Fold `development/2_<x>_changes.md` into the release notes.
-3. Run the gates: the full suite, and the docs build under `-W`.
-4. **Empty `dist/` first**, then `python -m build`, then `twine check dist/*`, then
-   upload **by explicit version glob** — `twine upload dist/ttkbootstrap-X.Y.Z*`.
-   `dist/` is gitignored, so it keeps whatever the last release built: at 2.1.0 it
-   still held the 2.0.0 wheel and sdist from July 19, and a bare `dist/*` upload
-   would have tried to re-publish 2.0.0 alongside the new version. Worth spending
-   a minute on the artifact while you are there — `twine check` validates metadata
-   but not contents, so confirm the wheel carries `ttkbootstrap/assets/icons/`
-   (the vendored Bootstrap Icons font is package data, and a wheel missing it
-   installs and then fails at first render) and that the sdist has no `docs/` or
-   `development/` in it.
-5. Annotated tag `vX.Y.Z`, plus a GitHub release titled the same way.
+3. Push `master` and confirm CI is green on it. Also run the docs under `-W`
+   locally if the release touched them — RTD builds on its own schedule and the
+   publish workflow does not gate on docs.
+4. Annotated tag `vX.Y.Z`, pushed. That triggers the publish workflow — **watch
+   it** (`gh run watch`) rather than assuming, because the upload is the one step
+   with no undo: PyPI refuses a re-upload of the same version, so a bad artifact
+   burns the number.
+5. A GitHub release titled `vX.Y.Z`, from the notes.
 6. Verify with a clean-environment `pip install ttkbootstrap==X.Y.Z`.
 
 ### Writing tests

--- a/tools/check_dist.py
+++ b/tools/check_dist.py
@@ -1,0 +1,122 @@
+"""Audit a built sdist + wheel before it is published.
+
+``twine check`` validates *metadata*; it never opens the archives. Everything
+that has actually gone wrong here is a contents problem instead:
+
+* The vendored Bootstrap Icons font is package **data**. A wheel missing
+  ``assets/icons/`` installs cleanly and then dies at the first icon render, so
+  the failure lands on users rather than on the release.
+* 2.0 shipped without the type stub, which silently disabled keyword checking
+  in every editor until 2.1.1 put it back. A stub that is present in the repo
+  but absent from the wheel looks identical from a checkout.
+* ``dist/`` is gitignored and keeps whatever the last release built, so a glob
+  can pick up a superseded version. Being explicit about *which* version is in
+  the directory is the check that catches it.
+
+Run it against a freshly built directory, optionally pinning the version the
+release is supposed to be (in CI, the tag):
+
+    python tools/check_dist.py dist
+    python tools/check_dist.py dist --expect-version 2.2.2
+
+Every check prints a PASS/FAIL line; the exit status is non-zero if any failed.
+"""
+import argparse
+import re
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+# Package data whose absence is invisible until runtime: the icon font and its
+# glyph tables, the ttk element rasters the recolor pipeline draws from, and the
+# typing marker plus the generated stub.
+REQUIRED_IN_WHEEL = (
+    "ttkbootstrap/assets/icons/bootstrap.ttf",
+    "ttkbootstrap/assets/icons/glyphmap.json",
+    "ttkbootstrap/assets/icons/icon_metrics.json",
+    "ttkbootstrap/assets/elements/manifest.json",
+    "ttkbootstrap/assets/elements/checkbox-checked.png",
+    "ttkbootstrap/py.typed",
+    "ttkbootstrap/__init__.pyi",
+)
+
+# The sdist is a build input, not a documentation bundle: docs/ and the
+# development/ design notes stay out of it.
+FORBIDDEN_IN_SDIST = ("docs/", "development/", "examples/", "gallery/")
+
+REQUIRED_IN_SDIST = (
+    "pyproject.toml",
+    "LICENSE",
+    "README.md",
+    "src/ttkbootstrap/assets/icons/bootstrap.ttf",
+    "src/ttkbootstrap/__init__.pyi",
+)
+
+_WHEEL_RE = re.compile(r"^ttkbootstrap-(?P<version>[^-]+)-py3-none-any\.whl$")
+_SDIST_RE = re.compile(r"^ttkbootstrap-(?P<version>.+)\.tar\.gz$")
+
+_failures = 0
+
+
+def check(label, ok, detail=""):
+    global _failures
+    if not ok:
+        _failures += 1
+    print(f"{'PASS' if ok else 'FAIL'}  {label}{f' -- {detail}' if detail else ''}")
+    return ok
+
+
+def _one(dist, pattern, kind):
+    """The single archive of `kind` in `dist`, with its version -- or (None, None)."""
+    found = [(p, m) for p in sorted(dist.iterdir()) if (m := pattern.match(p.name))]
+    if not check(f"exactly one {kind} in {dist}", len(found) == 1,
+                 ", ".join(p.name for p, _ in found) or "none found"):
+        return None, None
+    path, match = found[0]
+    return path, match.group("version")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dist", type=Path, help="directory holding the built artifacts")
+    parser.add_argument("--expect-version", help="the version this release is supposed to be")
+    args = parser.parse_args(argv)
+
+    if not args.dist.is_dir():
+        print(f"FAIL  {args.dist} is not a directory")
+        return 1
+
+    wheel, wheel_version = _one(args.dist, _WHEEL_RE, "wheel")
+    sdist, sdist_version = _one(args.dist, _SDIST_RE, "sdist")
+    if wheel is None or sdist is None:
+        return 1
+
+    check("wheel and sdist carry the same version", wheel_version == sdist_version,
+          f"wheel {wheel_version}, sdist {sdist_version}")
+    if args.expect_version:
+        check(f"version is {args.expect_version}", wheel_version == args.expect_version,
+              f"built {wheel_version}")
+
+    wheel_names = set(zipfile.ZipFile(wheel).namelist())
+    for name in REQUIRED_IN_WHEEL:
+        check(f"wheel contains {name}", name in wheel_names)
+
+    with tarfile.open(sdist) as tar:
+        # Every sdist path is prefixed with the ttkbootstrap-<version>/ root.
+        sdist_names = {n.split("/", 1)[1] for n in tar.getnames() if "/" in n}
+    for name in REQUIRED_IN_SDIST:
+        check(f"sdist contains {name}", name in sdist_names)
+    for prefix in FORBIDDEN_IN_SDIST:
+        offenders = sorted(n for n in sdist_names if n.startswith(prefix))
+        check(f"sdist excludes {prefix}", not offenders,
+              f"e.g. {offenders[0]} ({len(offenders)} total)" if offenders else "")
+
+    print()
+    print(f"{'FAILED' if _failures else 'OK'}: {_failures} failed check(s)"
+          if _failures else "OK: every check passed")
+    return 1 if _failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Retires the manual publish path, which has been the standing intent since 2.2.1.

Releasing was a hand sequence on a developer box: build, `twine check`, eyeball the wheel, upload with a long-lived token from a gitignored `.pypirc`. Every step was per-machine — 2.2.0 and 2.2.1 shipped from different Windows accounts with different tooling installed — and what reached PyPI was whatever that box produced.

## What this adds

**`.github/workflows/publish.yml`** — on a pushed `v*` tag: run the suite, build, `twine check`, audit the archives, then upload via **PyPI Trusted Publishing**. GitHub mints a short-lived OIDC token for this one workflow, so there is no API token stored anywhere.

- The suite runs because a tag can point at a commit CI never saw.
- `workflow_dispatch` runs everything **except** the upload (gated on `github.ref_type == 'tag'`), which is how to exercise the workflow without spending a version number.

**`tools/check_dist.py`** — opens the wheel and sdist, which `twine check` never does. Both of the classes it guards have shipped broken before:

- The vendored Bootstrap Icons font is package **data**, so a wheel missing `assets/icons/` installs cleanly and dies at the first icon render — the failure lands on users, not on the release.
- 2.0 shipped with no type stub at all, silently disabling keyword checking in every editor until 2.1.1 put it back. Present in the repo and absent from the wheel looks identical from a checkout.

It also asserts the sdist carries no `docs/`, `development/`, `examples/` or `gallery/`, and takes `--expect-version` — on a tag run that is the tag, so a tag pushed without the `pyproject.toml` bump fails the release instead of publishing the wrong version.

## Verification

- Run against the real 2.2.2 artifacts: 20 checks, all pass.
- Run against **doctored** artifacts — font removed, stub removed, a `docs/` entry added to the sdist, a mismatched `--expect-version` — it fails all four ways and exits non-zero. Per the repo convention, a new guard has to be shown failing against the bug rather than read as correct.
- Suite green locally (1052 passed, 5 skipped) and the workflow YAML parses.

## Also here

`CLAUDE.md`'s Releasing section, STATUS block, and tools list are rewritten to the new procedure, including the one-time PyPI trusted-publisher configuration (owner, repository, workflow `publish.yml`, environment `pypi`) and the reminder that the upload is the single step with no undo — PyPI refuses a re-upload, so a bad artifact burns the version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
